### PR TITLE
Changed priority of UnusedUseStatementsFixer

### DIFF
--- a/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
@@ -51,7 +51,8 @@ class UnusedUseStatementsFixer implements FixerInterface
 
     public function getPriority()
     {
-        return 0;
+        // should be run before the ExtraEmptyLinesFixer
+        return 5;
     }
 
     public function supports(\SplFileInfo $file)


### PR DESCRIPTION
the UnusedUseStatementsFixer should be run before ExtraEmptyLinesFixer:

you can see the problem there : https://github.com/composer/composer/commit/c65acb5d#L4R12
