### PR TITLE
Add PHP version check for phar-stub.

### DIFF
--- a/Symfony/CS/Resources/phar-stub.php
+++ b/Symfony/CS/Resources/phar-stub.php
@@ -10,6 +10,11 @@
  * with this source code in the file LICENSE.
  */
 
+if (version_compare(phpversion(), '5.3.6', '<')) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.3.6\n");
+    exit(1);
+}
+
 Phar::mapPhar('php-cs-fixer.phar');
 
 require_once 'phar://php-cs-fixer.phar/vendor/autoload.php';


### PR DESCRIPTION
Add PHP version check equivalent to PR #417.

Without it it crashes like this:
`Parse error: syntax error, unexpected T_STRING, expecting T_CONSTANT_ENCAPSED_STRING or '(' in /home/travis/build/bobthecow/mustache.php/php-cs-fixer.phar on line 17`
