### PR TITLE
Extract the cache manager instantiation to a method

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -158,7 +158,7 @@ class Fixer
 
         return $changed;
     }
-    
+
     protected function getCacheManager(ConfigInterface $config)
     {
         return new FileCacheManager($config->usingCache(), $config->getDir(), $config->getFixers());


### PR DESCRIPTION
This will allow people to easily override this. For example, I want to have a cache for my repos controlled outside the repo code because I am running hard git resets and would lose the cache if i stored it in the repo I'm fixing.
