### PR TITLE
Support for newline after multiple interfaces

### DIFF
--- a/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
+++ b/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
@@ -64,7 +64,7 @@ class CurlyBracketsNewlineFixer implements FixerInterface
     private function classDeclarationFix($content)
     {
         // [Structure] Add new line after class declaration
-        return preg_replace('/^([ \t]*)((?:[\w \t]+ )?(class|interface|trait) [\w \t\\\\]+?)[ \t]*{\s*$/m', self::ADD_NEWLINE, $content);
+        return preg_replace('/^([ \t]*)((?:[\w \t]+ )?(class|interface|trait) [\w, \t\\\\]+?)[ \t]*{\s*$/m', self::ADD_NEWLINE, $content);
     }
 
     private function functionDeclarationFix($content)

--- a/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
@@ -45,10 +45,10 @@ TEST;
         $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extendedFixed));
 
         $extended = <<<TEST
-abstract class TestClass extends BaseTestClass implements TestInterface {
+abstract class TestClass extends BaseTestClass implements TestInterface, TestInterface2 {
 TEST;
         $extendedFixed = <<<TEST
-abstract class TestClass extends BaseTestClass implements TestInterface
+abstract class TestClass extends BaseTestClass implements TestInterface, TestInterface2
 {
 TEST;
         $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extended));


### PR DESCRIPTION
php-cs-fixer won't fix this:

```
class Foo implements Bar, Baz {
}
```

This PR corrects this.
