### PR TITLE
Updated diff dependency

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\CS;
 
-use SebastianBergmann\Diff;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo as FinderSplFileInfo;
+use SebastianBergmann\Diff\Differ;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -28,7 +28,7 @@ class Fixer
 
     public function __construct()
     {
-        $this->diff = new Diff();
+        $this->diff = new Differ();
     }
 
     public function registerBuiltInFixers()

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "symfony/console": "~2.1",
         "symfony/filesystem": "~2.1",
         "symfony/finder": "~2.1",
-        "sebastian/diff": "1.0.*@dev"
+        "sebastian/diff": "1.1.*@dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\CS": "." }


### PR DESCRIPTION
Updated Diff dependency to 1.1

There does not seem to be any functional difference and all the tests pass. Have kept the `@dev` tag -- but maybe it would be better to remove it.
