### PR TITLE
Corrected TrailingCommaInMultiLineArrayFixer namespace

### DIFF
--- a/Symfony/CS/Fixer/All/TrailingCommaInMultiLineArrayFixer.php
+++ b/Symfony/CS/Fixer/All/TrailingCommaInMultiLineArrayFixer.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Fixer;
+namespace Symfony\CS\Fixer\All;
 
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Token;

--- a/Symfony/CS/Tests/Fixer/All/TrailingCommaInMultiLineArrayFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/All/TrailingCommaInMultiLineArrayFixerTest.php
@@ -9,9 +9,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests\Fixer;
+namespace Symfony\CS\Tests\Fixer\All;
 
-use Symfony\CS\Fixer\TrailingCommaInMultiLineArrayFixer as Fixer;
+use Symfony\CS\Fixer\All\TrailingCommaInMultiLineArrayFixer as Fixer;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>


### PR DESCRIPTION
This should have been put into the `All` namespace.
