### PR TITLE
Fixed Some Docblocks

### DIFF
--- a/Symfony/CS/ConfigAwareInterface.php
+++ b/Symfony/CS/ConfigAwareInterface.php
@@ -17,7 +17,7 @@ namespace Symfony\CS;
 interface ConfigAwareInterface
 {
     /**
-     * Sets the active config on the fixer
+     * Sets the active config on the fixer.
      *
      * @param ConfigInterface $config
      */

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -31,15 +31,16 @@ class FixCommand extends Command
 {
     /**
      * Stopwatch instance.
-     * @type \Symfony\Component\Stopwatch\Stopwatch
+     *
+     * @var \Symfony\Component\Stopwatch\Stopwatch
      */
     protected $stopwatch;
     protected $fixer;
     protected $defaultConfig;
 
     /**
-     * @param Fixer           $fixer
-     * @param ConfigInterface $config
+     * @param Fixer|null           $fixer
+     * @param ConfigInterface|null $config
      */
     public function __construct(Fixer $fixer = null, ConfigInterface $config = null)
     {

--- a/Symfony/CS/Finder/DefaultFinder.php
+++ b/Symfony/CS/Finder/DefaultFinder.php
@@ -56,7 +56,9 @@ class DefaultFinder extends Finder implements FinderInterface
     }
 
     /**
-     * Excludes files because modifying them would break (mainly useful for fixtures in unit tests).
+     * Excludes files because modifying them would break.
+     *
+     * This is mainly useful for fixtures in unit tests.
      *
      * @return array
      */

--- a/Symfony/CS/Finder/MagentoFinder.php
+++ b/Symfony/CS/Finder/MagentoFinder.php
@@ -58,7 +58,9 @@ class MagentoFinder extends DefaultFinder
     }
 
     /**
-     * Excludes files because modifying them would break (mainly useful for fixtures in unit tests).
+     * Excludes files because modifying them would break.
+     *
+     * This is mainly useful for fixtures in unit tests.
      *
      * @return array
      */

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -29,7 +29,8 @@ class Fixer
 
     /**
      * Stopwatch instance.
-     * @type \Symfony\Component\Stopwatch\Stopwatch|null
+     *
+     * @var \Symfony\Component\Stopwatch\Stopwatch|null
      */
     protected $stopwatch;
 
@@ -100,6 +101,8 @@ class Fixer
      * @param ConfigInterface $config A ConfigInterface instance
      * @param Boolean         $dryRun Whether to simulate the changes or not
      * @param Boolean         $diff   Whether to provide diff
+     *
+     * @return array
      */
     public function fix(ConfigInterface $config, $dryRun = false, $diff = false)
     {

--- a/Symfony/CS/StdinFileInfo.php
+++ b/Symfony/CS/StdinFileInfo.php
@@ -27,10 +27,7 @@ class StdinFileInfo extends \SplFileInfo
 
     public function getRealpath()
     {
-        /**
-         * So file_get_contents & friends will work.
-         */
-
+        // So file_get_contents & friends will work.
         return 'php://stdin';
     }
 

--- a/Symfony/CS/Token.php
+++ b/Symfony/CS/Token.php
@@ -21,25 +21,29 @@ class Token
 {
     /**
      * Content of token prototype.
-     * @type string
+     *
+     * @var string
      */
     public $content;
 
     /**
      * ID of token prototype, if available.
-     * @type int|null
+     *
+     * @var int|null
      */
     public $id;
 
     /**
      * If token prototype is an array.
-     * @type bool
+     *
+     * @var bool
      */
     private $isArray;
 
     /**
      * Line of token prototype occurrence, if available.
-     * @type int|null
+     *
+     * @var int|null
      */
     public $line;
 
@@ -63,6 +67,7 @@ class Token
 
     /**
      * Clear token at given index.
+     *
      * Clearing means override token by empty string.
      */
     public function clear()
@@ -202,7 +207,8 @@ class Token
     /**
      * Check if token is one of given kind.
      *
-     * @param  int|array $possibleKind kind or array of kinds
+     * @param int|array $possibleKind kind or array of kinds
+     *
      * @return bool
      */
     public function isGivenKind($possibleKind)
@@ -237,8 +243,9 @@ class Token
     /**
      * Check if token is a whitespace.
      *
-     * @param  array  $opts                array of extra options
-     * @param  string $opts['whitespaces'] string determining whitespaces chars, default is " \t\n"
+     * @param array  $opts                array of extra options
+     * @param string $opts['whitespaces'] string determining whitespaces chars, default is " \t\n"
+     *
      * @return bool
      */
     public function isWhitespace(array $opts = array())

--- a/Symfony/CS/Tokens.php
+++ b/Symfony/CS/Tokens.php
@@ -21,13 +21,15 @@ class Tokens extends \SplFixedArray
 {
     /**
      * Static class cache.
-     * @type array
+     *
+     * @var array
      */
     private static $cache = array();
 
     /**
      * crc32 hash of code string.
-     * @type array
+     *
+     * @var array
      */
     private $codeHash;
 
@@ -52,8 +54,9 @@ class Tokens extends \SplFixedArray
     /**
      * Get cache value for given key.
      *
-     * @param  int|string $key item key
-     * @return misc       item value
+     * @param int|string $key item key
+     *
+     * @return misc item value
      */
     private static function getCache($key)
     {
@@ -67,7 +70,8 @@ class Tokens extends \SplFixedArray
     /**
      * Check if given key exists in cache.
      *
-     * @param  int|string $key item key
+     * @param int|string $key item key
+     *
      * @return bool
      */
     private static function hasCache($key)
@@ -90,8 +94,9 @@ class Tokens extends \SplFixedArray
      * Check if given tokens are equal.
      * If tokens are arrays, then only keys defined in second token are checked.
      *
-     * @param  string|array $tokenA token prototype
-     * @param  string|array $tokenB token prototype or only few keys of it
+     * @param string|array $tokenA token prototype
+     * @param string|array $tokenB token prototype or only few keys of it
+     *
      * @return bool
      */
     public static function compare($tokenA, $tokenB)
@@ -119,8 +124,9 @@ class Tokens extends \SplFixedArray
     /**
      * Create token collection from array.
      *
-     * @param  array  $array       the array to import
-     * @param  bool   $saveIndexes save the numeric indexes used in the original array, default is yes
+     * @param array $array       the array to import
+     * @param bool  $saveIndexes save the numeric indexes used in the original array, default is yes
+     *
      * @return Tokens
      */
     public static function fromArray($array, $saveIndexes = null)
@@ -147,7 +153,8 @@ class Tokens extends \SplFixedArray
     /**
      * Create token collection directly from code.
      *
-     * @param  string $code PHP code
+     * @param string $code PHP code
+     *
      * @return Tokens
      */
     public static function fromCode($code)
@@ -295,6 +302,7 @@ class Tokens extends \SplFixedArray
 
     /**
      * Change code hash.
+     *
      * Remove old cache and set new one.
      *
      * @param string $codeHash new code hash
@@ -311,6 +319,7 @@ class Tokens extends \SplFixedArray
 
     /**
      * Clear empty tokens.
+     *
      * Empty tokens can occur e.g. after calling clear on element of collection.
      */
     public function clearEmptyTokens()
@@ -329,8 +338,9 @@ class Tokens extends \SplFixedArray
     /**
      * Find tokens of given kind.
      *
-     * @param  int|array $possibleKind kind or array of kind
-     * @return array     array of tokens of given kinds or assoc array of arrays
+     * @param int|array $possibleKind kind or array of kind
+     *
+     * @return array array of tokens of given kinds or assoc array of arrays
      */
     public function findGivenKind($possibleKind)
     {
@@ -499,12 +509,14 @@ class Tokens extends \SplFixedArray
 
     /**
      * Get closest next token which is non whitespace.
+     *
      * This method is shorthand for getNonWhitespaceSibling method.
      *
-     * @param  int      $index       token index
-     * @param  array    $opts        array of extra options for isWhitespace method
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param array    $opts        array of extra options for isWhitespace method
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getNextNonWhitespace($index, array $opts = array(), &$foundIndex = null)
     {
@@ -513,12 +525,14 @@ class Tokens extends \SplFixedArray
 
     /**
      * Get closest next token of given kind.
+     *
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param  int      $index       token index
-     * @param  array    $tokens      possible tokens
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param array    $tokens      possible tokens
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getNextTokenOfKind($index, array $tokens = array(), &$foundIndex = null)
     {
@@ -528,11 +542,12 @@ class Tokens extends \SplFixedArray
     /**
      * Get closest sibling token which is non whitespace.
      *
-     * @param  int      $index       token index
-     * @param  int      $direction   direction for looking, +1 or -1
-     * @param  array    $opts        array of extra options for isWhitespace method
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param int      $direction   direction for looking, +1 or -1
+     * @param array    $opts        array of extra options for isWhitespace method
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getNonWhitespaceSibling($index, $direction, array $opts = array(), &$foundIndex = null)
     {
@@ -555,12 +570,14 @@ class Tokens extends \SplFixedArray
 
     /**
      * Get closest previous token which is non whitespace.
+     *
      * This method is shorthand for getNonWhitespaceSibling method.
      *
-     * @param  int      $index       token index
-     * @param  array    $opts        array of extra options for isWhitespace method
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param array    $opts        array of extra options for isWhitespace method
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getPrevNonWhitespace($index, array $opts = array(), &$foundIndex = null)
     {
@@ -571,10 +588,11 @@ class Tokens extends \SplFixedArray
      * Get closest previous token of given kind.
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param  int      $index       token index
-     * @param  array    $tokens      possible tokens
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param array    $tokens      possible tokens
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getPrevTokenOfKind($index, array $tokens = array(), &$foundIndex = null)
     {
@@ -584,11 +602,12 @@ class Tokens extends \SplFixedArray
     /**
      * Get closest sibling token of given kind.
      *
-     * @param  int      $index       token index
-     * @param  int      $direction   direction for looking, +1 or -1
-     * @param  array    $tokens      possible tokens
-     * @param  int|null &$foundIndex index of found token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param int      $direction   direction for looking, +1 or -1
+     * @param array    $tokens      possible tokens
+     * @param int|null &$foundIndex index of found token, if any
+     *
+     * @return Token
      */
     public function getTokenOfKindSibling($index, $direction, array $tokens = array(), &$foundIndex = null)
     {
@@ -614,11 +633,12 @@ class Tokens extends \SplFixedArray
     /**
      * Get closest sibling token not of given kind.
      *
-     * @param  int      $index       token index
-     * @param  int      $direction   direction for looking, +1 or -1
-     * @param  array    $tokens      possible tokens
-     * @param  int|null &$foundIndex index of founded token, if any
-     * @return Token    token
+     * @param int      $index       token index
+     * @param int      $direction   direction for looking, +1 or -1
+     * @param array    $tokens      possible tokens
+     * @param int|null &$foundIndex index of founded token, if any
+     *
+     * @return Token
      */
     public function getTokenNotOfKindSibling($index, $direction, array $tokens = array(), &$foundIndex = null)
     {
@@ -647,7 +667,8 @@ class Tokens extends \SplFixedArray
      * Grab attributes before method token at gixen index.
      * It's a shorthand for grabAttribsBeforeToken method.
      *
-     * @param  int   $index token index
+     * @param int $index token index
+     *
      * @return array array of grabbed attributes
      */
     public function grabAttribsBeforeMethodToken($index)
@@ -677,7 +698,8 @@ class Tokens extends \SplFixedArray
      * Grab attributes before property token at gixen index.
      * It's a shorthand for grabAttribsBeforeToken method.
      *
-     * @param  int   $index token index
+     * @param int $index token index
+     *
      * @return array array of grabbed attributes
      */
     public function grabAttribsBeforePropertyToken($index)
@@ -702,11 +724,13 @@ class Tokens extends \SplFixedArray
 
     /**
      * Grab attributes before token at gixen index.
+     *
      * Grabbed attributes are cleared by overriding them with empty string and should be manually applied with applyTokenAttribs method.
      *
-     * @param  int   $index           token index
-     * @param  array $tokenAttribsMap token to attribute name map
-     * @param  array $attribs         array of token attributes
+     * @param int   $index           token index
+     * @param array $tokenAttribsMap token to attribute name map
+     * @param array $attribs         array of token attributes
+     *
      * @return array array of grabbed attributes
      */
     public function grabAttribsBeforeToken($index, array $tokenAttribsMap, array $attribs)
@@ -797,7 +821,9 @@ class Tokens extends \SplFixedArray
 
     /**
      * If $index is below zero, we know that it does not exist.
-     * This was added to be compatible with HHVM 3.2.0
+     *
+     * This was added to be compatible with HHVM 3.2.0.
+     * Note that HHVM 3.3.0 no longer requires this work around.
      *
      * @param int $index
      *


### PR DESCRIPTION
Just to keep everything the same:
- All short descriptions should end in `.`, `!`, or `?`, and should be followed by a blank line of comment.
- All long descriptions follow the same rules as the short descriptions
- All `@return` annotations should be separated from the `@param` annotations.

Example:

``` php
    /**
     * This is the short description.
     *
     * This is the long description.
     *
     * @param string   $foo
     * @param int|null $bar
     *
     * @return string[] An array of strings
     */
```

I've also standardised the use of `@var` and `@type`. There was a mixture of these, so I went for `@var` since it's supported by more ides/text editors.
