### PR TITLE
PSR2 MethodArgumentSpacerFixer clean additional spaces

### DIFF
--- a/Symfony/CS/Fixer/PSR2/MethodArgumentSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/MethodArgumentSpaceFixer.php
@@ -112,7 +112,7 @@ class MethodArgumentSpaceFixer extends AbstractFixer
     }
 
     /**
-     * Check if last item of current line is a comment
+     * Check if last item of current line is a comment.
      *
      * @param Tokens $tokens tokens to handle
      * @param int    $index  index of token
@@ -121,7 +121,19 @@ class MethodArgumentSpaceFixer extends AbstractFixer
      */
     private function isCommentLastLineToken(Tokens $tokens, $index)
     {
-        return $tokens[$index]->isComment() && 1 === substr_count($tokens[$index + 1]->getContent(), "\n");
+        if (!$tokens[$index]->isComment()) {
+            return false;
+        }
+
+        $nextToken = $tokens[$index + 1];
+
+        if (!$nextToken->isWhitespace()) {
+            return false;
+        }
+
+        $content = $nextToken->getContent();
+
+        return $content !== ltrim($content, "\r\n");
     }
 
     /**

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -34,20 +34,53 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                 '<?php function xyz($a=10, $b=20, $c=30) {',
                 '<?php function xyz($a=10,$b=20,$c=30) {',
             ),
+            // test method arguments with multiple spaces
+            array(
+                '<?php function xyz($a=10, $b=20, $c=30) {',
+                '<?php function xyz($a=10,         $b=20 , $c=30) {',
+            ),
             // test method call
             array(
                 '<?php xyz($a=10, $b=20, $c=30);',
                 '<?php xyz($a=10 ,$b=20,$c=30);',
+            ),
+            // test method call with multiple spaces
+            array(
+                '<?php xyz($a=10, $b=20, $c=30);',
+                '<?php xyz($a=10 , $b=20 ,          $c=30);',
+            ),
+            // test method call with tab
+            array(
+                '<?php xyz($a=10, $b=20, $c=30);',
+                "<?php xyz(\$a=10 , \$b=20 ,\t \$c=30);",
+            ),
+            // test method call with \n not affected
+            array(
+                "<?php xyz(\$a=10, \$b=20,\n                    \$c=30);",
+            ),
+            // test method call with \r\n not affected
+            array(
+                "<?php xyz(\$a=10, \$b=20,\r\n                    \$c=30);",
             ),
             // test method call
             array(
                 '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
                 '<?php xyz($a=10,$b=20 ,$this->foo() ,$c=30);',
             ),
+            // test method call with multiple spaces
+            array(
+                '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
+                '<?php xyz($a=10,$b=20 ,         $this->foo() ,$c=30);',
+            ),
             // test receiving data in list context with omitted values
             array(
                 '<?php list($a, $b, , , $c) = foo();',
                 '<?php list($a, $b,, ,$c) = foo();',
+            ),
+            // test receiving data in list context with omitted values and multiple spaces
+            array(
+                '<?php list($a, $b, , , $c) = foo();',
+                '<?php list($a, $b,,    ,$c) = foo();',
             ),
             // skip array
             array(
@@ -57,6 +90,39 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
             array(
                 '<?php list($path, $mode, ) = foo();',
                 '<?php list($path, $mode,) = foo();',
+            ),
+            //inline comments with spaces
+            array(
+                '<?php xyz($a=10, /*comment1*/ $b=2000, /*comment2*/ $c=30);',
+                '<?php xyz($a=10,    /*comment1*/ $b=2000,/*comment2*/ $c=30);',
+
+            ),
+            // must keep align comments
+            array(
+                '<?php function xyz(
+                    $a=10,      //comment1
+                    $b=20,      //comment2
+                    $c=30) {
+                }',
+            ),
+            array(
+                '<?php function xyz(
+                    $a=10,  //comment1
+                    $b=2000,//comment2
+                    $c=30) {
+                }',
+            ),
+            //multiline comments also must be ignored
+            array(
+                '<?php function xyz(
+                    $a=10,  /* comment1a
+                               comment1b
+                            */
+                    $b=2000,/* comment2a
+                        comment 2b
+                        comment 2c */
+                    $c=30) {
+                }',
             ),
             // multi line testing method arguments
             array(
@@ -83,6 +149,15 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                     $b=20,
                     $c=30
                     )',
+            ),
+            // skip arrays but replace arg methods
+            array(
+                '<?php fnc(1, array(2, func2(6, 7) ,4), 5);',
+                '<?php fnc(1,array(2, func2(6,    7) ,4),    5);',
+            ),
+            // ignore commas inside call argument
+            array(
+                '<?php fnc(1, array(2, 3 ,4), 5);',
             ),
             // skip multi line array
             array(

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -124,6 +124,29 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                     $c=30) {
                 }',
             ),
+            // multiline comments also must be ignored
+            array(
+                '<?php
+                    function xyz(
+                        $a=10, /* multiline comment
+                                 not at the end of line
+                                */ $b=2000,
+                        $a2=10 /* multiline comment
+                                 not at the end of line
+                                */, $b2=2000,
+                        $c=30) {
+                    }',
+                '<?php
+                    function xyz(
+                        $a=10, /* multiline comment
+                                 not at the end of line
+                                */ $b=2000,
+                        $a2=10 /* multiline comment
+                                 not at the end of line
+                                */ ,$b2=2000,
+                        $c=30) {
+                    }',
+            ),
             // multi line testing method arguments
             array(
                 '<?php function xyz(
@@ -172,7 +195,7 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
             array(
                 '<?php
     $foo = ["a"=>"apple", "b"=>"bed" ,"c"=>"car"];
-    $foo = ["a" ,"b" ,"c"];
+    $bar = ["a" ,"b" ,"c"];
     ',
             ),
             // don't change HEREDOC and NOWDOC


### PR DESCRIPTION
PSR2 MethodArgumentSpacerFixer clean additional spaces after a comma.
With this code one and only one space can be after a comma in a method call.

> 4.4. Method Arguments
> In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.

Thanks