### PR TITLE
Update project name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fabpot/php-cs-fixer",
+    "name": "friendsofphp/php-cs-fixer",
     "type": "application",
     "description": "A script to automatically fix Symfony Coding Standard",
     "license": "MIT",


### PR DESCRIPTION
Hi @fabpot @keradus 

I tried using the new name in my composer install and it failed.  I looked up on packagist and the install command still uses the old name.  I believe this change should fix that issue.  Please let me know otherwise.  

Thanks.

// cc @GrahamCampbell 
