### PR TITLE
Making WhitespacyLinesFixer not change the contents of strings

### DIFF
--- a/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
@@ -30,7 +30,7 @@ class TrailingSpacesFixer extends AbstractFixer
         $contentAfterRegex = preg_replace('/(?<=\S)[ \t]+$/m', '', $content);
 
         $originalTokens = Tokens::fromCode($content);
-        $newTokens      = Tokens::fromCode($contentAfterRegex);
+        $newTokens = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
             if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {

--- a/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
@@ -33,7 +33,7 @@ class TrailingSpacesFixer extends AbstractFixer
         $newTokens      = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
-            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
+            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {
                 $tokenBeforeRegex = $originalTokens[$tokenIndex];
                 $newToken->setContent($tokenBeforeRegex->getContent());
             }

--- a/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
@@ -12,6 +12,7 @@
 namespace Symfony\CS\Fixer\PSR2;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * Fixer for rules defined in PSR2 ¶2.3.
@@ -26,7 +27,19 @@ class TrailingSpacesFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         // [Structure] Don't add trailing spaces at the end of non-blank lines
-        return preg_replace('/(?<=\S)[ \t]+$/m', '', $content);
+        $contentAfterRegex = preg_replace('/(?<=\S)[ \t]+$/m', '', $content);
+
+        $originalTokens = Tokens::fromCode($content);
+        $newTokens      = Tokens::fromCode($contentAfterRegex);
+
+        foreach ($newTokens as $tokenIndex => $newToken) {
+            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
+                $tokenBeforeRegex = $originalTokens[$tokenIndex];
+                $newToken->setContent($tokenBeforeRegex->getContent());
+            }
+        }
+
+        return $newTokens->generateCode();
     }
 
     /**

--- a/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/TrailingSpacesFixer.php
@@ -33,7 +33,7 @@ class TrailingSpacesFixer extends AbstractFixer
         $newTokens = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
-            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {
+            if ($newToken->isGivenKind(array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
                 $tokenBeforeRegex = $originalTokens[$tokenIndex];
                 $newToken->setContent($tokenBeforeRegex->getContent());
             }

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -12,6 +12,7 @@
 namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -23,7 +24,19 @@ class WhitespacyLinesFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, $content)
     {
-        return preg_replace('/^\h+$/m', '', $content);
+        $contentAfterRegex = preg_replace('/^\h+$/m', '', $content);
+
+        $originalTokens = Tokens::fromCode($content);
+        $newTokens      = Tokens::fromCode($contentAfterRegex);
+
+        foreach ($newTokens as $tokenIndex => $newToken) {
+            if ($newToken->getId() === T_ENCAPSED_AND_WHITESPACE) {
+                $tokenBeforeRegex = $originalTokens[$tokenIndex];
+                $newToken->setContent($tokenBeforeRegex->getContent());
+            }
+        }
+
+        return $newTokens->generateCode();
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -27,7 +27,7 @@ class WhitespacyLinesFixer extends AbstractFixer
         $contentAfterRegex = preg_replace('/^\h+$/m', '', $content);
 
         $originalTokens = Tokens::fromCode($content);
-        $newTokens      = Tokens::fromCode($contentAfterRegex);
+        $newTokens = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
             if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -30,7 +30,7 @@ class WhitespacyLinesFixer extends AbstractFixer
         $newTokens      = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
-            if ($newToken->getId() === T_ENCAPSED_AND_WHITESPACE) {
+            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
                 $tokenBeforeRegex = $originalTokens[$tokenIndex];
                 $newToken->setContent($tokenBeforeRegex->getContent());
             }

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -13,6 +13,7 @@ namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;
+use Symfony\CS\Tokenizer\Token;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -30,7 +31,7 @@ class WhitespacyLinesFixer extends AbstractFixer
         $newTokens = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
-            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {
+            if ($newToken->isGivenKind(array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
                 $tokenBeforeRegex = $originalTokens[$tokenIndex];
                 $newToken->setContent($tokenBeforeRegex->getContent());
             }

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -13,7 +13,6 @@ namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;
-use Symfony\CS\Tokenizer\Token;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>

--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -30,7 +30,7 @@ class WhitespacyLinesFixer extends AbstractFixer
         $newTokens      = Tokens::fromCode($contentAfterRegex);
 
         foreach ($newTokens as $tokenIndex => $newToken) {
-            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING))) {
+            if (in_array($newToken->getId(), array(T_ENCAPSED_AND_WHITESPACE, T_CONSTANT_ENCAPSED_STRING), true)) {
                 $tokenBeforeRegex = $originalTokens[$tokenIndex];
                 $newToken->setContent($tokenBeforeRegex->getContent());
             }

--- a/Symfony/CS/Tests/Fixer/PSR2/TrailingSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/TrailingSpacesFixerTest.php
@@ -66,6 +66,9 @@ rassit et la posa sur ses genoux.
 EOT;
 ",
             ),
+            array(
+                "<?php\n\$string = 'x  \ny';\necho (strlen(\$string) === 5);"
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/TrailingSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/TrailingSpacesFixerTest.php
@@ -67,7 +67,7 @@ EOT;
 ",
             ),
             array(
-                "<?php\n\$string = 'x  \ny';\necho (strlen(\$string) === 5);"
+                "<?php\n\$string = 'x  \ny';\necho (strlen(\$string) === 5);",
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/Symfony/WhitespacyLinesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/WhitespacyLinesFixerTest.php
@@ -41,6 +41,12 @@ class WhitespacyLinesFixerTest extends AbstractFixerTestBase
                 "<?php\n\n\n\$b = 1;",
                 "<?php\n                \n	\n\$b = 1;",
             ),
+            array(
+                "<?php\nclass X\n{\n    \$string='Indentation should not break';\n}",
+            ),
+            array(
+                "<?php\n\$sql = 'SELECT * FROM products WHERE description = \"This product\n   \nis nice\";",
+            ),
         );
     }
 }


### PR DESCRIPTION
Fixes problem where regex changes the insides of string variables, resulting in accidental functional change.