### PR TITLE
initial commit, expecting comments

### DIFF
--- a/Symfony/CS/Fixer/MethodArgumentsFixer.php
+++ b/Symfony/CS/Fixer/MethodArgumentsFixer.php
@@ -81,11 +81,11 @@ DESC;
      */
     private function fixSingleLineArguments($content)
     {
-        $pattern = '/function[\w \s]+\(.*\)/';
+        $pattern = '/function\s+[a-z0-9_]+\s*\(.*\)/';
 
         if (preg_match_all($pattern, $content, $matches)) {
             foreach ($matches[0] as $match) {
-                $proper = preg_replace(array('/\s*\(\s*/', '/\s*\)\s*/', '/[\s]*\,[\s]*/'), array('(', ')', ', '), $match);
+                $proper = preg_replace(array('/\s*\(\s*/', '/\s*\)\s*/', '/[\s]*\,[\s]*/', '/\s*=>\s*/', '/\s*=(?!\>)\s*/'), array('(', ')', ', ', ' => ', ' = '), $match);
                 $content = str_replace($match, $proper, $content);
             }
         }

--- a/Symfony/CS/Tests/Fixer/MethodArgumentsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/MethodArgumentsFixerTest.php
@@ -33,9 +33,13 @@ class MethodArgumentsFixerTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('public function foo($a,$b,$c)', 'public function foo($a, $b, $c)'),
+            array('public function foo    ($a,$b,$c)', 'public function foo($a, $b, $c)'),
             array('function foo($a  ,$b , $c)', 'function foo($a, $b, $c)'),
             array('function foo(  $a  ,  $b , $c )', 'function foo($a, $b, $c)'),
             array("function foo(\t\$a,\t\$b,\$c)", 'function foo($a, $b, $c)'),
+            array('function foo( Typehint $a,Namespaced\Typehint $b,array $c,\Full\Namespaced\Typehint $d)', 'function foo(Typehint $a, Namespaced\Typehint $b, array $c, \Full\Namespaced\Typehint $d)'),
+            array('function foo($a,$b=12,$c="aaa",$d=array(1,2,3))', 'function foo($a, $b = 12, $c = "aaa", $d = array(1, 2, 3))'),
+            array('function foo($a=array(),$b=array(1=>"a",2=>array(2,3),3),$c=array("a"=>"b"))', 'function foo($a = array(), $b = array(1 => "a", 2 => array(2, 3), 3), $c = array("a" => "b"))'),
         );
     }
 


### PR DESCRIPTION
This is an initial commit for a CS fix about method arguments. (function( $a,$b,    $c ) -> function($a, $b, $c)

Just would like to know your opinion about this first fix, and keep working on that until methodArguments multiline and calls are also fixed as stated in PSR2 4.4.

My main concern is that I was not able to do it in a single regular expression, and preferred to split in 2 parts, to make it safer. What are your thoughts? Is that ok?

BTW, I have just tested this in a quite big project and it has fixed function definitions as expected by tests
