### PR TITLE
Fixed README.md (Symfony\CS\Config::create -> Symfony\CS\Config\Config::create)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ configure the fixers and the files and directories that need to be analyzed:
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config::create()
+    return Symfony\CS\Config\Config::create()
         ->fixers(array('indentation', 'elseif'))
         ->finder($finder)
     ;


### PR DESCRIPTION
The path of the Config class was not correct, using the example will result in an fatal error.
