### PR TITLE
Ignoring some special cases of functions getting visibility added

### DIFF
--- a/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/VisibilityFixerTest.php
@@ -21,6 +21,7 @@ class VisibilityFixerTest extends \PHPUnit_Framework_TestCase
         $file = new \SplFileInfo(__FILE__);
 
         $expected = <<<'EOF'
+<?php
 class Foo {
     public $var;
     protected $var_foo;
@@ -37,6 +38,7 @@ class Foo {
 EOF;
 
         $input = <<<'EOF'
+<?php
 class Foo {
     public $var;
     protected $var_foo;
@@ -62,6 +64,7 @@ EOF;
         $file = new \SplFileInfo(__FILE__);
 
         $expected = <<<'EOF'
+<?php
 class Foo {
     public function foo() {}
     public function foo() {}
@@ -87,6 +90,7 @@ class Foo {
 EOF;
 
         $input = <<<EOF
+<?php
 class Foo {
     public function foo() {}
     function foo() {}
@@ -123,12 +127,14 @@ EOF;
         $file = new \SplFileInfo(__FILE__);
 
         $expected = <<<'EOF'
+<?php
 function foo() {
     static $foo;
 }
 EOF;
 
         $input = <<<'EOF'
+<?php
 function foo() {
     static $foo;
 }
@@ -143,13 +149,122 @@ EOF;
         $file = new \SplFileInfo(__FILE__);
 
         $expected = <<<'EOF'
+<?php
 function foo() {
     static $class;
     $interface = 'foo';
-    $trait = 'bar;
+    $trait = 'bar';
 }
 EOF;
 
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneInsideConditionals()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return $arg;
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneInsideConditionalsWithOopWordInComment()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+/* class <= this is just a stop-word */
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return $arg;
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneWithOopWordInComment()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+/* class */
+function foo($arg)
+{
+    return $arg;
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneOutsideClassesWithOopWordInInlineHtml()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+    ?>
+        <div class="test"></div>
+    <?php
+        return $arg;
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneOutsideClassesWithOopWordInStringValue()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return 'she has class right?';
+    }
+}
+EOF;
+        $this->assertEquals($expected, $fixer->fix($file, $expected));
+    }
+
+    public function testLeaveFunctionsAloneOutsideClassesWithOopWordInFunctionName()
+    {
+        $fixer = new VisibilityFixer();
+        $file  = new \SplFileInfo(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+
+comment_class();
+
+if (!function_exists('foo')) {
+    function foo($arg)
+    {
+        return $arg;
+    }
+}
+EOF;
         $this->assertEquals($expected, $fixer->fix($file, $expected));
     }
 }


### PR DESCRIPTION
This is similar to #332, but this one includes a fix.  When running php-cs-fixer against more procedural style code (no oop) this visibility fixer would add "public" visibility keyword to the front of the function declarations, causing fatal syntax errors.  I added the test cases from #332, and added some more that I discovered it was processing (that it shouldn't be).

To pass these tests, I've modified the fixer to look for the OOP trigger words in what would be considered PHP code, rather than just the entire source content (ignores comments, doc blocks, strings and inline html).  I didn't see any easy way to do this with the regex used, but by using PHP's tokenizer I was able to strip these tokens from the content before the regex is run.

I had to add <?php tags to all of the tests for this class because otherwise the text is seen as T_INLINE_HTML to the tokenizer.
