### PR TITLE
Enhancement: Always add path from console input

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -177,8 +177,6 @@ EOF
             $path = getcwd().DIRECTORY_SEPARATOR.$path;
         }
 
-        $addSuppliedPathFromCli = true;
-
         $configFile = $input->getOption('config-file') ?: $path.'/.php_cs';
 
         if ($input->getOption('config')) {
@@ -201,19 +199,16 @@ EOF
             } else {
                 $output->writeln(sprintf('Loaded config from "%s"', $configFile));
             }
-            $addSuppliedPathFromCli = false;
         } else {
             $config = $this->defaultConfig;
         }
 
-        if ($addSuppliedPathFromCli) {
-            if (is_file($path)) {
-                $config->finder(new \ArrayIterator(array(new \SplFileInfo($path))));
-            } elseif ($stdin) {
-                $config->finder(new \ArrayIterator(array(new StdinFileInfo())));
-            } else {
-                $config->setDir($path);
-            }
+        if (is_file($path)) {
+            $config->finder(new \ArrayIterator(array(new \SplFileInfo($path))));
+        } elseif ($stdin) {
+            $config->finder(new \ArrayIterator(array(new StdinFileInfo())));
+        } else {
+            $config->setDir($path);
         }
 
         // register custom fixers from config


### PR DESCRIPTION
The change proposed in #262 makes the feature #251 work only with the change proposed in this PR:
## Steps to reproduce

Create a `.php_cs` file with the following contents:

``` php
return Symfony\CS\Config\Config::create()
    ->fixers([
        'indentation',
        'linefeed',
        // . . . 
    ])
;
```

Create some php file `foo.php` and run

```
$ bin/php-cs-fixer fix --config-file=.php_cs --dry-run --verbose foo.php
```
## Result

```
Loaded config from ".php_cs"



[LogicException]
You must call one of in() or append() methods before iterating over a Finder.



Exception trace:
() at /Users/localheinz/foo/vendor/symfony/finder/Symfony/Component/Finder/Finder.php:688
Symfony\Component\Finder\Finder->getIterator() at /Users/localheinz/foo/vendor/fabpot/php-cs-fixer/Symfony/CS/Fixer.php:92
Symfony\CS\Fixer->fix() at /Users/localheinz/foo/vendor/fabpot/php-cs-fixer/Symfony/CS/Console/Command/FixCommand.php:284
Symfony\CS\Console\Command\FixCommand->execute() at /Users/localheinz/foo/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:241
Symfony\Component\Console\Command\Command->run() at /Users/localheinz/foo/vendor/symfony/console/Symfony/Component/Console/Application.php:892
Symfony\Component\Console\Application->doRunCommand() at /Users/localheinz/foo/vendor/symfony/console/Symfony/Component/Console/Application.php:191
Symfony\Component\Console\Application->doRun() at /Users/localheinz/foo/vendor/symfony/console/Symfony/Component/Console/Application.php:121
Symfony\Component\Console\Application->run() at /Users/localheinz/foo/vendor/fabpot/php-cs-fixer/php-cs-fixer:27


fix [--config="..."] [--config-file[="..."]] [--dry-run] [--level="..."] [--fixers="..."] [--diff] [--format="..."] path
```

Updating the configuration in `.php_cs` and 

``` php
$finder = Symfony\CS\Finder\DefaultFinder::create()
    ->exclude('somedir')
    ->in(__DIR__)
;

return return Symfony\CS\Config\Config::create()
    ->finder($finder)
    ->fixers([
        'indentation',
        'linefeed',
        // . . . 
    ])
;
```

doesn't help because only the file(s) represented by or in the specified path should be fixed.
## Fix

Just add the path as specified from the console already, and this works!
