### PR TITLE
Better handling of indented multiline if/elseif.

### DIFF
--- a/Symfony/CS/Fixer/ControlSpacesFixer.php
+++ b/Symfony/CS/Fixer/ControlSpacesFixer.php
@@ -128,8 +128,8 @@ class ControlSpacesFixer implements FixerInterface
 
         return preg_replace(
             array(
-                sprintf('/(%s)[^\S\n]*\([^\S\n]*([^()]*?|(?R))[^\S\n]*\)[^\S\n]*{/', implode('|', $statements)), // Fix spacing inside brackets for simple bracket cases
-                sprintf('/(%s)[^\S\n]*\((.*)\)[^\S\n]*{/', implode('|', $statements))                            // Fix spacing for all cases leaving spacing inside brackets as is
+                sprintf('/(%s)[^\S\n]*\([^\S\n]*([^()\n]*?|(?R))[^\S\n]*\)[^\S\n]*{/', implode('|', $statements)), // Fix spacing inside brackets for simple bracket cases
+                sprintf('/(%s)[^\S\n]*\((.*)\)[^\S\n]*{/', implode('|', $statements))                              // Fix spacing for all cases leaving spacing inside brackets as is
             ),
             array(
                 '\\1 (\\2) {',

--- a/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
@@ -115,6 +115,29 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /*
+     * @see https://github.com/fabpot/PHP-CS-Fixer/issues/162
+     */
+    public function testIssue162()
+    {
+        $fixer = new Fixer();
+
+        $if = <<<'EOD'
+    if (
+        true &&
+        true
+    ) {
+        // ...
+    } elseif (
+        true &&
+        true
+    ) {
+        // ...
+    }
+EOD;
+        $this->assertEquals($if, $fixer->fix($this->getFileMock(), $if));
+    }
+
     private function getFileMock()
     {
         return $this->getMockBuilder('\SplFileInfo')


### PR DESCRIPTION
See #162.

Fixes the behaviour where:

``` php
<?php

    if (
        true &&
        true
    ) {
        // ...
    } elseif (
        true &&
        true
    ) {
        // ...
    }
```

Is incorrectly fixed to:

``` php
<?php

    if (
        true &&
        true
) {
        // ...
    } elseif (
        true &&
        true
) {
        // ...
    }
```
