### PR TITLE
Added test for conditional function definition

### DIFF
--- a/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
@@ -152,4 +152,52 @@ EOF;
 
         $this->assertEquals($expected, $fixer->fix($file, $expected));
     }
+
+    public function testLeaveFunctionsAloneInsideConditionals()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return $arg;
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneInsideConditionalsButOutsideClasses()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+/* class <= this is just a stop-word */
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return $arg;
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneOutsideClasses()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+/* class */
+function foo($arg)
+{
+    return $arg;
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
 }


### PR DESCRIPTION
Ran PHP-CS-Fixer on Bolt CMS, and it turned out that it adds visibility to methods defined in conditionals when there's `class` word somewhere in the comments.
These tests cover this exact case and some adjacent cases.
