### PR TITLE
Space fixer for "use" statement in lambda function

### DIFF
--- a/Symfony/CS/Fixer/ControlSpacesFixer.php
+++ b/Symfony/CS/Fixer/ControlSpacesFixer.php
@@ -29,6 +29,7 @@ class ControlSpacesFixer implements FixerInterface
         $content = $this->fixControlsWithParenthesesAndSuffixBrace($content);
         $content = $this->fixControlsWithPrefixBraceAndSuffixBrace($content);
         $content = $this->fixControlsWithPrefixBraceAndParenthesesAndSuffixBrace($content);
+        $content = $this->fixControlsWithPrefixBraceAndParenthesesAndSuffixBraceInLambdas($content);
         $content = $this->fixCasts($content);
 
         return $content;
@@ -160,6 +161,22 @@ class ControlSpacesFixer implements FixerInterface
         );
 
         return preg_replace(sprintf('/}[^\S\n]*(%s)[^\S\n]*\((.*)\)[^\S\n]*{/', implode('|', $statements)), '} \\1 (\\2) {', $content);
+    }
+
+    /**
+     * ") use (...) {"
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function fixControlsWithPrefixBraceAndParenthesesAndSuffixBraceInLambdas($content)
+    {
+        $statements = array(
+            'use',
+        );
+
+        return preg_replace(sprintf('/\)[^\S\n]*(%s)[^\S\n]*\((.*)\)[^\S\n]*{/', implode('|', $statements)), ') \\1 (\\2) {', $content);
     }
 
     /**

--- a/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
@@ -65,6 +65,16 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseifFixed));
     }
 
+    public function testFixControlsWithPrefixBraceAndParenthesesAndSuffixBraceInLambdas()
+    {
+        $fixer = new Fixer();
+
+        $use = ')use($test){';
+        $useFixed = ') use ($test) {';
+        $this->assertEquals($useFixed, $fixer->fix($this->getFileMock(), $use));
+        $this->assertEquals($useFixed, $fixer->fix($this->getFileMock(), $useFixed));
+    }
+
     /**
      * @dataProvider testFixCastsProvider
      */


### PR DESCRIPTION
This patch cover only the following case, transform something like:

``` php
$locked = $locker->handle($user, function()use($downloadable){ ...
```

in:

``` php
$locked = $locker->handle($user, function() use ($downloadable) { ...
```

Hope can be useful!
