### PR TITLE
IncludeFixer - fix 'undefined index: open' error

### DIFF
--- a/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
@@ -134,6 +134,10 @@ class IncludeFixerTest extends AbstractFixerTestBase
                 '<?php require ($a ? $b : $c) . $d;',
                 '<?php require($a ? $b : $c) . $d;',
             ),
+            array(
+                '<?php require_once SOME_CONST . "file.php"; require Foo::Bar($baz);',
+                '<?php require_once( SOME_CONST . "file.php" ); require Foo::Bar($baz);',
+            ),
         );
     }
 }


### PR DESCRIPTION
IncludeFixer - fix 'undefined index: open' error on fixing:

``` php
<?php require_once( SOME_CONST . "file.php" ); require Foo::Bar($baz);
```

Simplify IncludeFixer::findIncludies by the way...
