### PR TITLE
fix blacklist --fixer option (issue #149)

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -184,7 +184,7 @@ EOF
                 $level = FixerInterface::ALL_LEVEL;
                 break;
             case null:
-                $level = (!preg_match('{(^|,)-}', $input->getOption('fixers'))) ? null : $config->getFixers();
+                $level = preg_match('{(^|,)-}', $input->getOption('fixers')) ? $config->getFixers() : null;
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('The level "%s" is not defined.', $input->getOption('level')));


### PR DESCRIPTION
Fix the blacklist options (i. e. fix path/ --fixer=-psr0)

This option was closing the application without doing anything because the fixers were not been loaded properly.
