### PR TITLE
PhpdocParamsFixer: added aligning var/type annotations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,7 +293,8 @@ Choose from the list of available fixers:
                 same indentation as the documented
                 subject.
 
-* **phpdoc_params** [symfony] All items of the @param
+* **phpdoc_params** [symfony] All items of the @param,
+                @throws, @return, @var, and @type
                 phpdoc tags must be aligned
                 vertically.
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
@@ -29,11 +29,11 @@ class PhpdocParamsFixer extends AbstractFixer
         // e.g. @param <hint> <$var>
         $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>&?\$[^\s]+)';
         // e.g. @return <hint>
-        $returnThrowsTag = '(?P<tag2>return|throws)\s+(?P<hint2>[^\s]+?)';
+        $otherTags = '(?P<tag2>return|throws|var|type)\s+(?P<hint2>[^\s]+?)';
         // optional <desc>
         $desc = '(?:\s+(?P<desc>.*)|\s*)';
 
-        $this->regex = '/^ {5}\* @(?:'.$paramTag.'|'.$returnThrowsTag.')'.$desc.'$/';
+        $this->regex = '/^ {5}\* @(?:'.$paramTag.'|'.$otherTags.')'.$desc.'$/';
         $this->regexCommentLine = '/^ {5}\*(?:\s+(?P<desc>.+))$/';
     }
 
@@ -56,7 +56,7 @@ class PhpdocParamsFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'All items of the @param phpdoc tags must be aligned vertically.';
+        return 'All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically.';
     }
 
     private function fixDocBlock($content)

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocParamsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocParamsFixerTest.php
@@ -248,4 +248,113 @@ EOF;
 
         $this->makeTest($expected, $input);
     }
+
+    public function testFixWithVar()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var Type
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var   Type
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithType()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @type Type
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @type   Type
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithVarAndDescription()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * This is a variable.
+     *
+     * @var Type
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * This is a variable.
+     *
+     * @var   Type
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithVarAndInlineDescription()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var Type This is a variable.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var   Type   This is a variable.
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithTypeAndInlineDescription()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @type Type This is a variable.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @type   Type   This is a variable.
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
 }


### PR DESCRIPTION
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/838.

I've also added 2 failing tests to demonstrate other issues with this fixer.
