### PR TITLE
New with braces fixer add test

### DIFF
--- a/Symfony/CS/Tests/Fixer/All/NewWithBracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/All/NewWithBracesFixerTest.php
@@ -68,8 +68,7 @@ class NewWithBracesFixerTest extends \PHPUnit_Framework_TestCase
                 '<?php $a = new $b[$c]();',
                 '<?php $a = new $b[$c];',
             ),
-	    array(
-                '<?php $a = new $b["a"]()', '<?php $a = new $b["a"]()'),
+	    array('<?php $a = new $b["a"]()', '<?php $a = new $b["a"]()'),
             array(
                 '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]]();',
                 '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]];',


### PR DESCRIPTION
related to #443, but not fixed in #457 

Original code:

```
$a = new $b['foo'()]();
```

CS-fixed code:

```
$a = new $b['foo']();
```

(note the () added after $objectKey in the second line)
