### PR TITLE
[minor] Single-line arrays should not have trailing comma.

### DIFF
--- a/Symfony/CS/Fixer/ControlSpacesFixer.php
+++ b/Symfony/CS/Fixer/ControlSpacesFixer.php
@@ -103,7 +103,7 @@ class ControlSpacesFixer implements FixerInterface
     private function fixControlsWithPrefixBraceAndParentheses($content)
     {
         $statements = array(
-            'while'
+            'while',
         );
 
         return preg_replace(sprintf('/}[^\S\n]*(%s)[^\S\n]*\((.*)\)/', implode('|', $statements)), '} \\1 (\\2)', $content);
@@ -155,7 +155,7 @@ class ControlSpacesFixer implements FixerInterface
             ),
             array(
                 '\\1 (\\2\\3) {',
-                '\\1 (\\2) {'
+                '\\1 (\\2) {',
             ),
             $content
         );

--- a/Symfony/CS/Fixer/IncludeFixer.php
+++ b/Symfony/CS/Fixer/IncludeFixer.php
@@ -52,7 +52,7 @@ class IncludeFixer implements FixerInterface
                     $tokens->removeLeadingWhitespace($braces['close']);
                     $tokens->removeTrailingWhitespace($braces['close']);
 
-                    $tokens[$braces['open']] = new Token(array(T_WHITESPACE, ' ', ));
+                    $tokens[$braces['open']] = new Token(array(T_WHITESPACE, ' '));
                     $tokens[$braces['close']]->clear();
                 }
             }
@@ -67,7 +67,7 @@ class IncludeFixer implements FixerInterface
             if ($nextToken->isWhitespace()) {
                 $nextToken->content = ' ';
             } elseif ($braces) {
-                $tokens->insertAt($includy['begin'] + 1, new Token(array(T_WHITESPACE, ' ', )));
+                $tokens->insertAt($includy['begin'] + 1, new Token(array(T_WHITESPACE, ' ')));
             }
         }
     }

--- a/Symfony/CS/Fixer/LowercaseNativeConstantsFixer.php
+++ b/Symfony/CS/Fixer/LowercaseNativeConstantsFixer.php
@@ -26,9 +26,9 @@ class LowercaseNativeConstantsFixer implements FixerInterface
         foreach ($tokens as $index => $token) {
             if ($token->isNativeConstant()) {
                 if (
-                    $tokens->getPrevNonWhitespace($index, array('whitespaces' => " \t\n", ))->isArray()
+                    $tokens->getPrevNonWhitespace($index, array('whitespaces' => " \t\n"))->isArray()
                     ||
-                    $tokens->getNextNonWhitespace($index, array('whitespaces' => " \t\n", ))->isArray()
+                    $tokens->getNextNonWhitespace($index, array('whitespaces' => " \t\n"))->isArray()
                 ) {
                     continue;
                 }

--- a/Symfony/CS/Fixer/NewWithBracesFixer.php
+++ b/Symfony/CS/Fixer/NewWithBracesFixer.php
@@ -32,7 +32,7 @@ class NewWithBracesFixer implements FixerInterface
             }
 
             $nextIndex = null;
-            $nextToken = $tokens->getNextTokenOfKind($index, array(';', ',', '(', ')', '[', ']', ), $nextIndex);
+            $nextToken = $tokens->getNextTokenOfKind($index, array(';', ',', '(', ')', '[', ']'), $nextIndex);
 
             // no correct end of code - break
             if (null === $nextToken) {
@@ -44,7 +44,7 @@ class NewWithBracesFixer implements FixerInterface
                 $braceLevel = 1;
 
                 while (0 < $braceLevel) {
-                    $nextToken = $tokens->getNextTokenOfKind($nextIndex, array('[', ']', ), $nextIndex);
+                    $nextToken = $tokens->getNextTokenOfKind($nextIndex, array('[', ']'), $nextIndex);
                     $braceLevel += ('[' === $nextToken->content ? 1 : -1);
                 }
 
@@ -59,7 +59,7 @@ class NewWithBracesFixer implements FixerInterface
             $meaningBeforeNextIndex = null;
             $tokens->getPrevNonWhitespace($nextIndex, array(), $meaningBeforeNextIndex);
 
-            $tokens->insertAt($meaningBeforeNextIndex + 1, array(new Token('('), new Token(')'), ));
+            $tokens->insertAt($meaningBeforeNextIndex + 1, array(new Token('('), new Token(')')));
         }
 
         return $tokens->generateCode();

--- a/Symfony/CS/Fixer/ObjectOperatorFixer.php
+++ b/Symfony/CS/Fixer/ObjectOperatorFixer.php
@@ -32,12 +32,12 @@ class ObjectOperatorFixer implements FixerInterface
             }
 
             // clear whitespace before ->
-            if ($tokens[$index - 1]->isWhitespace(array('whitespaces' => " \t", )) && !$tokens[$index - 2]->isComment()) {
+            if ($tokens[$index - 1]->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isComment()) {
                 $tokens[$index - 1]->clear();
             }
 
             // clear whitespace after ->
-            if ($tokens[$index + 1]->isWhitespace(array('whitespaces' => " \t", )) && !$tokens[$index + 2]->isComment()) {
+            if ($tokens[$index + 1]->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index + 2]->isComment()) {
                 $tokens[$index + 1]->clear();
             }
         }

--- a/Symfony/CS/Fixer/PhpClosingTagFixer.php
+++ b/Symfony/CS/Fixer/PhpClosingTagFixer.php
@@ -24,7 +24,7 @@ class PhpClosingTagFixer implements FixerInterface
     {
         $tokens = Tokens::fromCode($content);
 
-        $kinds = $tokens->findGivenKind(array(T_OPEN_TAG, T_CLOSE_TAG, T_INLINE_HTML, ));
+        $kinds = $tokens->findGivenKind(array(T_OPEN_TAG, T_CLOSE_TAG, T_INLINE_HTML));
 
         // leave code intact if there is:
         // - any T_INLINE_HTML code

--- a/Symfony/CS/Fixer/ShortTagFixer.php
+++ b/Symfony/CS/Fixer/ShortTagFixer.php
@@ -46,7 +46,7 @@ class ShortTagFixer implements FixerInterface
                 continue;
             }
 
-            if ($token->isGivenKind(array(T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_STRING, ))) {
+            if ($token->isGivenKind(array(T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_STRING))) {
                 $tokenContent = '';
                 $tokenContentLength = 0;
                 $parts = explode('<?php ', $token->content);

--- a/Symfony/CS/Fixer/SpacesNearCastFixer.php
+++ b/Symfony/CS/Fixer/SpacesNearCastFixer.php
@@ -38,7 +38,7 @@ class SpacesNearCastFixer implements FixerInterface
                 $token->content = strtr($token->content, $insideCastSpaceReplaceMap);
 
                 // force single whitespace after cast token:
-                if ($tokens[$index + 1]->isWhitespace(array('whitespaces' => " \t", ))) {
+                if ($tokens[$index + 1]->isWhitespace(array('whitespaces' => " \t"))) {
                     // - if next token is whitespaces that contains only spaces and tabs - override next token with single space
                     $tokens[$index + 1]->content = ' ';
                 } elseif (!$tokens[$index + 1]->isWhitespace()) {

--- a/Symfony/CS/Fixer/TernarySpacesFixer.php
+++ b/Symfony/CS/Fixer/TernarySpacesFixer.php
@@ -79,7 +79,7 @@ class TernarySpacesFixer implements FixerInterface
             return;
         }
 
-        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ', $token->line, )));
+        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ', $token->line)));
     }
 
     public function getLevel()

--- a/Symfony/CS/Fixer/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/VisibilityFixer.php
@@ -31,8 +31,8 @@ class VisibilityFixer implements FixerInterface
                 // force whitespace between function keyword and function name to be single space char
                 $tokens[++$index]->content = ' ';
             } elseif ('property' === $element['type']) {
-                $prevToken = $tokens->getPrevTokenOfKind($index, array(';', ',', ));
-                $nextToken = $tokens->getNextTokenOfKind($index, array(';', ',', ));
+                $prevToken = $tokens->getPrevTokenOfKind($index, array(';', ','));
+                $nextToken = $tokens->getNextTokenOfKind($index, array(';', ','));
 
                 if (
                     (!$prevToken || ',' !== $prevToken->content) &&

--- a/Symfony/CS/Tests/Fixer/ObjectOperatorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ObjectOperatorFixerTest.php
@@ -45,7 +45,7 @@ class ObjectOperatorFixerTest extends \PHPUnit_Framework_TestCase
                         ->method3();',
                     '<?php $object->method()
                         ->method2()
-                        ->method3();'
+                        ->method3();',
             ),
             array(
                 '<?php $this
@@ -55,7 +55,7 @@ class ObjectOperatorFixerTest extends \PHPUnit_Framework_TestCase
                  '<?php $this
              ->add()
              // Some comment
-             ->delete();'
+             ->delete();',
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/ShortTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/ShortTagFixerTest.php
@@ -43,14 +43,15 @@ echo \'Foo\';
 
 echo \'Foo\';
 
-'),
+',
+            ),
             array(
                 "<?php if ('<?php' === '<?') { }",
                 "<? if ('<?php' === '<?') { }",
             ),
             array(
                 'foo <?php  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <?php echo "<? ";',
-                'foo <?  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <? echo "<? ";'
+                'foo <?  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <? echo "<? ";',
             ),
             array(
                 '<?php

--- a/Symfony/CS/Tests/TokenTest.php
+++ b/Symfony/CS/Tests/TokenTest.php
@@ -35,7 +35,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
     public function getForeachTokenPrototype()
     {
-        static $prototype = array(T_FOREACH, 'foreach', 123, );
+        static $prototype = array(T_FOREACH, 'foreach', 123);
 
         return $prototype;
     }
@@ -74,15 +74,15 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function provideIsCastCases()
     {
         return array(
-            array($this->getBraceToken(), false, ),
-            array($this->getForeachToken(), false, ),
-            array(new Token(array(T_ARRAY_CAST, '(array)', 1, )), true, ),
-            array(new Token(array(T_BOOL_CAST, '(bool)', 1, )), true, ),
-            array(new Token(array(T_DOUBLE_CAST, '(double)', 1, )), true, ),
-            array(new Token(array(T_INT_CAST, '(int)', 1, )), true, ),
-            array(new Token(array(T_OBJECT_CAST, '(object)', 1, )), true, ),
-            array(new Token(array(T_STRING_CAST, '(string)', 1, )), true, ),
-            array(new Token(array(T_UNSET_CAST, '(unset)', 1, )), true, ),
+            array($this->getBraceToken(), false),
+            array($this->getForeachToken(), false),
+            array(new Token(array(T_ARRAY_CAST, '(array)', 1, )), true),
+            array(new Token(array(T_BOOL_CAST, '(bool)', 1, )), true),
+            array(new Token(array(T_DOUBLE_CAST, '(double)', 1, )), true),
+            array(new Token(array(T_INT_CAST, '(int)', 1, )), true),
+            array(new Token(array(T_OBJECT_CAST, '(object)', 1, )), true),
+            array(new Token(array(T_STRING_CAST, '(string)', 1, )), true),
+            array(new Token(array(T_UNSET_CAST, '(unset)', 1, )), true),
         );
     }
 
@@ -97,14 +97,14 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function provideIsClassyCases()
     {
         $cases = array(
-            array($this->getBraceToken(), false, ),
-            array($this->getForeachToken(), false, ),
-            array(new Token(array(T_CLASS, 'class', 1, )), true, ),
-            array(new Token(array(T_INTERFACE, 'interface', 1, )), true, ),
+            array($this->getBraceToken(), false),
+            array($this->getForeachToken(), false),
+            array(new Token(array(T_CLASS, 'class', 1, )), true),
+            array(new Token(array(T_INTERFACE, 'interface', 1, )), true),
         );
 
         if (defined('T_TRAIT')) {
-            $cases[] = array(new Token(array(T_TRAIT, 'trait', 1, )), true, );
+            $cases[] = array(new Token(array(T_TRAIT, 'trait', 1, )), true);
         }
 
         return $cases;
@@ -121,10 +121,10 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function provideIsCommentCases()
     {
         return array(
-            array($this->getBraceToken(), false, ),
-            array($this->getForeachToken(), false, ),
-            array(new Token(array(T_COMMENT, '/* comment */', 1, )), true, ),
-            array(new Token(array(T_DOC_COMMENT, '/** docs */', 1, )), true, ),
+            array($this->getBraceToken(), false),
+            array($this->getForeachToken(), false),
+            array(new Token(array(T_COMMENT, '/* comment */', 1, )), true),
+            array(new Token(array(T_DOC_COMMENT, '/** docs */', 1, )), true),
         );
     }
 
@@ -136,7 +136,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $braceToken->content = '';
         $this->assertTrue($braceToken->isEmpty());
 
-        $whitespaceToken = new Token(array(T_WHITESPACE, ' ', ));
+        $whitespaceToken = new Token(array(T_WHITESPACE, ' '));
         $this->assertFalse($whitespaceToken->isEmpty());
 
         $whitespaceToken->content = '';
@@ -145,7 +145,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $whitespaceToken->id = null;
         $this->assertTrue($whitespaceToken->isEmpty());
 
-        $whitespaceToken = new Token(array(T_WHITESPACE, ' ', ));
+        $whitespaceToken = new Token(array(T_WHITESPACE, ' '));
         $whitespaceToken->clear();
         $this->assertTrue($whitespaceToken->isEmpty());
     }
@@ -157,15 +157,15 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($braceToken->isGivenKind(T_FOR));
         $this->assertFalse($braceToken->isGivenKind(T_FOREACH));
-        $this->assertFalse($braceToken->isGivenKind(array(T_FOR, )));
-        $this->assertFalse($braceToken->isGivenKind(array(T_FOREACH, )));
-        $this->assertFalse($braceToken->isGivenKind(array(T_FOR, T_FOREACH, )));
+        $this->assertFalse($braceToken->isGivenKind(array(T_FOR)));
+        $this->assertFalse($braceToken->isGivenKind(array(T_FOREACH)));
+        $this->assertFalse($braceToken->isGivenKind(array(T_FOR, T_FOREACH)));
 
         $this->assertFalse($foreachToken->isGivenKind(T_FOR));
         $this->assertTrue($foreachToken->isGivenKind(T_FOREACH));
-        $this->assertFalse($foreachToken->isGivenKind(array(T_FOR, )));
-        $this->assertTrue($foreachToken->isGivenKind(array(T_FOREACH, )));
-        $this->assertTrue($foreachToken->isGivenKind(array(T_FOR, T_FOREACH, )));
+        $this->assertFalse($foreachToken->isGivenKind(array(T_FOR)));
+        $this->assertTrue($foreachToken->isGivenKind(array(T_FOREACH)));
+        $this->assertTrue($foreachToken->isGivenKind(array(T_FOR, T_FOREACH)));
     }
 
     public function testIsKeywords()
@@ -185,13 +185,13 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function provideIsNativeConstantCases()
     {
         return array(
-            array($this->getBraceToken(), false, ),
-            array($this->getForeachToken(), false, ),
-            array(new Token(array(T_STRING, 'null', 1, )), true, ),
-            array(new Token(array(T_STRING, 'false', 1, )), true, ),
-            array(new Token(array(T_STRING, 'true', 1, )), true, ),
-            array(new Token(array(T_STRING, 'tRuE', 1, )), true, ),
-            array(new Token(array(T_STRING, 'TRUE', 1, )), true, ),
+            array($this->getBraceToken(), false),
+            array($this->getForeachToken(), false),
+            array(new Token(array(T_STRING, 'null', 1, )), true),
+            array(new Token(array(T_STRING, 'false', 1, )), true),
+            array(new Token(array(T_STRING, 'true', 1, )), true),
+            array(new Token(array(T_STRING, 'tRuE', 1, )), true),
+            array(new Token(array(T_STRING, 'TRUE', 1, )), true),
         );
     }
 
@@ -206,13 +206,13 @@ class TokenTest extends \PHPUnit_Framework_TestCase
     public function provideIsWhitespaceCases()
     {
         return array(
-            array($this->getBraceToken(), false, ),
-            array($this->getForeachToken(), false, ),
-            array(new Token(' '), true, ),
-            array(new Token("\t "), true, ),
-            array(new Token("\t "), false, array('whitespaces' => ' ', ), ),
-            array(new Token(array(T_WHITESPACE, "\n", 1, )), true, ),
-            array(new Token(array(T_WHITESPACE, "\n", 1, )), false, array('whitespaces' => " \t", ), ),
+            array($this->getBraceToken(), false),
+            array($this->getForeachToken(), false),
+            array(new Token(' '), true),
+            array(new Token("\t "), true),
+            array(new Token("\t "), false, array('whitespaces' => ' ')),
+            array(new Token(array(T_WHITESPACE, "\n", 1)), true),
+            array(new Token(array(T_WHITESPACE, "\n", 1)), false, array('whitespaces' => " \t", )),
         );
     }
 

--- a/Symfony/CS/Token.php
+++ b/Symfony/CS/Token.php
@@ -121,7 +121,7 @@ class Token
                 'T_INTERFACE', 'T_ISSET', 'T_LIST', 'T_LOGICAL_AND', 'T_LOGICAL_OR', 'T_LOGICAL_XOR',
                 'T_NAMESPACE', 'T_NEW', 'T_PRINT', 'T_PRIVATE', 'T_PROTECTED', 'T_PUBLIC', 'T_REQUIRE',
                 'T_REQUIRE_ONCE', 'T_RETURN', 'T_STATIC', 'T_SWITCH', 'T_THROW', 'T_TRAIT', 'T_TRY',
-                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD'
+                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD',
             );
 
             foreach ($keywordsStrings as $keywordName) {
@@ -152,7 +152,7 @@ class Token
      */
     public function isCast()
     {
-        static $castTokens = array(T_ARRAY_CAST, T_BOOL_CAST, T_DOUBLE_CAST, T_INT_CAST, T_OBJECT_CAST, T_STRING_CAST, T_UNSET_CAST, );
+        static $castTokens = array(T_ARRAY_CAST, T_BOOL_CAST, T_DOUBLE_CAST, T_INT_CAST, T_OBJECT_CAST, T_STRING_CAST, T_UNSET_CAST);
 
         return $this->isGivenKind($castTokens);
     }

--- a/Symfony/CS/Tokens.php
+++ b/Symfony/CS/Tokens.php
@@ -323,12 +323,12 @@ class Tokens extends \SplFixedArray
             }
 
             if (T_VARIABLE === $token->id && 0 === $bracesLevel) {
-                $elements[$index] = array('token' => $token, 'type' => 'property', );
+                $elements[$index] = array('token' => $token, 'type' => 'property');
                 continue;
             }
 
             if (T_FUNCTION === $token->id) {
-                $elements[$index] = array('token' => $token, 'type' => 'method', );
+                $elements[$index] = array('token' => $token, 'type' => 'method');
             }
         }
 
@@ -473,7 +473,7 @@ class Tokens extends \SplFixedArray
             array(
                 'abstract' => null,
                 'final' => null,
-                'visibility' => new Token(array(T_PUBLIC, 'public', )),
+                'visibility' => new Token(array(T_PUBLIC, 'public')),
                 'static' => null,
             )
         );
@@ -500,7 +500,7 @@ class Tokens extends \SplFixedArray
             $index,
             $tokenAttribsMap,
             array(
-                'visibility' => new Token(array(T_PUBLIC, 'public', )),
+                'visibility' => new Token(array(T_PUBLIC, 'public')),
                 'static' => null,
             )
         );
@@ -521,7 +521,7 @@ class Tokens extends \SplFixedArray
             $token = $this[--$index];
 
             if (!$token->isArray()) {
-                if (in_array($token->content, array('{', '}', '(', ')', ), true)) {
+                if (in_array($token->content, array('{', '}', '(', ')'), true)) {
                     break;
                 }
 
@@ -542,7 +542,7 @@ class Tokens extends \SplFixedArray
                 continue;
             }
 
-            if ($token->isGivenKind(array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, ))) {
+            if ($token->isGivenKind(array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT))) {
                 continue;
             }
 
@@ -560,7 +560,7 @@ class Tokens extends \SplFixedArray
      */
     public function insertAt($key, $items)
     {
-        $items = is_array($items) ? $items : array($items, );
+        $items = is_array($items) ? $items : array($items);
         $itemsCnt = count($items);
         $oldSize = count($this);
 


### PR DESCRIPTION
Single-line arrays should not have trailing comma - due to Symfony standards.

Discussed in #465.

@stof especially for you ;)
