### PR TITLE
[feat] NoTrailingCommaInSingLineArrayFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,106 +155,117 @@ automatically fix anything:
 
 Choose from the list of available fixers:
 
-* **psr0** [PSR-0] Classes must be in a path that matches
-   their namespace, be at least one namespace deep,
-   and the class name should match the file name.
+* **psr0** [PSR-0] Classes must be in a path that
+            matches their namespace, be at least one
+            namespace deep, and the class name should
+            match the file name.
 
-* **encoding** [PSR-1] PHP code MUST use only UTF-8 without BOM
-   (remove BOM).
+* **encoding** [PSR-1] PHP code MUST use only UTF-8
+            without BOM (remove BOM).
 
-* **short_tag** [PSR-1] PHP code must use the long <?php ?> tags or
-   the short-echo <?= ?> tags; it must not use the
-   other tag variations.
+* **short_tag** [PSR-1] PHP code must use the long <?php
+            ?> tags or the short-echo <?= ?> tags; it
+            must not use the other tag variations.
 
-* **braces** [PSR-2] Opening braces for classes, interfaces,
-   traits and methods must go on the next line, and
-   closing braces must go on the next line after the
-   body. Opening braces for control structures must go
-   on the same line, and closing braces must go on the
-   next line after the body.
+* **braces** [PSR-2] Opening braces for classes,
+            interfaces, traits and methods must go on
+            the next line, and closing braces must go
+            on the next line after the body. Opening
+            braces for control structures must go on
+            the same line, and closing braces must go
+            on the next line after the body.
 
-* **elseif** [PSR-2] The keyword elseif should be used instead
-   of else if so that all control keywords looks like
-   single words.
+* **elseif** [PSR-2] The keyword elseif should be used
+            instead of else if so that all control
+            keywords looks like single words.
 
-* **eof_ending** [PSR-2] A file must always end with an empty line
-   feed.
+* **eof_ending** [PSR-2] A file must always end with an
+            empty line feed.
 
-* **function_declaration** [PSR-2] Spaces should be properly placed in a
-   function declaration
+* **function_declaration** [PSR-2] Spaces should be properly placed
+            in a function declaration
 
-* **indentation** [PSR-2] Code MUST use an indent of 4 spaces, and
-   MUST NOT use tabs for indenting.
+* **indentation** [PSR-2] Code MUST use an indent of 4
+            spaces, and MUST NOT use tabs for
+            indenting.
 
 * **linefeed** [PSR-2] All PHP files must use the Unix LF
-   (linefeed) line ending.
+            (linefeed) line ending.
 
-* **lowercase_constants** [PSR-2] The PHP constants true, false, and null
-   MUST be in lower case.
+* **lowercase_constants** [PSR-2] The PHP constants true, false, and
+            null MUST be in lower case.
 
-* **lowercase_keywords** [PSR-2] PHP keywords MUST be in lower case.
+* **lowercase_keywords** [PSR-2] PHP keywords MUST be in lower
+            case.
 
-* **php_closing_tag** [PSR-2] The closing ?> tag MUST be omitted from
-   files containing only PHP.
+* **php_closing_tag** [PSR-2] The closing ?> tag MUST be omitted
+            from files containing only PHP.
 
-* **trailing_spaces** [PSR-2] Remove trailing whitespace at the end of
-   non-blank lines.
+* **trailing_spaces** [PSR-2] Remove trailing whitespace at the
+            end of non-blank lines.
 
 * **visibility** [PSR-2] Visibility MUST be declared on all
-   properties and methods; abstract and final MUST be
-   declared before the visibility; static MUST be
-   declared after the visibility.
+            properties and methods; abstract and final
+            MUST be declared before the visibility;
+            static MUST be declared after the
+            visibility.
 
-* **concat_without_spaces** [all] Concatenation should be used without spaces.
+* **concat_without_spaces** [all] Concatenation should be used without
+            spaces.
 
-* **controls_spaces** [all] A single space should be between: the closing
-   brace and the control, the control and the opening
-   parentheses, the closing parentheses and the
-   opening brace.
+* **controls_spaces** [all] A single space should be between:
+            the closing brace and the control, the
+            control and the opening parentheses, the
+            closing parentheses and the opening brace.
 
 * **extra_empty_lines** [all] Removes extra empty lines.
 
-* **include** [all] Include and file path should be divided with
-   a single space. File path should not be placed
-   under brackets.
+* **include** [all] Include and file path should be
+            divided with a single space. File path
+            should not be placed under brackets.
 
-* **new_with_braces** [all] All instances created with new keyword must
-   be followed by braces.
+* **new_with_braces** [all] All instances created with new
+            keyword must be followed by braces.
 
-* **object_operator** [all] There should not be space before or after
-   object T_OBJECT_OPERATOR.
+* **object_operator** [all] There should not be space before or
+            after object T_OBJECT_OPERATOR.
 
-* **operators_spaces** [all] Operators should be arounded by at least one
-   space.
+* **operators_spaces** [all] Operators should be arounded by at
+            least one space.
 
-* **phpdoc_params** [all] All items of the @param phpdoc tags must be
-   aligned vertically.
+* **phpdoc_params** [all] All items of the @param phpdoc tags
+            must be aligned vertically.
 
-* **return** [all] An empty line feed should precede a return
-   statement.
+* **return** [all] An empty line feed should precede a
+            return statement.
 
-* **spaces_cast** [all] A single space should be between cast and
-   variable.
+* **single_array_no_trailing_comma** [all] PHP single-line arrays should not
+            have trailing comma.
+
+* **spaces_cast** [all] A single space should be between
+            cast and variable.
 
 * **standardize_not_equal** [all] Replace all <> with !=.
 
-* **ternary_spaces** [all] Standardize spaces around ternary operator.
+* **ternary_spaces** [all] Standardize spaces around ternary
+            operator.
 
-* **unused_use** [all] Unused use statements must be removed.
+* **unused_use** [all] Unused use statements must be
+            removed.
 
-* **whitespacy_lines** [all] Remove trailing whitespace at the end of
-   lines.
+* **whitespacy_lines** [all] Remove trailing whitespace at the
+            end of lines.
 
-* **concat_with_spaces** [contrib] Concatenation should be used with at
-   least one whitespace around.
+* **concat_with_spaces** [contrib] Concatenation should be used
+            with at least one whitespace around.
 
 * **ordered_use** [contrib] Ordering use statements.
 
-* **short_array_syntax** [contrib] PHP array's should use the PHP 5.4
-   short-syntax
+* **short_array_syntax** [contrib] PHP array's should use the PHP
+            5.4 short-syntax
 
-* **strict** [contrib] Comparison should be strict. Warning!
-   This could change code behavior.
+* **strict** [contrib] Comparison should be strict.
+            Warning! This could change code behavior.
 
 
 The ``--config`` option customizes the files to analyse, based

--- a/Symfony/CS/Fixer/Contrib/NoTrailingCommaInSingLineArrayFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NoTrailingCommaInSingLineArrayFixer.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Tokens;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class NoTrailingCommaInSingLineArrayFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($index = 0, $c = $tokens->count(); $index < $c; ++$index) {
+            if ($tokens->isArray($index)) {
+                $this->fixArray($tokens, $index);
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::ALL_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+    }
+
+    public function getName()
+    {
+        return 'single_array_no_trailing_comma';
+    }
+
+    public function getDescription()
+    {
+        return 'PHP single-line arrays should not have trailing comma.';
+    }
+
+    private function fixArray(Tokens $tokens, &$index)
+    {
+        $bracesLevel = 0;
+
+        // Skip only when its an array, for short arrays we need the brace for correct
+        // level counting
+        if ($tokens[$index]->isGivenKind(T_ARRAY)) {
+            ++$index;
+        }
+
+        $multiline = $tokens->isArrayMultiLine($index);
+
+        for ($c = $tokens->count(); $index < $c; ++$index) {
+            $token = $tokens[$index];
+
+            if ('(' === $token->content || '[' === $token->content) {
+                ++$bracesLevel;
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_ARRAY) || $tokens->isShortArray($index)) {
+                $this->fixArray($tokens, $index);
+
+                continue;
+            }
+
+            if (')' === $token->content || ']' === $token->content) {
+                --$bracesLevel;
+
+                $foundIndex = null;
+
+                if (!$multiline && 0 === $bracesLevel && ',' === $tokens->getPrevNonWhitespace($index, array(), $foundIndex)->content) {
+                    $tokens->removeTrailingWhitespace($foundIndex);
+                    $tokens[$foundIndex]->clear();
+                }
+
+                if (0 === $bracesLevel) {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Symfony/CS/Fixer/SpacesAroundOperatorsFixer.php
+++ b/Symfony/CS/Fixer/SpacesAroundOperatorsFixer.php
@@ -32,11 +32,11 @@ class SpacesAroundOperatorsFixer implements FixerInterface
             }
 
             if (!$tokens[$index + 1]->isWhitespace()) {
-                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ', )));
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
             }
 
             if (!$tokens[$index - 1]->isWhitespace()) {
-                $tokens->insertAt($index, new Token(array(T_WHITESPACE, ' ', )));
+                $tokens->insertAt($index, new Token(array(T_WHITESPACE, ' ')));
             }
         }
 

--- a/Symfony/CS/Tests/Fixer/Contrib/NoTrailingCommaInSingLineArrayFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NoTrailingCommaInSingLineArrayFixerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Fixer\Contrib\NoTrailingCommaInSingLineArrayFixer as Fixer;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class NoTrailingCommaInSingLineArrayFixerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input)
+    {
+        $fixer = new Fixer();
+        $file = $this->getTestFile();
+
+        $this->assertSame($expected, $fixer->fix($file, $input));
+    }
+
+    public function provideExamples()
+    {
+        return array(
+            array('<?php $x = array();', '<?php $x = array();'),
+            array('<?php $x = array(());', '<?php $x = array(());'),
+            array('<?php $x = array("foo");', '<?php $x = array("foo");'),
+            array('<?php $x = array("foo");', '<?php $x = array("foo", );'),
+            array("<?php \$x = array(\n'foo', \n);", "<?php \$x = array(\n'foo', \n);"),
+            array("<?php \$x = array('foo', \n);", "<?php \$x = array('foo', \n);"),
+            array("<?php \$x = array(array('foo'), \n);", "<?php \$x = array(array('foo',), \n);"),
+            array("<?php \$x = array(array('foo',\n), \n);", "<?php \$x = array(array('foo',\n), \n);"),
+
+            // Short syntax
+            array('<?php $x = array([]);', '<?php $x = array([]);'),
+            array('<?php $x = [[]];', '<?php $x = [[]];'),
+            array('<?php $x = ["foo"];', '<?php $x = ["foo",];'),
+            array('<?php $x = bar(["foo"]);', '<?php $x = bar(["foo",]);'),
+            array("<?php \$x = bar(['foo'],\n]);", "<?php \$x = bar(['foo'],\n]);"),
+            array("<?php \$x = ['foo', \n];", "<?php \$x = ['foo', \n];"),
+            array('<?php $x = array([]);', '<?php $x = array([],);'),
+            array('<?php $x = [[]];', '<?php $x = [[],];'),
+            array('<?php $x = [$y[]];', '<?php $x = [$y[],];'),
+        );
+    }
+
+    private function getTestFile($filename = __FILE__)
+    {
+        static $files = array();
+
+        if (!isset($files[$filename])) {
+            $files[$filename] = new \SplFileInfo($filename);
+        }
+
+        return $files[$filename];
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -25,10 +25,10 @@ class FixerTest extends \PHPUnit_Framework_TestCase
         $fixer = new Fixer();
 
         $fxPrototypes = array(
-            array('getPriority' =>   0, ),
-            array('getPriority' => -10, ),
-            array('getPriority' =>  10, ),
-            array('getPriority' => -10, ),
+            array('getPriority' =>   0),
+            array('getPriority' => -10),
+            array('getPriority' =>  10),
+            array('getPriority' => -10),
         );
 
         $fxs = array();

--- a/Symfony/CS/Tests/TokenTest.php
+++ b/Symfony/CS/Tests/TokenTest.php
@@ -76,13 +76,13 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         return array(
             array($this->getBraceToken(), false),
             array($this->getForeachToken(), false),
-            array(new Token(array(T_ARRAY_CAST, '(array)', 1, )), true),
-            array(new Token(array(T_BOOL_CAST, '(bool)', 1, )), true),
-            array(new Token(array(T_DOUBLE_CAST, '(double)', 1, )), true),
-            array(new Token(array(T_INT_CAST, '(int)', 1, )), true),
-            array(new Token(array(T_OBJECT_CAST, '(object)', 1, )), true),
-            array(new Token(array(T_STRING_CAST, '(string)', 1, )), true),
-            array(new Token(array(T_UNSET_CAST, '(unset)', 1, )), true),
+            array(new Token(array(T_ARRAY_CAST, '(array)', 1)), true),
+            array(new Token(array(T_BOOL_CAST, '(bool)', 1)), true),
+            array(new Token(array(T_DOUBLE_CAST, '(double)', 1)), true),
+            array(new Token(array(T_INT_CAST, '(int)', 1)), true),
+            array(new Token(array(T_OBJECT_CAST, '(object)', 1)), true),
+            array(new Token(array(T_STRING_CAST, '(string)', 1)), true),
+            array(new Token(array(T_UNSET_CAST, '(unset)', 1)), true),
         );
     }
 
@@ -99,12 +99,12 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $cases = array(
             array($this->getBraceToken(), false),
             array($this->getForeachToken(), false),
-            array(new Token(array(T_CLASS, 'class', 1, )), true),
-            array(new Token(array(T_INTERFACE, 'interface', 1, )), true),
+            array(new Token(array(T_CLASS, 'class', 1)), true),
+            array(new Token(array(T_INTERFACE, 'interface', 1)), true),
         );
 
         if (defined('T_TRAIT')) {
-            $cases[] = array(new Token(array(T_TRAIT, 'trait', 1, )), true);
+            $cases[] = array(new Token(array(T_TRAIT, 'trait', 1)), true);
         }
 
         return $cases;
@@ -123,8 +123,8 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         return array(
             array($this->getBraceToken(), false),
             array($this->getForeachToken(), false),
-            array(new Token(array(T_COMMENT, '/* comment */', 1, )), true),
-            array(new Token(array(T_DOC_COMMENT, '/** docs */', 1, )), true),
+            array(new Token(array(T_COMMENT, '/* comment */', 1)), true),
+            array(new Token(array(T_DOC_COMMENT, '/** docs */', 1)), true),
         );
     }
 
@@ -187,11 +187,11 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         return array(
             array($this->getBraceToken(), false),
             array($this->getForeachToken(), false),
-            array(new Token(array(T_STRING, 'null', 1, )), true),
-            array(new Token(array(T_STRING, 'false', 1, )), true),
-            array(new Token(array(T_STRING, 'true', 1, )), true),
-            array(new Token(array(T_STRING, 'tRuE', 1, )), true),
-            array(new Token(array(T_STRING, 'TRUE', 1, )), true),
+            array(new Token(array(T_STRING, 'null', 1)), true),
+            array(new Token(array(T_STRING, 'false', 1)), true),
+            array(new Token(array(T_STRING, 'true', 1)), true),
+            array(new Token(array(T_STRING, 'tRuE', 1)), true),
+            array(new Token(array(T_STRING, 'TRUE', 1)), true),
         );
     }
 
@@ -212,7 +212,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             array(new Token("\t "), true),
             array(new Token("\t "), false, array('whitespaces' => ' ')),
             array(new Token(array(T_WHITESPACE, "\n", 1)), true),
-            array(new Token(array(T_WHITESPACE, "\n", 1)), false, array('whitespaces' => " \t", )),
+            array(new Token(array(T_WHITESPACE, "\n", 1)), false, array('whitespaces' => " \t")),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | no |
| New Feature? | yes |
| BC Breaks? | no |
| Deprecations? | n |
| Tests Pass? | yes |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

Fixer for `Single-line arrays should not have trailing comma.`

Sent using [Gush](https://github.com/gushphp/gush)
