### PR TITLE
[bugfix #426] NewWithBracesFixer - fix creating instances inside arrays.

### DIFF
--- a/Symfony/CS/Fixer/NewWithBracesFixer.php
+++ b/Symfony/CS/Fixer/NewWithBracesFixer.php
@@ -30,7 +30,7 @@ class NewWithBracesFixer implements FixerInterface
             }
 
             $nextIndex = null;
-            $nextToken = $tokens->getNextTokenOfKind($index, array('(', ';', ')'), $nextIndex);
+            $nextToken = $tokens->getNextTokenOfKind($index, array('(', ';', ',', ')', ']', ), $nextIndex);
 
             // no correct end of code - break
             if (null === $nextToken) {
@@ -42,7 +42,10 @@ class NewWithBracesFixer implements FixerInterface
                 continue;
             }
 
-            $tokens->insertAt($nextIndex, array(new Token('('), new Token(')'), ));
+            $meaningBeforeNextIndex = null;
+            $tokens->getPrevNonWhitespace($nextIndex, array(), $meaningBeforeNextIndex);
+
+            $tokens->insertAt($meaningBeforeNextIndex + 1, array(new Token('('), new Token(')'), ));
         }
 
         return $tokens->generateCode();

--- a/Symfony/CS/Tests/Fixer/NewWithBracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/NewWithBracesFixerTest.php
@@ -18,10 +18,7 @@ use Symfony\CS\Fixer\NewWithBracesFixer as Fixer;
  */
 class NewWithBracesFixerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @dataProvider provideCases
-     */
-    public function testFix($expected, $input)
+    public function makeTest($expected, $input)
     {
         $fixer = new Fixer();
         $file = $this->getTestFile();
@@ -30,11 +27,28 @@ class NewWithBracesFixerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $fixer->fix($file, $expected));
     }
 
-    public function provideCases()
+    /**
+     * @dataProvider provideStandardCases
+     */
+    public function testStandard($expected, $input)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @dataProvider provide54Cases
+     * @requires PHP 5.4
+     */
+    public function test54($expected, $input)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideStandardCases()
     {
         return array(
             array('<?php $x = new X();', '<?php $x = new X;', ),
-            array('<?php $y = new Y ();', '<?php $y = new Y ;', ),
+            array('<?php $y = new Y() ;', '<?php $y = new Y ;', ),
             array('<?php $foo = new $foo();', '<?php $foo = new $foo;', ),
             array('<?php $baz = new {$bar->baz}();', '<?php $baz = new {$bar->baz};', ),
             array('<?php $xyz = new X(new Y(new Z()));', '<?php $xyz = new X(new Y(new Z));', ),
@@ -42,6 +56,28 @@ class NewWithBracesFixerTest extends \PHPUnit_Framework_TestCase
             array('<?php $self = new self();', '<?php $self = new self;', ),
             array('<?php $static = new static();', '<?php $static = new static;', ),
             array('<?php $magic = new __CLASS__();', '<?php $magic = new __CLASS__;'),
+            array(
+                '<?php $a = array( "key" => new DateTime(), );',
+                '<?php $a = array( "key" => new DateTime, );',
+            ),
+            array(
+                '<?php $a = array( "key" => new DateTime() );',
+                '<?php $a = array( "key" => new DateTime );',
+            ),
+        );
+    }
+
+    public function provide54Cases()
+    {
+        return array(
+            array(
+                '<?php $a = [ "key" => new DateTime(), ];',
+                '<?php $a = [ "key" => new DateTime, ];',
+            ),
+            array(
+                '<?php $a = [ "key" => new DateTime() ];',
+                '<?php $a = [ "key" => new DateTime ];',
+            ),
         );
     }
 


### PR DESCRIPTION
NewWithBracesFixer - fix creating instances inside arrays (#426).

Also add () just after classname, not before expression end:
`new Foo ;` => `new Foo() ;` instead of `new Foo ();`

If merged please bump at least patch version, it seems to be an important fix
