### PR TITLE
FixCommand - override config dir only if path is set

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -222,7 +222,7 @@ EOF
             $config->finder(new \ArrayIterator(array(new \SplFileInfo($path))));
         } elseif ($stdin) {
             $config->finder(new \ArrayIterator(array(new StdinFileInfo())));
-        } else {
+        } elseif (null !== $path) {
             $config->setDir($path);
         }
 


### PR DESCRIPTION
Hey!

Let imagine that I have a project structure:

```
- root
    - A
    - B
    - C
```

In root dir I have a .php_cs file:

``` php
<?php

$config = Symfony\CS\Config\Config::create();
$config->setDir([__DIR__ . "/A", __DIR__ . "/C", ]);

return $config;
```

So I just want to fix A i C subdirs and leave alone B subdir. And I want to do it in config file.
It is a simple case just to show my problem, I known that I could exclude B subdir, but I have a little to include and a lot to exclude in one project :(

OK, let run the fixer:
`php-cs-fixer fix` (without path, because I defined it in config file)
? Is it work? No! FixCommand will call again ->setDir method (see: https://github.com/fabpot/PHP-CS-Fixer/blob/master/Symfony/CS/Console/Command/FixCommand.php#L226) with null argument and fixer will crash with msg: `You must call one of in() or append() methods before iterating over a Finder`

Conclusion
Let the fix command override `$config->dir` only if `path` argument was set.
