### PR TITLE
Enhancement: Make path argument optional

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -53,7 +53,7 @@ class FixCommand extends Command
         $this
             ->setName('fix')
             ->setDefinition(array(
-                new InputArgument('path', InputArgument::REQUIRED, 'The path'),
+                new InputArgument('path', InputArgument::OPTIONAL, 'The path', null),
                 new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration name', null),
                 new InputOption('config-file', '', InputOption::VALUE_OPTIONAL, 'The path to a .php_cs file ', null),
                 new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified'),
@@ -172,12 +172,18 @@ EOF
             $input->setOption('dry-run', true);
         }
 
-        $filesystem = new Filesystem();
-        if (!$filesystem->isAbsolutePath($path)) {
-            $path = getcwd().DIRECTORY_SEPARATOR.$path;
+        if (null !== $path) {
+            $filesystem = new Filesystem();
+            if (!$filesystem->isAbsolutePath($path)) {
+                $path = getcwd() . DIRECTORY_SEPARATOR . $path;
+            }
         }
 
-        $configFile = $input->getOption('config-file') ?: $path.'/.php_cs';
+        $configFile = $input->getOption('config-file');
+        if (null === $configFile) {
+            $configDir = $path ?: getcwd();
+            $configFile = $configDir . DIRECTORY_SEPARATOR . '.php_cs';
+        }
 
         if ($input->getOption('config')) {
             $config = null;


### PR DESCRIPTION
Some people - namely the [ZF2](http://github.com/zendframework/zf2) community - have been experiencing failing builds on Travis as a result of https://github.com/fabpot/PHP-CS-Fixer/pull/342 and the following setup:
### Steps to reproduce
- requiring `fabpot/php-cs-fixer: "dev-master"`
- running (note the `.` as `path` argument)
  
  ```
   $ vendor/bin/php-cs-fixer fix -v --dry-run .
  ```
  
  while having a `.php_cs` that specifies directories
  
  ``` php
  $finder = Symfony\CS\Finder\DefaultFinder::create()
      ->in(__DIR__ . '/library')
      ->in(__DIR__ . '/tests')
      ->in(__DIR__ . '/bin')
  ;
  ```
  
  and while having files within `__DIR__` (or other directories therein not listed above) that will cause the script to exit with something else than `0` as status.

Basically, the problem is that the `path` argument is _required_, and in a setup as described above and with the changes introduced in #342, the `.` path gets added to the `Finder` while before #342, it wasn't.
### Solution

Either revert #342 or make the `path` argument optional.

This PR makes the `path` argument optional.
