### PR TITLE
Sort fixers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,56 +158,23 @@ Choose from the list of available fixers:
 * **encoding** [PSR-1] PHP code MUST use only UTF-8 without BOM
    (remove BOM).
 
-* **linefeed** [PSR-2] All PHP files must use the Unix LF
-   (linefeed) line ending.
-
 * **indentation** [PSR-2] Code MUST use an indent of 4 spaces, and
    MUST NOT use tabs for indenting.
+
+* **linefeed** [PSR-2] All PHP files must use the Unix LF
+   (linefeed) line ending.
 
 * **trailing_spaces** [PSR-2] Remove trailing whitespace at the end of
    lines.
 
-* **unused_use** [all] Unused use statements must be removed.
-
 * **php_closing_tag** [PSR-2] The closing ?> tag MUST be omitted from
    files containing only PHP.
 
-* **phpdoc_params** [all] All items of the @param phpdoc tags must be
-   aligned vertically.
-
-* **standardize_not_equal** [all] Replace all <> with !=.
+* **unused_use** [all] Unused use statements must be removed.
 
 * **short_tag** [PSR-1] PHP code must use the long <?php ?> tags or
    the short-echo <?= ?> tags; it must not use the
    other tag variations.
-
-* **ternary_spaces** [all] Standardize spaces around ternary operator.
-
-* **spaces_cast** [all] A single space should be between cast and
-   variable.
-
-* **object_operator** [all] There should not be space before or after
-   object T_OBJECT_OPERATOR.
-
-* **visibility** [PSR-2] Visibility MUST be declared on all
-   properties and methods; abstract and final MUST be
-   declared before the visibility; static MUST be
-   declared after the visibility.
-
-* **return** [all] An empty line feed should precede a return
-   statement.
-
-* **function_declaration** [PSR-2] Spaces should be properly placed in a
-   function declaration
-
-* **include** [all] Include and file path should be divided with
-   a single space. File path should not be placed
-   under brackets.
-
-* **extra_empty_lines** [all] Removes extra empty lines.
-
-* **new_with_braces** [all] All instances created with new keyword must
-   be followed by braces.
 
 * **braces** [PSR-2] Opening braces for classes, interfaces,
    traits and methods must go on the next line, and
@@ -216,22 +183,55 @@ Choose from the list of available fixers:
    on the same line, and closing braces must go on the
    next line after the body.
 
+* **function_declaration** [PSR-2] Spaces should be properly placed in a
+   function declaration
+
+* **lowercase_constants** [PSR-2] The PHP constants true, false, and null
+   MUST be in lower case.
+
 * **lowercase_keywords** [PSR-2] PHP keywords MUST be in lower case.
+
+* **visibility** [PSR-2] Visibility MUST be declared on all
+   properties and methods; abstract and final MUST be
+   declared before the visibility; static MUST be
+   declared after the visibility.
+
+* **extra_empty_lines** [all] Removes extra empty lines.
+
+* **include** [all] Include and file path should be divided with
+   a single space. File path should not be placed
+   under brackets.
+
+* **new_with_braces** [all] All instances created with new keyword must
+   be followed by braces.
+
+* **object_operator** [all] There should not be space before or after
+   object T_OBJECT_OPERATOR.
+
+* **phpdoc_params** [all] All items of the @param phpdoc tags must be
+   aligned vertically.
+
+* **return** [all] An empty line feed should precede a return
+   statement.
+
+* **spaces_cast** [all] A single space should be between cast and
+   variable.
+
+* **standardize_not_equal** [all] Replace all <> with !=.
+
+* **ternary_spaces** [all] Standardize spaces around ternary operator.
 
 * **short_array_syntax** [contrib] PHP array's should use the PHP 5.4
    short-syntax
 
-* **lowercase_constants** [PSR-2] The PHP constants true, false, and null
-   MUST be in lower case.
+* **psr0** [PSR-0] Classes must be in a path that matches
+   their namespace, be at least one namespace deep,
+   and the class name should match the file name.
 
 * **controls_spaces** [all] A single space should be between: the closing
    brace and the control, the control and the opening
    parentheses, the closing parentheses and the
    opening brace.
-
-* **psr0** [PSR-0] Classes must be in a path that matches
-   their namespace, be at least one namespace deep,
-   and the class name should match the file name.
 
 * **elseif** [PSR-2] The keyword elseif should be used instead
    of else if so that all control keywords looks like

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -24,24 +24,32 @@ class FixerTest extends \PHPUnit_Framework_TestCase
     {
         $fixer = new Fixer();
 
-        $f1 = $this->getMock('Symfony\CS\FixerInterface');
-        $f1->expects($this->any())->method('getPriority')->will($this->returnValue(0));
+        $fxPrototypes = array(
+            array('getPriority' =>   0, 'getLevel' => FixerInterface::PSR0_LEVEL, 'getName' => 'aaa', ),
+            array('getPriority' => -10, 'getLevel' => FixerInterface::PSR1_LEVEL, 'getName' => 'bbb', ),
+            array('getPriority' =>  10, 'getLevel' => FixerInterface::PSR0_LEVEL, 'getName' => 'ccc', ),
+            array('getPriority' => -10, 'getLevel' => FixerInterface::PSR0_LEVEL, 'getName' => 'eee', ),
+            array('getPriority' => -10, 'getLevel' => FixerInterface::PSR0_LEVEL, 'getName' => 'ddd', ),
+        );
 
-        $f2 = $this->getMock('Symfony\CS\FixerInterface');
-        $f2->expects($this->any())->method('getPriority')->will($this->returnValue(-10));
+        $fxs = array();
 
-        $f3 = $this->getMock('Symfony\CS\FixerInterface');
-        $f3->expects($this->any())->method('getPriority')->will($this->returnValue(10));
+        foreach ($fxPrototypes as $fxPrototype) {
+            $fx = $this->getMock('Symfony\CS\FixerInterface');
+            $fx->expects($this->any())->method('getPriority')->willReturn($fxPrototype['getPriority']);
+            $fx->expects($this->any())->method('getLevel')->willReturn($fxPrototype['getLevel']);
+            $fx->expects($this->any())->method('getName')->willReturn($fxPrototype['getName']);
 
-        $f4 = $this->getMock('Symfony\CS\FixerInterface');
-        $f4->expects($this->any())->method('getPriority')->will($this->returnValue(-10));
+            $fixer->addFixer($fx);
+            $fxs[] = $fx;
+        }
 
-        $fixer->addFixer($f1);
-        $fixer->addFixer($f2);
-        $fixer->addFixer($f3);
-        $fixer->addFixer($f4);
-
-        $this->assertSame(array($f3, $f1, $f4, $f2), $fixer->getFixers());
+        $this->assertSame(
+            array($fxs[2], $fxs[0], $fxs[4], $fxs[3], $fxs[1]),
+            // supress warning: usort(): Array was modified by the user comparision function
+            // because accessing the getters of the mocks changed their state
+            @$fixer->getFixers()
+        );
     }
 
     /**


### PR DESCRIPTION
Inside Fixer class:
- do not sort fixers two times
- sort not only by priority, but also by level and names

Why I propose that changes?
- Sometimes after adding new fixer or rebuild readme on different env order of sorted fixers was differ (shuffle fixers with same priority) and then README.rst was totally reorganized. The diff was awful.
- At start I had no idea what is the order of fixers in readme file. Now it will be clear for any new one in project.
