### PR TITLE
Implemented code block alignment fixer + tokenizer utility

### DIFF
--- a/Symfony/CS/Fixer/AlignmentFixer.php
+++ b/Symfony/CS/Fixer/AlignmentFixer.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer;
+
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Util\Tokenizer;
+
+/**
+ * This fixer aligns code bodies properly given the depth of the code block.
+ *
+ * @author Evan Villemez <evillemez@gmail.com>
+ */
+class AlignmentFixer implements FixerInterface
+{
+
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $this->tokenizer = new Tokenizer;
+
+        $content = $this->fixWhitespace($content);
+
+        return $content;
+    }
+
+    /**
+     * Make sure that code block bodies are aligned properly given their level
+     * of depth in nested code blocks.
+     *
+     * @param  string $content
+     * @return string
+     */
+    protected function fixWhitespace($content)
+    {
+        $final = '';
+        $tokens = $this->tokenizer->getTokens($content);
+        $depth = 0;
+
+        for ($i = 0; $i < count($tokens); $i++) {
+            $t = $tokens[$i];
+            $p = isset($tokens[$i - 1]) ? $tokens[$i - 1] : false;
+            $n = isset($tokens[$i + 1]) ? $tokens[$i + 1] : false;
+
+            //check for depth changes based on opening/closing braces
+            if (T_CURLY_BRACE_OPEN === $t[0]) {
+                $depth += 1;
+            }
+
+            if (T_CURLY_BRACE_CLOSE === $t[0]) {
+                $depth -= 1;
+            }
+
+            //if this is the beginning of a new line (as near as we can tell)
+            if ($p && $t[2] > $p[2]) {
+                //replace whitespace at beginning of line with proper length
+                if (T_WHITESPACE === $t[0]) {
+                    //if the next token is a closing brace, decrease whitespace length
+                    if ($n && T_CURLY_BRACE_CLOSE === $n[0]) {
+                        $final .= $this->getWhitespaceForDepth($depth - 1);
+                    } else {
+                        $final .= $this->getWhitespaceForDepth($depth);
+                    }
+                }
+                //check for potential multiline strings, if new lines are present
+                elseif (in_array($p[0], array(T_NUM_STRING, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_STRING_VARNAME, T_STRING))) {
+                    $v = str_replace("\r\n", "\n", $p[1]);
+
+                    //if new lines present then do NOT modify, can do unexpected things
+                    if (false === strpos($v, "\n")) {
+                        $final .= $this->getWhitespaceForDepth($depth).$t[1];
+                    } else {
+                        $final .= $t[1];
+                    }
+                }
+
+                //NEW CONDITIONS HERE
+
+                else {
+                    $final .= $this->getWhitespaceForDepth($depth).$t[1];
+                }
+            } else {
+                $final .= $t[1];
+            }
+        }
+
+        return $final;
+    }
+
+    protected function getWhitespaceForDepth($depth)
+    {
+        $whitespace = '';
+
+        for ($i = 0; $i < $depth; $i++) {
+            $whitespace .= '    ';
+        }
+
+        return $whitespace;
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::ALL_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+    }
+
+    public function getName()
+    {
+        return 'alignment';
+    }
+
+    public function getDescription()
+    {
+        return 'Class, method, function and control statement bodies should be consistently aligned.';
+    }
+}

--- a/Symfony/CS/Util/Tokenizer.php
+++ b/Symfony/CS/Util/Tokenizer.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Symfony\CS\Util;
+
+//custom token constants
+define('T_NEW_LINE', -500);                   // \n
+define('T_CURLY_BRACE_OPEN', -501);           // {
+define('T_CURLY_BRACE_CLOSE', -502);          // }
+define('T_PAREN_OPEN', -503);                 // (
+define('T_PAREN_CLOSE', -504);                // )
+define('T_SEMI_COLON', -505);                 // ;
+define('T_COMMA', -506);                      // ,
+define('T_EQUALS', -507);                     // =
+define('T_AT', -508);                         // @
+define('T_EXCLAMATION', -509);                // !
+define('T_PERIOD', -510);                     // .
+define('T_DOUBLE_QUOTE', -511);               // "
+define('T_PLUS', -512);                       // +
+define('T_FORWARD_SLASH', -513);              // /
+define('T_BRACKET_OPEN', -514);               // [
+define('T_BRACKET_CLOSE', -515);              // ]
+define('T_ASTERISK', -516);                   // *
+define('T_DASH', -517);                       // -
+define('T_AMP', -518);                        // &
+define('T_LT', -519);                         // <
+define('T_GT', -520);                         // >
+define('T_QUESTION', -521);                   // ?
+define('T_COLON', -522);                      // :
+define('T_PERCENT', -523);                    // %
+define('T_PIPE', -524);                       // |
+
+
+/**
+ * The built-in tokenizer doesn't treat all tokens equally, which makes
+ * processing tokens harder when you need to know about newlines and/or
+ * accurate line numbers for braces.  This extends the built-in 'token_get_all'
+ * implementation to treat new lines as tokens, as well as give accurate numbers
+ * for braces, parentheses and semicolons.
+ *
+ * Some of this code was taken from the PHP.net comments, kudos
+ * to [Dennis Robinson from basnetworks dot net] for sharing his solution.
+ * http://us3.php.net/manual/en/function.token-get-all.php#91847
+ *
+ * The biggest change from the default `token_get_all` implementation is that T_WHITESPACE
+ * is separated into multiple tokens if new lines "\n" characters are found.  New line
+ * characters are then added as their own token called T_NEW_LINE.
+ *
+ * @author Evan Villemez <evillemez@gmail.com>
+ */
+class Tokenizer
+{
+    /**
+     * Return array of tokens.  Each token is an array in the following format:
+     * array(
+     *    integer,   //int corresponding to token name constant defined by PHP or constants above
+     *    string,    //the content of the token
+     *    integer,   //the line number where the token occurs in the file
+     * );
+     *
+     * @param  string $content
+     * @return array
+     */
+    public function getTokens($content)
+    {
+        $tokens = array();
+        $currentline = 0;
+        foreach (token_get_all($content) as $token) {
+
+            if (is_array($token)) {
+
+                //keep track of line number
+                $currentline = $token[2];
+
+                //check for whitespace tokens
+                if (T_WHITESPACE === $token[0]) {
+                    //make sure any line endings are the proper format in the whitespace
+                    $token[1] = str_replace("\r\n", "\n", $token[1]);
+
+                    //if whitespace does NOT contain newline, leave it alone, but keep track of current line
+                    if (false === strpos($token[1], "\n")) {
+                        $tokens[] = $token;
+                    } else {
+                        //if it DOES contain newlines, treat them as separate tokens and increment the line number accordingly
+                        $exp = explode("\n", $token[1]);
+                        $count = count($exp);
+                        for ($i = 0; $i < $count; $i++) {
+                            //add whitespace token back in (without the newline characters, and only if actually has length)
+                            if (strlen($exp[$i]) > 0) {
+                                $tokens[] = array(T_WHITESPACE, $exp[$i], $currentline);
+                            }
+
+                            //if this isn't the last element, add a newline token to current line, THEN increment line #
+                            if ($i < $count - 1) {
+                                $tokens[] = array(T_NEW_LINE, "\n", $currentline);
+                                $currentline++;
+                            }
+                        }
+                    }
+                } else {
+                    //if not a whitespace token, leave it alone
+                    $tokens[] = $token;
+                }
+            } else {
+                //create custom tokens to keep a consistent format
+                switch ($token) {
+                    case '{' : $tokens[] = array(T_CURLY_BRACE_OPEN, $token, $currentline); break;
+                    case '}' : $tokens[] = array(T_CURLY_BRACE_CLOSE, $token, $currentline); break;
+                    case '(' : $tokens[] = array(T_PAREN_OPEN, $token, $currentline); break;
+                    case ')' : $tokens[] = array(T_PAREN_CLOSE, $token, $currentline); break;
+                    case ';' : $tokens[] = array(T_SEMI_COLON, $token, $currentline); break;
+                    case ',' : $tokens[] = array(T_COMMA, $token, $currentline); break;
+                    case '=' : $tokens[] = array(T_EQUALS, $token, $currentline); break;
+                    case '@' : $tokens[] = array(T_AT, $token, $currentline); break;
+                    case '!' : $tokens[] = array(T_EXCLAMATION, $token, $currentline); break;
+                    case '.' : $tokens[] = array(T_PERIOD, $token, $currentline); break;
+                    case '"' : $tokens[] = array(T_DOUBLE_QUOTE, $token, $currentline); break;
+                    case '+' : $tokens[] = array(T_PLUS, $token, $currentline); break;
+                    case '/' : $tokens[] = array(T_FORWARD_SLASH, $token, $currentline); break;
+                    case '[' : $tokens[] = array(T_BRACKET_OPEN, $token, $currentline); break;
+                    case ']' : $tokens[] = array(T_BRACKET_CLOSE, $token, $currentline); break;
+                    case '*' : $tokens[] = array(T_ASTERISK, $token, $currentline); break;
+                    case '-' : $tokens[] = array(T_DASH, $token, $currentline); break;
+                    case '&' : $tokens[] = array(T_AMP, $token, $currentline); break;
+                    case '<' : $tokens[] = array(T_LT, $token, $currentline); break;
+                    case '>' : $tokens[] = array(T_GT, $token, $currentline); break;
+                    case '?' : $tokens[] = array(T_QUESTION, $token, $currentline); break;
+                    case ':' : $tokens[] = array(T_COLON, $token, $currentline); break;
+                    case '%' : $tokens[] = array(T_PERCENT, $token, $currentline); break;
+                    case '|' : $tokens[] = array(T_PIPE, $token, $currentline); break;
+//                    default : echo(sprintf("Did not account for token '%s' in %s".PHP_EOL, $token, __METHOD__));
+                    default : throw new \RuntimeException(sprintf("Did not account for token '%s' in %s!", $token, __METHOD__));
+                }
+            }
+        }
+
+        return $tokens;
+    }
+}


### PR DESCRIPTION
This is a work in progress to address issue #112.

Hoping for comments about the general approach.  I think the tokenizer (needs tests) could be useful for other more complex fixers.

This works for the case I mentioned in the issue, and I've run it on some fairly complicated files and had good results, but I'm sure there are cases I don't account for.

Thoughts?
