### PR TITLE
ShortTagFixer won't work with short tags alone on their line

### DIFF
--- a/Symfony/CS/Fixer/ShortTagFixer.php
+++ b/Symfony/CS/Fixer/ShortTagFixer.php
@@ -21,7 +21,7 @@ class ShortTagFixer implements FixerInterface
     public function fix(\SplFileInfo $file, $content)
     {
         // [Structure] Never use short tags (<?)
-        return preg_replace('/<\?(\s)/i', '<?php$1', $content);
+        return preg_replace('/<\?(\s)/', '<?php$1', $content);
     }
 
     public function supports(\SplFileInfo $file)


### PR DESCRIPTION
This pull request fixes this behavior. In particular, it allows to fix misused shorttags at the beginning of PHP files.
