### PR TITLE
Fix: Regression introduced with 86a0f41

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -183,7 +183,7 @@ EOF
         if (null === $configFile) {
             if (is_file($path) && $dirName = pathinfo($path, PATHINFO_DIRNAME)) {
                 $configDir = $dirName;
-            } elseif ($stdin) {
+            } elseif ($stdin || null === $path) {
                 $configDir = getcwd();
                 // path is directory
             } else {


### PR DESCRIPTION
86a0f41 introduced a regression for cases when `null === $path`.
