### PR TITLE
Include fixer

### DIFF
--- a/Symfony/CS/Fixer/IncludeFixer.php
+++ b/Symfony/CS/Fixer/IncludeFixer.php
@@ -23,20 +23,20 @@ class IncludeFixer implements FixerInterface
      */
     public function fix(\SplFileInfo $file, $content)
     {
-        $statements = array(
+        $statements = implode('|', array(
             'include',
             'include_once',
             'require',
             'require_once',
-        );
+        ));
 
         return preg_replace(
             array(
-                sprintf('/(%s)\s*\(\s*([^)]+?)\s*\)/', implode('|', $statements)), // Remove enclosing brackets and trailing spaces
-                sprintf('/(%s)\s+(.*)/', implode('|', $statements)),               // Replace multiple spaces with single between include and file path
+                sprintf('/(%s)\s*\(?\s*[\'"]{1}(?!\")([a-zA-Z0-9\-_.\/]*)[\'"]{1}\s*\)?/', $statements), // Remove enclosing brackets, trailing spaces and convert double with single quotes
+                sprintf('/(%s)[^\S\n]+(.*)/', $statements),                                              // Replace multiple spaces with single between include and file path
             ),
             array(
-                '\\1 \\2',
+                "\\1 '\\2'",
                 '\\1 \\2',
             ),
             $content

--- a/Symfony/CS/Tests/Fixer/IncludeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/IncludeFixerTest.php
@@ -33,11 +33,18 @@ class IncludeFixerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array("include   'foo.php'", "include 'foo.php'"),
+            array('include   "foo.php"', "include 'foo.php'"),
+            array('include (  "Buzz/foo-Bar.php" )', "include 'Buzz/foo-Bar.php'"),
             array("include('foo.php')", "include 'foo.php'"),
-            array("include_once( 'foo1.php' )", "include_once 'foo1.php'"),
-            array('require("foo.php")', 'require "foo.php"'),
-            array("require_once  __DIR__ . 'sasa.php'", "require_once __DIR__ . 'sasa.php'"),
+            array("include_once( 'foo.php' )", "include_once 'foo.php'"),
+            array('require("foo.php")', "require 'foo.php'"),
+            array("require_once  __DIR__.'foo.php'", "require_once __DIR__.'foo.php'"),
+            array("require_once  __DIR__.('foo.php')", "require_once __DIR__.('foo.php')"),
+            array("require_once  (__DIR__.('foo.php'))", "require_once (__DIR__.('foo.php'))"),
+            array("require_once (dirname(__FILE__).'foo.php')", "require_once (dirname(__FILE__).'foo.php')"),
             array('$includeVar', '$includeVar'),
+            array("ClassCollectionLoader::load(include(\$this->getCacheDir().'classes.map'), \$this->getCacheDir(), \$name, \$this->debug, false, \$extension)", "ClassCollectionLoader::load(include(\$this->getCacheDir().'classes.map'), \$this->getCacheDir(), \$name, \$this->debug, false, \$extension)"),
+            array("require_once '\".__DIR__.\"/../bootstrap.php'", "require_once '\".__DIR__.\"/../bootstrap.php'"),
         );
     }
 


### PR DESCRIPTION
At first, I wanted to implement removing outer braces for all cases, but it turned out that there are too many cases and dealing with recursive regex would lead to unnecessary complexity and would probably be slower. So I implemented simplified version. It will also replace double with single quotes and fix spacing.

Some examples:
1. `include   "foo.php"` => `include 'foo.php'`
2. `include (  "Buzz/foo-Bar.php" )` => `include 'Buzz/foo-Bar.php'`
3. `require_once  (__DIR__.('foo.php'))` => `require_once (__DIR__.('foo.php'))`

For cases like 3. it only fix white spaces between include and path leaving brackets as they are.

This should fix issue [#47](https://github.com/fabpot/PHP-CS-Fixer/issues/47).
