### PR TITLE
Remove unused use statements

### DIFF
--- a/Symfony/CS/Config/Symfony20Config.php
+++ b/Symfony/CS/Config/Symfony20Config.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\CS\Config;
 
-use Symfony\CS\FixerInterface;
-use Symfony\CS\ConfigInterface;
 use Symfony\CS\Finder\Symfony20Finder;
 
 /**

--- a/Symfony/CS/Config/Symfony21Config.php
+++ b/Symfony/CS/Config/Symfony21Config.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\CS\Config;
 
-use Symfony\CS\FixerInterface;
-use Symfony\CS\ConfigInterface;
 use Symfony\CS\Finder\Symfony21Finder;
 
 /**


### PR DESCRIPTION
Executed the PHP-CS-Fixer on itself and found two unused use statements.
