### PR TITLE
Add docblock indent fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,6 +289,10 @@ Choose from the list of available fixers:
 * **operators_spaces** [symfony] Operators should be arounded
                 by at least one space.
 
+* **phpdoc_indent** [symfony] Docblocks should have the
+                same indentation as the documented
+                subject.
+
 * **phpdoc_params** [symfony] All items of the @param
                 phpdoc tags must be aligned
                 vertically.
@@ -336,10 +340,6 @@ Choose from the list of available fixers:
                 closing semicolon are prohibited.
 
 * **ordered_use** [contrib] Ordering use statements.
-
-* **phpdoc_indent** [contrib] Docblocks should have the
-                same indentation as the documented
-                subject.
 
 * **short_array_syntax** [contrib] PHP array's should use the
                 PHP 5.4 short-syntax.

--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Fixer\Contrib;
+namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests\Fixer\Contrib;
+namespace Symfony\CS\Tests\Fixer\Symfony;
 
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 


### PR DESCRIPTION
Ensure that docblocks for class methods and attributes are indented if present
EDIT: Ensure that any docblock uses the same indentation as the documented subject, regardless the type
