### PR TITLE
Adding level to Config

### DIFF
--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\CS\Config;
 
-use Symfony\CS\ConfigInterface;
-use Symfony\CS\FinderInterface;
-use Symfony\CS\Finder\DefaultFinder;
 use Symfony\CS\FixerInterface;
+use Symfony\CS\FinderInterface;
+use Symfony\CS\ConfigInterface;
+use Symfony\CS\Finder\DefaultFinder;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -231,7 +231,10 @@ EOF
 
         $allFixers = $this->fixer->getFixers();
 
-        switch ($input->getOption('level')) {
+        $levelOption = $input->getOption('level') ?: $config->getLevel();
+        $fixerOption = $input->getOption('fixers') ?: (is_string($config->getFixers()) ? $config->getFixers() : null);
+
+        switch ($levelOption) {
             case 'psr0':
                 $level = FixerInterface::PSR0_LEVEL;
                 break;
@@ -245,7 +248,6 @@ EOF
                 $level = FixerInterface::ALL_LEVEL;
                 break;
             case null:
-                $fixerOption = $input->getOption('fixers');
                 if (empty($fixerOption) || preg_match('{(^|,)-}', $fixerOption)) {
                     $level = $config->getFixers();
                 } else {
@@ -273,14 +275,14 @@ EOF
         }
 
         // remove/add fixers based on the fixers option
-        if (preg_match('{(^|,)-}', $input->getOption('fixers'))) {
+        if (preg_match('{(^|,)-}', $fixerOption)) {
             foreach ($fixers as $key => $fixer) {
-                if (preg_match('{(^|,)-'.preg_quote($fixer->getName()).'}', $input->getOption('fixers'))) {
+                if (preg_match('{(^|,)-'.preg_quote($fixer->getName()).'}', $fixerOption)) {
                     unset($fixers[$key]);
                 }
             }
-        } elseif ($input->getOption('fixers')) {
-            $names = array_map('trim', explode(',', $input->getOption('fixers')));
+        } elseif ($fixerOption) {
+            $names = array_map('trim', explode(',', $fixerOption));
 
             foreach ($allFixers as $fixer) {
                 if (in_array($fixer->getName(), $names) && !in_array($fixer, $fixers)) {


### PR DESCRIPTION
This change will allow for using the config file similarly to command line params.
Morover, you will be able to use string in fixers.

This is not a verry clean solution, but it will be useful when using contrib fixers. You can set `level` to `all` and then choose one (or more) aditional fixers (those not in `LEVEL_ALL`).
