### PR TITLE
Fixer that converts old style constructors into __construct()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,6 +332,9 @@ Choose from the list of available fixers:
 * **multiline_spaces_before_semicolon** [contrib] Multi-line whitespace before
                 closing semicolon are prohibited.
 
+* **old_style_constructor** [contrib] Fixer converts old style
+                constructors to __construct.
+
 * **ordered_use** [contrib] Ordering use statements.
 
 * **short_array_syntax** [contrib] PHP array's should use the

--- a/Symfony/CS/Fixer/Contrib/OldStyleConstructorFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OldStyleConstructorFixer.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Szymon Piasecki <szymon.piasecki@gmail.com>
+ */
+class OldStyleConstructorFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_CLASS) as $index => $classToken) {
+            $classOpen = $tokens->getNextTokenOfKind($index, array('{'));
+            $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classOpen);
+
+            if ($this->hasMethodNamed($tokens, "__construct", $classOpen, $classEnd)) {
+                continue;
+            }
+
+            $className = $tokens[$tokens->getNextNonWhitespace($index)]->getContent();
+            if (!$this->hasMethodNamed($tokens, $className, $classOpen, $classEnd)) {
+                continue;
+            }
+
+            $constructorIndex = $this->getMethodByName($tokens, $className, $classOpen, $classEnd);
+            $tokens[$tokens->getNextNonWhitespace($constructorIndex)]->setContent("__construct");
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * Check if class has a method with given name.
+     *
+     * @param Tokens $tokens collection of tokens
+     * @param string $name   method name to find
+     * @param int    $start  index of class start
+     * @param int    $end    index of class end
+     *
+     * @return bool
+     */
+    protected function hasMethodNamed(Tokens $tokens, $name, $start, $end)
+    {
+        return $this->getMethodByName($tokens, $name, $start, $end) !== null;
+    }
+
+    /**
+     * Get index of class method with given name.
+     *
+     * @param Tokens $tokens collection of tokens
+     * @param string $name   method name to find
+     * @param int    $start  index of class start
+     * @param int    $end    index of class end
+     *
+     * @return int|null
+     */
+    protected function getMethodByName(Tokens $tokens, $name, $start, $end)
+    {
+        for ($i = $start;$i <= $end; $i++) {
+            if (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $methodName = $tokens->getNextNonWhitespace($i);
+            if ($tokens[$methodName]->getContent() === $name) {
+                return $i;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'An old PHP style constructors fixer.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run after PSR2\VisibilityFixer
+        return -10;
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/OldStyleConstructorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/OldStyleConstructorFixerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+class OldStyleConstructorFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+
+class SomeOldClass
+{
+    public function __construct($foo)
+    {
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+class SomeOldClass
+{
+    public function SomeOldClass($foo)
+    {
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testMixedConstructorsFix()
+    {
+        $input = <<<'EOF'
+<?php
+
+class SomeNewClass
+{
+    public function __construct($foo)
+    {
+    }
+
+    public function SomeNewClass($foo)
+    {
+    }
+}
+EOF;
+
+        $this->makeTest($input, $input);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/OldStyleConstructorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/OldStyleConstructorFixerTest.php
@@ -15,7 +15,65 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 class OldStyleConstructorFixerTest extends AbstractFixerTestBase
 {
-    public function testFix()
+    public function testClassWithAnonymous()
+    {
+        $input = <<<'EOF'
+<?php
+
+class Foo {
+
+    public function foo()
+    {
+        $bar = function () {};
+    }
+}
+
+EOF;
+        $this->makeTest($input);
+    }
+
+    public function classWithComments()
+    {
+        $input = <<<'EOF'
+<?php
+
+class /* test */ Foo {
+    public function /* test */ Foo($param) {
+
+    }
+}
+EOF;
+
+        $expected = <<<'EOF'
+<?php
+
+class /* test */ Foo {
+    public function /* test */ __construct($param) {
+
+    }
+}
+EOF;
+        $this->makeTest($input, $expected);
+    }
+
+    public function testWithNamespace()
+    {
+        $input = <<<'EOF'
+<?php
+namespace Testing;
+
+class SomeOldClass
+{
+    public function SomeOldClass($foo)
+    {
+    }
+}
+EOF;
+
+        $this->makeTest($input);
+    }
+
+    public function testConstuctorFix()
     {
         $expected = <<<'EOF'
 <?php
@@ -59,6 +117,6 @@ class SomeNewClass
 }
 EOF;
 
-        $this->makeTest($input, $input);
+        $this->makeTest($input);
     }
 }


### PR DESCRIPTION
Please share your thoughts on this fixer.

I need to implement ignoring of oldstyle constructors in namespaced classes (added in PHP 5.3.3), and the fixer should be done.

I'm wodndering if there are some more rules that i should consider in this fixer?