### PR TITLE
LowercaseKeywordsFixer - __HALT_COMPILER must not be lowercased

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -10,7 +10,6 @@ return Symfony\CS\Config\Config::create()
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()
             ->exclude('Symfony/CS/Tests/Fixtures')
-            ->notName('phar-stub.php')
             ->notName('ShortTagFixerTest.php')
             ->in(__DIR__)
     )

--- a/Symfony/CS/Fixer/PSR2/LowercaseKeywordsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LowercaseKeywordsFixer.php
@@ -21,6 +21,8 @@ use Symfony\CS\Tokenizer\Tokens;
  */
 class LowercaseKeywordsFixer extends AbstractFixer
 {
+    private static $excludedTokens = array(T_HALT_COMPILER);
+
     /**
      * {@inheritdoc}
      */
@@ -29,7 +31,7 @@ class LowercaseKeywordsFixer extends AbstractFixer
         $tokens = Tokens::fromCode($content);
 
         foreach ($tokens as $token) {
-            if ($token->isKeyword()) {
+            if ($token->isKeyword() && !$token->isGivenKind(self::$excludedTokens)) {
                 $token->setContent(strtolower($token->getContent()));
             }
         }

--- a/Symfony/CS/Tests/Fixer/PSR2/LowercaseKeywordsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LowercaseKeywordsFixerTest.php
@@ -34,4 +34,12 @@ class LowercaseKeywordsFixerTest extends AbstractFixerTestBase
             array('<?php echo "GOOD AS NEW";'),
         );
     }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testHaltCompiler()
+    {
+        $this->makeTest('<?php __HALT_COMPILER();');
+    }
 }


### PR DESCRIPTION
When __HALT_COMPILER is lowercase then PHP produce an error:

```
PharException: internal corruption of phar "foo.phar" (__HALT_COMPILER(); not found)
```

So we should stop lowercasing it.
