### PR TITLE
Remove risky test: Psr0FixerTest - Fixer do not print anything.

### DIFF
--- a/Symfony/CS/Tests/Fixer/Psr0FixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Psr0FixerTest.php
@@ -117,9 +117,7 @@ namespace Foo\Bar\Baz\FIXER;
 class Psr0Fixer {}
 EOF;
 
-        ob_start();
         $this->assertSame($expected, $fixer->fix($file, $input));
-        $this->assertSame('', ob_get_clean());
 
         $config->setDir(__DIR__.'/../../Fixer');
         $expected = <<<'EOF'
@@ -131,9 +129,7 @@ namespace Foo\Bar\Baz;
 class Psr0Fixer {}
 EOF;
 
-        ob_start();
         $this->assertSame($expected, $fixer->fix($file, $input));
-        $this->assertSame('', ob_get_clean());
     }
 
     public function testFixLeadingSpaceNamespace()
@@ -149,9 +145,8 @@ EOF;
  namespace LeadingSpace;
 class Psr0Fixer {}
 EOF;
-        ob_start();
+
         $this->assertSame($expected, $fixer->fix($file, $input));
-        ob_clean();
     }
 
     private function getTestFile($filename = __FILE__)


### PR DESCRIPTION
Psr0FixerTest - Fixer do not print anything so there is no need to catch and check output buffer.
This allow us to remove risky test reported by PHPUnit
