### PR TITLE
Refactoring Utils

### DIFF
--- a/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
@@ -14,11 +14,13 @@ namespace Symfony\CS\Fixer\PSR2;
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
+use Symfony\CS\Utils;
 
 /**
  * Fixer for rules defined in PSR2 ¶3.
  *
  * @author Ceeram <ceeram@cakephp.org>
+ * @author Graham Campbell <graham@mineuk.com>
  */
 class SingleLineAfterImportsFixer extends AbstractFixer
 {
@@ -33,8 +35,10 @@ class SingleLineAfterImportsFixer extends AbstractFixer
             // if previous line ends with comment and current line starts with whitespace, use current indent
             if ($tokens[$index - 1]->isWhitespace(array('whitespaces' => " \t")) && $tokens[$index - 2]->isGivenKind(T_COMMENT)) {
                 $indent = $tokens[$index - 1]->getContent();
+            } elseif ($tokens[$index - 1]->isWhitespace()) {
+                $indent = Utils::calculateTrailingWhitespaceIndent($tokens[$index - 1]);
             } else {
-                $indent = $this->calculateIndent($tokens[$index - 1]->getContent());
+                $indent = '';
             }
 
             $newline = "\n";
@@ -48,7 +52,7 @@ class SingleLineAfterImportsFixer extends AbstractFixer
 
             // Do not add newline after inline T_COMMENT as it is part of T_COMMENT already
             if ($tokens[$insertIndex]->isGivenKind(T_COMMENT)) {
-                $newline = "";
+                $newline = '';
             }
 
             // Increment insert index for inline T_COMMENT or T_DOC_COMMENT
@@ -78,17 +82,5 @@ class SingleLineAfterImportsFixer extends AbstractFixer
     public function getDescription()
     {
         return 'Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.';
-    }
-
-    /**
-     * Calculate used indentation in whitespace.
-     *
-     * @param string $content Whitespace
-     *
-     * @return string
-     */
-    private function calculateIndent($content)
-    {
-        return ltrim(strrchr(str_replace(array("\r\n", "\r"), "\n", $content), 10), "\n");
     }
 }

--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -13,9 +13,11 @@ namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;
+use Symfony\CS\Utils;
 
 /**
  * @author Ceeram <ceeram@cakephp.org>
+ * @author Graham Campbell <graham@mineuk.com>
  */
 class PhpdocIndentFixer extends AbstractFixer
 {
@@ -28,13 +30,14 @@ class PhpdocIndentFixer extends AbstractFixer
 
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
             $nextIndex = $tokens->getNextMeaningfulToken($index);
+
             if (null === $nextIndex) {
                 continue;
             }
 
             $prevToken = $tokens[$index - 1];
 
-            //ignore inline docblocks
+            // ignore inline docblocks
             if (
                 ($prevToken->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isGivenKind(T_OPEN_TAG))
                 || $prevToken->equalsAny(array(';', '{'))
@@ -42,21 +45,13 @@ class PhpdocIndentFixer extends AbstractFixer
                 continue;
             }
 
-            $indent = $this->calculateIndent($tokens[$nextIndex - 1]->getContent());
+            $indent = Utils::calculateTrailingWhitespaceIndent($tokens[$nextIndex - 1]);
 
             $prevToken->setContent($this->fixWhitespaceBefore($prevToken->getContent(), $indent));
             $token->setContent($this->fixDocBlock($token->getContent(), $indent));
         }
 
         return $tokens->generateCode();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDescription()
-    {
-        return 'Docblocks should have the same indentation as the documented subject.';
     }
 
     /**
@@ -86,14 +81,10 @@ class PhpdocIndentFixer extends AbstractFixer
     }
 
     /**
-     * Calculate used indentation from the whitespace before documented subject.
-     *
-     * @param string $content Whitespace before documented subject
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    private function calculateIndent($content)
+    public function getDescription()
     {
-        return ltrim(strrchr(str_replace(array("\r\n", "\r"), "\n", $content), 10), "\n");
+        return 'Docblocks should have the same indentation as the documented subject.';
     }
 }

--- a/Symfony/CS/Tests/UtilsTest.php
+++ b/Symfony/CS/Tests/UtilsTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\CS\Tests;
 
+use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Utils;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Graham Campbell <graham@mineuk.com>
  */
 class UtilsTest extends \PHPUnit_Framework_TestCase
 {
@@ -88,5 +90,38 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
                 "aaa\r\n\n\n\r\n bbb\n",
             ),
         );
+    }
+
+    /**
+     * @dataProvider provideCalculateTrailingWhitespaceIndentCases
+     */
+    public function testCalculateTrailingWhitespaceIndent($spaces, $input)
+    {
+        $token = new Token(array(T_WHITESPACE, $input));
+
+        $this->assertSame($spaces, Utils::calculateTrailingWhitespaceIndent($token));
+    }
+
+    public function provideCalculateTrailingWhitespaceIndentCases()
+    {
+        return array(
+            array('    ', "\n\n    "),
+            array(' ', "\r\n\r\r\r "),
+            array("\t", "\r\n\t"),
+            array('', "\t\n\r"),
+            array('', "\n"),
+            array('', ''),
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage The given token must be whitespace.
+     */
+    public function testCalculateTrailingWhitespaceIndentFail()
+    {
+        $token = new Token(array(T_STRING, 'foo'));
+
+        Utils::calculateTrailingWhitespaceIndent($token);
     }
 }

--- a/Symfony/CS/Utils.php
+++ b/Symfony/CS/Utils.php
@@ -11,11 +11,21 @@
 
 namespace Symfony\CS;
 
+use Symfony\CS\Tokenizer\Token;
+
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Graham Campbell <graham@mineuk.com>
  */
 class Utils
 {
+    /**
+     * Converts a camel cased string to an snake cased string.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
     public static function camelCaseToUnderscore($string)
     {
         return preg_replace_callback(
@@ -27,6 +37,17 @@ class Utils
         );
     }
 
+    /**
+     * Compare two integers for equality.
+     *
+     * We'll return 0 if they're equal, 1 if the first is bigger than the
+     * second, and -1 if the second is bigger than the first.
+     *
+     * @param int $a
+     * @param int $b
+     *
+     * @return int
+     */
     public static function cmpInt($a, $b)
     {
         if ($a === $b) {
@@ -36,10 +57,40 @@ class Utils
         return $a < $b ? -1 : 1;
     }
 
+    /**
+     * Split a multi-line string up into an array of strings.
+     *
+     * We're retaining a newline character at the end of non-blank lines, and
+     * discarding other lines, so this function is unsuitable for anyone for
+     * wishing to retain the exact number of line endings. If a single-line
+     * string is passed, we'll just return an array with a element.
+     *
+     * @param string $content
+     *
+     * @return string[]
+     */
     public static function splitLines($content)
     {
         preg_match_all("/[^\n\r]+[\r\n]*/", $content, $matches);
 
         return $matches[0];
+    }
+
+    /**
+     * Calculate the trailing whitespace indentation.
+     *
+     * What we're doing here is grabbing everything after the final newline.
+     *
+     * @param Token $token
+     *
+     * @return string
+     */
+    public static function calculateTrailingWhitespaceIndent(Token $token)
+    {
+        if (!$token->isWhitespace()) {
+            throw new \InvalidArgumentException('The given token must be whitespace.');
+        }
+
+        return ltrim(strrchr(str_replace(array("\r\n", "\r"), "\n", $token->getContent()), 10), "\n");
     }
 }


### PR DESCRIPTION
This removes duplication regarding the `calculateIndent` function, adds missing docblocks, and adds tests for the `calculateIndent` function too.
