### PR TITLE
NoEmptyLinesAfterPhpdocsFixer - fix bug with Windows style lines

### DIFF
--- a/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
@@ -49,7 +49,7 @@ class NoEmptyLinesAfterPhpdocsFixer extends AbstractFixer
     {
         $content = $token->getContent();
         // if there is more than one new line in the whitespace, then we need to fix it
-        if ((substr_count($content, "\n") + substr_count($content, "\r")) > 1) {
+        if (substr_count($content, "\n") > 1) {
             // the final bit of the whitespace must be the next statement's indentation
             $lines = Utils::splitLines($content);
             $token->setContent("\n".end($lines));

--- a/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
@@ -203,4 +203,13 @@ EOF;
 
         $this->makeTest($expected, $input);
     }
+
+    public function testFixesWindowsStyle()
+    {
+        $expected = "<?php\r\n    /**     * Constant!     */\n    \$foo = 123;";
+
+        $input = "<?php\r\n    /**     * Constant!     */\r\n\r\n\r\n    \$foo = 123;";
+
+        $this->makeTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Very sorry for implementing this wrong the first time. :/
