### PR TITLE
Fix: multiple spaces between 'else' and 'if' not fixed

### DIFF
--- a/Symfony/CS/Fixer/ElseifFixer.php
+++ b/Symfony/CS/Fixer/ElseifFixer.php
@@ -21,7 +21,7 @@ class ElseifFixer implements FixerInterface
     public function fix(\SplFileInfo $file, $content)
     {
         // [Structure] elseif, not else if
-        return str_replace('} else if (', '} elseif (', $content);
+        return preg_replace('/} else +if \(/', '} elseif (', $content);
     }
 
     public function getLevel()

--- a/Symfony/CS/Tests/Fixer/ElseifFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ElseifFixerTest.php
@@ -32,6 +32,11 @@ class ElseifFixerTest extends \PHPUnit_Framework_TestCase
             'if ($some) { $test = true } elseif ($some != "test") { $test = false; }',
             $fixer->fix($this->getFileMock(), 'if ($some) { $test = true } else if ($some != "test") { $test = false; }'
         ));
+
+        $this->assertSame(
+            'if ($some) { $test = true } elseif ($some != "test") { $test = false; }',
+            $fixer->fix($this->getFileMock(), 'if ($some) { $test = true } else  if ($some != "test") { $test = false; }'
+        ));
     }
 
     /**


### PR DESCRIPTION
Multiple spaces between "else" and "if" aren't fixed - just single spaces.
