### PR TITLE
Relax php version dependency

### DIFF
--- a/Symfony/CS/Fixer/ControlSpacesFixer.php
+++ b/Symfony/CS/Fixer/ControlSpacesFixer.php
@@ -54,7 +54,7 @@ class ControlSpacesFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     /**

--- a/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
+++ b/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
@@ -48,7 +48,7 @@ class CurlyBracketsNewlineFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/ElseifFixer.php
+++ b/Symfony/CS/Fixer/ElseifFixer.php
@@ -38,7 +38,7 @@ class ElseIfFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/IndentationFixer.php
+++ b/Symfony/CS/Fixer/IndentationFixer.php
@@ -39,7 +39,7 @@ class IndentationFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PhpdocParamsAlignmentFixer.php
+++ b/Symfony/CS/Fixer/PhpdocParamsAlignmentFixer.php
@@ -100,7 +100,7 @@ class PhpdocParamsAlignmentFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/ReturnStatementsFixer.php
+++ b/Symfony/CS/Fixer/ReturnStatementsFixer.php
@@ -48,7 +48,7 @@ class ReturnStatementsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/ShortTagFixer.php
+++ b/Symfony/CS/Fixer/ShortTagFixer.php
@@ -37,7 +37,7 @@ class ShortTagFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
@@ -56,7 +56,7 @@ class UnusedUseStatementsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' == $file->getExtension();
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     public function getName()

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.6",
+        "php": ">=5.3.3",
         "symfony/console": "2.1.*",
         "symfony/filesystem": "2.1.*",
         "symfony/finder": "2.1.*"


### PR DESCRIPTION
I was trying to test the php-cs-fixer, but I cannot run it because of php version.

I'm running Debian Squeeze (stable) which includes PHP 5.3.3, so I've pached the source to use an alternative method for finding file extension when running a PHP version lower than 5.3.6. This method is suggested in http://www.php.net/manual/en/splfileinfo.getextension.php#refsect1-splfileinfo.getextension-notes
