### PR TITLE
Support for newline after interface and trait definitions

### DIFF
--- a/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
+++ b/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
@@ -58,13 +58,13 @@ class CurlyBracketsNewlineFixer implements FixerInterface
 
     public function getDescription()
     {
-        return 'Opening braces for classes and methods must go on the next line, and closing braces must go on the next line after the body. Opening braces for control structures must go on the same line, and closing braces must go on the next line after the body.';
+        return 'Opening braces for classes, interfaces, traits and methods must go on the next line, and closing braces must go on the next line after the body. Opening braces for control structures must go on the same line, and closing braces must go on the next line after the body.';
     }
 
     private function classDeclarationFix($content)
     {
         // [Structure] Add new line after class declaration
-        return preg_replace('/^([ \t]*)((?:[\w \t]+ )?class [\w \t\\\\]+?)[ \t]*{\s*$/m', self::ADD_NEWLINE, $content);
+        return preg_replace('/^([ \t]*)((?:[\w \t]+ )?(class|interface|trait) [\w \t\\\\]+?)[ \t]*{\s*$/m', self::ADD_NEWLINE, $content);
     }
 
     private function functionDeclarationFix($content)

--- a/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
@@ -5,14 +5,34 @@ use Symfony\CS\Fixer\CurlyBracketsNewlineFixer as Fixer;
 
 class CurlyBracketsNewlineFixerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testClassDefinitions()
+    /**
+     * @dataProvider testSimpleTypeDefinitionsProvider
+     */
+    public function testSimpleTypeDefinitions($type)
     {
         $fixer = new Fixer();
 
-        $simple = "class TestClass  {";
-        $simpleFixed = "class TestClass\n{";
+        $simple = "$type TestType  {";
+        $simpleFixed = "$type TestType\n{";
         $this->assertEquals($simpleFixed, $fixer->fix($this->getFileMock(), $simple));
         $this->assertEquals($simpleFixed, $fixer->fix($this->getFileMock(), $simpleFixed));
+
+        $emptyType = "$type TestType {}";
+        $this->assertEquals($emptyType, $fixer->fix($this->getFileMock(), $emptyType));
+    }
+
+    public function testSimpleTypeDefinitionsProvider()
+    {
+        return array(
+            array('class'),
+            array('interface'),
+            array('trait'),
+        );
+    }
+
+    public function testExtendedClassDefinitions()
+    {
+        $fixer = new Fixer();
 
         $extended = <<<TEST
 class TestClass extends BaseTestClass implements TestInterface {
@@ -23,9 +43,6 @@ class TestClass extends BaseTestClass implements TestInterface
 TEST;
         $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extended));
         $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extendedFixed));
-
-        $emptyClass = "class TestClass {}";
-        $this->assertEquals($emptyClass, $fixer->fix($this->getFileMock(), $emptyClass));
 
         $extended = <<<TEST
 abstract class TestClass extends BaseTestClass implements TestInterface {


### PR DESCRIPTION
To keep the test cases DRY, I added a dataProvider for the simple tests. But now that test case isn't as easy to understand at a glance as before. Let me know if you don't like it that way and I'll factor the trait and interface tests into their own methods.
