### PR TITLE
Space control test

### DIFF
--- a/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
@@ -39,7 +39,7 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $if = 'if($test){';
+        $if = 'if( $test ){';
         $ifFixed = 'if ($test) {';
         $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
         $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));


### PR DESCRIPTION
Updated testFixControlsWithParenthesesAndSuffixBrace which fails now since `ControlSpacesFixer` is missing to fix "Opening parentheses for control structures have no space after them, and closing parentheses for control structures have no space before." from PSR-1. 
