### PR TITLE
All Transformer classes should be named with Transformer as suffix

### DIFF
--- a/Symfony/CS/Tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class ClassConstantTest extends AbstractTransformerTestBase
+class ArrayTypehintTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases
@@ -30,9 +30,14 @@ class ClassConstantTest extends AbstractTransformerTestBase
     {
         return array(
             array(
-                '<?php echo X::class',
+                '<?php
+$a = array(1, 2, 3);
+function foo (array /** @type array */ $bar)
+{
+}',
                 array(
-                    5 => 'CT_CLASS_CONSTANT',
+                    5  => 'T_ARRAY',
+                    22 => 'CT_ARRAY_TYPEHINT',
                 ),
             ),
         );

--- a/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class CurlyCloseTest extends AbstractTransformerTestBase
+class ClassConstantTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases
@@ -30,24 +30,9 @@ class CurlyCloseTest extends AbstractTransformerTestBase
     {
         return array(
             array(
-                '<?php echo "This is {$great}";',
+                '<?php echo X::class',
                 array(
-                    5 => 'T_CURLY_OPEN',
-                    7 => 'CT_CURLY_CLOSE',
-                ),
-            ),
-            array(
-                '<?php $a = "a{$b->c()}d";',
-                array(
-                    7  => 'T_CURLY_OPEN',
-                    13 => 'CT_CURLY_CLOSE',
-                ),
-            ),
-            array(
-                '<?php echo "I\'d like an {${beers::$ale}}\n";',
-                array(
-                    5  => 'T_CURLY_OPEN',
-                    12 => 'CT_CURLY_CLOSE',
+                    5 => 'CT_CLASS_CONSTANT',
                 ),
             ),
         );

--- a/Symfony/CS/Tests/Tokenizer/Transformer/CurlyCloseTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/CurlyCloseTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class ArrayTypehintTest extends AbstractTransformerTestBase
+class CurlyCloseTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases
@@ -30,14 +30,24 @@ class ArrayTypehintTest extends AbstractTransformerTestBase
     {
         return array(
             array(
-                '<?php
-$a = array(1, 2, 3);
-function foo (array /** @type array */ $bar)
-{
-}',
+                '<?php echo "This is {$great}";',
                 array(
-                    5  => 'T_ARRAY',
-                    22 => 'CT_ARRAY_TYPEHINT',
+                    5 => 'T_CURLY_OPEN',
+                    7 => 'CT_CURLY_CLOSE',
+                ),
+            ),
+            array(
+                '<?php $a = "a{$b->c()}d";',
+                array(
+                    7  => 'T_CURLY_OPEN',
+                    13 => 'CT_CURLY_CLOSE',
+                ),
+            ),
+            array(
+                '<?php echo "I\'d like an {${beers::$ale}}\n";',
+                array(
+                    5  => 'T_CURLY_OPEN',
+                    12 => 'CT_CURLY_CLOSE',
                 ),
             ),
         );

--- a/Symfony/CS/Tests/Tokenizer/Transformer/DollarCloseCurlyBraceTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/DollarCloseCurlyBraceTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class DollarCloseCurlyBraceTest extends AbstractTransformerTestBase
+class DollarCloseCurlyBraceTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases

--- a/Symfony/CS/Tests/Tokenizer/Transformer/DynamicPropBraceTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/DynamicPropBraceTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class DynamicPropBraceTest extends AbstractTransformerTestBase
+class DynamicPropBraceTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases

--- a/Symfony/CS/Tests/Tokenizer/Transformer/DynamicVarBraceTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/DynamicVarBraceTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-class DynamicVarBraceTest extends AbstractTransformerTestBase
+class DynamicVarBraceTransformerTest extends AbstractTransformerTestBase
 {
     /**
      * @dataProvider provideProcessCases

--- a/Symfony/CS/Tokenizer/AbstractTransformer.php
+++ b/Symfony/CS/Tokenizer/AbstractTransformer.php
@@ -37,7 +37,7 @@ abstract class AbstractTransformer implements TransformerInterface
     public function getName()
     {
         $nameParts = explode('\\', get_called_class());
-        $name = end($nameParts);
+        $name = substr(end($nameParts), 0, -strlen('Transformer'));
 
         return Utils::camelCaseToUnderscore($name);
     }

--- a/Symfony/CS/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -15,25 +15,25 @@ use Symfony\CS\Tokenizer\AbstractTransformer;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
- * Transform `class` class' constant from T_CLASS into CT_CLASS_CONSTANT.
+ * Transform `array` typehint from T_ARRAY into T_ARRAY_TYPEHINT.
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @internal
  */
-class ClassConstant extends AbstractTransformer
+class ArrayTypehintTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}
      */
     public function process(Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_CLASS) as $index => $token) {
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            $prevToken = $tokens[$prevIndex];
+        foreach ($tokens->findGivenKind(T_ARRAY) as $index => $token) {
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            $nextToken = $tokens[$nextIndex];
 
-            if ($prevToken->isGivenKind(T_DOUBLE_COLON)) {
-                $token->override(array(CT_CLASS_CONSTANT, $token->getContent(), $token->getLine()));
+            if (!$nextToken->equals('(')) {
+                $token->override(array(CT_ARRAY_TYPEHINT, $token->getContent(), $token->getLine()));
             }
         }
     }
@@ -43,6 +43,6 @@ class ClassConstant extends AbstractTransformer
      */
     public function getCustomTokenNames()
     {
-        return array('CT_CLASS_CONSTANT');
+        return array('CT_ARRAY_TYPEHINT');
     }
 }

--- a/Symfony/CS/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -15,25 +15,25 @@ use Symfony\CS\Tokenizer\AbstractTransformer;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
- * Transform `array` typehint from T_ARRAY into T_ARRAY_TYPEHINT.
+ * Transform `class` class' constant from T_CLASS into CT_CLASS_CONSTANT.
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @internal
  */
-class ArrayTypehint extends AbstractTransformer
+class ClassConstantTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}
      */
     public function process(Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_ARRAY) as $index => $token) {
-            $nextIndex = $tokens->getNextMeaningfulToken($index);
-            $nextToken = $tokens[$nextIndex];
+        foreach ($tokens->findGivenKind(T_CLASS) as $index => $token) {
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            $prevToken = $tokens[$prevIndex];
 
-            if (!$nextToken->equals('(')) {
-                $token->override(array(CT_ARRAY_TYPEHINT, $token->getContent(), $token->getLine()));
+            if ($prevToken->isGivenKind(T_DOUBLE_COLON)) {
+                $token->override(array(CT_CLASS_CONSTANT, $token->getContent(), $token->getLine()));
             }
         }
     }
@@ -43,6 +43,6 @@ class ArrayTypehint extends AbstractTransformer
      */
     public function getCustomTokenNames()
     {
-        return array('CT_ARRAY_TYPEHINT');
+        return array('CT_CLASS_CONSTANT');
     }
 }

--- a/Symfony/CS/Tokenizer/Transformer/CurlyCloseTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/CurlyCloseTransformer.php
@@ -21,7 +21,7 @@ use Symfony\CS\Tokenizer\Tokens;
  *
  * @internal
  */
-class CurlyClose extends AbstractTransformer
+class CurlyCloseTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Tokenizer/Transformer/DollarCloseCurlyBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DollarCloseCurlyBraceTransformer.php
@@ -21,7 +21,7 @@ use Symfony\CS\Tokenizer\Tokens;
  *
  * @internal
  */
-class DollarCloseCurlyBrace extends AbstractTransformer
+class DollarCloseCurlyBraceTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Tokenizer/Transformer/DynamicPropBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DynamicPropBraceTransformer.php
@@ -21,7 +21,7 @@ use Symfony\CS\Tokenizer\Tokens;
  *
  * @internal
  */
-class DynamicPropBrace extends AbstractTransformer
+class DynamicPropBraceTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Tokenizer/Transformer/DynamicVarBraceTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/DynamicVarBraceTransformer.php
@@ -21,7 +21,7 @@ use Symfony\CS\Tokenizer\Tokens;
  *
  * @internal
  */
-class DynamicVarBrace extends AbstractTransformer
+class DynamicVarBraceTransformer extends AbstractTransformer
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
To maintain consistency with Fixers and avoid problems with `use` transformer (can't call class Use (reserved word), must be UseTransformer)
