### PR TITLE
Renamed LineAfterNamespaceFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,9 +210,6 @@ Choose from the list of available fixers:
                 spaces, and MUST NOT use tabs for
                 indenting.
 
-* **line_after_namespace** [PSR-2] There MUST be one blank line
-                after the namespace declaration.
-
 * **linefeed** [PSR-2] All PHP files must use the
                 Unix LF (linefeed) line ending.
 
@@ -238,6 +235,9 @@ Choose from the list of available fixers:
 * **php_closing_tag** [PSR-2] The closing ?> tag MUST be
                 omitted from files containing only
                 PHP.
+
+* **single_line_after_namespace** [PSR-2] There MUST be one blank line
+                after the namespace declaration.
 
 * **trailing_spaces** [PSR-2] Remove trailing whitespace at
                 the end of non-blank lines.

--- a/Symfony/CS/Fixer/PSR2/SingleLineAfterNamespaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SingleLineAfterNamespaceFixer.php
@@ -20,7 +20,7 @@ use Symfony\CS\Tokenizer\Tokens;
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class LineAfterNamespaceFixer extends AbstractFixer
+class SingleLineAfterNamespaceFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Tests/Fixer/PSR2/SingleLineAfterNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/SingleLineAfterNamespaceFixerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class LineAfterNamespaceFixerTest extends AbstractFixerTestBase
+class SingleLineAfterNamespaceFixerTest extends AbstractFixerTestBase
 {
     /**
      * @dataProvider provideCases


### PR DESCRIPTION
Its new name is SingleLineAfterNamespaceFixer.
