### PR TITLE
Add a test case on PhpdocParamsAlignmentFixer test

### DIFF
--- a/Symfony/CS/Tests/Fixer/PhpdocParamsAlignmentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PhpdocParamsAlignmentFixerTest.php
@@ -65,6 +65,36 @@ EOF;
         $this->assertEquals($expected, $fixer->fix($file, $input));
     }
 
+    /**
+     * References the issue #55 on github issue
+     * https://github.com/fabpot/PHP-CS-Fixer/issues/55
+     */
+    public function testFixThreeParamsWithReturn()
+    {
+        $fixer = new PhpdocParamsAlignmentFixer();
+        $file = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+
+     * @param  string $param1
+     * @param  bool   $param2 lorem ipsum
+     * @param  string $param3 lorem ipsum
+     * @return int    lorem ipsum
+
+EOF;
+
+        $input = <<<'EOF'
+
+     * @param   string $param1
+     * @param bool   $param2 lorem ipsum
+     * @param    string $param3 lorem ipsum
+     * @return int lorem ipsum
+
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
+
     public function testFixOnlyReturn()
     {
         $fixer = new PhpdocParamsAlignmentFixer();


### PR DESCRIPTION
As I had an issue I have added a test case. Actually I missed something so the error was on my side...

But I searched if somebody had the error I though I had and I saw the issue #55, so I wrote the test case for this.
