### PR TITLE
Inform people how to get homebrew-php

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,9 @@ Then, just run ``php-cs-fixer``.
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~
 
-PHP-CS-Fixer is part of the homebrew-php project:
+PHP-CS-Fixer is part of the homebrew-php project. Follow the installation
+instructions at https://github.com/josegonzalez/homebrew-php if you don't
+already have it.
 
 .. code-block:: bash
 


### PR DESCRIPTION
When I followed the brew installation instructions, I received the error:

"php-cs-fixer: Missing PHP53, PHP54 or PHP55 from homebrew-php. Please install one of them before continuing"

But, there was no info on how to get that. Adding a section to the README, though ideally this error message would contain it. (I wasn't able to find this string in the source, though.)
