### PR TITLE
Added More Phpdoc Fixers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -327,14 +327,49 @@ Choose from the list of available fixers:
                 Docblocks should have the same
                 indentation as the documented subject.
 
+* **phpdoc_no_empty_return** [symfony]
+                @return void and @return null
+                annotations should be omitted from
+                phpdocs.
+
+* **phpdoc_no_package** [symfony]
+                @package and @subpackage annotations
+                should be omitted from phpdocs.
+
 * **phpdoc_params** [symfony]
                 All items of the @param, @throws,
                 @return, @var, and @type phpdoc tags
                 must be aligned vertically.
 
+* **phpdoc_separation** [symfony]
+                Annotations in phpdocs should be
+                grouped together so that annotations
+                of the same type immediately follow
+                each other, and annotations of a
+                different type are separated by a
+                single blank line.
+
+* **phpdoc_short_description** [symfony]
+                Phpdocs short descriptions should end
+                in either a full stop, exclamation
+                mark, or question mark.
+
 * **phpdoc_to_comment** [symfony]
                 Docblocks should only be used on
                 structural elements.
+
+* **phpdoc_trim** [symfony]
+                Phpdocs should start and end with
+                content, excluding the very fist and
+                last line of the docblocks.
+
+* **phpdoc_type_to_var** [symfony]
+                @type should always be written as
+                @var.
+
+* **phpdoc_var_without_name** [symfony]
+                @var and @type annotations should not
+                contain the variable name.
 
 * **remove_leading_slash_use** [symfony]
                 Remove leading slashes in use clauses.
@@ -413,6 +448,16 @@ Choose from the list of available fixers:
                 Convert PHP4-style constructors to
                 __construct. Warning! This could
                 change code behavior.
+
+* **phpdoc_order** [contrib]
+                Annotations in phpdocs should be
+                ordered so that param annotations come
+                first, then throws annotations, then
+                return annotations.
+
+* **phpdoc_var_to_type** [contrib]
+                @var should always be written as
+                @type.
 
 * **short_array_syntax** [contrib]
                 PHP array's should use the PHP 5.4

--- a/Symfony/CS/DocBlock/Annotation.php
+++ b/Symfony/CS/DocBlock/Annotation.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\DocBlock;
+
+/**
+ * This represents an entire annotation from a docblock.
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class Annotation
+{
+    /**
+     * The lines that make up the annotation.
+     *
+     * Note that the array indexes represent the position in the docblock.
+     *
+     * @var Lines[]
+     */
+    private $lines;
+
+    /**
+     * The associated tag.
+     *
+     * @var Tag|null
+     */
+    private $tag;
+
+    /**
+     * Create a new line instance.
+     *
+     * @param Lines[] $lines
+     */
+    public function __construct(array $lines)
+    {
+        $this->lines = $lines;
+    }
+
+    /**
+     * Get the start position of this annotation.
+     *
+     * @return int
+     */
+    public function getStart()
+    {
+        $keys = array_keys($this->lines);
+
+        return $keys[0];
+    }
+
+    /**
+     * Get the end position of this annotation.
+     *
+     * @return int
+     */
+    public function getEnd()
+    {
+        $keys = array_keys($this->lines);
+
+        return end($keys);
+    }
+
+    /**
+     * Get the associated tag.
+     *
+     * @return Tag
+     */
+    public function getTag()
+    {
+        if (null === $this->tag) {
+            $values = array_values($this->lines);
+            $this->tag = new Tag($values[0]->getContent());
+        }
+
+        return $this->tag;
+    }
+
+    /**
+     * Remove this annotation by removing all its lines.
+     */
+    public function remove()
+    {
+        foreach ($this->lines as $line) {
+            $line->remove();
+        }
+    }
+
+    /**
+     * Get the annotation content.
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        return implode($this->lines);
+    }
+
+    /**
+     * Get the string representation of object.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getContent();
+    }
+}

--- a/Symfony/CS/DocBlock/DocBlock.php
+++ b/Symfony/CS/DocBlock/DocBlock.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\DocBlock;
+
+use Symfony\CS\Utils;
+
+/**
+ * This class represents a docblock.
+ *
+ * It internally splits it up into "lines" that we can manipulate.
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class DocBlock
+{
+    /**
+     * The array of lines.
+     *
+     * @var Line[]
+     */
+    private $lines = array();
+
+    /**
+     * The array of annotations.
+     *
+     * @var Annotation[]|null
+     */
+    private $annotations;
+
+    /**
+     * Create a new docblock instance.
+     *
+     * @param string $content
+     */
+    public function __construct($content)
+    {
+        foreach (Utils::splitLines($content) as $line) {
+            $this->lines[] = new Line($line);
+        }
+    }
+
+    /**
+     * Get this docblock's lines.
+     *
+     * @return Line[]
+     */
+    public function getLines()
+    {
+        return $this->lines;
+    }
+
+    /**
+     * Get a single line.
+     *
+     * @param int $pos
+     *
+     * @return Line|null
+     */
+    public function getLine($pos)
+    {
+        if (isset($this->lines[$pos])) {
+            return $this->lines[$pos];
+        }
+    }
+
+    /**
+     * Get this docblock's annotations.
+     *
+     * @return Annotation[]
+     */
+    public function getAnnotations()
+    {
+        if (null === $this->annotations) {
+            $this->annotations = array();
+            $total = count($this->lines);
+
+            for ($index = 0; $index < $total; ++$index) {
+                if ($this->lines[$index]->containsATag()) {
+                    // get all the lines that make up the annotation
+                    $lines = array_slice($this->lines, $index, $this->findAnnotationLength($index), true);
+                    $annotation = new Annotation($lines);
+                    // move the index to the end of the annotation to avoid
+                    // checking it again because we know the lines inside the
+                    // current annotation cannot be part of another annotation
+                    $index = $annotation->getEnd();
+                    // add the current annotation to the list of annotations
+                    $this->annotations[] = $annotation;
+                }
+            }
+        }
+
+        return $this->annotations;
+    }
+
+    private function findAnnotationLength($start)
+    {
+        $index = $start;
+
+        while ($line = $this->getLine(++$index)) {
+            if ($line->containsATag()) {
+                // we've 100% reached the end of the description if we get here
+                break;
+            }
+
+            if (!$line->containsUsefulContent()) {
+                // if we next line is also non-useful, or contains a tag, then we're done here
+                $next = $this->getLine($index + 1);
+                if (null === $next || !$next->containsUsefulContent() || $next->containsATag()) {
+                    break;
+                }
+                // otherwise, continue, the annotation must have contained a blank line in its description
+            }
+        }
+
+        return $index - $start;
+    }
+
+    /**
+     * Get a single annotation.
+     *
+     * @param int $pos
+     *
+     * @return Annotation|null
+     */
+    public function getAnnotation($pos)
+    {
+        $annotations = $this->getAnnotations();
+
+        if (isset($annotations[$pos])) {
+            return $annotations[$pos];
+        }
+    }
+
+    /**
+     * Get specific types of annotations only.
+     *
+     * If none exist, we're returning an empty array.
+     *
+     * @param string|string[] $types
+     *
+     * @return Annotations[]
+     */
+    public function getAnnotationsOfType($types)
+    {
+        $annotations = array();
+        $types = (array) $types;
+
+        foreach ($this->getAnnotations() as $annotation) {
+            $tag = $annotation->getTag()->getName();
+            foreach ($types as $type) {
+                if ($type === $tag) {
+                    $annotations[] = $annotation;
+                }
+            }
+        }
+
+        return $annotations;
+    }
+
+    /**
+     * Get the actual content of this docblock.
+     *
+     * @return string
+     */
+    public function getContent()
+    {
+        return implode($this->lines);
+    }
+
+    /**
+     * Get the string representation of object.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getContent();
+    }
+}

--- a/Symfony/CS/DocBlock/Line.php
+++ b/Symfony/CS/DocBlock/Line.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\DocBlock;
+
+/**
+ * This represents a line of a docblock.
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class Line
+{
+    /**
+     * The content of this line.
+     *
+     * @var string
+     */
+    private $content;
+
+    /**
+     * Create a new line instance.
+     *
+     * @param string $content
+     */
+    public function __construct($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Get the content of this line.
+     *
+     * @return int
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * Does this line contain useful content?
+     *
+     * If the line contains text or tags, then this is true.
+     *
+     * @return bool
+     */
+    public function containsUsefulContent()
+    {
+        return 0 !== preg_match('/\\*\s*\S+/', $this->content) && !$this->isTheStart() && !$this->isTheEnd();
+    }
+
+    /**
+     * Does the line contain a tag?
+     *
+     * If this is true, then it must be the first line of an annotation.
+     *
+     * @return bool
+     */
+    public function containsATag()
+    {
+        return 0 !== preg_match('/\\*\s*@/', $this->content);
+    }
+
+    /**
+     * Is the line the start of a docblock?
+     *
+     * @return bool
+     */
+    public function isTheStart()
+    {
+        return false !== strpos($this->content, '/**');
+    }
+
+    /**
+     * Is the line the end of a docblock?
+     *
+     * @return bool
+     */
+    public function isTheEnd()
+    {
+        return false !== strpos($this->content, '*/');
+    }
+
+    /**
+     * Set the content of this line.
+     *
+     * @param string $content
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+
+    /**
+     * Remove this line by clearing its contents.
+     *
+     * Note that this method technically brakes the internal state of the
+     * docblock, but is useful when we need to retain the indexes of lines
+     * during the execution of an algorithm.
+     */
+    public function remove()
+    {
+        $this->content = '';
+    }
+
+    /**
+     * Append a blank docblock line to this line's contents.
+     *
+     * Note that this method technically brakes the internal state of the
+     * docblock, but is useful when we need to retain the indexes of lines
+     * during the execution of an algorithm.
+     */
+    public function addBlank()
+    {
+        preg_match_all('/\ *\*/', $this->content, $matches);
+
+        $this->content .= $matches[0][0]."\n";
+    }
+
+    /**
+     * Get the string representation of object.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->content;
+    }
+}

--- a/Symfony/CS/DocBlock/Tag.php
+++ b/Symfony/CS/DocBlock/Tag.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\DocBlock;
+
+/**
+ * This represents a tag, as defined by the proposed PSR PHPDoc standard.
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class Tag
+{
+    /**
+     * All the tags defined by the proposed PSR PHPDoc standard.
+     *
+     * @var string[]
+     */
+    private static $tags = array(
+        'api', 'author', 'category', 'copyright', 'deprecated', 'example',
+        'global', 'internal', 'license', 'link', 'method', 'package', 'param',
+        'property', 'return', 'see', 'since', 'struct', 'subpackage', 'throws',
+        'todo', 'typedef', 'uses', 'var', 'version',
+    );
+
+    /**
+     * The tag name.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * Create a new tag instance.
+     *
+     * @param string $content
+     */
+    public function __construct($content)
+    {
+        preg_match_all('/@[a-zA-Z0-9_]+/', $content, $matches);
+
+        if (isset($matches[0][0])) {
+            $this->name = strtolower(ltrim($matches[0][0], '@'));
+        } else {
+            $this->name = 'other';
+        }
+    }
+
+    /**
+     * Get the tag name.
+     *
+     * This may be "param", or "return", etc.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Is the tag a known tag.
+     *
+     * This is defined by if it exists in the proposed PSR PHPDoc standard.
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        return in_array($this->name, self::$tags, true);
+    }
+}

--- a/Symfony/CS/DocBlock/TagComparator.php
+++ b/Symfony/CS/DocBlock/TagComparator.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\DocBlock;
+
+/**
+ * This class is responsible for comparing tags to see if they should be kept
+ * together, or kept apart.
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class TagComparator
+{
+    /**
+     * Groups of tags that should be allowed to immediately follow each other.
+     *
+     * @var array
+     */
+    private static $groups = array(
+        array('deprecated', 'link', 'see', 'since'),
+        array('author', 'copyright', 'license'),
+        array('package', 'subpackage'),
+    );
+
+    /**
+     * Should the given tags be kept together, or kept apart?
+     *
+     * @param Tag $first
+     * @param Tag $second
+     *
+     * @return bool
+     */
+    public static function shouldBeTogether(Tag $first, Tag $second)
+    {
+        $firstName = $first->getName();
+        $secondName = $second->getName();
+
+        if ($firstName === $secondName) {
+            return true;
+        }
+
+        foreach (self::$groups as $group) {
+            if (in_array($firstName, $group, true) && in_array($secondName, $group, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Symfony/CS/Fixer/Contrib/EregToPregFixer.php
+++ b/Symfony/CS/Fixer/Contrib/EregToPregFixer.php
@@ -113,7 +113,7 @@ class EregToPregFixer extends AbstractFixer
     }
 
     /**
-     * Check the validity of a PCRE
+     * Check the validity of a PCRE.
      *
      * @param string $pattern the regular expression
      *

--- a/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
+++ b/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
@@ -24,7 +24,7 @@ class HeaderCommentFixer extends AbstractFixer
     private static $headerComment = '';
 
     /**
-     * Sets the desired header text
+     * Sets the desired header text.
      *
      * The given text will be trimmed and enclosed into a multiline comment.
      * If the text is empty, when a file get fixed, the header comment will be
@@ -79,9 +79,10 @@ class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Encloses the given text in a comment block
+     * Encloses the given text in a comment block.
      *
-     * @param  string $header
+     * @param string $header
+     *
      * @return string
      */
     private static function encloseTextInComment($header)
@@ -97,7 +98,7 @@ class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Removes the header comment, if any
+     * Removes the header comment, if any.
      *
      * @param Tokens $tokens
      */
@@ -110,9 +111,10 @@ class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Finds the index where the header comment must be inserted
+     * Finds the index where the header comment must be inserted.
      *
-     * @param  Tokens $tokens
+     * @param Tokens $tokens
+     *
      * @return int
      */
     private function findHeaderCommentInsertionIndex(Tokens $tokens)
@@ -128,7 +130,7 @@ class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Inserts the header comment at the given index
+     * Inserts the header comment at the given index.
      *
      * @param Tokens $tokens
      * @param int    $index

--- a/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
+++ b/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
@@ -262,15 +262,14 @@ class Php4ConstructorFixer extends AbstractFixer
      * @param int    $startIndex the search start index
      * @param int    $endIndex   the search end index
      *
-     * @return array|null {
-     *                    The function/method data, if a match is found.
+     * @return array|null An associative array, if a match is found:
      *
-     *      @var int   $nameIndex  the index of the function/method name
-     *      @var int   $startIndex the index of the function/method start
-     *      @var int   $endIndex   the index of the function/method end
-     *      @var int   $bodyIndex  the index of the function/method body
-     *      @var array $modifiers  the modifiers as array keys and their index as value, e.g. array(T_PUBLIC => 10)
-     * }
+     *     - nameIndex (int): The index of the function/method name.
+     *     - startIndex (int): The index of the function/method start.
+     *     - endIndex (int): The index of the function/method end.
+     *     - bodyIndex (int): The index of the function/method body.
+     *     - modifiers (array): The modifiers as array keys and their index as
+     *       the values, e.g. array(T_PUBLIC => 10).
      */
     private function findFunction(Tokens $tokens, $name, $startIndex, $endIndex)
     {

--- a/Symfony/CS/Fixer/Contrib/PhpdocOrderFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpdocOrderFixer.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocOrderFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $content = $token->getContent();
+            // move param to start, return to end, leave throws in the middle
+            $content = $this->moveParamAnnotations($content);
+            // we're parsing the content again to make sure the internal
+            // state of the dockblock is correct after the modifications
+            $content = $this->moveReturnAnnotations($content);
+            // persist the content at the end
+            $token->setContent($content);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Annotations in phpdocs should be ordered so that param annotations come first, then throws annotations, then return annotations.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must be run before the PhpdocSeperationFixer
+
+        /*
+         * Should be run before the php_doc_seperation fixer so that if we
+         * create incorrect annotation grouping while moving the annotations
+         * about, we're still ok.
+         */
+        return 5;
+    }
+
+    /**
+     * Move all param annotations in before throws and return annotations.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function moveParamAnnotations($content)
+    {
+        $doc = new DocBlock($content);
+        $params = $doc->getAnnotationsOfType('param');
+
+        // nothing to do if there are no param annotations
+        if (empty($params)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(array('throws', 'return'));
+
+        if (empty($others)) {
+            return $content;
+        }
+
+        // get the index of the final line of the final param annotation
+        $end = end($params)->getEnd();
+
+        $line = $doc->getLine($end);
+
+        // move stuff about if required
+        foreach ($others as $other) {
+            if ($other->getStart() < $end) {
+                // we're doing this to maintain the original line indexes
+                $line->setContent($line->getContent().$other->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+
+    /**
+     * Move all return annotations after param and throws annotations.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function moveReturnAnnotations($content)
+    {
+        $doc = new DocBlock($content);
+        $returns = $doc->getAnnotationsOfType('return');
+
+        // nothing to do if there are no return annotations
+        if (empty($returns)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(array('param', 'throws'));
+
+        // nothing to do if there are no other annotations
+        if (empty($others)) {
+            return $content;
+        }
+
+        // get the index of the first line of the first return annotation
+        $start = $returns[0]->getStart();
+        $line = $doc->getLine($start);
+
+        // move stuff about if required
+        foreach (array_reverse($others) as $other) {
+            if ($other->getEnd() > $start) {
+                // we're doing this to maintain the original line indexes
+                $line->setContent($other->getContent().$line->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+}

--- a/Symfony/CS/Fixer/Contrib/PhpdocVarToTypeFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpdocVarToTypeFixer.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocVarToTypeFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType('var');
+
+            if (empty($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $line = $doc->getLine($annotation->getStart());
+                $line->setContent(str_replace('@var', '@type', $line->getContent()));
+            }
+
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return '@var should always be written as @type.';
+    }
+}

--- a/Symfony/CS/Fixer/PSR2/ElseifFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ElseifFixer.php
@@ -22,7 +22,7 @@ use Symfony\CS\Tokenizer\Tokens;
 class ElseifFixer extends AbstractFixer
 {
     /**
-     * Replace all `else if` (T_ELSE T_IF) with `elseif` (T_ELSEIF)
+     * Replace all `else if` (T_ELSE T_IF) with `elseif` (T_ELSEIF).
      *
      * {@inheritdoc}
      */

--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -67,6 +67,22 @@ class PhpdocIndentFixer extends AbstractFixer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        /*
+         * Should be run before all other docblock fixers apart from the
+         * phpdoc_to_comment fixer to make sure all fixers apply correct
+         * indentation to new code they add, and the phpdoc_params fixer only
+         * works on correctly indented docblocks. We also need to be running
+         * after the psr2 indentation fixer for obvious reasons.
+         * comments.
+         */
+        return 20;
+    }
+
+    /**
      * Fix indentation of Docblock.
      *
      * @param string $content Docblock contents

--- a/Symfony/CS/Fixer/Symfony/PhpdocNoEmptyReturnFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocNoEmptyReturnFixer.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\Annotation;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocNoEmptyReturnFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType('return');
+
+            if (empty($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $this->fixAnnotation($doc, $annotation);
+            }
+
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return '@return void and @return null annotations should be omitted from phpdocs.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must be run before the PhpdocSeperationFixer and PhpdocOrderFixer
+        return 10;
+    }
+
+    /**
+     * Remove return void or return null annotations..
+     *
+     * @param DocBlock   $doc
+     * @param Annotation $annotation
+     */
+    private function fixAnnotation(DocBlock $doc, Annotation $annotation)
+    {
+        if (1 === preg_match('/@return\s+(void|null)(?!\|)/', $doc->getLine($annotation->getStart())->getContent())) {
+            $annotation->remove();
+        }
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocNoPackageFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocNoPackageFixer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\Annotation;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocNoPackageFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType(array('package', 'subpackage'));
+
+            // nothing to do if there are no annotations
+            if (empty($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $annotation->remove();
+            }
+
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return '@package and @subpackage annotations should be omitted from phpdocs.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must be run before the PhpdocSeperationFixer and PhpdocOrderFixer
+        return 10;
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
@@ -46,22 +46,11 @@ class PhpdocParamsFixer extends AbstractFixer
     {
         $tokens = Tokens::fromCode($content);
 
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
-            $tokens[$index]->setContent($this->fixDocBlock($token->getContent()));
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $token->setContent($this->fixDocBlock($token->getContent()));
         }
 
         return $tokens->generateCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority()
-    {
-        // should be run after the PhpdocIndentFixer
-        // this is because this fixer currently only deals with docblocks that
-        // are correctly indented, and skips those that are not
-        return -10;
     }
 
     /**
@@ -72,6 +61,26 @@ class PhpdocParamsFixer extends AbstractFixer
         return 'All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically.';
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        /*
+         * Should be run after all other docblock fixers. This because they
+         * modify other annotations to change their type and or separation
+         * which totally change the behavior of this fixer. It's important that
+         * annotations are of the correct type, and are grouped correctly
+         * before running this fixer.
+         */
+        return -10;
+    }
+
+    /**
+     * Fix a given docblock.
+     *
+     * @param string $content
+     */
     private function fixDocBlock($content)
     {
         $lines = Utils::splitLines($content);
@@ -156,6 +165,14 @@ class PhpdocParamsFixer extends AbstractFixer
         return implode($lines);
     }
 
+    /**
+     * Get all matches.
+     *
+     * @param string $line
+     * @param bool   $matchCommentOnly
+     *
+     * @return string[]|null
+     */
     private function getMatches($line, $matchCommentOnly = false)
     {
         if (preg_match($this->regex, $line, $matches)) {

--- a/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\Annotation;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\DocBlock\TagComparator;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocSeparationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+            $doc = new DocBlock($token->getContent());
+            $this->fixDescription($doc);
+            $this->fixAnnotations($doc);
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Annotations in phpdocs should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.';
+    }
+
+    /**
+     * Make sure the description is separated from the annotations.
+     *
+     * @param DocBlock $doc
+     */
+    private function fixDescription(DocBlock $doc)
+    {
+        foreach ($doc->getLines() as $index => $line) {
+            if ($line->containsATag()) {
+                break;
+            }
+
+            if ($line->containsUsefulContent()) {
+                $next = $doc->getLine($index + 1);
+
+                if ($next->containsATag()) {
+                    $line->addBlank();
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Make sure the annotations are correctly separated.
+     *
+     * @param DocBlock $doc
+     */
+    private function fixAnnotations(DocBlock $doc)
+    {
+        foreach ($doc->getAnnotations() as $index => $annotation) {
+            $next = $doc->getAnnotation($index + 1);
+
+            if (null === $next) {
+                break;
+            }
+
+            if (true === $next->getTag()->valid()) {
+                if (TagComparator::shouldBeTogether($annotation->getTag(), $next->getTag())) {
+                    $this->ensureAreTogether($doc, $annotation, $next);
+                } else {
+                    $this->ensureAreSeparate($doc, $annotation, $next);
+                }
+            }
+        }
+
+        return $doc->getContent();
+    }
+
+    /**
+     * Force the given annotations to immediately follow each other.
+     *
+     * @param DocBlock   $doc
+     * @param Annotation $first
+     * @param Annotation $second
+     */
+    private function ensureAreTogether(DocBlock $doc, Annotation $first, Annotation $second)
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart();
+
+        for (++$pos; $pos < $final; ++$pos) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+
+    /**
+     * Force the given annotations to have one empty line between each other.
+     *
+     * @param DocBlock   $doc
+     * @param Annotation $first
+     * @param Annotation $second
+     */
+    private function ensureAreSeparate(DocBlock $doc, Annotation $first, Annotation $second)
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart() - 1;
+
+        // check if we need to add a line, or need to remove one or more lines
+        if ($pos === $final) {
+            $doc->getLine($pos)->addBlank();
+
+            return;
+        }
+
+        for (++$pos; $pos < $final; ++$pos) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocShortDescriptionFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocShortDescriptionFixer.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocShortDescriptionFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+            $end = $this->findShortDescriptionEnd($doc->getLines());
+
+            if (null !== $end) {
+                $line = $doc->getLine($end);
+                $content = rtrim($line->getContent());
+
+                if (!$this->isCorrectlyFormatted($content)) {
+                    $line->setContent($content.".\n");
+                    $token->setContent($doc->getContent());
+                }
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Phpdocs short descriptions should end in either a full stop, exclamation mark, or question mark.';
+    }
+
+    /**
+     * Find the line number of the line containing the end of the short
+     * description, if present.
+     *
+     * @param Lines[] $lines
+     *
+     * @return int|null
+     */
+    private function findShortDescriptionEnd(array $lines)
+    {
+        $reachedContent = false;
+
+        foreach ($lines as $index => $line) {
+            // we went past a description, then hit a tag or blank line, so
+            // the last line of the description must be the one before this one
+            if ($reachedContent && ($line->containsATag() || !$line->containsUsefulContent())) {
+                return $index - 1;
+            }
+
+            // no short description was found
+            if ($line->containsATag()) {
+                return;
+            }
+
+            // we've reached content, but need to check the next lines too
+            // in case the short description is multi-line
+            if ($line->containsUsefulContent()) {
+                $reachedContent = true;
+            }
+        }
+    }
+
+    /**
+     * Is the last line of the short description correctly formatted?
+     *
+     * @param string $content
+     *
+     * @return bool
+     */
+    private function isCorrectlyFormatted($content)
+    {
+        if (false !== strpos(strtolower($content), '{@inheritdoc}')) {
+            return true;
+        }
+
+        return $content !== rtrim($content, '.!?¡¿');
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -79,10 +79,11 @@ class PhpdocToCommentFixer extends AbstractFixer
     public function getPriority()
     {
         /*
-         * Should be run before the PhpdocIndentFixer, PhpdocParamsFixer and NoEmptyLinesAfterPhpdocsFixer
-         * so that these fixers don't touch doc comments which are meant to be converted to regular comments.
+         * Should be run before all other docblock fixers so that these fixers
+         * don't touch doc comments which are meant to be converted to regular
+         * comments.
          */
-        return 5;
+        return 25;
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocTrimFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $content = $token->getContent();
+            $content = $this->fixStart($content);
+            // we need re-parse the docblock after fixing the start before
+            // fixing the end in order for the lines to be correctly indexed
+            $content = $this->fixEnd($content);
+            $token->setContent($content);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Phpdocs should start and end with content, excluding the very fist and last line of the docblocks.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        /*
+         * Should be run after all phpdoc fixers that add or remove tags, or
+         * alter descriptions. This is so that they don't leave behind blank
+         * lines this fixer would have otherwise cleaned up.
+         */
+        return -5;
+    }
+
+    /**
+     * Make sure the first useful line starts immediately after the first line.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function fixStart($content)
+    {
+        $doc = new DocBlock($content);
+        $lines = $doc->getLines();
+        $total = count($lines);
+
+        foreach ($lines as $index => $line) {
+            if (!$line->isTheStart()) {
+                // don't remove lines with content and don't entirely delete docblocks
+                if ($line->containsUsefulContent() || $total - $index < 3) {
+                    break;
+                }
+
+                $line->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+
+    /**
+     * Make sure the last useful is immediately before after the final line.
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    private function fixEnd($content)
+    {
+        $doc = new DocBlock($content);
+        $lines = array_reverse($doc->getLines());
+        $total = count($lines);
+
+        foreach ($lines as $index => $line) {
+            if (!$line->isTheEnd()) {
+                // don't remove lines with content and don't entirely delete docblocks
+                if ($line->containsUsefulContent() || $total - $index < 3) {
+                    break;
+                }
+
+                $line->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocTypeToVarFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType('type');
+
+            if (empty($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $line = $doc->getLine($annotation->getStart());
+                $line->setContent(str_replace('@type', '@var', $line->getContent()));
+            }
+
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return '@type should always be written as @var.';
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\DocBlock\Line;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocVarWithoutNameFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+            $doc = new DocBlock($token->getContent());
+
+            // don't process single line docblocks
+            if (1 === count($doc->getLines())) {
+                continue;
+            }
+
+            $annotations = $doc->getAnnotationsOfType(array('var', 'type'));
+
+            if (empty($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $this->fixLine($doc->getLine($annotation->getStart()));
+            }
+
+            $token->setContent($doc->getContent());
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return '@var and @type annotations should not contain the variable name.';
+    }
+
+    private function fixLine(Line $line)
+    {
+        $content = $line->getContent();
+
+        preg_match_all('/ \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $content, $matches);
+
+        if (isset($matches[0][0])) {
+            $line->setContent(str_replace($matches[0][0], '', $content));
+        }
+    }
+}

--- a/Symfony/CS/Tests/DocBlock/AnnotationTest.php
+++ b/Symfony/CS/Tests/DocBlock/AnnotationTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\DocBlock;
+
+use Symfony\CS\DocBlock\Annotation;
+use Symfony\CS\DocBlock\DocBlock;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class AnnotationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * This represents the content an entire docblock.
+     *
+     * @var string
+     */
+    private static $sample = '/**
+     * Test docblock.
+     *
+     * @param string $hello
+     * @param bool $test Description
+     *        extends over many lines
+     *
+     * @param adkjbadjasbdand $asdnjkasd
+     *
+     * @throws \Exception asdnjkasd
+     *
+     * asdasdasdasdasdasdasdasd
+     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
+     *
+     * @return void
+     */';
+
+    /**
+     * This represents the content of each annotation.
+     *
+     * @var string[]
+     */
+    private static $content = array(
+        "     * @param string \$hello\n",
+        "     * @param bool \$test Description\n     *        extends over many lines\n",
+        "     * @param adkjbadjasbdand \$asdnjkasd\n",
+        "     * @throws \Exception asdnjkasd\n     *\n     * asdasdasdasdasdasdasdasd\n     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb\n",
+        "     * @return void\n",
+    );
+
+    /**
+     * This represents the start indexes of each annotation.
+     *
+     * @var int[]
+     */
+    private static $start = array(3, 4, 7, 9, 14);
+
+    /**
+     * This represents the start indexes of each annotation.
+     *
+     * @var int[]
+     */
+    private static $end = array(3, 5, 7, 12, 14);
+
+    /**
+     * This represents the tag type of each annotation.
+     *
+     * @var int[]
+     */
+    private static $tags = array('param', 'param', 'param', 'throws', 'return');
+
+    /**
+     * @dataProvider provideContent
+     */
+    public function testGetContent($index, $content)
+    {
+        $doc = new DocBlock(self::$sample);
+        $annotation = $doc->getAnnotation($index);
+
+        $this->assertSame($content, $annotation->getContent());
+        $this->assertSame($content, (string) $annotation);
+    }
+
+    public function provideContent()
+    {
+        $cases = array();
+
+        foreach (self::$content as $index => $content) {
+            $cases[] = array($index, $content);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideStartCases
+     */
+    public function testStart($index, $start)
+    {
+        $doc = new DocBlock(self::$sample);
+        $annotation = $doc->getAnnotation($index);
+
+        $this->assertSame($start, $annotation->getStart());
+    }
+
+    public function provideStartCases()
+    {
+        $cases = array();
+
+        foreach (self::$start as $index => $start) {
+            $cases[] = array($index, $start);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideEndCases
+     */
+    public function testEnd($index, $end)
+    {
+        $doc = new DocBlock(self::$sample);
+        $annotation = $doc->getAnnotation($index);
+
+        $this->assertSame($end, $annotation->getEnd());
+    }
+
+    public function provideEndCases()
+    {
+        $cases = array();
+
+        foreach (self::$end as $index => $end) {
+            $cases[] = array($index, $end);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideTags
+     */
+    public function testGetTag($index, $tag)
+    {
+        $doc = new DocBlock(self::$sample);
+        $annotation = $doc->getAnnotation($index);
+
+        $this->assertSame($tag, $annotation->getTag()->getName());
+    }
+
+    public function provideTags()
+    {
+        $cases = array();
+
+        foreach (self::$tags as $index => $tag) {
+            $cases[] = array($index, $tag);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideRemoveCases
+     */
+    public function testRemove($index, $start, $end)
+    {
+        $doc = new DocBlock(self::$sample);
+        $annotation = $doc->getAnnotation($index);
+
+        $annotation->remove();
+        $this->assertSame('', $annotation->getContent());
+        $this->assertSame('', $doc->getLine($start)->getContent());
+        $this->assertSame('', $doc->getLine($end)->getContent());
+    }
+
+    public function provideRemoveCases()
+    {
+        $cases = array();
+
+        foreach (self::$start as $index => $start) {
+            $cases[] = array($index, $start, self::$end[$index]);
+        }
+
+        return $cases;
+    }
+}

--- a/Symfony/CS/Tests/DocBlock/DocBlockTest.php
+++ b/Symfony/CS/Tests/DocBlock/DocBlockTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\DocBlock;
+
+use Symfony\CS\DocBlock\DocBlock;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class DocBlockTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * This represents the content an entire docblock.
+     *
+     * @var string
+     */
+    private static $sample = '/**
+     * Test docblock.
+     *
+     * @param string $hello
+     * @param bool $test Description
+     *        extends over many lines
+     *
+     * @param adkjbadjasbdand $asdnjkasd
+     *
+     * @throws \Exception asdnjkasd
+     * asdasdasdasdasdasdasdasd
+     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
+     *
+     * @return void
+     */';
+
+    public function testContent()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $this->assertSame(self::$sample, $doc->getContent());
+        $this->assertSame(self::$sample, (string) $doc);
+    }
+
+    public function testEmptyContent()
+    {
+        $doc = new DocBlock('');
+
+        $this->assertSame('', $doc->getContent());
+    }
+
+    public function testGetLines()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $this->assertInternalType('array', $doc->getLines());
+        $this->assertCount(15, $doc->getLines());
+
+        foreach ($doc->getLines() as $index => $line) {
+            $this->assertInstanceOf('Symfony\CS\DocBlock\Line', $line);
+            $this->assertSame($doc->getLine($index), $line);
+        }
+
+        $this->assertEmpty($doc->getLine(15));
+    }
+
+    public function testGetAnnotations()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $this->assertInternalType('array', $doc->getAnnotations());
+        $this->assertCount(5, $doc->getAnnotations());
+
+        foreach ($doc->getAnnotations() as $index => $annotations) {
+            $this->assertInstanceOf('Symfony\CS\DocBlock\Annotation', $annotations);
+            $this->assertSame($doc->getAnnotation($index), $annotations);
+        }
+
+        $this->assertEmpty($doc->getAnnotation(5));
+    }
+
+    public function testGetAnnotationsOfTypeParam()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $annotations = $doc->getAnnotationsOfType('param');
+
+        $this->assertInternalType('array', $annotations);
+        $this->assertCount(3, $annotations);
+
+        $first = '     * @param string $hello
+';
+        $second = '     * @param bool $test Description
+     *        extends over many lines
+';
+        $third = '     * @param adkjbadjasbdand $asdnjkasd
+';
+
+        $this->assertSame($first, $annotations[0]->getContent());
+        $this->assertSame($second, $annotations[1]->getContent());
+        $this->assertSame($third, $annotations[2]->getContent());
+    }
+
+    public function testGetAnnotationsOfTypeThrows()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $annotations = $doc->getAnnotationsOfType('throws');
+
+        $this->assertInternalType('array', $annotations);
+        $this->assertCount(1, $annotations);
+
+        $content = '     * @throws \Exception asdnjkasd
+     * asdasdasdasdasdasdasdasd
+     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
+';
+
+        $this->assertSame($content, $annotations[0]->getContent());
+    }
+
+    public function testGetAnnotationsOfTypeReturn()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $annotations = $doc->getAnnotationsOfType('return');
+
+        $this->assertInternalType('array', $annotations);
+        $this->assertCount(1, $annotations);
+
+        $content = '     * @return void
+';
+
+        $this->assertSame($content, $annotations[0]->getContent());
+    }
+
+    public function testGetAnnotationsOfTypeFoo()
+    {
+        $doc = new DocBlock(self::$sample);
+
+        $annotations = $doc->getAnnotationsOfType('foo');
+
+        $this->assertInternalType('array', $annotations);
+        $this->assertCount(0, $annotations);
+    }
+}

--- a/Symfony/CS/Tests/DocBlock/LineTest.php
+++ b/Symfony/CS/Tests/DocBlock/LineTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\DocBlock;
+
+use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\DocBlock\Line;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class LineTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * This represents the content an entire docblock.
+     *
+     * @var string
+     */
+    private static $sample = '/**
+     * Test docblock.
+     *
+     * @param string $hello
+     * @param bool $test Description
+     *        extends over many lines
+     *
+     * @param adkjbadjasbdand $asdnjkasd
+     *
+     * @throws \Exception asdnjkasd
+     * asdasdasdasdasdasdasdasd
+     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
+     *
+     * @return void
+     */';
+
+    /**
+     * This represents the content of each line.
+     *
+     * @var string[]
+     */
+    private static $content = array(
+        "/**\n",
+        "     * Test docblock.\n",
+        "     *\n",
+        "     * @param string \$hello\n",
+        "     * @param bool \$test Description\n",
+        "     *        extends over many lines\n",
+        "     *\n",
+        "     * @param adkjbadjasbdand \$asdnjkasd\n",
+        "     *\n",
+        "     * @throws \Exception asdnjkasd\n",
+        "     * asdasdasdasdasdasdasdasd\n",
+        "     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb\n",
+        "     *\n",
+        "     * @return void\n",
+        "     */",
+    );
+
+    /**
+     * This represents the if each line is "useful".
+     *
+     * @var bool[]
+     */
+    private static $useful = array(
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+    );
+
+    /**
+     * This represents the if each line "contains a tag".
+     *
+     * @var bool[]
+     */
+    private static $tag = array(
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        false,
+        true,
+        false,
+    );
+
+    /**
+     * @dataProvider provideLines
+     */
+    public function testPosAndContent($pos, $content)
+    {
+        $doc = new DocBlock(self::$sample);
+        $line = $doc->getLine($pos);
+
+        $this->assertSame($content, $line->getContent());
+    }
+
+    /**
+     * @dataProvider provideLines
+     */
+    public function testStarOrEndPos($pos)
+    {
+        $doc = new DocBlock(self::$sample);
+        $line = $doc->getLine($pos);
+
+        switch ($pos) {
+            case 0:
+                $this->assertTrue($line->isTheStart());
+                $this->assertFalse($line->isTheEnd());
+                break;
+            case 14:
+                $this->assertFalse($line->isTheStart());
+                $this->assertTrue($line->isTheEnd());
+                break;
+            default:
+                $this->assertFalse($line->isTheStart());
+                $this->assertFalse($line->isTheEnd());
+        }
+    }
+
+    public function provideLines()
+    {
+        $cases = array();
+
+        foreach (self::$content as $index => $content) {
+            $cases[] = array($index, $content);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideLinesWithUseful
+     */
+    public function testUseful($pos, $useful)
+    {
+        $doc = new DocBlock(self::$sample);
+        $line = $doc->getLine($pos);
+
+        $this->assertSame($useful, $line->containsUsefulContent());
+    }
+
+    public function provideLinesWithUseful()
+    {
+        $cases = array();
+
+        foreach (self::$useful as $index => $useful) {
+            $cases[] = array($index, $useful);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideLinesWithTag
+     */
+    public function testTag($pos, $tag)
+    {
+        $doc = new DocBlock(self::$sample);
+        $line = $doc->getLine($pos);
+
+        $this->assertSame($tag, $line->containsATag());
+    }
+
+    public function provideLinesWithTag()
+    {
+        $cases = array();
+
+        foreach (self::$tag as $index => $tag) {
+            $cases[] = array($index, $tag);
+        }
+
+        return $cases;
+    }
+
+    public function testSetContent()
+    {
+        $doc = new DocBlock('');
+        $line = new Line("     * @param \$foo Hi!\n");
+
+        $this->assertSame("     * @param \$foo Hi!\n", $line->getContent());
+
+        $line->addBlank();
+        $this->assertSame("     * @param \$foo Hi!\n     *\n", $line->getContent());
+
+        $line->setContent("     * test\n");
+        $this->assertSame("     * test\n", $line->getContent());
+
+        $line->remove();
+        $this->assertSame('', $line->getContent());
+    }
+}

--- a/Symfony/CS/Tests/DocBlock/TagComparatorTest.php
+++ b/Symfony/CS/Tests/DocBlock/TagComparatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\DocBlock;
+
+use Symfony\CS\DocBlock\Tag;
+use Symfony\CS\DocBlock\TagComparator;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class TagComparatorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideComparatorCases
+     */
+    public function testComparatorTogether($first, $second, $expected)
+    {
+        $tag1 = new Tag('* @'.$first);
+        $tag2 = new Tag('* @'.$second);
+
+        $this->assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
+    }
+
+    public function provideComparatorCases()
+    {
+        return array(
+            array('return', 'return', true),
+            array('param', 'param', true),
+            array('return', 'param', false),
+            array('var', 'foo', false),
+            array('api', 'deprecated', false),
+            array('author', 'copyright', true),
+            array('author', 'since', false),
+            array('link', 'see', true),
+        );
+    }
+}

--- a/Symfony/CS/Tests/DocBlock/TagTest.php
+++ b/Symfony/CS/Tests/DocBlock/TagTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\DocBlock;
+
+use Symfony\CS\DocBlock\Tag;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class TagTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideNameCases
+     */
+    public function testName($expected, $input)
+    {
+        $tag = new Tag($input);
+
+        $this->assertSame($expected, $tag->getName());
+    }
+
+    public function provideNameCases()
+    {
+        return array(
+            array('param', '     * @param Foo $foo'),
+            array('return', '*   @return            false'),
+            array('throws', '*@thRoWs \Exception'),
+            array('throwsss', "\t@THROWSSS\t  \t RUNTIMEEEEeXCEPTION\t\t\t\t\t\t\t\n\n\n"),
+            array('other', ' *   @\Foo\Bar(baz = 123)'),
+            array('expectedexception', '     * @expectedException Exception'),
+        );
+    }
+
+    /**
+     * @dataProvider provideValidCases
+     */
+    public function testValid($expected, $input)
+    {
+        $tag = new Tag($input);
+
+        $this->assertSame($expected, $tag->valid());
+    }
+
+    public function provideValidCases()
+    {
+        return array(
+            array(true, '     * @param Foo $foo'),
+            array(true, '*   @return            false'),
+            array(true, '*@thRoWs \Exception'),
+            array(false, "\t@THROWSSS\t  \t RUNTIMEEEEeXCEPTION\t\t\t\t\t\t\t\n\n\n"),
+            array(false, ' *   @\Foo\Bar(baz = 123)'),
+            array(false, '     * @expectedException Exception'),
+        );
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpdocOrderFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpdocOrderFixerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocOrderFixerTest extends AbstractFixerTestBase
+{
+    public function testNoChanges()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Do some cool stuff.
+     *
+     * @param EngineInterface $templating
+     * @param string          $name
+     *
+     * @throws Exception
+     *
+     * @return void|bar
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testOnlyParams()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     * @param string          $name
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testOnlyReturns()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     * @return void|bar
+     *
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testEmpty()
+    {
+        $this->makeTest('/***/');
+    }
+
+    public function testNoAnnotations()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     *
+     *
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testFixBasicCase()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param string $foo
+     * @throws Exception
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @throws Exception
+     * @return bool
+     * @param string $foo
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixCompeteCase()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     *
+     *
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     *
+     *
+     *
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     * @return bool Return false on failure.
+     * @return int  Return the number of changes.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     *
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     *
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     *
+     *
+     * @return bool Return false on failure.
+     * @return int  Return the number of changes.
+     *
+     * @param string $foo
+     * @param bool   $bar Bar
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testExampleFromSymfony()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Renders a template.
+     *
+     * @param mixed $name       A template name
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @throws \InvalidArgumentException if the template does not exist
+     * @throws \RuntimeException         if the template cannot be rendered
+     * @return string The evaluated template as a string
+     *
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Renders a template.
+     *
+     * @param mixed $name       A template name
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @return string The evaluated template as a string
+     *
+     * @throws \InvalidArgumentException if the template does not exist
+     * @throws \RuntimeException         if the template cannot be rendered
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpdocVarToTypeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpdocVarToTypeFixerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocVarToTypeFixerTest extends AbstractFixerTestBase
+{
+    public function testBasicFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @type string Hello!
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var string Hello!
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testNoChanges()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @type string Hello!
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testSingleLine()
+    {
+        $this->makeTest('<?php /** @type string Hello! */', '<?php /** @var string Hello! */');
+    }
+
+    public function testEmpty()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocNoEmptyReturnFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocNoEmptyReturnFixerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocNoEmptyReturnFixerTest extends AbstractFixerTestBase
+{
+    public function testFixVoid()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixNull()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @return null
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixFull()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello!
+     *
+     * @param string $foo
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello!
+     *
+     * @param string $foo
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testDoNothing()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var null
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testDoNothingAgain()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @return null|int
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testOtherDoNothing()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @return int|null
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocNoPackageFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocNoPackageFixerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocNoPackageFixerTest extends AbstractFixerTestBase
+{
+    public function testFixPackage()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @package Foo\Bar
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixSubpackage()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @subpackage Foo\Bar\Baz
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixMany()
+    {
+        $expected = <<<'EOF'
+<?php
+/**
+ * Hello!
+ */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+/**
+ * Hello!
+ * @package
+ * @subpackage
+ */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testDoNothing()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var package
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocParamsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocParamsFixerTest.php
@@ -153,7 +153,7 @@ EOF;
 
     /**
      * References the issue #55 on github issue
-     * https://github.com/FriendsOfPhp/PHP-CS-Fixer/issues/55
+     * https://github.com/FriendsOfPhp/PHP-CS-Fixer/issues/55.
      */
     public function testFixThreeParamsWithReturn()
     {

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
@@ -1,0 +1,538 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocSeparationFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     *
+     * @return void
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixMoreTags()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * @internal
+     *
+     * @param string $foo
+     *
+     * @throws Exception
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     * @internal
+     * @param string $foo
+     * @throws Exception
+     *
+     *
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixSpreadOut()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @param string $foo
+     * @param bool   $bar Bar
+     *
+     * @throws Exception|RuntimeException
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     * @param string $foo
+     *
+     *
+     * @param bool   $bar Bar
+     *
+     *
+     *
+     * @throws Exception|RuntimeException
+     *
+     *
+     *
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testMultiLineComments()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @param string $foo test 123
+     *                    asdasdasd
+     * @param bool  $bar qwerty
+     *
+     * @throws Exception|RuntimeException
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     * @param string $foo test 123
+     *                    asdasdasd
+     * @param bool  $bar qwerty
+     * @throws Exception|RuntimeException
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testCrazyMultiLineComments()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Clients accept an array of constructor parameters.
+     *
+     * Here's an example of creating a client using an URI template for the
+     * client's base_url and an array of default request options to apply
+     * to each request:
+     *
+     *     $client = new Client([
+     *         'base_url' => [
+     *              'http://www.foo.com/{version}/',
+     *              ['version' => '123']
+     *          ],
+     *         'defaults' => [
+     *             'timeout'         => 10,
+     *             'allow_redirects' => false,
+     *             'proxy'           => '192.168.16.1:10'
+     *         ]
+     *     ]);
+     *
+     * @param array $config Client configuration settings
+     *     - base_url: Base URL of the client that is merged into relative URLs.
+     *       Can be a string or an array that contains a URI template followed
+     *       by an associative array of expansion variables to inject into the
+     *       URI template.
+     *     - handler: callable RingPHP handler used to transfer requests
+     *     - message_factory: Factory used to create request and response object
+     *     - defaults: Default request options to apply to each request
+     *     - emitter: Event emitter used for request events
+     *     - fsm: (internal use only) The request finite state machine. A
+     *       function that accepts a transaction and optional final state. The
+     *       function is responsible for transitioning a request through its
+     *       lifecycle events.
+     * @param string $foo
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testDoctrineExample()
+    {
+        $expected = <<<'EOF'
+<?php
+/**
+ * PersistentObject base class that implements getter/setter methods for all mapped fields and associations
+ * by overriding __call.
+ *
+ * This class is a forward compatible implementation of the PersistentObject trait.
+ *
+ * Limitations:
+ *
+ * 1. All persistent objects have to be associated with a single ObjectManager, multiple
+ *    ObjectManagers are not supported. You can set the ObjectManager with `PersistentObject#setObjectManager()`.
+ * 2. Setters and getters only work if a ClassMetadata instance was injected into the PersistentObject.
+ *    This is either done on `postLoad` of an object or by accessing the global object manager.
+ * 3. There are no hooks for setters/getters. Just implement the method yourself instead of relying on __call().
+ * 4. Slower than handcoded implementations: An average of 7 method calls per access to a field and 11 for an association.
+ * 5. Only the inverse side associations get autoset on the owning side as well. Setting objects on the owning side
+ *    will not set the inverse side associations.
+ *
+ * @example
+ *
+ *  PersistentObject::setObjectManager($em);
+ *
+ *  class Foo extends PersistentObject
+ *  {
+ *      private $id;
+ *  }
+ *
+ *  $foo = new Foo();
+ *  $foo->getId(); // method exists through __call
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testSymfonyExample()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Constructor.
+     *
+     * Depending on how you want the storage driver to behave you probably
+     * want to override this constructor entirely.
+     *
+     * List of options for $options array with their defaults.
+     *
+     * @see http://php.net/session.configuration for options
+     *
+     * but we omit 'session.' from the beginning of the keys for convenience.
+     *
+     * ("auto_start", is not supported as it tells PHP to start a session before
+     * PHP starts to execute user-land code. Setting during runtime has no effect).
+     *
+     * cache_limiter, "nocache" (use "0" to prevent headers from being sent entirely).
+     * cookie_domain, ""
+     * cookie_httponly, ""
+     * cookie_lifetime, "0"
+     * cookie_path, "/"
+     * cookie_secure, ""
+     * entropy_file, ""
+     * entropy_length, "0"
+     * gc_divisor, "100"
+     * gc_maxlifetime, "1440"
+     * gc_probability, "1"
+     * hash_bits_per_character, "4"
+     * hash_function, "0"
+     * name, "PHPSESSID"
+     * referer_check, ""
+     * serialize_handler, "php"
+     * use_cookies, "1"
+     * use_only_cookies, "1"
+     * use_trans_sid, "0"
+     * upload_progress.enabled, "1"
+     * upload_progress.cleanup, "1"
+     * upload_progress.prefix, "upload_progress_"
+     * upload_progress.name, "PHP_SESSION_UPLOAD_PROGRESS"
+     * upload_progress.freq, "1%"
+     * upload_progress.min-freq, "1"
+     * url_rewriter.tags, "a=href,area=href,frame=src,form=,fieldset="
+     *
+     * @param array                                                            $options Session configuration options.
+     * @param AbstractProxy|NativeSessionHandler|\SessionHandlerInterface|null $handler
+     * @param MetadataBag                                                      $metaBag MetadataBag.
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testDepricatedAndSeeTags()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hi!
+     *
+     * @author Bar Baz <foo@example.com>
+     *
+     * @deprecated As of some version.
+     * @see Replacement
+     *      described here.
+     *
+     * @param string $foo test 123
+     * @param bool  $bar qwerty
+     *
+     * @return void
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hi!
+     *
+     * @author Bar Baz <foo@example.com>
+     * @deprecated As of some version.
+     *
+     * @see Replacement
+     *      described here.
+     * @param string $foo test 123
+     * @param bool  $bar qwerty
+     *
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testClassDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+/**
+ * This is a class that does classy things.
+ *
+ * @internal
+ *
+ * @package Foo
+ * @subpackage Foo\Bar
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Graham Campbell <graham@mineuk.com>
+ * @copyright Foo Bar
+ * @license MIT
+ */
+class Bar {}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+/**
+ * This is a class that does classy things.
+ * @internal
+ * @package Foo
+ *
+ *
+ * @subpackage Foo\Bar
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @author Graham Campbell <graham@mineuk.com>
+ *
+ * @copyright Foo Bar
+ *
+ *
+ * @license MIT
+ */
+class Bar {}
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testPoorAlignment()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+/**
+*      This is a class that does classy things.
+    *
+*    @internal
+*
+ *          @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+    *@author Graham Campbell <graham@mineuk.com>
+ */
+class Bar {}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+/**
+*      This is a class that does classy things.
+    *
+*    @internal
+   *
+*
+*
+ *          @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+     *
+                             *
+    *@author Graham Campbell <graham@mineuk.com>
+ */
+class Bar {}
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testDoNotMoveUnknownAnnotations()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @excpectedException Exception
+     * @excpectedExceptionMessage Oh Noes!
+     * Something when wrong!
+     *
+     *
+     * @Hello\Test\Foo(asd)
+     *
+     * @param string $expected
+     * @param string $input
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @excpectedException Exception
+     * @excpectedExceptionMessage Oh Noes!
+     * Something when wrong!
+     *
+     *
+     * @Hello\Test\Foo(asd)
+     *
+     * @param string $expected
+     *
+     * @param string $input
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testInheritDoc()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * {@inheritdoc}
+     *
+     * @param string $expected
+     * @param string $input
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * {@inheritdoc}
+     * @param string $expected
+     * @param string $input
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testEmptyDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testLargerEmptyDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     *
+     *
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocShortDescriptionFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocShortDescriptionFixerTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocShortDescriptionFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testWithQuestionMark()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello?
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testWithExclimationMark()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello¡
+     */
+
+EOF;
+        $this->makeTest($expected);
+    }
+
+    public function testFixIncBlank()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hi.
+     *
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hi
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixMultiline()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello
+     * there.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello
+     * there
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testWithTags()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there.
+     *
+     * @param string $foo
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * @param string $foo
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testWithLongDescription()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there.
+     *
+     * Long description
+     * goes here.
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testCrazyMultiLineComments()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Clients accept an array of constructor parameters.
+     *
+     * Here's an example of creating a client using an URI template for the
+     * client's base_url and an array of default request options to apply
+     * to each request:
+     *
+     *     $client = new Client([
+     *         'base_url' => [
+     *              'http://www.foo.com/{version}/',
+     *              ['version' => '123']
+     *          ],
+     *         'defaults' => [
+     *             'timeout'         => 10,
+     *             'allow_redirects' => false,
+     *             'proxy'           => '192.168.16.1:10'
+     *         ]
+     *     ]);
+     *
+     * @param array $config Client configuration settings
+     *     - base_url: Base URL of the client that is merged into relative URLs.
+     *       Can be a string or an array that contains a URI template followed
+     *       by an associative array of expansion variables to inject into the
+     *       URI template.
+     *     - handler: callable RingPHP handler used to transfer requests
+     *     - message_factory: Factory used to create request and response object
+     *     - defaults: Default request options to apply to each request
+     *     - emitter: Event emitter used for request events
+     *     - fsm: (internal use only) The request finite state machine. A
+     *       function that accepts a transaction and optional final state. The
+     *       function is responsible for transitioning a request through its
+     *       lifecycle events.
+     * @param string $foo
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Clients accept an array of constructor parameters
+     *
+     * Here's an example of creating a client using an URI template for the
+     * client's base_url and an array of default request options to apply
+     * to each request:
+     *
+     *     $client = new Client([
+     *         'base_url' => [
+     *              'http://www.foo.com/{version}/',
+     *              ['version' => '123']
+     *          ],
+     *         'defaults' => [
+     *             'timeout'         => 10,
+     *             'allow_redirects' => false,
+     *             'proxy'           => '192.168.16.1:10'
+     *         ]
+     *     ]);
+     *
+     * @param array $config Client configuration settings
+     *     - base_url: Base URL of the client that is merged into relative URLs.
+     *       Can be a string or an array that contains a URI template followed
+     *       by an associative array of expansion variables to inject into the
+     *       URI template.
+     *     - handler: callable RingPHP handler used to transfer requests
+     *     - message_factory: Factory used to create request and response object
+     *     - defaults: Default request options to apply to each request
+     *     - emitter: Event emitter used for request events
+     *     - fsm: (internal use only) The request finite state machine. A
+     *       function that accepts a transaction and optional final state. The
+     *       function is responsible for transitioning a request through its
+     *       lifecycle events.
+     * @param string $foo
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testWithNoDescription()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @return bool
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testWithInheritDoc()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * {@inheritdoc}
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testEmptyDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocTrimFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocTrimFixerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocTrimFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param EngineInterface $templating
+     *
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testFixMore()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     * @internal
+     *@param string $foo
+     *@throws Exception
+     *
+    *
+     *
+     *  @return bool
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     *
+  *
+     * Hello there!
+     * @internal
+     *@param string $foo
+     *@throws Exception
+     *
+    *
+     *
+     *  @return bool
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testClassDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+  /**
+ * This is a class that does classy things.
+ *
+ * @internal
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Graham Campbell <graham@mineuk.com>
+   */
+class Bar {}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+  /**
+   *
+ *
+ * This is a class that does classy things.
+ *
+ * @internal
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Graham Campbell <graham@mineuk.com>
+ *
+    *
+  *
+   */
+class Bar {}
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testEmptyDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testEmptyLargerEmptyDocBlock()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     *
+     *
+     *
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testSuperSimpleDocBlockStart()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Test.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     *
+     * Test.
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testSuperSimpleDocBlockEnd()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Test.
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Test.
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypeToVarFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypeToVarFixerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocTypeToVarFixerTest extends AbstractFixerTestBase
+{
+    public function testBasicFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var string Hello!
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @type string Hello!
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testNoChanges()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var string Hello!
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testSingleLine()
+    {
+        $this->makeTest('<?php /** @var string Hello! */', '<?php /** @type string Hello! */');
+    }
+
+    public function testEmpty()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Graham Campbell <graham@mineuk.com>
+ */
+class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestBase
+{
+    public function testFixVar()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var string Hello!
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var string $foo Hello!
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixType()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var int|null
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var int|null $bar
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testDoNothing()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var Foo\Bar This is a variable.
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testSingleLine()
+    {
+        $expected = <<<'EOF'
+<?php
+    /** @var Foo\Bar $bar */
+    $bar;
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testEmpty()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     *
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -182,6 +182,15 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['standardize_not_equal'], $fixers['strict']),
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['multiline_array_trailing_comma']),
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['align_double_arrow']),
+            array($fixers['indentation'], $fixers['phpdoc_indent']),
+            array($fixers['phpdoc_order'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_order']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_order']),
+            array($fixers['phpdoc_trim'], $fixers['phpdoc_params']),
+            array($fixers['phpdoc_order'], $fixers['phpdoc_params']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_params']),
             array($fixers['phpdoc_indent'], $fixers['phpdoc_params']),
             array($fixers['phpdoc_to_comment'], $fixers['phpdoc_params']),
             array($fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']),
@@ -206,7 +215,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
      */
     public function testFixersDescriptionConsistency(FixerInterface $fixer)
     {
-        $this->assertRegExp('/^[A-Z].*\.$/', $fixer->getDescription(), 'Description must start with capital letter and end with dot.');
+        $this->assertRegExp('/^[A-Z@].*\.$/', $fixer->getDescription(), 'Description must start with capital letter or an @ and end with dot.');
     }
 
     public function provideFixersDescriptionConsistencyCases()

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -166,7 +166,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             $fixers[$fixer->getName()] = $fixer;
         }
 
-        return array(
+        $cases = array(
             array($fixers['php_closing_tag'], $fixers['short_tag']),
             array($fixers['unused_use'], $fixers['extra_empty_lines']),
             array($fixers['multiple_use'], $fixers['unused_use']),
@@ -188,14 +188,38 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_order']),
             array($fixers['phpdoc_no_package'], $fixers['phpdoc_separation']),
             array($fixers['phpdoc_no_package'], $fixers['phpdoc_order']),
-            array($fixers['phpdoc_trim'], $fixers['phpdoc_params']),
-            array($fixers['phpdoc_order'], $fixers['phpdoc_params']),
-            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_params']),
-            array($fixers['phpdoc_indent'], $fixers['phpdoc_params']),
-            array($fixers['phpdoc_to_comment'], $fixers['phpdoc_params']),
-            array($fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']),
-            array($fixers['phpdoc_to_comment'], $fixers['no_empty_lines_after_phpdocs']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_separation'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_short_description'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
         );
+
+        $docFixerNames = array_filter(
+            array_keys($fixers),
+            function ($name) {
+                return false !== strpos($name, 'phpdoc');
+            }
+        );
+
+        // prepare bulk tests for phpdoc fixers to test if:
+        // * `phpdoc_to_comment` is first
+        // * `phpdoc_indent` is second
+        // * `phpdoc_params` is last
+        $cases[] = array($fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']);
+        foreach ($docFixerNames as $docFixerName) {
+            if (!in_array($docFixerName, array('phpdoc_to_comment', 'phpdoc_indent'), true)) {
+                $cases[] = array($fixers['phpdoc_to_comment'], $fixers[$docFixerName]);
+                $cases[] = array($fixers['phpdoc_indent'], $fixers[$docFixerName]);
+            }
+
+            if ('phpdoc_params' !== $docFixerName) {
+                $cases[] = array($fixers[$docFixerName], $fixers['phpdoc_params']);
+            }
+        }
+
+        return $cases;
     }
 
     public static function getFixerLevels()

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -362,6 +362,7 @@ PHP;
 
     /**
      * @dataProvider provideMonolithicPhpDetection
+     *
      * @param string $source
      * @param bool   $monolitic
      */
@@ -387,6 +388,7 @@ PHP;
 
     /**
      * @dataProvider provideShortOpenTagMonolithicPhpDetection
+     *
      * @param string $source
      * @param bool   $monolitic
      */
@@ -422,6 +424,7 @@ PHP;
 
     /**
      * @dataProvider provideShortOpenTagEchoMonolithicPhpDetection
+     *
      * @param string $source
      * @param bool   $monolitic
      */

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -368,7 +368,7 @@ class Token
     }
 
     /**
-     * Check if token is one of structure alternative end syntax (T_END...)
+     * Check if token is one of structure alternative end syntax (T_END...).
      *
      * @return bool
      */

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -1073,7 +1073,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * Clear tokens in the given range
+     * Clear tokens in the given range.
      *
      * @param int $indexStart
      * @param int $indexEnd
@@ -1086,7 +1086,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * Checks for monolithic PHP code
+     * Checks for monolithic PHP code.
      *
      * Checks that the code is pure PHP code, in a single code block, starting
      * with an open tag.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,9 @@
         <testsuite name="tokenizer">
             <directory>./Symfony/CS/Tests/Tokenizer/</directory>
         </testsuite>
+        <testsuite name="docblock">
+            <directory>./Symfony/CS/Tests/DocBlock/</directory>
+        </testsuite>
     </testsuites>
 
     <filter>


### PR DESCRIPTION
TODO:
* [x] Added phpdoc_seperation
* [x] Fix the behaviour with some annotations like the phpunit ones - introduced a tag class
* [x] Refactor the docblock classes to model the situation more clearly
* [x] Add tests for the `Tag` class
* [x] Add tests for the `DocBlock` class
* [x] Added phpdoc_order
* [x] Perform regression testing on league/flysystem
* [x] Based on results from testing, make improvements
* [x] Add phpdoc_var fixer
* [x] Perform regression testing on symfony/symfony
* [x] Based on results from testing, make improvements, add more test cases
* [x] Move the phpdoc_order fixer to contrib level
* [x] Add a phpdoc_trim fixer at symfony level, partly taken from phpdoc_separation
* [x] Added phpdoc_no_return_void
* [x] Review fixer orders
* [x] Perform regression testing on guzzle/guzzle
* [x] `@see`, `@link`, `@deprecated`, `@since`, `@author`, `@copyright`, and `@license` annotations should be kept together rather than forced apart by the separation fixer
* [x] Support annotations with descriptions including bank lines
* [x] Perform regression testing on doctrine/common
* [x] Perform regression testing on guzzle/guzzle and symfony/symfony again
* [x] Fix more bugs, and add more test cases
* [x] Perform regression testing on flysystem guzzle, doctrine, symfony again
* [x] Analyse current code coverage and cleanup code
* [x] Add tests for the `TagComparator`
* [x] Add missing `DocBlock` class tests
* [x] Add tests for the `Line` class
* [x] Add tests for the `Annotation` class
* [x] Test on dingo/api, factory-muffin, aws sdk v2 and v3
* [x] Discuss fixer names
* [x] Add fixers to change var to type and type to var
* [x] Add a fixer to ensure short descriptions end in a `.`, `?`, or `!`
* [x] Review by @keradus
* [x] Cleanup the docblock classes
* [x] Add a fixer to remove package and subpackage annotations
* [x] Complete reviews and testing

I THINK WE'RE DONE! :)