### PR TITLE
Fixed braces fixer for else if statements.

### DIFF
--- a/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
+++ b/Symfony/CS/Fixer/CurlyBracketsNewlineFixer.php
@@ -83,6 +83,7 @@ class CurlyBracketsNewlineFixer implements FixerInterface
     {
         $statements = array(
             '\bif\s*\(.*\)',
+            '\belse\s*if\s*\(.*\)',
             '\belse\b',
             '\bfor\s*\(.*\)',
             '\bdo\b',

--- a/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
@@ -80,6 +80,11 @@ TEST;
         $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
         $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
 
+        $elseif = "else if (...)\n{";
+        $elseifFixed = "else if (...) {";
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseif));
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseifFixed));
+
         $func = "function download() {\n}";
         $funcFixed = "function download()\n{\n}";
         $this->assertEquals($funcFixed, $fixer->fix($this->getFileMock(), $func));


### PR DESCRIPTION
Hey there,

I found out a weird case with some "else if" statements. It is related to the braces fixer. When it encounters something like

``` php
if (...)
{ 
    // ...
}
else if (...)
{
    // ...
}
```

It will convert it to

```
if (...) {
    // ...
} else { if (...)
    // ...
}
```

Which is totally wrong. If you have several "else if" statements, you end up with successive "else" statements, resulting in a parse error.
