### PR TITLE
DuplicateSemicolonFixer - fix clearing whitespace after duplicated semicolon

### DIFF
--- a/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
@@ -39,7 +39,7 @@ class DuplicateSemicolonFixer extends AbstractFixer
                 continue;
             }
 
-            $tokens->removeTrailingWhitespace($index);
+            $tokens->removeLeadingWhitespace($index);
             $token->clear();
         }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
@@ -43,6 +43,10 @@ class DuplicateSemicolonFixerTest extends AbstractFixerTestBase
 ;
     ;',
             ),
+            array(
+                '<?php $foo = 1; ',
+                '<?php $foo = 1;; ',
+            ),
         );
     }
 }


### PR DESCRIPTION
Fix #724
