### PR TITLE
ignore Tests folder not needed in the phar file

### DIFF
--- a/Symfony/CS/Util/Compiler.php
+++ b/Symfony/CS/Util/Compiler.php
@@ -83,7 +83,7 @@ class Compiler
 
     protected function getFiles()
     {
-        $iterator = Finder::create()->files()->name('*.php')->in(array('vendor', 'Symfony'));
+        $iterator = Finder::create()->files()->exclude('Tests')->name('*.php')->in(array('vendor', 'Symfony'));
 
         return array_merge(array('LICENSE'), iterator_to_array($iterator));
     }


### PR DESCRIPTION
The phar files don't need the test classe so i add the exclude for it. This reduced the phar files size -45% to ~300K.

There are also other files like README composer.json ... but there are very small files.
