### PR TITLE
Fix $open_mode value from constant to string

### DIFF
--- a/Symfony/CS/StdinFileInfo.php
+++ b/Symfony/CS/StdinFileInfo.php
@@ -161,7 +161,7 @@ class StdinFileInfo extends \SplFileInfo
         return false;
     }
 
-    public function openFile($open_mode = r, $use_include_path = false, $context = NULL)
+    public function openFile($open_mode = 'r', $use_include_path = false, $context = NULL)
     {
         throw new \RuntimeException("Not implemented");
     }


### PR DESCRIPTION
This was a bug in documentation which I fixed. It worked because `r` (if not defined) was assumed to be `'r'` (string) + E_NOTICE.
