### PR TITLE
Fixes #239, test character before function keyword

### DIFF
--- a/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
+++ b/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
@@ -74,12 +74,12 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
     {
         $content = preg_replace(
             $this->regex(array('params', 'end')),
-            'function (\1)\2',
+            '\1function (\2)\3',
             $content
         );
         $content = preg_replace(
             $this->regex(array('params', 'use', 'end')),
-            'function (\1) use (\2)\3',
+            '\1function (\2) use (\3)\4',
             $content
         );
         return $content;
@@ -89,7 +89,7 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
     {
         return preg_replace(
             $this->regex(array('name', 'params', 'end')),
-            'function \1(\2)\3',
+            '\1function \2(\3)\4',
             $content
         );
     }
@@ -127,7 +127,7 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
         );
         $map['use'] = '\s*use'.$map['params'];
 
-        return '/function'.implode('', array_map(function ($key) use ($map) {
+        return '/(^|[^a-zA-Z0-9_\x7f-\xff\$])function' . implode('', array_map(function ($key) use ($map) {
             return $map[$key];
         }, $keys)).'/x';
     }

--- a/Symfony/CS/Tests/Fixer/FunctionDeclarationSpacingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/FunctionDeclarationSpacingFixerTest.php
@@ -28,6 +28,9 @@ class FunctionDeclarationSpacingFixerTest extends \PHPUnit_Framework_TestCase
             array("function foo( \$a)\n{", "function foo(\$a)\n{"),
             array("function foo( \$a)\t\n\t{", "function foo(\$a)\n\t{"),
             array("function foo(\n\$a\n) {", "function foo(\n\$a\n) {"),
+            array("function _function () {", "function _function() {"),
+            array("\$function = function(){", "\$function = function () {"),
+            array("\$function('');", "\$function('');"),
         );
     }
 


### PR DESCRIPTION
Infront of the function keyword, there may not be a valid functionname character

Added a data set for the bug and change regex
