### PR TITLE
Add PHPUnit to composer require-dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "symfony/finder": "~2.1",
         "sebastian/diff": "1.1.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~3.7"
+    },
     "autoload": {
         "psr-0": { "Symfony\\CS": "." }
     },


### PR DESCRIPTION
I think that is good show what version of PHPUnit is expected to be used with the project
