### PR TITLE
Moved unused-use to work with tokens

### DIFF
--- a/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
@@ -34,13 +34,6 @@ class UnusedUseStatementsFixer implements FixerInterface
                 $currentUse[] = $key;
 
                 if ($val === ';') {
-                    // We have to delete also the space before the use
-                    reset($currentUse);
-                    $firstKey = current($currentUse) - 1;
-                    if (isset($token[$firstKey]) and static::isTokenType($token[$firstKey], T_WHITESPACE)) {
-                        $currentUse[] = $firstKey;
-                    }
-
                     $usesToDelete[$lastElement] = $currentUse;
                     $currentUse = array();
                 }
@@ -60,9 +53,22 @@ class UnusedUseStatementsFixer implements FixerInterface
             }
         }
 
+        if (empty($usesToDelete)) {
+            return $content;
+        }
+
         foreach ($usesToDelete as $linesToDrop) {
             foreach ($linesToDrop as $key) {
                 unset($token[$key]);
+            }
+
+            // We have to delete also the space after the use
+            $whitespaceKey = end($linesToDrop) + 1;
+            if (isset($token[$whitespaceKey]) and static::isTokenType($token[$whitespaceKey], T_WHITESPACE)) {
+                // If new lines are more then 1 we have to preserve at least one
+                $newlines = explode(PHP_EOL, $token[$whitespaceKey][1]);
+                array_shift($newlines);
+                $token[$whitespaceKey] = implode(PHP_EOL, $newlines);
             }
         }
 

--- a/Symfony/CS/Tests/Fixer/UnusedUseStatementsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/UnusedUseStatementsFixerTest.php
@@ -23,6 +23,8 @@ class UnusedUseStatementsFixerTest extends \PHPUnit_Framework_TestCase
         $expected = <<<'EOF'
 <?php
 
+namespace My;
+
 use Foo\Bar;
 use Foo\Bar\FooBar as FooBaz;
 use SomeClass;
@@ -39,8 +41,10 @@ EOF;
         $input = <<<'EOF'
 <?php
 
-use Foo\Bar;
+namespace My;
+
 use Foo\Bar\Baz;
+use Foo\Bar;
 use Foo\Bar\FooBar as FooBaz;
 use Foo\Bar\Foo as Fooo;
 use Foo\Bar\Baar\Baar;


### PR DESCRIPTION
There is no way we can do serious cs fixing with regular expressions: indeed with some cunning test, regex are easy to broke and difficult to mantain.

If you like this PR, we can organize some token helper to share between fixers.

[![Build Status](https://secure.travis-ci.org/Slamdunk/PHP-CS-Fixer.png?branch=unsed-use-token)](http://travis-ci.org/#!/Slamdunk/PHP-CS-Fixer/builds/1978496)
