### PR TITLE
MultilineArrayTrailingCommaFixer - fix bug that adds comma for empty multiline array

### DIFF
--- a/Symfony/CS/Tests/Fixer/All/MultilineArrayTrailingCommaFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/All/MultilineArrayTrailingCommaFixerTest.php
@@ -29,6 +29,7 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
     public function provideExamples()
     {
         return array(
+            // long syntax tests
             array('<?php $x = array();'),
             array('<?php $x = array(());'),
             array('<?php $x = array("foo");'),
@@ -40,10 +41,17 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
             array("<?php \$x = array('foo',\n/* boo */\n);", "<?php \$x = array('foo'\n/* boo */\n);"),
             array("<?php \$x = array(\narray('foo',\n),\n);", "<?php \$x = array(\narray('foo'\n)\n);"),
             array("<?php \$x = array(\narray('foo'),\n);", "<?php \$x = array(\narray('foo')\n);"),
+            array("<?php \$x = array(\n /* He */ \n);"),
+            array(
+                '<?php
 
+                $foo = array(
+                    array(
+                    ),
+                );',
+            ),
             array(
                 "<?php
-
                 \$x = array(
                     'foo',
                     'bar',
@@ -55,32 +63,8 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
                             'bar',
                             array(
                                 'foo',
-                                ('bar' ? true : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-                );
-
-                \$y = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? true : !(false)),
+                                ('bar' ? true : !false),
+                                ('bar' ? array(true) : !(false)),
                                 array(
                                     'foo',
                                     'bar',
@@ -94,7 +78,6 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
                     ),
                 );",
                 "<?php
-
                 \$x = array(
                     'foo',
                     'bar',
@@ -106,32 +89,8 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
                             'bar',
                             array(
                                 'foo',
-                                ('bar' ? true : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    )
-                                )
-                            )
-                        )
-                    )
-                );
-
-                \$y = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? true : !(false)),
+                                ('bar' ? true : !false),
+                                ('bar' ? array(true) : !(false)),
                                 array(
                                     'foo',
                                     'bar',
@@ -146,7 +105,7 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
                 );",
             ),
 
-            // Short syntax
+            // short syntax tests
             array('<?php $x = array([]);'),
             array('<?php $x = [[]];'),
             array('<?php $x = ["foo",];'),
@@ -156,110 +115,54 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
             array('<?php $x = array([],);'),
             array('<?php $x = [[],];'),
             array('<?php $x = [$y[],];'),
+            array("<?php \$x = [\n /* He */ \n];"),
+            array(
+                '<?php
 
+                $foo = [
+                    [
+                    ],
+                ];',
+            ),
+
+            // no array tests
             array(
                 "<?php
 
-                \$x = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? [true] : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
-                );
-
-                \$y = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? [true] : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    ),
-                                ),
-                            ),
-                        ),
-                    ),
+                throw new BadMethodCallException(
+                    sprintf(
+                        'Method \"%s\" not implemented',
+                        __METHOD__
+                    )
                 );",
+            ),
+            array(
                 "<?php
 
-                \$x = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? [true] : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    )
-                                )
-                            )
-                        )
-                    )
-                );
+                throw new BadMethodCallException(sprintf(
+                    'Method \"%s\" not implemented',
+                    __METHOD__
+                ));",
+            ),
+            array(
+                "<?php
 
-                \$y = array(
-                    'foo',
-                    'bar',
-                    array(
-                        'foo',
-                        'bar',
-                        array(
-                            'foo',
-                            'bar',
-                            array(
-                                'foo',
-                                ('bar' ? [true] : !(false)),
-                                array(
-                                    'foo',
-                                    'bar',
-                                    array(
-                                        'foo',
-                                        ('bar'),
-                                    )
-                                )
-                            )
-                        )
-                    )
-                );",
+                namespace FOS\\RestBundle\\Controller;
+
+                class ExceptionController extends ContainerAware
+                {
+                    public function showAction(Request \$request, \$exception, DebugLoggerInterface \$logger = null, \$format = 'html')
+                    {
+                        if (!\$exception instanceof DebugFlattenException && !\$exception instanceof HttpFlattenException) {
+                            throw new \\InvalidArgumentException(sprintf(
+                                'ExceptionController::showAction can only accept some exceptions (%s, %s), \"%s\" given',
+                                'Symfony\\Component\\HttpKernel\\Exception\\FlattenException',
+                                'Symfony\\Component\\Debug\\Exception\\FlattenException',
+                                get_class(\$exception)
+                            ));
+                        }
+                    }
+                }",
             ),
         );
     }

--- a/Symfony/CS/Tokens.php
+++ b/Symfony/CS/Tokens.php
@@ -21,6 +21,7 @@ class Tokens extends \SplFixedArray
 {
     const BLOCK_TYPE_PARENTHESIS_BRACE = 1;
     const BLOCK_TYPE_CURLY_BRACE = 2;
+    const BLOCK_TYPE_SQUARE_BRACE = 3;
 
     /**
      * Array defining possible block edge.
@@ -34,6 +35,10 @@ class Tokens extends \SplFixedArray
         self::BLOCK_TYPE_PARENTHESIS_BRACE => array(
             'start' => '(',
             'end' => ')',
+        ),
+        self::BLOCK_TYPE_SQUARE_BRACE => array(
+            'start' => '[',
+            'end' => ']',
         ),
     );
 


### PR DESCRIPTION
MultilineArrayTrailingCommaFixer - fix bug that adds comma for empty multiline array.

Clone of PR #534 but squashed manually.
