### PR TITLE
MultilineArrayTrailingCommaFixer - do not move array end to new line

### DIFF
--- a/Symfony/CS/Fixer/Symfony/MultilineArrayTrailingCommaFixer.php
+++ b/Symfony/CS/Fixer/Symfony/MultilineArrayTrailingCommaFixer.php
@@ -67,9 +67,9 @@ class MultilineArrayTrailingCommaFixer extends AbstractFixer
         if ($startIndex !== $beforeEndIndex && !$beforeEndToken->equalsAny(array(',', array(T_END_HEREDOC)))) {
             $tokens->insertAt($beforeEndIndex + 1, new Token(','));
 
-            if ($tokens[$endIndex]->isComment()) {
-                $tokens->ensureWhitespaceAtIndex($endIndex, 1, "\n");
-            } elseif (!$tokens[$endIndex]->isWhitespace()) {
+            $endToken = $tokens[$endIndex];
+
+            if (!$endToken->isComment() && !$endToken->isWhitespace()) {
                 $tokens->ensureWhitespaceAtIndex($endIndex, 1, ' ');
             }
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/MultilineArrayTrailingCommaFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/MultilineArrayTrailingCommaFixerTest.php
@@ -229,6 +229,26 @@ class MultilineArrayTrailingCommaFixerTest extends AbstractFixerTestBase
         //comment
     );',
             ),
+            array(
+                '<?php
+    $var = array(
+        "string",
+        /* foo */);',
+                '<?php
+    $var = array(
+        "string"
+        /* foo */);',
+            ),
+            array(
+                '<?php
+    $var = [
+        "string",
+        /* foo */];',
+                '<?php
+    $var = [
+        "string"
+        /* foo */];',
+            ),
         );
     }
 }


### PR DESCRIPTION
Currently

``` php
<?php
    $var = array(
        "string",
        /* foo */);
```

is changed:

``` diff
 <?php
     $var = array(
-        "string"
-        /* foo */);
+        "string",
+        /* foo */ 
+);
```

First, this fixer is not supposed to move end of array, and next, the end of array is wrongly placed (no indent)

The fixer should only add a comma, like:

``` diff
 <?php
     $var = array(
-        "string"
+        "string",
         /* foo */);
```
