### PR TITLE
Fix $config(Dir|File)

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -181,7 +181,14 @@ EOF
 
         $configFile = $input->getOption('config-file');
         if (null === $configFile) {
-            $configDir = $path ?: getcwd();
+            if (is_file($path) && $dirName = pathinfo($path, PATHINFO_DIRNAME)) {
+                $configDir = $dirName;
+            } elseif ($stdin) {
+                $configDir = getcwd();
+                // path is directory
+            } else {
+                $configDir = $path;
+            }
             $configFile = $configDir . DIRECTORY_SEPARATOR . '.php_cs';
         }
 


### PR DESCRIPTION
Current way of looking for `.php_cs` is a bit broken, here are few examples:

```
# OK
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run vendor
"/opt/PHP-CS-Fixer/vendor/.php_cs"
# FAIL
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run vendor/autoload.php
"/opt/PHP-CS-Fixer/vendor/autoload.php/.php_cs"
# FAIL
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run - < vendor/autoload.php
"/opt/PHP-CS-Fixer/-/.php_cs"
```

With fix (I can't say it's elegant):

```
# OK
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run vendor
"/opt/PHP-CS-Fixer/vendor/.php_cs"
# OK
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run vendor/autoload.php
"/opt/PHP-CS-Fixer/vendor/.php_cs"
# OK, assume current directory for STDIN
/opt/PHP-CS-Fixer>php php-cs-fixer fix --dry-run - < vendor/autoload.php
"/opt/PHP-CS-Fixer/.php_cs"
```
