### PR TITLE
Enable the selfupdate command only when using the PHAR

### DIFF
--- a/Symfony/CS/Console/Application.php
+++ b/Symfony/CS/Console/Application.php
@@ -13,7 +13,6 @@ namespace Symfony\CS\Console;
 
 use Symfony\CS\Console\Command\FixCommand;
 use Symfony\CS\Console\Command\ReadmeCommand;
-use Symfony\CS\Console\Command\SelfUpdateCommand;
 use Symfony\CS\Fixer;
 use Symfony\Component\Console\Application as BaseApplication;
 
@@ -33,7 +32,6 @@ class Application extends BaseApplication
 
         $this->add(new FixCommand());
         $this->add(new ReadmeCommand());
-        $this->add(new SelfUpdateCommand());
     }
 
     public function getLongVersion()

--- a/Symfony/CS/Resources/phar-stub.php
+++ b/Symfony/CS/Resources/phar-stub.php
@@ -20,8 +20,10 @@ Phar::mapPhar('php-cs-fixer.phar');
 require_once 'phar://php-cs-fixer.phar/vendor/autoload.php';
 
 use Symfony\CS\Console\Application;
+use Symfony\CS\Console\Command\SelfUpdateCommand;
 
 $application = new Application();
+$application->add(new SelfUpdateCommand());
 $application->run();
 
 __HALT_COMPILER();


### PR DESCRIPTION
The `selfupdate` command does not really make sense IMHO when installing PHP-CS-Fixer globally via composer or homebrew.
