### PR TITLE
Fix Psr0Test to not print warning

### DIFF
--- a/Symfony/CS/Tests/Fixer/Psr0FixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Psr0FixerTest.php
@@ -211,7 +211,8 @@ EOF;
  namespace LeadingSpace;
 class Psr0Fixer {}
 EOF;
-
+        ob_start();
         $this->assertEquals($expected, $fixer->fix($file, $input));
+        ob_clean();
     }
 }


### PR DESCRIPTION
Currently the Psr0Test prints a warning like this:

```
Configuration read from /.../phpunit.xml.dist

...............................................................  63 / 149 ( 42%)
.......................................................! The namespace LeadingSpace in /.../vendor/fabpot/php-cs-fixer/Symfony/CS/Fixer/Psr0Fixer.php does not match the file path according to PSR-0 rules
........ 126 / 149 ( 84%)
.......................

Time: 266 ms, Memory: 7.00Mb
```

Surrounded the test with outputbuffer, like in the other tests.
