### PR TITLE
Return non-zero status code if anything was fixed

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -230,7 +230,7 @@ EOF
 
         $status = !empty($changed) ? 1 : 0;
 
-        exit($status);
+        return $status;
     }
 
     protected function getFixersHelp()


### PR DESCRIPTION
This is so that commit hooks, or CI tools can easily fail.

fixes #158
