### PR TITLE
ExtraEmptyLines fails to remove lines when a comment has a quote

### DIFF
--- a/Symfony/CS/Tests/Fixer/ExtraEmptyLinesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ExtraEmptyLinesFixerTest.php
@@ -221,4 +221,39 @@ EOF;
 
         $this->assertEquals($expected, $fixer->fix($file, $input));
     }
+
+    public function testFixWithCommentWithAQuote()
+    {
+        $fixer = new ExtraEmptyLinesFixer();
+        $file = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+$a = 'foo';
+
+// my comment's gotta have a quote
+$b = 'foobar';
+
+$c = 'bar';
+
+EOF;
+
+        $input = <<<'EOF'
+$a = 'foo';
+
+
+
+
+// my comment's gotta have a quote
+$b = 'foobar';
+
+
+
+
+
+$c = 'bar';
+
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
 }


### PR DESCRIPTION
ExtraEmptyLines fixer is failing to remove lines when a comment has a quote.

I've added a test for the problem.
