### PR TITLE
Change level of "eof_ending" fixer to PSR-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Choose from the list of available fixers:
  * **phpdoc_params**     [all] All items of the @param phpdoc tags must be
                      aligned vertically.
 
- * **eof_ending**        [all] A file must always end with an empty line feed.
+ * **eof_ending**        [PSR-2] A file must always end with an empty line feed.
 
  * **extra_empty_lines** [all] Removes extra empty lines.
 

--- a/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
+++ b/Symfony/CS/Fixer/EndOfFileLineFeedFixer.php
@@ -33,7 +33,7 @@ class EndOfFileLineFeedFixer implements FixerInterface
 
     public function getLevel()
     {
-        return FixerInterface::ALL_LEVEL;
+        return FixerInterface::PSR2_LEVEL;
     }
 
     public function getPriority()


### PR DESCRIPTION
Since the optimization performed by the `eof_ending` fixer is a [requirement of PSR-2](https://github.com/php-fig/fig-standards/blob/3e49c27/accepted/PSR-2-coding-style-guide.md#22-files) it should have the level PSR-2.

I had to combine the changes with the grammar fix to avoid hitting the line length recommendation in `README.md` :smirk:
