### PR TITLE
[feature] Order use statements alphabetically (clean version)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,6 +248,8 @@ Choose from the list of available fixers:
 * **concat_with_spaces** [contrib] Concatenation should be used with at
    least one whitespace around.
 
+* **ordered_use** [contrib] Ordering use statements.
+
 * **short_array_syntax** [contrib] PHP array's should use the PHP 5.4
    short-syntax
 

--- a/Symfony/CS/Fixer/Contrib/OrderUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OrderUseStatementsFixer.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Tokens;
+
+/**
+ * @author Paweł Zaremba <pawzar@gmail.com>
+ */
+class OrderUseStatementsFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $allLines = explode("\n", $content);
+        $tokens   = Tokens::fromCode($content);
+
+        $unorderedLines = $this->findLines($allLines, $tokens);
+        if (count($unorderedLines)) {
+            $lineOrder = $this->getNewOrder($unorderedLines);
+
+            $idx = 0;
+            foreach (array_keys($unorderedLines) as $lineNumber) {
+                $allLines[$lineNumber] = $unorderedLines[$lineOrder[$idx++]];
+            }
+
+            return implode("\n", $allLines);
+        }
+
+        return $content;
+    }
+
+    private function findLines($allLines, $tokens)
+    {
+        $lines = array();
+        foreach ($tokens as $index => $token) {
+            if (T_USE === $token->id) {
+                $nextToken = $tokens->getNextNonWhitespace($index);
+                if ($nextToken && $nextToken->id) {
+                    $lines[$token->line - 1] = $allLines[$nextToken->line - 1];
+                }
+            }
+        }
+
+        return $lines;
+    }
+
+    private function getNewOrder(array $lines)
+    {
+        $newLines = array_map(function ($str) {
+            return trim($str);
+        }, $lines);
+        asort($newLines);
+
+        $lineOrder = array();
+        foreach ($newLines as $k => $v) {
+            $lineOrder[] = $k;
+        }
+
+        return $lineOrder;
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::CONTRIB_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+    }
+
+    public function getName()
+    {
+        return 'ordered_use';
+    }
+
+    public function getDescription()
+    {
+        return 'Ordering use statements.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/OrderUseStatementsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/OrderUseStatementsFixerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Fixer\Contrib\OrderUseStatementsFixer as Fixer;
+
+class OrderUseStatementsFixerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFix()
+    {
+        $fixer = new Fixer();
+        $file  = $this->getTestFile();
+
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+ use Foo\Bar;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use Foo\Bar\FooBar as FooBaz;
+use Foo\Zar\Baz;
+use SomeClass;
+use Symfony\Annotation\Template;
+use Symfony\Doctrine\Entities\Entity;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Zoo\Bar, Zoo\Tar;
+
+class AnnotatedClass
+{
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $baz) {};
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Foo\Bar\FooBar as FooBaz;
+use Zoo\Bar, Zoo\Tar;
+ use Foo\Bar;
+use Foo\Zar\Baz;
+use Symfony\Annotation\Template;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use SomeClass;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Symfony\Doctrine\Entities\Entity;
+
+class AnnotatedClass
+{
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $baz) {};
+    }
+}
+EOF;
+
+        $this->assertEquals($expected, $fixer->fix($file, $input));
+    }
+
+    private function getTestFile($filename = __FILE__)
+    {
+        static $files = array();
+
+        if (!isset($files[$filename])) {
+            $files[$filename] = new \SplFileInfo($filename);
+        }
+
+        return $files[$filename];
+    }
+}


### PR DESCRIPTION
Based on #397, ignore merges, cherry-picked fixer itself, resolve conflicts btw
