### PR TITLE
[feature] SpacesAroundOperatorsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,9 @@ Choose from the list of available fixers:
 * **object_operator** [all] There should not be space before or after
    object T_OBJECT_OPERATOR.
 
+* **operators_spaces** [all] Operators should be arounded by at least one
+   space.
+
 * **phpdoc_params** [all] All items of the @param phpdoc tags must be
    aligned vertically.
 

--- a/Symfony/CS/Fixer/SpacesAroundOperatorsFixer.php
+++ b/Symfony/CS/Fixer/SpacesAroundOperatorsFixer.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer;
+
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Token;
+use Symfony\CS\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ */
+class SpacesAroundOperatorsFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if (!$this->isOperator($token)) {
+                continue;
+            }
+
+            if (!$tokens[$index + 1]->isWhitespace()) {
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ', )));
+            }
+
+            if (!$tokens[$index - 1]->isWhitespace()) {
+                $tokens->insertAt($index, new Token(array(T_WHITESPACE, ' ', )));
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    private function isOperator(Token $token)
+    {
+        static $arrayOperators = array(
+            T_AND_EQUAL             => true,    // &=
+            T_BOOLEAN_AND           => true,    // &&
+            T_BOOLEAN_OR            => true,    // ||
+            T_CONCAT_EQUAL          => true,    // .=
+            T_DIV_EQUAL             => true,    // /=
+            T_DOUBLE_ARROW          => true,    // =>
+            T_IS_EQUAL              => true,    // ==
+            T_IS_GREATER_OR_EQUAL   => true,    // >=
+            T_IS_IDENTICAL          => true,    // ===
+            T_IS_NOT_EQUAL          => true,    // !=, <>
+            T_IS_NOT_IDENTICAL      => true,    // !==
+            T_IS_SMALLER_OR_EQUAL   => true,    // <=
+            T_LOGICAL_AND           => true,    // and
+            T_LOGICAL_OR            => true,    // or
+            T_LOGICAL_XOR           => true,    // xor
+            T_MINUS_EQUAL           => true,    // -=
+            T_MOD_EQUAL             => true,    // %=
+            T_MUL_EQUAL             => true,    // *=
+            T_OR_EQUAL              => true,    // |=
+            T_PLUS_EQUAL            => true,    // +=
+            T_SL                    => true,    // <<
+            T_SL_EQUAL              => true,    // <<=
+            T_SR                    => true,    // >>
+            T_SR_EQUAL              => true,    // >>=
+            T_XOR_EQUAL             => true,    // ^=
+        );
+
+        static $nonArrayOperators = array(
+            '=' => true,
+        );
+
+        return $token->isArray() ? isset($arrayOperators[$token->id]) : isset($nonArrayOperators[$token->content]);
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::ALL_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+    }
+
+    public function getName()
+    {
+        return 'operators_spaces';
+    }
+
+    public function getDescription()
+    {
+        return 'Operators should be arounded by at least one space.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/SpacesAroundOperatorsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/SpacesAroundOperatorsFixerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer;
+
+use Symfony\CS\Fixer\SpacesAroundOperatorsFixer as Fixer;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ */
+class SpacesAroundOperatorsFixerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input)
+    {
+        $fixer = new Fixer();
+
+        $this->assertSame($expected, $fixer->fix($this->getTestFile(), $input));
+        $this->assertSame($expected, $fixer->fix($this->getTestFile(), $expected));
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php $a &= $b;',
+                '<?php $a&=$b;',
+            ),
+            array(
+                '<?php $a &= $b;',
+                '<?php $a &=$b;',
+            ),
+            array(
+                '<?php $a &= $b;',
+                '<?php $a&= $b;',
+            ),
+            array(
+                '<?php $a &= $b;',
+                '<?php $a &= $b;',
+            ),
+            array(
+                '<?php $a  &=   $b;',
+                '<?php $a  &=   $b;',
+            ),
+            array(
+                '<?php $a &=
+$b;',
+                '<?php $a &=
+$b;',
+            ),
+
+            array(
+                '<?php $a
+&= $b;',
+                '<?php $a
+&=$b;',
+            ),
+            array(
+                '<?php $a && $b;',
+                '<?php $a&&$b;',
+            ),
+            array(
+                '<?php $a || $b;',
+                '<?php $a||$b;',
+            ),
+            array(
+                '<?php $a .= $b;',
+                '<?php $a.=$b;',
+            ),
+            array(
+                '<?php $a /= $b;',
+                '<?php $a/=$b;',
+            ),
+            array(
+                '<?php $a == $b;',
+                '<?php $a==$b;',
+            ),
+            array(
+                '<?php $a >= $b;',
+                '<?php $a>=$b;',
+            ),
+            array(
+                '<?php $a === $b;',
+                '<?php $a===$b;',
+            ),
+            array(
+                '<?php $a != $b;',
+                '<?php $a!=$b;',
+            ),
+            array(
+                '<?php $a <> $b;',
+                '<?php $a<>$b;',
+            ),
+            array(
+                '<?php $a !== $b;',
+                '<?php $a!==$b;',
+            ),
+            array(
+                '<?php $a <= $b;',
+                '<?php $a<=$b;',
+            ),
+            array(
+                '<?php (1) and 2;',
+                '<?php (1)and 2;',
+            ),
+            array(
+                '<?php 1 or ($b-$c);',
+                '<?php 1 or($b-$c);',
+            ),
+            array(
+                '<?php "a" xor (2);',
+                '<?php "a"xor(2);',
+            ),
+            array(
+                '<?php $a -= $b;',
+                '<?php $a-=$b;',
+            ),
+            array(
+                '<?php $a %= $b;',
+                '<?php $a%=$b;',
+            ),
+            array(
+                '<?php $a *= $b;',
+                '<?php $a*=$b;',
+            ),
+            array(
+                '<?php $a |= $b;',
+                '<?php $a|=$b;',
+            ),
+            array(
+                '<?php $a += $b;',
+                '<?php $a+=$b;',
+            ),
+            array(
+                '<?php $a << $b;',
+                '<?php $a<<$b;',
+            ),
+            array(
+                '<?php $a <<= $b;',
+                '<?php $a<<=$b;',
+            ),
+            array(
+                '<?php $a >> $b;',
+                '<?php $a>>$b;',
+            ),
+            array(
+                '<?php $a >>= $b;',
+                '<?php $a>>=$b;',
+            ),
+            array(
+                '<?php $a ^= $b;',
+                '<?php $a^=$b;',
+            ),
+            array(
+                '<?php $a = $b;',
+                '<?php $a=$b;',
+            ),
+            array(
+                '<?php $a = array("b" => "c", );',
+                '<?php $a = array("b"=>"c", );',
+            ),
+        );
+    }
+
+    private function getTestFile()
+    {
+        return new \SplFileInfo(__FILE__);
+    }
+}


### PR DESCRIPTION
Ensure there ise at least one space around operator, e.g. `$a =1` => `$a = 1`;
