### PR TITLE
Fixing EndOfFileLine according to PSR-2

### DIFF
--- a/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
+++ b/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
@@ -25,7 +25,7 @@ class EndOfFileLineFeedFixer implements FixerInterface
         $content = rtrim($content);
 
         if (strlen($content)) {
-            return $content."\n";
+            return $content."\n\n";
         }
 
         return $content;
@@ -33,7 +33,7 @@ class EndOfFileLineFeedFixer implements FixerInterface
 
     public function getLevel()
     {
-        return FixerInterface::ALL_LEVEL;
+        return FixerInterface::PSR2_LEVEL;
     }
 
     public function getPriority()


### PR DESCRIPTION
This fixes issue #122
As stated in PSR-2 §2.2 a file must end with a complete empty line, which means after trimming the content a "\n\n" must be appended.
