### PR TITLE
Fix - trailing whitespaces after class or alias name in an use statement

### DIFF
--- a/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/UnusedUseStatementsFixer.php
@@ -26,7 +26,7 @@ class UnusedUseStatementsFixer implements FixerInterface
         }
 
         // [Structure] remove unused use statements
-        preg_match_all('/^use (?P<class>[^\s;]+)(?:\s+as\s+(?P<alias>.*))?;/m', $content, $matches, PREG_SET_ORDER);
+        preg_match_all('/^use (?P<class>[^\s;]+)(?:\s+as\s+(?P<alias>[^\s;]+))?\s*;/m', $content, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
             if (isset($match['alias'])) {
                 $short = $match['alias'];

--- a/Symfony/CS/Tests/Fixer/UnusedUseStatementsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/UnusedUseStatementsFixerTest.php
@@ -45,4 +45,30 @@ EOF;
 
         $this->assertEquals($expected, $fixer->fix($file, $input));
     }
+
+    public function testTrailingSpaces()
+    {
+        $fixer = new UnusedUseStatementsFixer();
+        $file = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+use Foo\Bar ;
+use Foo\Bar\FooBar as FooBaz ;
+
+$a = new Bar();
+$a = new FooBaz();
+EOF;
+
+        $input = <<<'EOF'
+use Foo\Bar ;
+use Foo\Bar\FooBar as FooBaz ;
+use Foo\Bar\Foo as Fooo ;
+use SomeClass ;
+
+$a = new Bar();
+$a = new FooBaz();
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
 }


### PR DESCRIPTION
This change fixes following bugs:
- doesn't match an use statement when there're trailing whitespaces after class name
- matches an alias name with trailing whitespaces (when there're whitespaces after alias name) and deletes an alias with use operator even if alias is used
