### PR TITLE
Better ControlSpacesFixer multiline indentation.

### DIFF
--- a/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
@@ -46,6 +46,22 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
     }
 
+    public function testFixControlClosingParenthesesKeepsIndentation()
+    {
+        $fixer = new Fixer();
+
+        $if = 'if(true === true
+            && true === true
+        )    {';
+
+        $ifFixed = 'if (true === true
+            && true === true
+        ) {';
+
+        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
+    }
+
     public function testFixControlsWithParenthesesAndSuffixBraceProvider()
     {
         return array(


### PR DESCRIPTION
Before this fix, ControlSpacesFixer lost the indentation of multiline
if -control statement for outer closing parenthesis.

Before:

<pre>
        if(true === true
            && false === false
        ) {
</pre>

Became:

<pre>
        if (true === true
            && false === false
) {
</pre>


Now:

<pre>
        if (true === true
            && false === false
        ) {
</pre>


Commit also comments the regular expression with inline comment, so it's
easier to understand.

In ControlSpacesFixer::fixControlsWithParenthesesAndSuffixBrace()

<pre>(%s)[^\S\n]*\([^\S\n]*([^()]*?|(?R))[^\S\n]*\)[^\S\n]*{</pre>

Became:

<pre>(%s)[^\S\n]*\([^\S\n]*([^()]*?|(?R))[^\S\n]*(\s*)\)[^\S\n]*{</pre>


Fixes problem reported at #162
