### PR TITLE
Fix broken handling of trailing comment inside array in MultilineArrayTrailingCommaFixer

### DIFF
--- a/Symfony/CS/Fixer/Symfony/MultilineArrayTrailingCommaFixer.php
+++ b/Symfony/CS/Fixer/Symfony/MultilineArrayTrailingCommaFixer.php
@@ -67,7 +67,9 @@ class MultilineArrayTrailingCommaFixer extends AbstractFixer
         if ($startIndex !== $beforeEndIndex && !$beforeEndToken->equalsAny(array(',', array(T_END_HEREDOC)))) {
             $tokens->insertAt($beforeEndIndex + 1, new Token(','));
 
-            if (!$tokens[$endIndex]->isWhitespace()) {
+            if ($tokens[$endIndex]->isComment()) {
+                $tokens->ensureWhitespaceAtIndex($endIndex, 1, "\n");
+            } elseif (!$tokens[$endIndex]->isWhitespace()) {
                 $tokens->ensureWhitespaceAtIndex($endIndex, 1, ' ');
             }
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/MultilineArrayTrailingCommaFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/MultilineArrayTrailingCommaFixerTest.php
@@ -193,6 +193,18 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
         );
     }',
             ),
+            array(
+                '<?php
+    $var = array(
+        "string",
+        //comment
+    );',
+                '<?php
+    $var = array(
+        "string"
+        //comment
+    );',
+            ),
         );
     }
 }


### PR DESCRIPTION
This is to fix #630
