### PR TITLE
Inline control statement that's missing braces does NOT get fixed.

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -117,6 +117,14 @@ class BracesFixerTest extends AbstractFixerTestBase
         }
     }',
             ),
+            array(
+                '<?php
+    if (true) echo 1;',
+                '<?php
+    if (true) {
+        echo 1;
+    }'
+            )
         );
     }
 


### PR DESCRIPTION
Hi @fabpot,

This is a great tool for developers who doesn't use fancy IDEs like PHPStorm, which has PSR2 code formatting built-in.

However, I did find one case that this tool did not fix.  That is an inline control statement that doesn't have braces.  I've added a test case in the existing unit test and it did fail.

Was there a particular reason why this is not supported?

Thanks.
