### PR TITLE
TrailingCommaInMultiLineArrayFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,9 @@ Choose from the list of available fixers:
             divided with a single space. File path
             should not be placed under brackets.
 
+* **multiline_array_trailing_comma** [all] PHP Multi-line arrays should have a
+            trailing comma
+
 * **new_with_braces** [all] All instances created with new
             keyword must be followed by braces.
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -68,7 +68,7 @@ class FixCommand extends Command
                 new InputOption('level', '', InputOption::VALUE_REQUIRED, 'The level of fixes (can be psr0, psr1, psr2, or all)', null),
                 new InputOption('fixers', '', InputOption::VALUE_REQUIRED, 'A list of fixers to run'),
                 new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
-                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt')
+                new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
             ))
             ->setDescription('Fixes a directory or a file')
             ->setHelp(<<<EOF

--- a/Symfony/CS/Finder/MagentoFinder.php
+++ b/Symfony/CS/Finder/MagentoFinder.php
@@ -37,8 +37,8 @@ class MagentoFinder extends DefaultFinder
                 'app/design/frontend/default',
                 'app/design/frontend/enterprise/default',
                 'app/design/frontend/base',
-                'app/design/adminhtml/default')
-            )
+                'app/design/adminhtml/default',
+            ))
         ;
     }
 

--- a/Symfony/CS/Fixer/TrailingCommaInMultiLineArrayFixer.php
+++ b/Symfony/CS/Fixer/TrailingCommaInMultiLineArrayFixer.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer;
+
+use Symfony\CS\FixerInterface;
+use Symfony\CS\Token;
+use Symfony\CS\Tokens;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class TrailingCommaInMultiLineArrayFixer implements FixerInterface
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            if ($tokens->isArray($index)) {
+                $this->fixArray($tokens, $index);
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::ALL_LEVEL;
+    }
+
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+    }
+
+    public function getName()
+    {
+        return 'multiline_array_trailing_comma';
+    }
+
+    public function getDescription()
+    {
+        return 'PHP multi-line arrays should have a trailing comma';
+    }
+
+    private function fixArray(Tokens $tokens, $index)
+    {
+        $bracesLevel = 0;
+
+        // Skip only when it is an array, for short arrays we need the brace for correct
+        // level counting
+        if ($tokens[$index]->isGivenKind(T_ARRAY)) {
+            ++$index;
+        }
+
+        if (!$tokens->isArrayMultiLine($index)) {
+            return ;
+        }
+
+        for ($c = $tokens->count(); $index < $c; ++$index) {
+            $token = $tokens[$index];
+
+            if ('(' === $token->content || '[' === $token->content) {
+                ++$bracesLevel;
+
+                continue;
+            }
+
+            if (')' === $token->content || ']' === $token->content) {
+                --$bracesLevel;
+
+                if (0 !== $bracesLevel) {
+                    continue;
+                }
+
+                $foundIndex = null;
+                $prevToken = $tokens->getTokenNotOfKindSibling($index, -1, array(array(T_WHITESPACE), array(T_COMMENT), array(T_DOC_COMMENT)), $foundIndex);
+
+                if (',' !== $prevToken->content) {
+                    $tokens->insertAt($foundIndex + 1, array(new Token(',')));
+                }
+
+                break;
+            }
+        }
+    }
+}

--- a/Symfony/CS/Tests/Fixer/TrailingCommaInMultiLineArrayFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/TrailingCommaInMultiLineArrayFixerTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer;
+
+use Symfony\CS\Fixer\TrailingCommaInMultiLineArrayFixer as Fixer;
+
+/**
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ */
+class TrailingCommaInMultiLineArrayFixerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input)
+    {
+        $fixer = new Fixer();
+        $file = $this->getTestFile();
+
+        $this->assertSame($expected, $fixer->fix($file, $input));
+    }
+
+    public function provideExamples()
+    {
+        return array(
+            array('<?php $x = array();', '<?php $x = array();'),
+            array('<?php $x = array(());', '<?php $x = array(());'),
+            array('<?php $x = array("foo");', '<?php $x = array("foo");'),
+            array('<?php $x = array("foo", );', '<?php $x = array("foo", );'),
+            array("<?php \$x = array(\n'foo',\n);", "<?php \$x = array(\n'foo'\n);"),
+            array("<?php \$x = array('foo',\n);", "<?php \$x = array('foo',\n);"),
+            array("<?php \$x = array('foo',\n);", "<?php \$x = array('foo'\n);"),
+            array("<?php \$x = array('foo', /* boo */\n);", "<?php \$x = array('foo' /* boo */\n);"),
+            array("<?php \$x = array('foo',\n/* boo */\n);", "<?php \$x = array('foo'\n/* boo */\n);"),
+            array("<?php \$x = array(\narray('foo',\n),\n);", "<?php \$x = array(\narray('foo'\n)\n);"),
+            array("<?php \$x = array(\narray('foo'),\n);", "<?php \$x = array(\narray('foo')\n);"),
+
+            array(
+                "<?php
+
+                \$x = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? true : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                );
+
+                \$y = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? true : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                );",
+                "<?php
+
+                \$x = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? true : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );
+
+                \$y = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? true : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );",
+            ),
+
+            // Short syntax
+            array('<?php $x = array([]);', '<?php $x = array([]);'),
+            array('<?php $x = [[]];', '<?php $x = [[]];'),
+            array('<?php $x = ["foo",];', '<?php $x = ["foo",];'),
+            array('<?php $x = bar(["foo",]);', '<?php $x = bar(["foo",]);'),
+            array("<?php \$x = bar(['foo',\n]]);", "<?php \$x = bar(['foo'\n]]);"),
+            array("<?php \$x = ['foo', \n];", "<?php \$x = ['foo', \n];"),
+            array('<?php $x = array([],);', '<?php $x = array([],);'),
+            array('<?php $x = [[],];', '<?php $x = [[],];'),
+            array('<?php $x = [$y[],];', '<?php $x = [$y[],];'),
+
+            array(
+                "<?php
+
+                \$x = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? [true] : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                );
+
+                \$y = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? [true] : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                );",
+                "<?php
+
+                \$x = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? [true] : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );
+
+                \$y = array(
+                    'foo',
+                    'bar',
+                    array(
+                        'foo',
+                        'bar',
+                        array(
+                            'foo',
+                            'bar',
+                            array(
+                                'foo',
+                                ('bar' ? [true] : !(false)),
+                                array(
+                                    'foo',
+                                    'bar',
+                                    array(
+                                        'foo',
+                                        ('bar'),
+                                    )
+                                )
+                            )
+                        )
+                    )
+                );",
+            ),
+        );
+    }
+
+    private function getTestFile($filename = __FILE__)
+    {
+        static $files = array();
+
+        if (!isset($files[$filename])) {
+            $files[$filename] = new \SplFileInfo($filename);
+        }
+
+        return $files[$filename];
+    }
+}

--- a/Symfony/CS/Tokens.php
+++ b/Symfony/CS/Tokens.php
@@ -550,6 +550,38 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * Get closest sibling token not of given kind.
+     *
+     * @param  int      $index       token index
+     * @param  int      $direction   direction for looking, +1 or -1
+     * @param  array    $tokens      possible tokens
+     * @param  int|null &$foundIndex index of founded token, if any
+     * @return Token    token
+     */
+    public function getTokenNotOfKindSibling($index, $direction, array $tokens = array(), &$foundIndex = null)
+    {
+        while (true) {
+            $index += $direction;
+
+            if (!$this->offsetExists($index)) {
+                return null;
+            }
+
+            $token = $this[$index];
+
+            foreach ($tokens as $tokenKind) {
+                if (static::compare($token->getPrototype(), $tokenKind)) {
+                    continue 2;
+                }
+            }
+
+            $foundIndex = $index;
+
+            return $token;
+        }
+    }
+
+    /**
      * Grab attributes before method token at gixen index.
      * It's a shorthand for grabAttribsBeforeToken method.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | yes |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | yes |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

This adds the TrailingCommaInMultiLineArrayFixer: PHP Multi-line arrays should have a trailing comma

There is only minor problem that I was unable to resolve, when you have an array like.

``` php
<?php

$x = array(
    array());

?>
```

The result will be.

``` php
<?php

$x = array(
    array(),);

?>
```

Which is not fully correct, but the detection for this is problamatic.

We can't just add a new line, as that will move the closing brace to the beginging of the line.
And looking for the previous whitespace as something like `($y ? 'yes' : 'no')` will detect the wrong whitespace for indenting.

So we can either detect the missing new-line and add it, and let a nother fixer (or manual change) fix this.
Or leave this as it is now, and try to fix this later using either another fixer or improving this fixer.
