### PR TITLE
Issue 245. SplFileInfo::getExtension is not supported on old PHP versions.

### DIFF
--- a/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
+++ b/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
@@ -51,7 +51,7 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return $file->getExtension() === 'php';
+        return pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     /**


### PR DESCRIPTION
PHP 5.3.3 does not support SplFileInfo::getExtension.
