### PR TITLE
Anonymous function in 5.4 array lead to indentation problem

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -626,6 +626,34 @@ function foo()
     }
 
     /**
+     * @dataProvider provideFixShortArraySyntax54Cases
+     * @requires PHP 5.4
+     */
+    public function testFixShortArraySyntax54($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixShortArraySyntax54Cases()
+    {
+        return array(
+            array(
+                '<?php
+    function myFunction()
+    {
+        return [
+            [
+                "callback" => function ($data) {
+                    return true;
+                }
+            ],
+        ];
+    }'
+            ),
+        );
+    }
+
+    /**
      * @dataProvider provideFixCommentBeforeBraceCases
      */
     public function testFixCommentBeforeBrace($expected, $input = null)


### PR DESCRIPTION
Actually the `BracesFixer` break the indentation.

```
--- Expected
+++ Actual
@@ @@
                 }
-            ],
+        ],
         ];
     }
```
