### PR TITLE
Add .php_cs file to test CS of this repository

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,21 @@
+<?php
+
+use Symfony\CS\FixerInterface;
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->notName('LICENSE')
+    ->notName('README.md')
+    ->notName('.php_cs')
+    ->notName('composer.*')
+    ->notName('phpunit.xml*')
+    ->notName('*.phar')
+    ->exclude('vendor')
+    ->exclude('Symfony/CS/Tests/Fixer')
+    ->notName('ElseifFixer.php')
+    ->in(__DIR__)
+;
+
+return Symfony\CS\Config\Config::create()
+    ->finder($finder)
+;
+


### PR DESCRIPTION
I ignored most of the important files that don't need to be checked. Additionally, some test files need to be ignored.

So this means running a command like this in the root dir to check the CS of this repo:

```
php ./php-cs-fixer fix --level=all .
```

Note: I've not used the Finder component much, so happy to hear any best practice suggestions here.
