### PR TITLE
[minor] fix namespace for NoTrailingCommaInSingLineArrayFixer and it's tests

### DIFF
--- a/Symfony/CS/Fixer/NoTrailingCommaInSingLineArrayFixer.php
+++ b/Symfony/CS/Fixer/NoTrailingCommaInSingLineArrayFixer.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Fixer\Contrib;
+namespace Symfony\CS\Fixer;
 
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Tokens;

--- a/Symfony/CS/Tests/Fixer/NoTrailingCommaInSingLineArrayFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/NoTrailingCommaInSingLineArrayFixerTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests\Fixer\Contrib;
+namespace Symfony\CS\Tests\Fixer;
 
-use Symfony\CS\Fixer\Contrib\NoTrailingCommaInSingLineArrayFixer as Fixer;
+use Symfony\CS\Fixer\NoTrailingCommaInSingLineArrayFixer as Fixer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>


### PR DESCRIPTION
Just couse level is all and not contrib
