### PR TITLE
[Travis] Add 5.3.3 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
   - php composer.phar install --dev
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
   - 5.5


### PR DESCRIPTION
Adds 5.3.3 since is the minimum supported version.
