### PR TITLE
Stop parsing files that contain no OO code but do contain variables that look like OO keywords

### DIFF
--- a/Symfony/CS/Fixer/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/VisibilityFixer.php
@@ -21,7 +21,7 @@ class VisibilityFixer implements FixerInterface
     public function fix(\SplFileInfo $file, $content)
     {
         // skip files with no OOP code
-        if (!preg_match('{\b(?:class|interface|trait)\b}i', $content)) {
+        if (!preg_match('{(?:^|[^$])\b(?:class|interface|trait)\b}i', $content)) {
             return $content;
         }
 

--- a/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
@@ -120,4 +120,25 @@ EOF;
 
         $this->assertEquals($expected, $fixer->fix($file, $input));
     }
+
+
+    public function testDontGetTrickedIntoParsingFunctionsWithOoKeywordVariables()
+    {
+        $fixer = new VisibilityFixer();
+        $file = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+function foo($class) {
+    static $foo;
+}
+EOF;
+
+        $input = <<<'EOF'
+function foo($class) {
+    static $foo;
+}
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
 }


### PR DESCRIPTION
Files are ignored if they don't contain any OO keywords in them
ZF2 autoload functions have a $class variable meaning they got parsed

return function ($class) {
    static $map;
    ...
}

The OO keyword regex wasn't including the "$" inside the word boundary.
