### PR TITLE
Bump version to 0.6

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -21,7 +21,7 @@ use SebastianBergmann\Diff\Differ;
  */
 class Fixer
 {
-    const VERSION = '0.5-DEV';
+    const VERSION = '0.6-DEV';
 
     protected $fixers = array();
     protected $configs = array();

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "bin": ["php-cs-fixer"],
     "extra": {
         "branch-alias": {
-            "dev-master": "0.5.x-dev"
+            "dev-master": "0.6.x-dev"
         }
     }
 }


### PR DESCRIPTION
The [changes](https://github.com/fabpot/PHP-CS-Fixer/compare/v0.5.7...master) since `v0.5.7` definitely warrant the next release being `v0.6.0`, not `v0.5.8`. There's been a fair bit of refactoring going on, and all the fixers have been moved to different namespaces. Patch releases are meant to fix bugs, while minor releases introduce new things (and in 0.x, introduce BC breaks if required). The changes since the last release are not only significant, but are technically breaking. Do you see my point here?
