### PR TITLE
fix GH-207 - static variables in functions become invalid

### DIFF
--- a/Symfony/CS/Fixer/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/VisibilityFixer.php
@@ -28,8 +28,8 @@ class VisibilityFixer implements FixerInterface
         // Visibility MUST be declared on all properties and methods;
         // abstract and final MUST be declared before the visibility;
         // static MUST be declared after the visibility
-        $content = preg_replace_callback('/^( {2,4}|\t)((?:(?:public|protected|private|static|var)\s+)+)\s*(\$[a-z0-9_]+)/im', function ($matches) {
-            $flags = explode(' ', strtolower(trim($matches[2])));
+        $content = preg_replace_callback('/^( {2,4}|\t)((?:static\s+)?)((?:(?:public|protected|private|var)\s+)+)((?:static\s+)?)\s*(\$[a-z0-9_]+)/im', function ($matches) {
+            $flags = explode(' ', strtolower(trim($matches[3])));
             if (in_array('protected', $flags)) {
                 $visibility = 'protected';
             } elseif (in_array('private', $flags)) {
@@ -39,8 +39,8 @@ class VisibilityFixer implements FixerInterface
             }
 
             return $matches[1] . $visibility
-                . (in_array('static', $flags) ? ' static' : '')
-                . ' ' . $matches[3];
+                . (strlen(trim($matches[2])) > 0 || strlen(trim($matches[4])) > 0 ? ' static' : '')
+                . ' ' . $matches[5];
         }, $content);
 
         $content = preg_replace_callback('/^( {2,4}|\t)((?:(?:public|protected|private|static|abstract|final)\s+)*)(?:function\s+([a-z0-9_]+))/im', function ($matches) {

--- a/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
@@ -80,6 +80,7 @@ class Foo {
         function ($foo) {}
         function() {
             static $foo;
+    static $foo;
         }
 }
 EOF;
@@ -105,6 +106,7 @@ class Foo {
         function (\$foo) {}
         function() {
             static \$foo;
+    static \$foo;
         }
 }
 EOF;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #207 |
| License | MIT |

This fixes changing of static variables inside a function, it only happens under rare conditions but none the less its a bug. A minor breakage is that `static $var;` without a visibility is no longer fixed (but this was not tested in the old version, so I'm not sure if this is a problem).
