### PR TITLE
Make EOF LineFeed run last

### DIFF
--- a/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
+++ b/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
@@ -38,7 +38,8 @@ class EndOfFileLineFeedFixer implements FixerInterface
 
     public function getPriority()
     {
-        return 0;
+        // must run last to be sure the file is properly formatted before it runs
+        return -50;
     }
 
     public function supports(\SplFileInfo $file)


### PR DESCRIPTION
In some occurences with the current code you have to run the fixer twice to get rid of all errors, I think because of the deleted ?> or something along those lines. Anyway this fixes it.
