### PR TITLE
Only add path from commandline if no .php_cs file present

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -157,12 +157,12 @@ EOF
             $config = include $file;
         } else {
             $config = $this->defaultConfig;
-        }
-
-        if (is_file($path)) {
-            $config->finder(new \ArrayIterator(array(new \SplFileInfo($path))));
-        } else {
-            $config->setDir($path);
+            
+            if (is_file($path)) {
+                $config->finder(new \ArrayIterator(array(new \SplFileInfo($path))));
+            } else {
+                $config->setDir($path);
+            }
         }
 
         // register custom fixers from config


### PR DESCRIPTION
Currently when specifing a .php_cs file the finder in there is nearly useless, because i have to supply . on the command line as path, but this path is added to the finder, so my complete repo is searched, although i had a complete config on which folders to scan in .php_cs.
I could of course mark all folders as ignored, but i think it's better to have a whitelist instead of blacklist sometimes.

The change is to only add the path from the commandline if there was no .php_cs file found.
