### PR TITLE
add FileCacheManager

### DIFF
--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -27,6 +27,7 @@ class Config implements ConfigInterface
     protected $fixers;
     protected $dir;
     protected $customFixers;
+    protected $usingCache = false;
 
     public function __construct($name = 'default', $description = 'A default configuration')
     {
@@ -45,6 +46,13 @@ class Config implements ConfigInterface
     public function setDir($dir)
     {
         $this->dir = $dir;
+    }
+
+    public function setUsingCache($usingCache)
+    {
+        $this->usingCache = $usingCache;
+
+        return $this;
     }
 
     public function getDir()
@@ -100,5 +108,10 @@ class Config implements ConfigInterface
     public function getCustomFixers()
     {
         return $this->customFixers;
+    }
+
+    public function usingCache()
+    {
+        return $this->usingCache;
     }
 }

--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -32,12 +32,14 @@ class FileCacheManager
     const COMPOSER_PACKAGE_NAME = 'fabpot/php-cs-fixer';
 
     private $dir;
-    private $oldHashes = array();
+    private $isEnabled;
     private $newHashes = array();
+    private $oldHashes = array();
     private $scriptDir;
 
-    public function __construct($dir)
+    public function __construct($isEnabled, $dir)
     {
+        $this->isEnabled = $isEnabled;
         $this->dir = null !== $dir ? $dir.DIRECTORY_SEPARATOR : '';
         $this->scriptDir = dirname($_SERVER['SCRIPT_NAME']);
         $this->readFromFile();
@@ -50,7 +52,7 @@ class FileCacheManager
 
     public function needFixing($file, $fileContent)
     {
-        if (!$this->isCacheSupported()) {
+        if (!$this->isCacheAvailable()) {
             return true;
         }
 
@@ -70,7 +72,7 @@ class FileCacheManager
 
     public function setFile($file, $fileContent)
     {
-        if (!$this->isCacheSupported()) {
+        if (!$this->isCacheAvailable()) {
             return;
         }
 
@@ -113,12 +115,12 @@ class FileCacheManager
         return Fixer::VERSION;
     }
 
-    private function isCacheSupported()
+    private function isCacheAvailable()
     {
         static $result;
 
         if (null === $result) {
-            $result = $this->isInstalledAsPhar() || $this->isInstalledByComposer();
+            $result = $this->isEnabled && ($this->isInstalledAsPhar() || $this->isInstalledByComposer());
         }
 
         return $result;
@@ -126,7 +128,7 @@ class FileCacheManager
 
     private function isSameFixerVersion($cacheVersion)
     {
-        if (!$this->isCacheSupported()) {
+        if (!$this->isCacheAvailable()) {
             return false;
         }
 
@@ -157,7 +159,7 @@ class FileCacheManager
 
     private function readFromFile()
     {
-        if (!$this->isCacheSupported()) {
+        if (!$this->isCacheAvailable()) {
             return;
         }
 
@@ -177,7 +179,7 @@ class FileCacheManager
 
     private function saveToFile()
     {
-        if (!$this->isCacheSupported()) {
+        if (!$this->isCacheAvailable()) {
             return;
         }
 

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -114,7 +114,7 @@ class Fixer
             $this->stopwatch->openSection();
         }
 
-        $fileCacheManager = new FileCacheManager($config->getDir());
+        $fileCacheManager = new FileCacheManager($config->usingCache(), $config->getDir());
 
         foreach ($config->getFinder() as $file) {
             if ($file->isDir()) {


### PR DESCRIPTION
Add support for caching information about state of fixing files.
Cache is supported only for phar version and version installed via composer.

 File will be processed by PHP CS Fixer only if any of the following conditions is fulfilled:
- cache is not available,
- fixer version changed,
- file is new,
- file changed.
