### PR TITLE
replaced getExtension() to be compatible with PHP < 5.3.6

### DIFF
--- a/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
+++ b/Symfony/CS/Fixer/FunctionDeclarationSpacingFixer.php
@@ -51,7 +51,7 @@ class FunctionDeclarationSpacingFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return $file->getExtension() === 'php';
+        return 'php' == pathinfo($file->getFilename(), PATHINFO_EXTENSION);
     }
 
     /**


### PR DESCRIPTION
see: https://github.com/fabpot/PHP-CS-Fixer/issues/48
