### PR TITLE
Fix $configFile to handle both files and dirs

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -178,8 +178,9 @@ EOF
         }
 
         $addSuppliedPathFromCli = true;
-
-        $configFile = $input->getOption('config-file') ?: dirname($path).'/.php_cs';
+        
+        $dir = is_dir($path) ? $path : dirname($path);
+        $configFile = $input->getOption('config-file') ?: $dir.'/.php_cs';
 
         if ($input->getOption('config')) {
             $config = null;


### PR DESCRIPTION
Currently, if one runs the following command:

```
/opt/php-cs-fixer> php php-cs-fixer fix crap.php -vvv
```

It would result in search of ...

```
/opt/php-cs-fixer/crap.php/.php_cs
```

... config file which doesn't exist and thus is not loaded. Modifying this results in something like:

```
Loaded config from "/opt/php-cs-fixer/.php_cs"
```
