### PR TITLE
improve OrderUseStatementsFixer parsing logic

### DIFF
--- a/Symfony/CS/Tests/Fixer/Contrib/OrderedUseFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/OrderedUseFixerTest.php
@@ -27,19 +27,19 @@ use Foo\Zar\Baz;
 
 <?php
 
- use Foo\Bar;
-   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
-use Foo\Bar\FooBar as FooBaz;
+use Foo\Bar;
+use Foo\Bar\Foo as Fooo, Foo\Bar\FooBar as FooBaz;
+ use Foo\Bir as FBB;
 use Foo\Zar\Baz;
 use SomeClass;
-use Symfony\Annotation\Template;
-use Symfony\Doctrine\Entities\Entity;
+   use Symfony\Annotation\Template, Symfony\Doctrine\Entities\Entity;
+use Zoo\Bar;
 
 $a = new Bar();
 $a = new FooBaz();
 $a = new someclass();
 
-use Zoo\Bar, Zoo\Tar;
+use Zoo\Tar;
 
 class AnnotatedClass
 {
@@ -52,7 +52,7 @@ class AnnotatedClass
         $bar = $foo->toArray();
         /** @var ArrayInterface $bar */
 
-        return function () use ($bar, $baz) {};
+        return function () use ($bar, $foo) {};
     }
 }
 EOF;
@@ -83,6 +83,400 @@ use Symfony\Doctrine\Entities\Entity;
 
 class AnnotatedClass
 {
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithMultipleNamespace()
+    {
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+namespace FooRoo {
+
+    use Foo\Bar;
+    use Foo\Bar\Foo as Fooo, Foo\Bar\FooBar as FooBaz;
+     use Foo\Bir as FBB;
+    use Foo\Zar\Baz;
+    use SomeClass;
+       use Symfony\Annotation\Template, Zoo\Bar;
+    use Zoo\Tar;
+
+    $a = new Bar();
+    $a = new FooBaz();
+    $a = new someclass();
+
+    use Zoo\Tar;
+
+    class AnnotatedClass
+    {
+        /**
+         * @Template(foobar=21)
+         * @param Entity $foo
+         */
+        public function doSomething($foo)
+        {
+            $bar = $foo->toArray();
+            /** @var ArrayInterface $bar */
+
+            return function () use ($bar, $foo) {};
+        }
+    }
+}
+
+namespace BlaRoo {
+
+    use Foo\Zar\Baz;
+  use SomeClass;
+    use Symfony\Annotation\Template;
+  use Symfony\Doctrine\Entities\Entity, Zoo\Bar;
+
+    class AnnotatedClass
+    {
+        /**
+         * @Template(foobar=21)
+         * @param Entity $foo
+         */
+        public function doSomething($foo)
+        {
+            $bar = $foo->toArray();
+            /** @var ArrayInterface $bar */
+
+            return function () use ($bar, $foo) {};
+        }
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+namespace FooRoo {
+
+    use Foo\Bar\FooBar as FooBaz;
+    use Zoo\Bar, Zoo\Tar;
+     use Foo\Bar;
+    use Foo\Zar\Baz;
+    use Symfony\Annotation\Template;
+       use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+    use SomeClass;
+
+    $a = new Bar();
+    $a = new FooBaz();
+    $a = new someclass();
+
+    use Zoo\Tar;
+
+    class AnnotatedClass
+    {
+        /**
+         * @Template(foobar=21)
+         * @param Entity $foo
+         */
+        public function doSomething($foo)
+        {
+            $bar = $foo->toArray();
+            /** @var ArrayInterface $bar */
+
+            return function () use ($bar, $foo) {};
+        }
+    }
+}
+
+namespace BlaRoo {
+
+    use Foo\Zar\Baz;
+  use Zoo\Bar;
+    use SomeClass;
+  use Symfony\Annotation\Template, Symfony\Doctrine\Entities\Entity;
+
+    class AnnotatedClass
+    {
+        /**
+         * @Template(foobar=21)
+         * @param Entity $foo
+         */
+        public function doSomething($foo)
+        {
+            $bar = $foo->toArray();
+            /** @var ArrayInterface $bar */
+
+            return function () use ($bar, $foo) {};
+        }
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithComment()
+    {
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Foo\Bar;
+use Foo\Bar\Foo as Fooo, Foo\Bar\FooBar /* He there */ as FooBaz;
+ use Foo\Bir as FBB;
+use Foo\Zar\Baz;
+use SomeClass;
+   use /* FIXME */Symfony\Annotation\Template, Symfony\Doctrine\Entities\Entity;
+use Zoo\Bar;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Zoo\Tar;
+
+class AnnotatedClass
+{
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Foo\Bar\FooBar /* He there */ as FooBaz;
+use Zoo\Bar, Zoo\Tar;
+ use Foo\Bar;
+use Foo\Zar\Baz;
+use /* FIXME */Symfony\Annotation\Template;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use SomeClass;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Symfony\Doctrine\Entities\Entity;
+
+class AnnotatedClass
+{
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function test54()
+    {
+        $expected = <<<'EOF'
+<?php
+
+use Foo\Bar;
+use Foo\Bar\Foo as Fooo, Foo\Bar\FooBar as FooBaz;
+ use Foo\Bir as FBB;
+use Foo\Zar\Baz;
+use SomeClass;
+   use Symfony\Annotation\Template, Symfony\Doctrine\Entities\Entity;
+use Zoo\Bar;
+
+use Zoo\Tar;
+
+trait Foo {}
+
+trait Bar {}
+
+class AnnotatedClass
+{
+    use Foo, Bar;
+
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use Foo\Bar\FooBar as FooBaz;
+use Zoo\Bar, Zoo\Tar;
+ use Foo\Bar;
+use Foo\Zar\Baz;
+use Symfony\Annotation\Template;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use SomeClass;
+
+use Symfony\Doctrine\Entities\Entity;
+
+trait Foo {}
+
+trait Bar {}
+
+class AnnotatedClass
+{
+    use Foo, Bar;
+
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testFixWithTraitImports()
+    {
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Acme\MyReusableTrait;
+use Foo\Bar, Foo\Bar\Foo as Fooo;
+ use Foo\Bar\FooBar as FooBaz;
+use Foo\Bir as FBB;
+use Foo\Zar\Baz;
+use SomeClass;
+   use Symfony\Annotation\Template, Symfony\Doctrine\Entities\Entity;
+use Zoo\Bar;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Zoo\Tar;
+
+class AnnotatedClass
+{
+    use MyReusableTrait;
+
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $baz) {};
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Foo\Bar\FooBar as FooBaz;
+use Zoo\Bar, Zoo\Tar;
+ use Foo\Bar;
+use Foo\Zar\Baz;
+use Acme\MyReusableTrait;
+use Symfony\Annotation\Template;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use SomeClass;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Symfony\Doctrine\Entities\Entity;
+
+class AnnotatedClass
+{
+    use MyReusableTrait;
+
     /**
      * @Template(foobar=21)
      * @param Entity $foo

--- a/Symfony/CS/Tokens.php
+++ b/Symfony/CS/Tokens.php
@@ -484,14 +484,19 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * Get indexes of namespae uses.
+     * Get indexes of namespace uses.
+     *
+     * @param bool $perNamespace Return namespace uses per namespace
+     *
+     * @return array|array[]
      */
-    public function getNamespaceUseIndexes()
+    public function getNamespaceUseIndexes($perNamespace = false)
     {
         $this->rewind();
 
         $uses = array();
         $bracesLevel = 0;
+        $namespaceIndex = 0;
 
         $namespaceWithBraces = false;
 
@@ -501,6 +506,10 @@ class Tokens extends \SplFixedArray
 
                 if ('{' === $nextToken->content) {
                     $namespaceWithBraces = true;
+                }
+
+                if ($perNamespace) {
+                    ++$namespaceIndex;
                 }
 
                 continue;
@@ -527,7 +536,15 @@ class Tokens extends \SplFixedArray
                 continue;
             }
 
-            $uses[] = $index;
+            if (!isset($usesInNamespace[$namespaceIndex])) {
+                $usesInNamespace[$namespaceIndex] = array();
+            }
+
+            $uses[$namespaceIndex][] = $index;
+        }
+
+        if (!$perNamespace && isset($uses[$namespaceIndex])) {
+            return $uses[$namespaceIndex];
         }
 
         return $uses;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | yes |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | yes |
| Fixed Tickets | #499 |
| License | MIT |
- Sort only the actual namespaces and not complete lines
- Detect traits correctly
- Preserve original white space

Todo:
- [x] Resolve Tokens cache bug
- [x] Add some tests with multiple namespaces 
- [x] Fix comments being moved to the wrong position

Sent using [Gush](https://github.com/gushphp/gush)
