### PR TITLE
fix diff version number causing 3.0.x-dev to not be instable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/console": "~2.1",
         "symfony/filesystem": "~2.1",
         "symfony/finder": "~2.1",
-        "sebastian/diff": "1.1.*@dev"
+        "sebastian/diff": "1.0.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\CS": "." }


### PR DESCRIPTION
fixes

```
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - fabpot/php-cs-fixer 0.3.x-dev requires sebastian/diff 1.0.*@dev -> no matching package found.
    - fabpot/php-cs-fixer 0.3.x-dev requires sebastian/diff 1.0.*@dev -> no matching package found.
    - Installation request for fabpot/php-cs-fixer 0.3.x-dev -> satisfiable by fabpot/php-cs-fixer[0.3.x-dev].
Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.
Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
