### PR TITLE
Indentation - tabs include some preceding spaces

### DIFF
--- a/Symfony/CS/Fixer/IndentationFixer.php
+++ b/Symfony/CS/Fixer/IndentationFixer.php
@@ -22,7 +22,8 @@ class IndentationFixer implements FixerInterface
     {
         // [Structure] Indentation is done by steps of four spaces (tabs are never allowed)
         return preg_replace_callback('/^([ \t]+)/m', function ($matches) use ($content) {
-            return str_replace("\t", '    ', $matches[0]);
+            // Tabs may include 1 to 3 (but not 4) preceding spaces
+            return preg_replace('/(?:(?<! ) {1,3})?\t/', '    ', $matches[0]);
         }, $content);
     }
 

--- a/Symfony/CS/Tests/Fixer/IndentationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/IndentationFixerTest.php
@@ -20,6 +20,23 @@ class IndentationFixerTest extends \PHPUnit_Framework_TestCase
         $fixer = new IndentationFixer();
         $file = new \SplFileInfo(__FILE__);
 
-        $this->assertEquals('           FOO', $fixer->fix($file, " \t \t FOO"));
+        // Indentation only
+        $this->assertEquals('        ALPHA', $fixer->fix($file, "\t\tALPHA"));
+        $this->assertEquals('        BRAVO', $fixer->fix($file, "\t\tBRAVO"));
+        $this->assertEquals('        CHARLIE', $fixer->fix($file, " \t\tCHARLIE"));
+        $this->assertEquals('        DELTA', $fixer->fix($file, "  \t\tDELTA"));
+        $this->assertEquals('        ECHO', $fixer->fix($file, "   \t\tECHO"));
+        $this->assertEquals('        FOXTROT', $fixer->fix($file, "\t \tFOXTROT"));
+        $this->assertEquals('        GOLF', $fixer->fix($file, "\t  \tGOLF"));
+        $this->assertEquals('        HOTEL', $fixer->fix($file, "\t   \tHOTEL"));
+        $this->assertEquals('        INDIA', $fixer->fix($file, "\t    INDIA"));
+        $this->assertEquals('        JULIET', $fixer->fix($file, " \t   \tJULIET"));
+        $this->assertEquals('        KILO', $fixer->fix($file, "  \t  \tKILO"));
+        $this->assertEquals('        MIKE', $fixer->fix($file, "   \t \tMIKE"));
+        $this->assertEquals('        NOVEMBER', $fixer->fix($file, "    \tNOVEMBER"));
+        // Indentation and alignment
+        $this->assertEquals('         OSCAR', $fixer->fix($file, "\t \t OSCAR"));
+        $this->assertEquals('          PAPA', $fixer->fix($file, "\t \t  PAPA"));
+        $this->assertEquals('           QUEBEC', $fixer->fix($file, "\t \t   QUEBEC"));
     }
 }


### PR DESCRIPTION
The indentation fix assumes that a tab is just 4 spaces - rather than an indentation to the next multiple of 4 spaces.

For example, in an editor, the following would look identical:

```
<space><space><space><space>FOO
<space><space><space><tab>FOO
<space><space><tab>FOO
<space><tab>FOO
<tab>FOO
```

The existing code would fix it as

```
<space><space><space><space>FOO
<space><space><space><space><space><space><space>FOO
<space><space><space><space><space><space>FOO
<space><space><space><space><space>FOO
<space><space><space><space>FOO
```

This new code would fix it as

```
<space><space><space><space>FOO
<space><space><space><space>FOO
<space><space><space><space>FOO
<space><space><space><space>FOO
<space><space><space><space>FOO
```
