### PR TITLE
[WIP:RFC] Feature/add replace fixer

### DIFF
--- a/Symfony/CS/Fixer/ReplacerFixer.php
+++ b/Symfony/CS/Fixer/ReplacerFixer.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer;
+
+use Symfony\CS\FixerInterface;
+
+/**
+ * @author Luis Cordova <cordoval@gmail.com>
+ * @author Raul Rodriguez <raulrodriguez782@gmail.com>
+ */
+class ReplacerFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        // let's wait for the PR to be merged :D
+    }
+
+    public function fixWithOptions(\SplFileInfo $file, $content, $options)
+    {
+        // @todo create own closure using $options to replace
+        //   $options['target']
+        //   $options['source']
+        $content = str_replace($options['target'], $options['source'], $content);
+
+        return $content;
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::ALL_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        $extensions = array('php', 'js', 'css', 'html');
+        $currentExtension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+
+        return in_array($currentExtension, $extensions);
+    }
+
+    public function getName()
+    {
+        return 'replacer';
+    }
+
+    public function getDescription()
+    {
+        return 'Replacer is a fixer that replaces a target string with a passed option input string.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/ReplacerFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ReplacerFixerTest.php
@@ -11,17 +11,13 @@
 
 namespace Symfony\CS\Tests\Fixer;
 
-use Symfony\CS\Fixer\VisibilityFixer;
+use Symfony\CS\Fixer\ReplacerFixer;
 
-/**
- * @author Luis Cordova <cordoval@gmail.com>
- * @author Raul Rodriguez <raulrodriguez782@gmail.com>
- */
-class ReplaceFixerTest extends \PHPUnit_Framework_TestCase
+class ReplacerFixerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testFixReplaceEqualString()
+    public function testFixReplacerEqualString()
     {
-        $fixer = new ReplaceFixer();
+        $fixer = new ReplacerFixer();
         $file = new \SplFileInfo(__FILE__);
 
         $expected = <<<'EOF'
@@ -43,9 +39,7 @@ class Foo {
     }
 }
 EOF;
-
-        $this->assertEquals($expected, $fixer->fix($file, $input));
+        $options = array('target'=>'expressionWithTypo', 'source'=> 'expressionWithoutTypo');
+        $this->assertEquals($expected, $fixer->fixWithOptions($file, $input, $options));
     }
-
-
 }


### PR DESCRIPTION
Starting Replacer Fixer with the intent of having a tool to replaces small repetitive glitches or typos for some projects. The use case is valid since that happens a lot and it can be simply done probably with a script but php-cs-fixer could be a better way to transport those needs as the operations can be tailored further and be very extensible or accommodate other Coding-Style practices within specific organizations.

could you please provide me with some feedback? Thanks

with @raul782
