### PR TITLE
Fix unit tests for PHP >= 5.4.29 or >= 5.5.13

### DIFF
--- a/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ControlSpacesFixerTest.php
@@ -21,8 +21,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
 
         $try = 'try{';
         $tryFixed = 'try {';
-        $this->assertEquals($tryFixed, $fixer->fix($this->getFileMock(), $try));
-        $this->assertEquals($tryFixed, $fixer->fix($this->getFileMock(), $tryFixed));
+        $this->assertEquals($tryFixed, $fixer->fix($this->getTestFile(), $try));
+        $this->assertEquals($tryFixed, $fixer->fix($this->getTestFile(), $tryFixed));
     }
 
     public function testFixControlsWithPrefixBraceAndParentheses()
@@ -31,8 +31,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
 
         $while = 'do { ... }while($test);';
         $whileFixed = 'do { ... } while ($test);';
-        $this->assertEquals($whileFixed, $fixer->fix($this->getFileMock(), $while));
-        $this->assertEquals($whileFixed, $fixer->fix($this->getFileMock(), $whileFixed));
+        $this->assertEquals($whileFixed, $fixer->fix($this->getTestFile(), $while));
+        $this->assertEquals($whileFixed, $fixer->fix($this->getTestFile(), $whileFixed));
     }
 
     /**
@@ -42,8 +42,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $if));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $ifFixed));
     }
 
     public function testFixControlClosingParenthesesKeepsIndentation()
@@ -58,8 +58,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
             && true === true
         ) {';
 
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $if));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $ifFixed));
     }
 
     public function testFixControlsWithParenthesesAndSuffixBraceProvider()
@@ -81,8 +81,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
 
         $else = '}else{';
         $elseFixed = '} else {';
-        $this->assertEquals($elseFixed, $fixer->fix($this->getFileMock(), $else));
-        $this->assertEquals($elseFixed, $fixer->fix($this->getFileMock(), $elseFixed));
+        $this->assertEquals($elseFixed, $fixer->fix($this->getTestFile(), $else));
+        $this->assertEquals($elseFixed, $fixer->fix($this->getTestFile(), $elseFixed));
     }
 
     public function testFixControlsWithPrefixBraceAndParenthesesAndSuffixBrace()
@@ -91,8 +91,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
 
         $elseif = '}elseif($test){';
         $elseifFixed = '} elseif ($test) {';
-        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseif));
-        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseifFixed));
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getTestFile(), $elseif));
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getTestFile(), $elseifFixed));
     }
 
     public function testFixControlsWithPrefixBraceAndParenthesesAndSuffixBraceInLambdas()
@@ -101,8 +101,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
 
         $use = ')use($test){';
         $useFixed = ') use ($test) {';
-        $this->assertEquals($useFixed, $fixer->fix($this->getFileMock(), $use));
-        $this->assertEquals($useFixed, $fixer->fix($this->getFileMock(), $useFixed));
+        $this->assertEquals($useFixed, $fixer->fix($this->getTestFile(), $use));
+        $this->assertEquals($useFixed, $fixer->fix($this->getTestFile(), $useFixed));
     }
 
     /**
@@ -112,8 +112,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $this->assertEquals($castFixed, $fixer->fix($this->getFileMock(), $cast));
-        $this->assertEquals($castFixed, $fixer->fix($this->getFileMock(), $castFixed));
+        $this->assertEquals($castFixed, $fixer->fix($this->getTestFile(), $cast));
+        $this->assertEquals($castFixed, $fixer->fix($this->getTestFile(), $castFixed));
     }
 
     public function testFixCastsProvider()
@@ -131,10 +131,8 @@ class ControlSpacesFixerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function getFileMock()
+    private function getTestFile()
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo(__FILE__);
     }
 }

--- a/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/CurlyBracketsNewlineFixerTest.php
@@ -14,11 +14,11 @@ class CurlyBracketsNewlineFixerTest extends \PHPUnit_Framework_TestCase
 
         $simple = "$type TestType  {";
         $simpleFixed = "$type TestType\n{";
-        $this->assertEquals($simpleFixed, $fixer->fix($this->getFileMock(), $simple));
-        $this->assertEquals($simpleFixed, $fixer->fix($this->getFileMock(), $simpleFixed));
+        $this->assertEquals($simpleFixed, $fixer->fix($this->getTestFile(), $simple));
+        $this->assertEquals($simpleFixed, $fixer->fix($this->getTestFile(), $simpleFixed));
 
         $emptyType = "$type TestType {}";
-        $this->assertEquals($emptyType, $fixer->fix($this->getFileMock(), $emptyType));
+        $this->assertEquals($emptyType, $fixer->fix($this->getTestFile(), $emptyType));
     }
 
     public function testSimpleTypeDefinitionsProvider()
@@ -41,8 +41,8 @@ TEST;
 class TestClass extends BaseTestClass implements TestInterface
 {
 TEST;
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extended));
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extendedFixed));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extended));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extendedFixed));
 
         $extended = <<<TEST
 abstract class TestClass extends BaseTestClass implements TestInterface, TestInterface2 {
@@ -51,8 +51,8 @@ TEST;
 abstract class TestClass extends BaseTestClass implements TestInterface, TestInterface2
 {
 TEST;
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extended));
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extendedFixed));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extended));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extendedFixed));
 
         $extended = <<<TEST
 abstract class TestClass extends \\Base\\TestClass implements \\TestInterface {
@@ -62,8 +62,8 @@ abstract class TestClass extends \\Base\\TestClass implements \\TestInterface
 {
 TEST;
 
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extended));
-        $this->assertEquals($extendedFixed, $fixer->fix($this->getFileMock(), $extendedFixed));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extended));
+        $this->assertEquals($extendedFixed, $fixer->fix($this->getTestFile(), $extendedFixed));
     }
 
     public function testControlStatements()
@@ -72,38 +72,38 @@ TEST;
 
         $if = "if (\$someTest)\n {";
         $ifFixed = 'if ($someTest) {';
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $if));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $ifFixed));
 
         $if = "if (test) // foo  \n{";
         $ifFixed = "if (test) { // foo";
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $if));
-        $this->assertEquals($ifFixed, $fixer->fix($this->getFileMock(), $ifFixed));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $if));
+        $this->assertEquals($ifFixed, $fixer->fix($this->getTestFile(), $ifFixed));
 
         $elseif = "else if (...)\n{";
         $elseifFixed = "else if (...) {";
-        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseif));
-        $this->assertEquals($elseifFixed, $fixer->fix($this->getFileMock(), $elseifFixed));
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getTestFile(), $elseif));
+        $this->assertEquals($elseifFixed, $fixer->fix($this->getTestFile(), $elseifFixed));
 
         $func = "function download() {\n}";
         $funcFixed = "function download()\n{\n}";
-        $this->assertEquals($funcFixed, $fixer->fix($this->getFileMock(), $func));
-        $this->assertEquals($funcFixed, $fixer->fix($this->getFileMock(), $funcFixed));
+        $this->assertEquals($funcFixed, $fixer->fix($this->getTestFile(), $func));
+        $this->assertEquals($funcFixed, $fixer->fix($this->getTestFile(), $funcFixed));
 
         $while = "    while (\$file = \$this->getFile())\n    {";
         $whileFixed = '    while ($file = $this->getFile()) {';
-        $this->assertEquals($whileFixed, $fixer->fix($this->getFileMock(), $while));
-        $this->assertEquals($whileFixed, $fixer->fix($this->getFileMock(), $whileFixed));
+        $this->assertEquals($whileFixed, $fixer->fix($this->getTestFile(), $while));
+        $this->assertEquals($whileFixed, $fixer->fix($this->getTestFile(), $whileFixed));
 
         $switch = "switch(\$statement)   \n{";
         $switchFixed = 'switch($statement) {';
-        $this->assertEquals($switchFixed, $fixer->fix($this->getFileMock(), $switch));
-        $this->assertEquals($switchFixed, $fixer->fix($this->getFileMock(), $switchFixed));
+        $this->assertEquals($switchFixed, $fixer->fix($this->getTestFile(), $switch));
+        $this->assertEquals($switchFixed, $fixer->fix($this->getTestFile(), $switchFixed));
 
         $try = "try \n{\n ... \n} \n catch (Exception \$e)\n{";
         $tryFixed = "try {\n ... \n} catch (Exception \$e) {";
-        $this->assertEquals($tryFixed, $fixer->fix($this->getFileMock(), $try));
-        $this->assertEquals($tryFixed, $fixer->fix($this->getFileMock(), $tryFixed));
+        $this->assertEquals($tryFixed, $fixer->fix($this->getTestFile(), $try));
+        $this->assertEquals($tryFixed, $fixer->fix($this->getTestFile(), $tryFixed));
 
         $tryInClassName = <<<'TEST'
 
@@ -111,7 +111,7 @@ TEST;
         {
             private $fields = array();
 TEST;
-        $this->assertEquals($tryInClassName, $fixer->fix($this->getFileMock(), $tryInClassName));
+        $this->assertEquals($tryInClassName, $fixer->fix($this->getTestFile(), $tryInClassName));
     }
 
     public function testFunctionDeclaration()
@@ -120,16 +120,16 @@ TEST;
 
         $declaration = '    public function test()     {';
         $fixedDeclaration = "    public function test()\n    {";
-        $this->assertEquals($fixedDeclaration, $fixer->fix($this->getFileMock(), $declaration));
-        $this->assertEquals($fixedDeclaration, $fixer->fix($this->getFileMock(), $fixedDeclaration));
+        $this->assertEquals($fixedDeclaration, $fixer->fix($this->getTestFile(), $declaration));
+        $this->assertEquals($fixedDeclaration, $fixer->fix($this->getTestFile(), $fixedDeclaration));
 
         $goodAnonymous = "filter(function () {\n    return true;\n})";
-        $this->assertEquals($goodAnonymous, $fixer->fix($this->getFileMock(), $goodAnonymous));
+        $this->assertEquals($goodAnonymous, $fixer->fix($this->getTestFile(), $goodAnonymous));
 
         $badAnonymous = "filter(function   () \n {\n});";
         $fixedBadAnonymous = "filter(function   () {\n});";
-        $this->assertEquals($fixedBadAnonymous, $fixer->fix($this->getFileMock(), $badAnonymous));
-        $this->assertEquals($fixedBadAnonymous, $fixer->fix($this->getFileMock(), $fixedBadAnonymous));
+        $this->assertEquals($fixedBadAnonymous, $fixer->fix($this->getTestFile(), $badAnonymous));
+        $this->assertEquals($fixedBadAnonymous, $fixer->fix($this->getTestFile(), $fixedBadAnonymous));
 
         $correctMethod = <<<'EOF'
     public function __construct($id, $name)
@@ -139,7 +139,7 @@ TEST;
     }
 EOF;
 
-        $this->assertEquals($correctMethod, $fixer->fix($this->getFileMock(), $correctMethod));
+        $this->assertEquals($correctMethod, $fixer->fix($this->getTestFile(), $correctMethod));
     }
 
     public function testDoWhile()
@@ -162,8 +162,8 @@ EOF;
     } while ($test = $this->getTest());
 
 EOF;
-        $this->assertEquals($fixedDoWhile, $fixer->fix($this->getFileMock(), $doWhile));
-        $this->assertEquals($fixedDoWhile, $fixer->fix($this->getFileMock(), $fixedDoWhile));
+        $this->assertEquals($fixedDoWhile, $fixer->fix($this->getTestFile(), $doWhile));
+        $this->assertEquals($fixedDoWhile, $fixer->fix($this->getTestFile(), $fixedDoWhile));
     }
 
     /*
@@ -175,24 +175,22 @@ EOF;
 
         $declarationWithDo = '    public function test($do)     {';
         $fixedDeclarationWithDo = "    public function test(\$do)\n    {";
-        $this->assertEquals($fixedDeclarationWithDo, $fixer->fix($this->getFileMock(), $declarationWithDo));
-        $this->assertEquals($fixedDeclarationWithDo, $fixer->fix($this->getFileMock(), $fixedDeclarationWithDo));
+        $this->assertEquals($fixedDeclarationWithDo, $fixer->fix($this->getTestFile(), $declarationWithDo));
+        $this->assertEquals($fixedDeclarationWithDo, $fixer->fix($this->getTestFile(), $fixedDeclarationWithDo));
 
         $declarationWithElse = '    public function test($else)     {';
         $fixedDeclarationWithElse = "    public function test(\$else)\n    {";
-        $this->assertEquals($fixedDeclarationWithElse, $fixer->fix($this->getFileMock(), $declarationWithElse));
-        $this->assertEquals($fixedDeclarationWithElse, $fixer->fix($this->getFileMock(), $fixedDeclarationWithElse));
+        $this->assertEquals($fixedDeclarationWithElse, $fixer->fix($this->getTestFile(), $declarationWithElse));
+        $this->assertEquals($fixedDeclarationWithElse, $fixer->fix($this->getTestFile(), $fixedDeclarationWithElse));
 
         $declarationWithTry = '    public function test($try)     {';
         $fixedDeclarationWithTry = "    public function test(\$try)\n    {";
-        $this->assertEquals($fixedDeclarationWithTry, $fixer->fix($this->getFileMock(), $declarationWithTry));
-        $this->assertEquals($fixedDeclarationWithTry, $fixer->fix($this->getFileMock(), $fixedDeclarationWithTry));
+        $this->assertEquals($fixedDeclarationWithTry, $fixer->fix($this->getTestFile(), $declarationWithTry));
+        $this->assertEquals($fixedDeclarationWithTry, $fixer->fix($this->getTestFile(), $fixedDeclarationWithTry));
     }
 
-    private function getFileMock()
+    private function getTestFile()
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo(__FILE__);
     }
 }

--- a/Symfony/CS/Tests/Fixer/ElseifFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ElseifFixerTest.php
@@ -30,12 +30,12 @@ class ElseifFixerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(
             'if ($some) { $test = true } elseif ($some != "test") { $test = false; }',
-            $fixer->fix($this->getFileMock(), 'if ($some) { $test = true } else if ($some != "test") { $test = false; }'
+            $fixer->fix($this->getTestFile(), 'if ($some) { $test = true } else if ($some != "test") { $test = false; }'
         ));
 
         $this->assertSame(
             'if ($some) { $test = true } elseif ($some != "test") { $test = false; }',
-            $fixer->fix($this->getFileMock(), 'if ($some) { $test = true } else  if ($some != "test") { $test = false; }'
+            $fixer->fix($this->getTestFile(), 'if ($some) { $test = true } else  if ($some != "test") { $test = false; }'
         ));
     }
 
@@ -80,32 +80,24 @@ class ElseifFixerTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatOnlyPHPFilesAreSupported()
     {
-        $phpFile = $this->getFileMock();
-        $phpFile->expects($this->any())
-            ->method('getFilename')
-            ->will($this->returnValue('file.php'));
+        $phpFile = $this->getTestFile();
 
-        $otherFile = $this->getFileMock();
-        $otherFile->expects($this->any())
-            ->method('getFilename')
-            ->will($this->returnValue('file.js'));
+        $otherFile = $this->getTestFile(__DIR__ . '/../../../../README.rst');
 
-       $fixer = new ElseIfFixer();
+        $fixer = new ElseIfFixer();
 
-       $this->assertTrue($fixer->supports($phpFile));
-       $this->assertFalse($fixer->supports($otherFile));
+        $this->assertTrue($fixer->supports($phpFile));
+        $this->assertFalse($fixer->supports($otherFile));
     }
 
     public function testThatAreDefinedInPSR2()
     {
-       $fixer = new ElseIfFixer();
-       $this->assertSame(FixerInterface::PSR2_LEVEL, $fixer->getLevel());
+        $fixer = new ElseIfFixer();
+        $this->assertSame(FixerInterface::PSR2_LEVEL, $fixer->getLevel());
     }
 
-    private function getFileMock()
+    private function getTestFile($filename = __FILE__)
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo($filename);
     }
 }

--- a/Symfony/CS/Tests/Fixer/FunctionDeclarationSpacingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/FunctionDeclarationSpacingFixerTest.php
@@ -40,7 +40,7 @@ class FunctionDeclarationSpacingFixerTest extends \PHPUnit_Framework_TestCase
     public function testDouble($source, $target)
     {
         $fixer = new Fixer();
-        $this->assertSame($target, $fixer->fix($this->getFileMock(), $target));
+        $this->assertSame($target, $fixer->fix($this->getTestFile(), $target));
     }
 
     /**
@@ -49,13 +49,11 @@ class FunctionDeclarationSpacingFixerTest extends \PHPUnit_Framework_TestCase
     public function testSimple($source, $target)
     {
         $fixer = new Fixer();
-        $this->assertSame($target, $fixer->fix($this->getFileMock(), $source));
+        $this->assertSame($target, $fixer->fix($this->getTestFile(), $source));
     }
 
-    private function getFileMock()
+    private function getTestFile()
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo(__FILE__);
     }
 }

--- a/Symfony/CS/Tests/Fixer/IncludeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/IncludeFixerTest.php
@@ -25,8 +25,8 @@ class IncludeFixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $this->assertEquals($includeFixed, $fixer->fix($this->getFileMock(), $include));
-        $this->assertEquals($includeFixed, $fixer->fix($this->getFileMock(), $includeFixed));
+        $this->assertEquals($includeFixed, $fixer->fix($this->getTestFile(), $include));
+        $this->assertEquals($includeFixed, $fixer->fix($this->getTestFile(), $includeFixed));
     }
 
     public function testFixProvider()
@@ -51,10 +51,8 @@ class IncludeFixerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function getFileMock()
+    private function getTestFile()
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo(__FILE__);
     }
 }

--- a/Symfony/CS/Tests/Fixer/ReturnStatementsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ReturnStatementsFixerTest.php
@@ -22,8 +22,8 @@ class ReturnStatementsFixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $this->assertEquals($returnFixed, $fixer->fix($this->getFileMock(), $return));
-        $this->assertEquals($returnFixed, $fixer->fix($this->getFileMock(), $returnFixed));
+        $this->assertEquals($returnFixed, $fixer->fix($this->getTestFile(), $return));
+        $this->assertEquals($returnFixed, $fixer->fix($this->getTestFile(), $returnFixed));
     }
 
     public function testFixProvider()
@@ -130,10 +130,8 @@ TEST;
         );
     }
 
-    private function getFileMock()
+    private function getTestFile()
     {
-        return $this->getMockBuilder('\SplFileInfo')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new \SplFileInfo(__FILE__);
     }
 }


### PR DESCRIPTION
Fix for #351

Fixes the unit tests when running on the PHP versions that changed the serialization behavior. There's no way to mock internal classes without calling the constructor, so the easiest fix is to use an actual instance of SplFileInfo instead of using a mock.
