### PR TITLE
Added support for reference parameters to PhpdocParamsAlignmentFixer

### DIFF
--- a/Symfony/CS/Fixer/PhpdocParamsAlignmentFixer.php
+++ b/Symfony/CS/Fixer/PhpdocParamsAlignmentFixer.php
@@ -23,7 +23,7 @@ class PhpdocParamsAlignmentFixer implements FixerInterface
     public function __construct()
     {
         // e.g. @param <hint> <$var>
-        $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>\$[^\s]+)';
+        $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>&?\$[^\s]+)';
         // e.g. @return <hint>
         $returnThrowsTag = '(?P<tag2>return|throws)\s+(?P<hint2>[^$]+?)';
         // optional <desc>

--- a/Symfony/CS/Tests/Fixer/PhpdocParamsAlignmentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PhpdocParamsAlignmentFixerTest.php
@@ -26,6 +26,7 @@ class PhpdocParamsAlignmentFixerTest extends \PHPUnit_Framework_TestCase
      * @param string          $format
      * @param integer         $code       An HTTP response status code
      * @param Boolean         $debug
+     * @param mixed           &$reference A parameter passed by reference
 
 EOF;
 
@@ -35,6 +36,7 @@ EOF;
      * @param string      $format
      * @param  integer  $code       An HTTP response status code
      * @param    Boolean      $debug
+     * @param  mixed    &$reference     A parameter passed by reference
 
 EOF;
 
@@ -49,6 +51,7 @@ EOF;
         $expected = <<<'EOF'
 
      * @param  EngineInterface $templating
+     * @param  mixed           &$reference A parameter passed by reference
      * @throws Bar             description bar
      * @return Foo             description foo
 
@@ -57,6 +60,7 @@ EOF;
         $input = <<<'EOF'
 
      * @param EngineInterface       $templating
+     * @param  mixed    &$reference     A parameter passed by reference
      * @throws   Bar description bar
      * @return  Foo     description foo
 


### PR DESCRIPTION
A simple addition to the regex to support alignment of pass-by-reference parameters.
