### PR TITLE
[minor] simplify Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
-before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+install:
+  - composer install
 
 script:
   - phpunit


### PR DESCRIPTION
No need to download composer installer via curl and install it by php.
Just to save few secs on Travis jobs
