### PR TITLE
Download php-cs-fixer.phar without sudo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,19 +30,20 @@ your system:
 
 .. code-block:: bash
 
-    $ sudo wget http://get.sensiolabs.org/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer
+    $ wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    $ sudo curl http://get.sensiolabs.org/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer
+    $ curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 
 .. code-block:: bash
 
-    $ sudo chmod a+x /usr/local/bin/php-cs-fixer
+    $ sudo chmod a+x php-cs-fixer
+    $ sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
 
 Then, just run ``php-cs-fixer``.
 

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -69,19 +69,20 @@ your system:
 
 .. code-block:: bash
 
-    \$ sudo wget http://get.sensiolabs.org/php-cs-fixer.phar -O /usr/local/bin/php-cs-fixer
+    \$ wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    \$ sudo curl http://get.sensiolabs.org/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer
+    \$ curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 
 .. code-block:: bash
 
-    \$ sudo chmod a+x /usr/local/bin/php-cs-fixer
+    \$ sudo chmod a+x php-cs-fixer
+    \$ sudo mv php-cs-fixer /usr/local/bin/php-cs-fixer
 
 Then, just run ``php-cs-fixer``.
 


### PR DESCRIPTION
It should not be recommended to download something using `sudo`.
Better to download first without `sudo`, and only do the move using `sudo`.
