### PR TITLE
Added a fixer for extra empty lines

### DIFF
--- a/Symfony/CS/Fixer/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/ExtraEmptyLinesFixer.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer;
+
+use Symfony\CS\FixerInterface;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ExtraEmptyLinesFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        // [Structure] Duplicated empty lines should not be used.
+        return str_replace("\n\n\n", "\n\n", $content);
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return true;
+    }
+}

--- a/Symfony/CS/Tests/Fixer/ExtraEmptyLinesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ExtraEmptyLinesFixerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer;
+
+use Symfony\CS\Fixer\ExtraEmptyLinesFixer;
+
+class ExtraEmptyLinesFixerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFix()
+    {
+        $fixer = new ExtraEmptyLinesFixer();
+        $file = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+$a = new Bar();
+
+$a = new FooBaz();
+EOF;
+
+        $input = <<<'EOF'
+$a = new Bar();
+
+
+$a = new FooBaz();
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
+}


### PR DESCRIPTION
Ideally, this fixer should be used after the fixers removing trailing whitespaces (so that empty lines are really empty), fixing line endings (as it only handles `\n`) and removing use statements (to handle the case where all use statements are removed). But as there is no priority, it simply means that running the fix command twice will be needed to fix everything.

When trying to run it on the Symfony 2.1 source code, I found an issue with the excluded files: the sfTests.php file was changed by the command, whereas it should be excluded.
