### PR TITLE
Enabled the ordered_use fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,6 +1,8 @@
 <?php
 
-return Symfony\CS\Config\Config::create()->finder(Symfony\CS\Finder\DefaultFinder::create()
+return Symfony\CS\Config\Config::create()
+    ->fixers(array('ordered_use'))
+    ->finder(Symfony\CS\Finder\DefaultFinder::create()
     ->exclude('Symfony/CS/Tests/Fixtures')
     ->notName('phar-stub.php')
     ->notName('ShortTagFixerTest.php')


### PR DESCRIPTION
@keradus. I've seen at least 2 pull request applying this fixer, so why not actually enable it?
