### PR TITLE
Fix indents containing a half-tab

### DIFF
--- a/Symfony/CS/Fixer/IndentationFixer.php
+++ b/Symfony/CS/Fixer/IndentationFixer.php
@@ -21,8 +21,10 @@ class IndentationFixer implements FixerInterface
     public function fix(\SplFileInfo $file, $content)
     {
         // [Structure] Indentation is done by steps of four spaces (tabs are never allowed)
-        return preg_replace_callback('/^([ \t]+)/m', function ($matches) use ($content) {
-            return str_replace("\t", '    ', $matches[0]);
+        return  preg_replace_callback('/^([ \t]+)/m', function ($matches) use ($content) {
+            $spaceCount = substr_count($matches[0], " ");
+            $spaceCount += substr_count($matches[0], "\t") * 4;
+            return str_repeat("    ", floor($spaceCount / 4));
         }, $content);
     }
 


### PR DESCRIPTION
Now also lines that are indented with a few spaces + a half-tab (tab equal to 2 spaces) are fixed correctly. This weird indentation is present for example in a lot of files of the Opencart project (github.com/opencart/opencart).

For example: (space)(space)(tab) becomes 6 spaces in the old version, but it should be converted to 4 spaces since indents can only be multiples of 4 spaces. This problem can occur when a texteditor's tabsize is set to 2 and the writer uses tabs while the existing indents are spaces.
