### PR TITLE
remove extension check in FixerInterface::supports in fixers working with tokens

### DIFF
--- a/Symfony/CS/Fixer/All/ConcatWithoutSpaces.php
+++ b/Symfony/CS/Fixer/All/ConcatWithoutSpaces.php
@@ -46,7 +46,7 @@ class ConcatWithoutSpaces implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/All/ExtraEmptyLinesFixer.php
@@ -70,7 +70,7 @@ class ExtraEmptyLinesFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/IncludeFixer.php
+++ b/Symfony/CS/Fixer/All/IncludeFixer.php
@@ -181,7 +181,7 @@ class IncludeFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     /**

--- a/Symfony/CS/Fixer/All/NewWithBracesFixer.php
+++ b/Symfony/CS/Fixer/All/NewWithBracesFixer.php
@@ -77,7 +77,7 @@ class NewWithBracesFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/NoTrailingCommaInSingLineArrayFixer.php
+++ b/Symfony/CS/Fixer/All/NoTrailingCommaInSingLineArrayFixer.php
@@ -44,7 +44,7 @@ class NoTrailingCommaInSingLineArrayFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/ObjectOperatorFixer.php
+++ b/Symfony/CS/Fixer/All/ObjectOperatorFixer.php
@@ -57,7 +57,7 @@ class ObjectOperatorFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/SpacesAroundOperatorsFixer.php
+++ b/Symfony/CS/Fixer/All/SpacesAroundOperatorsFixer.php
@@ -92,7 +92,7 @@ class SpacesAroundOperatorsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/SpacesNearCastFixer.php
+++ b/Symfony/CS/Fixer/All/SpacesNearCastFixer.php
@@ -72,7 +72,7 @@ class SpacesNearCastFixer implements FixerInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     /**

--- a/Symfony/CS/Fixer/All/StandardizeNotEqualFixer.php
+++ b/Symfony/CS/Fixer/All/StandardizeNotEqualFixer.php
@@ -44,7 +44,7 @@ class StandardizeNotEqualFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/All/TernarySpacesFixer.php
+++ b/Symfony/CS/Fixer/All/TernarySpacesFixer.php
@@ -94,7 +94,7 @@ class TernarySpacesFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/Contrib/ConcatWithSpaces.php
+++ b/Symfony/CS/Fixer/Contrib/ConcatWithSpaces.php
@@ -54,7 +54,7 @@ class ConcatWithSpaces implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/Contrib/OrderUseStatementsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OrderUseStatementsFixer.php
@@ -80,7 +80,7 @@ class OrderUseStatementsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
@@ -82,7 +82,7 @@ class ShortArraySyntaxFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/Contrib/StrictFixer.php
+++ b/Symfony/CS/Fixer/Contrib/StrictFixer.php
@@ -62,7 +62,7 @@ class StrictFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR1/EncodingFixer.php
+++ b/Symfony/CS/Fixer/PSR1/EncodingFixer.php
@@ -48,7 +48,7 @@ class EncodingFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR1/ShortTagFixer.php
+++ b/Symfony/CS/Fixer/PSR1/ShortTagFixer.php
@@ -90,7 +90,7 @@ class ShortTagFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/BlankLineAfterNamespace.php
+++ b/Symfony/CS/Fixer/PSR2/BlankLineAfterNamespace.php
@@ -61,7 +61,7 @@ class BlankLineAfterNamespace implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/ElseifFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ElseifFixer.php
@@ -71,7 +71,7 @@ class ElseifFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/IndentationFixer.php
+++ b/Symfony/CS/Fixer/PSR2/IndentationFixer.php
@@ -47,7 +47,7 @@ class IndentationFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/LowercaseKeywordsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LowercaseKeywordsFixer.php
@@ -45,7 +45,7 @@ class LowercaseKeywordsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/LowercaseNativeConstantsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LowercaseNativeConstantsFixer.php
@@ -53,7 +53,7 @@ class LowercaseNativeConstantsFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/MultipleUseStatementFixer.php
+++ b/Symfony/CS/Fixer/PSR2/MultipleUseStatementFixer.php
@@ -84,7 +84,7 @@ class MultipleUseStatementFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/PhpClosingTagFixer.php
+++ b/Symfony/CS/Fixer/PSR2/PhpClosingTagFixer.php
@@ -62,7 +62,7 @@ class PhpClosingTagFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
@@ -59,7 +59,7 @@ class VisibilityFixer implements FixerInterface
 
     public function supports(\SplFileInfo $file)
     {
-        return 'php' === pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+        return true;
     }
 
     public function getName()

--- a/Symfony/CS/Tests/Fixer/PSR2/ElseifFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/ElseifFixerTest.php
@@ -83,21 +83,6 @@ if ($b) {
         $this->assertNotEmpty($fixer->getDescription());
     }
 
-    /**
-     * @covers Symfony\CS\Fixer\ElseifFixer::supports
-     */
-    public function testThatOnlyPHPFilesAreSupported()
-    {
-        $phpFile = $this->getTestFile();
-
-        $otherFile = $this->getTestFile(__DIR__.'/../../../../README.rst');
-
-        $fixer = new ElseIfFixer();
-
-        $this->assertTrue($fixer->supports($phpFile));
-        $this->assertFalse($fixer->supports($otherFile));
-    }
-
     public function testThatAreDefinedInPSR2()
     {
         $fixer = new ElseIfFixer();


### PR DESCRIPTION
Extension check should be done in Finder.
If one want to fix only php file he should set it in Finder.
Now we have a Finder that finds .php, .twig etc - but almost all fixers will fix only .php.
What's more - if one have his own extension to fix, like .php5, .inc or .module and set it in Finder, then fixers still do not fix them.
