### PR TITLE
Cleanup the extra empty lines fixer

### DIFF
--- a/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
@@ -26,11 +26,7 @@ class ExtraEmptyLinesFixer extends AbstractFixer
     {
         $tokens = Tokens::fromCode($content);
 
-        foreach ($tokens as $token) {
-            if (!$token->isGivenKind(T_WHITESPACE)) {
-                continue;
-            }
-
+        foreach ($tokens->findGivenKind(T_WHITESPACE) as $token) {
             $content = '';
             $count = 0;
             $parts = explode("\n", $token->getContent());


### PR DESCRIPTION
We can just iterate over the content of `findGivenKind` here instead of getting everything, then checking the kind.
