### PR TITLE
[ElseifFixer] Use str_replace instead of a preg_replace

### DIFF
--- a/Symfony/CS/Fixer/ElseifFixer.php
+++ b/Symfony/CS/Fixer/ElseifFixer.php
@@ -21,7 +21,7 @@ class ElseIfFixer implements FixerInterface
     public function fix(\SplFileInfo $file, $content)
     {
         // [Structure] elseif, not else if
-        return preg_replace('/} else if \(/', '} elseif (', $content);
+        return str_replace('} else if (', '} elseif (', $content);
     }
 
     public function getLevel()


### PR DESCRIPTION
Hi,

In in the ElseifFixer, I think that using `preg_replace` is a little overkill (and also unnecessarily consuming perfs) ; why not use `str_replace` instead, as suggested in this PR ?

Cheers.
