### PR TITLE
[bug] fix ReadmeCommand

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -144,6 +144,8 @@ and directories that need to be analyzed:
         ->finder(\$finder)
     ;
 
+    ?>
+
 You may also use a blacklist for the Fixers instead of the above shown whitelist approach.
 The following example shows how to use all Fixers but the `psr0` fixer.
 Note the additional <comment>-</comment> in front of the Fixer name.
@@ -159,6 +161,8 @@ Note the additional <comment>-</comment> in front of the Fixer name.
         ->fixers(array('-psr0'))
         ->finder(\$finder)
     ;
+
+    ?>
 
 With the <comment>--config-file</comment> option you can specify the path to the
 <comment>.php_cs</comment> file.

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -197,11 +197,13 @@ EOF;
         $help = preg_replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
         $help = preg_replace('#^ \* ``(.+)``#m', '* **$1**', $help);
         $help = preg_replace("#^\n( +)#m", "\n.. code-block:: bash\n\n$1", $help);
+        $help = preg_replace("#^\.\. code-block:: bash\n\n( +<\?php)#m", ".. code-block:: php\n\n$1", $help);
+        $help = preg_replace_callback("#<\?php.*?\?>#s", function ($matches) {
+            return preg_replace("#\n\n +\?>#", '', preg_replace("#^\.\. code-block:: bash\n\n#m", '', $matches[0]));
+        }, $help);
         $help = preg_replace('#^                        #m', '  ', $help);
         $help = preg_replace('#\*\* +\[#', '** [', $help);
 
-        $output->writeln($header);
-        $output->writeln($help);
-        $output->write($footer);
+        $output->write($header."\n".$help."\n".$footer);
     }
 }


### PR DESCRIPTION
Based on #448 but without problem it generates.
1. Fix overriding `code-block:: php` with `code-block:: bash`
2. Fix adding to output `\r` when running command on Windows and PHP_EOL = "\r\n".

I added `?>` to close php section in FixCommand's help. `?>` is removed in generated README
