### PR TITLE
Added support for multiple paths to fix command.

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -28,6 +28,13 @@ class Fixer
 
     public function __construct()
     {
+        $this->reset();
+    }
+
+    public function reset()
+    {
+        $this->fixers = array();
+        $this->configs = array();
         $this->diff = new Diff();
     }
 


### PR DESCRIPTION
This PR allows the user to specify multiple path arguments to the "fix" command, which means it also supports *nix glob patterns.

``` console
php-cs-fixer fix src tests
php-cs-fixer fix foo*.php
```
