### PR TITLE
Makes code compatible with PHP 5.3.3

### DIFF
--- a/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
+++ b/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
@@ -51,7 +51,7 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return $file->getExtension() === 'php';
+        return pathinfo($file->getFilename(), PATHINFO_EXTENSION) === 'php';
     }
 
     /**


### PR DESCRIPTION
`SplFileInfo::getExtension()` is only available since PHP 5.3.6
