### PR TITLE
Extra semicolon is appended after the closing brace that happens to be at EOF with a PHP closing tag

### DIFF
--- a/Symfony/CS/Fixer/PSR2/PhpClosingTagFixer.php
+++ b/Symfony/CS/Fixer/PSR2/PhpClosingTagFixer.php
@@ -45,7 +45,7 @@ class PhpClosingTagFixer extends AbstractFixer
             $prevIndex = $tokens->getPrevNonWhitespace($index);
             $prevToken = $tokens[$prevIndex];
 
-            if (!$prevToken->equals(';')) {
+            if (!$prevToken->equalsAny(array(';', '}'))) {
                 $tokens->insertAt($prevIndex + 1, new Token(';'));
             }
         }

--- a/Symfony/CS/Tests/Fixer/PSR2/PhpClosingTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/PhpClosingTagFixerTest.php
@@ -58,6 +58,46 @@ echo \'Foo\';
 <?php echo \'Foo\'; ?>',
             ),
             array('<?php echo "foo";', '<?php echo "foo" ?>'),
+            array(
+                '<?php
+class foo
+{
+    public function bar()
+    {
+        echo "Here I am!";
+    }
+}',
+                '<?php
+class foo
+{
+    public function bar()
+    {
+        echo "Here I am!";
+    }
+}?>',
+            ),
+            array(
+                '<?php
+public function bar()
+{
+    echo "Here I am!";
+}',
+                '<?php
+public function bar()
+{
+    echo "Here I am!";
+}?>',
+            ),
+            array(
+                '<?php
+if (true) {
+    echo "Here I am!";
+}',
+                '<?php
+if (true) {
+    echo "Here I am!";
+}?>',
+            ),
         );
     }
 


### PR DESCRIPTION
Hi @fabpot and @keradus,

I added 3 more cases to the provideCasesWithFullOpenTag test to show that an extra semicolon is appended after the closing brace if that happens to be at EOF with a PHP closing tag.

If these cases are not appropriate to be in this test, I'll be more than happy to move them to a new test.

This is in regards to issues #294. #455.

I will patch up this PR with the fix if this is deemed valid and worthy.

Thanks.
