### PR TITLE
OneClassPerFileFixer - remove T_TRAIT defining

### DIFF
--- a/Symfony/CS/Fixer/OneClassPerFileFixer.php
+++ b/Symfony/CS/Fixer/OneClassPerFileFixer.php
@@ -14,10 +14,6 @@ namespace Symfony\CS\Fixer;
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Tokens;
 
-if (!defined('T_TRAIT')) {
-    define('T_TRAIT', 1001);
-}
-
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */


### PR DESCRIPTION
Remove T_TRAIT conditionally defining.
Fixer do not use T_TRAIT constant, neither do Tokens class.

Testet od PHP 5.5.3 and PHP 5.3.3-7+squeeze19
