### PR TITLE
Added phpdoc_separation fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,9 @@ Choose from the list of available fixers:
                 phpdoc tags must be aligned
                 vertically.
 
+* **phpdoc_separation** [symfony] Annotations in phpdocs
+                should be separated correctly.
+
 * **remove_leading_slash_use** [symfony] Remove leading slashes in
                 use clauses.
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocSeparationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+            $tokens[$index]->setContent($this->fixDocBlock($token->getContent()));
+        }
+
+        return $tokens->generateCode();
+    }
+
+    private function fixDocBlock($content)
+    {
+        $lines = explode("\n", str_replace(array("\r\n", "\r"), "\n", $content));
+
+        $l = count($lines);
+
+        for ($i = 0; $i < $l; ++$i) {
+            $line = $lines[$i];
+            if ($this->lineIsAnAnnotation($line)) {
+                $type = $this->getAnnotationType($line);
+                $next = $i + 1;
+                while (true) {
+                    if ($next > $l - 1) {
+                        break;
+                    }
+
+                    $nextLine = $lines[$next];
+
+                    if (!$this->lineHasContent($nextLine) || $this->lineIsATerminator($nextLine)) {
+                        break;
+                    }
+
+                    if ($this->lineIsAnAnnotation($nextLine)) {
+                        if ($type !== $this->getAnnotationType($nextLine)) {
+                            $new = str_pad("*", strlen($line) - strlen(ltrim($line)) + 1, ' ', STR_PAD_LEFT);
+                            array_splice($lines, $next, 0, array($new));
+                        }
+
+                        break;
+                    }
+
+                    ++$next;
+                }
+            } elseif ($this->lineHasContent($line)) {
+                $next = $i + 1;
+                while (true) {
+                    if ($next > $l - 1) {
+                        break;
+                    }
+
+                    $nextLine = $lines[$next];
+
+                    if (!$this->lineHasContent($nextLine) || $this->lineIsATerminator($nextLine)) {
+                        break;
+                    }
+
+                    if ($this->lineIsAnAnnotation($nextLine)) {
+                        $new = str_pad("*", strlen($line) - strlen(ltrim($line)) + 1, ' ', STR_PAD_LEFT);
+                        array_splice($lines, $next, 0, array($new));
+
+                        break;
+                    }
+
+                    ++$next;
+                }
+
+                // update the line count
+                $l = count($lines);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function lineHasContent($line)
+    {
+        return 0 !== preg_match('/\\*\s+\S+/', $line);
+    }
+
+    private function lineIsAnAnnotation($line)
+    {
+        return 0 !== preg_match('/\\*\s+@/', $line);
+    }
+
+    private function getAnnotationType($line)
+    {
+        if (preg_match('/\\*\s+@param/', $line)) {
+            return 'param';
+        }
+
+        if (preg_match('/\\*\s+@throws/', $line)) {
+            return 'throws';
+        }
+
+        if (preg_match('/\\*\s+@return/', $line)) {
+            return 'return';
+        }
+    }
+
+    private function lineIsATerminator($line)
+    {
+        return 0 !== preg_match('/\\*\//', $line);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Annotations in phpdocs should be separated correctly.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run before the PhpdocParamsFixer
+        return 10;
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocSeparationFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     *
+     * @return void
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixMore()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * @param string $foo
+     *
+     * @throws Exception
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     * @param string $foo
+     * @throws Exception
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixEverything()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @param string $foo
+     *  @param bool  $bar
+     *
+     * @throws Exception|RuntimeException
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     * @param string $foo
+     *  @param bool  $bar
+     * @throws Exception|RuntimeException
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -182,6 +182,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['standardize_not_equal'], $fixers['strict']),
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['multiline_array_trailing_comma']),
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['align_double_arrow']),
+            array($fixers['phpdoc_separation'], $fixers['phpdoc_params']),
         );
     }
 


### PR DESCRIPTION
The idea here is to go from:

``` php
    /**
     * @param EngineInterface $templating
     * @return void
     */
```

to 

``` php
    /**
     * @param EngineInterface $templating
     *
     * @return void
     */
```
