### PR TITLE
remove Token::$line

### DIFF
--- a/Symfony/CS/Fixer/Contrib/StrictFixer.php
+++ b/Symfony/CS/Fixer/Contrib/StrictFixer.php
@@ -42,7 +42,7 @@ class StrictFixer extends AbstractFixer
             $tokenId = $token->getId();
 
             if (isset($map[$tokenId])) {
-                $token->override(array($map[$tokenId]['id'], $map[$tokenId]['content'], $token->getLine()));
+                $token->override(array($map[$tokenId]['id'], $map[$tokenId]['content']));
             }
         }
 

--- a/Symfony/CS/Fixer/PSR2/ElseifFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ElseifFixer.php
@@ -44,7 +44,7 @@ class ElseifFixer extends AbstractFixer
             $tokens[$index + 1]->clear();
 
             // 2. change token from T_ELSE into T_ELSEIF
-            $token->override(array(T_ELSEIF, 'elseif', $token->getLine()));
+            $token->override(array(T_ELSEIF, 'elseif'));
 
             // 3. clear succeeding T_IF
             $nextToken->clear();

--- a/Symfony/CS/Fixer/Symfony/TernarySpacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/TernarySpacesFixer.php
@@ -82,7 +82,7 @@ class TernarySpacesFixer extends AbstractFixer
             return;
         }
 
-        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ', $token->getLine())));
+        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ')));
     }
 
     /**

--- a/Symfony/CS/Tests/Tokenizer/TokenTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokenTest.php
@@ -35,7 +35,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
     public function getForeachTokenPrototype()
     {
-        static $prototype = array(T_FOREACH, 'foreach', 123);
+        static $prototype = array(T_FOREACH, 'foreach');
 
         return $prototype;
     }
@@ -47,7 +47,6 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('', $token->getContent());
         $this->assertNull($token->getId());
-        $this->assertNull($token->getLine());
         $this->assertFalse($token->isArray());
     }
 
@@ -226,7 +225,6 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($prototype[0], $token->getId());
         $this->assertSame($prototype[1], $token->getContent());
-        $this->assertSame($prototype[2], $token->getLine());
         $this->assertTrue($token->isArray());
     }
 
@@ -237,7 +235,6 @@ class TokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($prototype, $token->getContent());
         $this->assertNull($token->getId());
-        $this->assertNull($token->getLine());
         $this->assertFalse($token->isArray());
     }
 }

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -41,13 +41,6 @@ class Token
     private $isArray;
 
     /**
-     * Line of token prototype occurrence, if available.
-     *
-     * @var int|null
-     */
-    private $line;
-
-    /**
      * Constructor.
      *
      * @param string|array $token token prototype
@@ -58,7 +51,6 @@ class Token
             $this->isArray = true;
             $this->id = $token[0];
             $this->content = $token[1];
-            $this->line = isset($token[2]) ? $token[2] : null;
         } else {
             $this->isArray = false;
             $this->content = $token;
@@ -139,7 +131,6 @@ class Token
         return array(
             $this->id,
             $this->content,
-            $this->line,
         );
     }
 
@@ -369,7 +360,6 @@ class Token
             $this->isArray = true;
             $this->id = $prototype[0];
             $this->content = $prototype[1];
-            $this->line = isset($prototype[2]) ? $prototype[2] : null;
 
             return;
         }
@@ -377,7 +367,6 @@ class Token
         $this->isArray = false;
         $this->id = null;
         $this->content = $prototype;
-        $this->line = null;
     }
 
     /**
@@ -396,7 +385,6 @@ class Token
             'id'      => $this->id,
             'name'    => $this->getName(),
             'content' => $this->content,
-            'line'    => $this->line,
             'isArray' => $this->isArray,
         );
     }

--- a/Symfony/CS/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -33,7 +33,7 @@ class ArrayTypehintTransformer extends AbstractTransformer
             $nextToken = $tokens[$nextIndex];
 
             if (!$nextToken->equals('(')) {
-                $token->override(array(CT_ARRAY_TYPEHINT, $token->getContent(), $token->getLine()));
+                $token->override(array(CT_ARRAY_TYPEHINT, $token->getContent()));
             }
         }
     }

--- a/Symfony/CS/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -33,7 +33,7 @@ class ClassConstantTransformer extends AbstractTransformer
             $prevToken = $tokens[$prevIndex];
 
             if ($prevToken->isGivenKind(T_DOUBLE_COLON)) {
-                $token->override(array(CT_CLASS_CONSTANT, $token->getContent(), $token->getLine()));
+                $token->override(array(CT_CLASS_CONSTANT, $token->getContent()));
             }
         }
     }

--- a/Symfony/CS/Tokenizer/Transformer/CurlyCloseTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/CurlyCloseTransformer.php
@@ -47,7 +47,7 @@ class CurlyCloseTransformer extends AbstractTransformer
                 }
             }
 
-            $tokens[$nestIndex]->override(array(CT_CURLY_CLOSE, '}', $tokens[$nestIndex]->getLine()));
+            $tokens[$nestIndex]->override(array(CT_CURLY_CLOSE, '}'));
         }
     }
 

--- a/Symfony/CS/Tokenizer/Transformer/DollarCloseCurlyBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DollarCloseCurlyBraceTransformer.php
@@ -30,7 +30,7 @@ class DollarCloseCurlyBraceTransformer extends AbstractTransformer
     {
         foreach ($tokens->findGivenKind(T_DOLLAR_OPEN_CURLY_BRACES) as $index => $token) {
             $nextIndex = $tokens->getNextTokenOfKind($index, array('}'));
-            $tokens[$nextIndex]->override(array(CT_DOLLAR_CLOSE_CURLY_BRACES, '}', $tokens[$nextIndex]->getLine()));
+            $tokens[$nextIndex]->override(array(CT_DOLLAR_CLOSE_CURLY_BRACES, '}'));
         }
     }
 

--- a/Symfony/CS/Tokenizer/Transformer/DynamicPropBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DynamicPropBraceTransformer.php
@@ -36,8 +36,8 @@ class DynamicPropBraceTransformer extends AbstractTransformer
             $openIndex = $index + 1;
             $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openIndex);
 
-            $tokens[$openIndex]->override(array(CT_DYNAMIC_PROP_BRACE_OPEN, '{', $tokens[$openIndex]->getLine()));
-            $tokens[$closeIndex]->override(array(CT_DYNAMIC_PROP_BRACE_CLOSE, '}', $tokens[$closeIndex]->getLine()));
+            $tokens[$openIndex]->override(array(CT_DYNAMIC_PROP_BRACE_OPEN, '{'));
+            $tokens[$closeIndex]->override(array(CT_DYNAMIC_PROP_BRACE_CLOSE, '}'));
         }
     }
 

--- a/Symfony/CS/Tokenizer/Transformer/DynamicVarBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DynamicVarBraceTransformer.php
@@ -48,8 +48,8 @@ class DynamicVarBraceTransformer extends AbstractTransformer
             $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openIndex);
             $closeToken = $tokens[$closeIndex];
 
-            $openToken->override(array(CT_DYNAMIC_VAR_BRACE_OPEN, '{', $openToken->getLine()));
-            $closeToken->override(array(CT_DYNAMIC_VAR_BRACE_CLOSE, '}', $closeToken->getLine()));
+            $openToken->override(array(CT_DYNAMIC_VAR_BRACE_OPEN, '{'));
+            $closeToken->override(array(CT_DYNAMIC_VAR_BRACE_CLOSE, '}'));
         }
     }
 


### PR DESCRIPTION
Remove Token::$line due to:
- we don't use it anywhere;
- non-array tokens like ; doesn't have line property set, only array tokens like T_IF have
- when adding new token we don't set line property
- when changing new lines we don't update line of following tokens.

Coming from #907 issue
