### PR TITLE
fixed removal of PHP closing tags for templates

### DIFF
--- a/Symfony/CS/Fixer/PhpClosingTagFixer.php
+++ b/Symfony/CS/Fixer/PhpClosingTagFixer.php
@@ -20,7 +20,9 @@ class PhpClosingTagFixer implements FixerInterface
 {
     public function fix(\SplFileInfo $file, $content)
     {
-        if (strpos($content, '<?php') === 0) {
+        // if there is more than one opening PHP tag, it's probably a template
+        // for which we don't want to remove the last closing PHP tag
+        if (strpos($content, '<?php') === 0 && substr_count($content, '<?php') < 2) {
             return preg_replace('/( *)\?>\s*$/s', '', $content);
         }
 

--- a/Symfony/CS/Tests/Fixer/PhpClosingTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PhpClosingTagFixerTest.php
@@ -43,7 +43,17 @@ echo \'Foo\';
 echo \'Foo\';
 
 ?>
-    ')
+    ',
+            ),
+            array('<?php echo \'Foo\'; ?>
+<p><?php echo \'this is a template\'; ?></p>
+<?php echo \'Foo\'; ?>
+',
+                  '<?php echo \'Foo\'; ?>
+<p><?php echo \'this is a template\'; ?></p>
+<?php echo \'Foo\'; ?>
+',
+            ),
         );
     }
 }


### PR DESCRIPTION
In a PHP template, we don't want to remove closing PHP tags.
