### PR TITLE
remove the --no-progress option (replaced by the standard -v)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ problems as possible on a given file or directory:
     php php-cs-fixer.phar fix /path/to/dir
     php php-cs-fixer.phar fix /path/to/file
 
-The ``--verbose`` option displays progress notification.
+The ``--verbose`` option displays progress notification and show applied fixers.
 
 The ``--level`` option limits the fixers to apply on the
 project:

--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -31,7 +31,7 @@ class Config implements ConfigInterface
     protected $customFixers;
     protected $usingCache = false;
     protected $usingLinter = true;
-    protected $showProgress = true;
+    protected $hideProgress = false;
 
     public function __construct($name = 'default', $description = 'A default configuration')
     {
@@ -122,9 +122,9 @@ class Config implements ConfigInterface
         return $this->description;
     }
 
-    public function getShowProgress()
+    public function getHideProgress()
     {
-        return $this->showProgress;
+        return $this->hideProgress;
     }
 
     public function addCustomFixer(FixerInterface $fixer)
@@ -139,9 +139,9 @@ class Config implements ConfigInterface
         return $this->customFixers;
     }
 
-    public function showProgress($showProgress)
+    public function hideProgress($hideProgress)
     {
-        $this->showProgress = $showProgress;
+        $this->hideProgress = $hideProgress;
 
         return $this;
     }

--- a/Symfony/CS/ConfigurationResolver.php
+++ b/Symfony/CS/ConfigurationResolver.php
@@ -26,7 +26,7 @@ class ConfigurationResolver
     protected $options = array(
         'fixers' => null,
         'level'  => null,
-        'no-progress' => null,
+        'progress' => null,
     );
 
     public function setAllFixers(array $allFixers)
@@ -84,7 +84,7 @@ class ConfigurationResolver
 
     public function getProgress()
     {
-        return !$this->options['no-progress'] && $this->config->getShowProgress();
+        return $this->options['progress'] && !$this->config->getHideProgress();
     }
 
     protected function resolveByLevel()

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -117,7 +117,7 @@ problems as possible on a given file or directory:
     <info>php %command.full_name% /path/to/dir</info>
     <info>php %command.full_name% /path/to/file</info>
 
-The <comment>--verbose</comment> option displays progress notification.
+The <comment>--verbose</comment> option displays progress notification and show applied fixers.
 
 The <comment>--level</comment> option limits the fixers to apply on the
 project:
@@ -345,9 +345,9 @@ EOF
             ->setAllFixers($this->fixer->getFixers())
             ->setConfig($config)
             ->setOptions(array(
-                'level'         => $input->getOption('level'),
-                'fixers'        => $input->getOption('fixers'),
-                'no-progress'   => !$output->isVerbose(),
+                'level'     => $input->getOption('level'),
+                'fixers'    => $input->getOption('fixers'),
+                'progress'  => $output->isVerbose(),
             ))
             ->resolve();
 

--- a/Symfony/CS/Tests/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/ConfigurationResolverTest.php
@@ -233,27 +233,32 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveProgressWithPositiveConfigAndPositiveOption()
     {
-        $this->resolver->setOption('no-progress', true);
+        $this->config->hideProgress(true);
+        $this->resolver->setOption('progress', true);
 
         $this->assertFalse($this->resolver->getProgress());
     }
 
     public function testResolveProgressWithPositiveConfigAndNegativeOption()
     {
-        $this->assertTrue($this->resolver->getProgress());
-    }
-
-    public function testResolveProgressWithNegativeConfigAndPositiveOption()
-    {
-        $this->config->showProgress(false);
-        $this->resolver->setOption('no-progress', true);
+        $this->config->hideProgress(true);
+        $this->resolver->setOption('progress', false);
 
         $this->assertFalse($this->resolver->getProgress());
     }
 
+    public function testResolveProgressWithNegativeConfigAndPositiveOption()
+    {
+        $this->config->hideProgress(false);
+        $this->resolver->setOption('progress', true);
+
+        $this->assertTrue($this->resolver->getProgress());
+    }
+
     public function testResolveProgressWithNegativeConfigAndNegativeOption()
     {
-        $this->config->showProgress(false);
+        $this->config->hideProgress(false);
+        $this->resolver->setOption('progress', false);
 
         $this->assertFalse($this->resolver->getProgress());
     }


### PR DESCRIPTION
This fixes two problems:
- We already have a way to make things quiet or verbose via the various `-v` option, so adding yet another one (`--no-progress`) seems unnecessary;
- Displaying progress by default is a small BC break especially for people using the fixer in their continuous integration workflow.
