### PR TITLE
Fixing readme generator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,9 +253,9 @@ Choose from the list of available configurations:
 
 * **default** A default configuration
 
-* **magento** The configuration for a Magento application
-
 * **sf23**    The configuration for the Symfony 2.3+ branch
+
+* **magento** The configuration for a Magento application
 
 The ``--dry-run`` option displays the files that need to be
 fixed but without actually modifying them:
@@ -273,7 +273,6 @@ and directories that need to be analyzed:
 .. code-block:: php
 
     <?php
-
     $finder = Symfony\CS\Finder\DefaultFinder::create()
         ->exclude('somedir')
         ->in(__DIR__)
@@ -291,7 +290,6 @@ Note the additional ``-`` in front of the Fixer name.
 .. code-block:: php
 
     <?php
-
     $finder = Symfony\CS\Finder\DefaultFinder::create()
         ->exclude('somedir')
         ->in(__DIR__)

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -133,7 +133,6 @@ your project. The file must return an instance of
 and directories that need to be analyzed:
 
     <?php
-
     \$finder = Symfony\CS\Finder\DefaultFinder::create()
         ->exclude('somedir')
         ->in(__DIR__)
@@ -149,7 +148,6 @@ The following example shows how to use all Fixers but the `psr0` fixer.
 Note the additional <comment>-</comment> in front of the Fixer name.
 
     <?php
-
     \$finder = Symfony\CS\Finder\DefaultFinder::create()
         ->exclude('somedir')
         ->in(__DIR__)

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -197,6 +197,7 @@ EOF;
         $help = preg_replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
         $help = preg_replace('#^ \* ``(.+)``#m', '* **$1**', $help);
         $help = preg_replace("#^\n( +)#m", "\n.. code-block:: bash\n\n$1", $help);
+        $help = preg_replace("#^.. code-block:: bash\n\n( +\<\?php)#m", ".. code-block:: php\n\n$1", $help);
         $help = preg_replace('#^                        #m', '  ', $help);
         $help = preg_replace('#\*\* +\[#', '** [', $help);
 


### PR DESCRIPTION
As mentioned in #397 [comment](https://github.com/fabpot/PHP-CS-Fixer/pull/397#commitcomment-7316182) I am trying to fix the readme generator. It seems to be working, but I guess it can be done better than replacing previously inserted `code-block:: bash`.

Now, there is adifferent problem. I deleted a blank lnie in FixCommand help message to avoid double inserts, but the fixer run on itself keeps adding a blank line before return even in a string.
