### PR TITLE
add WhitespacyCommentTransformer

### DIFF
--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -68,13 +68,14 @@ class BracesFixer extends AbstractFixer
             }
 
             $tokenTmp = $tokens[$afterCommentIndex];
-            $tokens[$afterCommentIndex - 1]->setContent(rtrim($tokens[$afterCommentIndex - 1]->getContent()));
+            $tokens[$afterCommentIndex - 1]->setContent(rtrim($tokens[$afterCommentIndex - 1]->getContent(), " \t"));
 
             for ($i = $afterCommentIndex; $i > $afterParenthesisIndex; --$i) {
                 $tokens[$i] = $tokens[$i - 1];
             }
 
             $tokens[$afterParenthesisIndex] = $tokenTmp;
+            $tokens->insertAt($afterParenthesisIndex + 1, new Token(array(T_WHITESPACE, "\n")));
         }
     }
 

--- a/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
@@ -52,11 +52,6 @@ class SingleLineAfterImportsFixer extends AbstractFixer
                 ++$insertIndex;
             }
 
-            // Do not add newline after inline T_COMMENT as it is part of T_COMMENT already
-            if ($tokens[$insertIndex]->isGivenKind(T_COMMENT)) {
-                $newline = '';
-            }
-
             // Increment insert index for inline T_COMMENT or T_DOC_COMMENT
             if ($tokens[$insertIndex]->isComment()) {
                 ++$insertIndex;

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1137,7 +1137,7 @@ if (true) {
 }',
             ),
             array(
-                "<?php if (true) {\r\n\r\n// CRLF newline\r\n}",
+                "<?php if (true) {\r\n\r\n// CRLF newline\n}",
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -583,6 +583,27 @@ function mixedComplex()
     }',
             ),
             array(
+                '<?php
+    if (true) {
+        // foo
+        /* bar */
+        if (true) {
+            print("foo");
+            print("bar");
+        }
+    }',
+                '<?php
+    if (true)
+        // foo
+        /* bar */{
+        if (true)
+        {
+            print("foo");
+            print("bar");
+        }
+    }',
+            ),
+            array(
                 '<?php if (true) {
     echo "s";
 } ?>x',

--- a/Symfony/CS/Tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
@@ -38,21 +38,24 @@ class WhitespacyCommentTransformerTest extends AbstractTransformerTestBase
     {
         return array(
             array(
-                '<?php
-    // foo
-    $a = 1;',
+                "<?php // foo\n    \$a = 1;",
                 array(
-                    2 => array(T_COMMENT, '// foo'),
-                    3 => array(T_WHITESPACE, "\n    "),
+                    1 => array(T_COMMENT, '// foo'),
+                    2 => array(T_WHITESPACE, "\n    "),
                 ),
             ),
             array(
-                '<?php
-    // foo
-',
+                "<?php // foo\n\n ",
                 array(
-                    2 => array(T_COMMENT, '// foo'),
-                    3 => array(T_WHITESPACE, "\n"),
+                    1 => array(T_COMMENT, '// foo'),
+                    2 => array(T_WHITESPACE, "\n\n "),
+                ),
+            ),
+            array(
+                "<?php // foo \r\n ",
+                array(
+                    1 => array(T_COMMENT, '// foo'),
+                    2 => array(T_WHITESPACE, " \r\n "),
                 ),
             ),
         );

--- a/Symfony/CS/Tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Tokenizer\Transformer;
+
+use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ */
+class WhitespacyCommentTransformerTest extends AbstractTransformerTestBase
+{
+    /**
+     * @dataProvider provideProcessCases
+     */
+    public function testProcess($source, array $expectedTokens)
+    {
+        $tokens = Tokens::fromCode($source);
+
+        foreach ($expectedTokens as $index => $expectedToken) {
+            $token = $tokens[$index];
+
+            $this->assertSame($expectedToken[1], $token->getContent());
+            $this->assertSame($expectedToken[0], $token->getId());
+        }
+    }
+
+    public function provideProcessCases()
+    {
+        return array(
+            array(
+                '<?php
+    // foo
+    $a = 1;',
+                array(
+                    2 => array(T_COMMENT, '// foo'),
+                    3 => array(T_WHITESPACE, "\n    "),
+                ),
+            ),
+            array(
+                '<?php
+    // foo
+',
+                array(
+                    2 => array(T_COMMENT, '// foo'),
+                    3 => array(T_WHITESPACE, "\n"),
+                ),
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tokenizer\Transformer;
+
+use Symfony\CS\Tokenizer\AbstractTransformer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Move trailing whitespaces from comments and docs into following T_WHITESPACE token.
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+class WhitespacyCommentTransformer extends AbstractTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens)
+    {
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if (!$token->isComment()) {
+                continue;
+            }
+
+            if (preg_match("/^(.*)([ \t\r\n]+)$/", $token->getContent(), $matches)) {
+                $token->setContent($matches[1]);
+
+                if (isset($tokens[$index + 1]) && $tokens[$index + 1]->isGivenKind(T_WHITESPACE)) {
+                    $tokens[$index + 1]->setContent($matches[2].$tokens[$index + 1]->getContent());
+                } else {
+                    $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, $matches[2])));
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokenNames()
+    {
+        return array();
+    }
+}

--- a/Symfony/CS/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -36,14 +36,22 @@ class WhitespacyCommentTransformer extends AbstractTransformer
                 continue;
             }
 
-            if (preg_match("/^(.*)([ \t\r\n]+)$/", $token->getContent(), $matches)) {
-                $token->setContent($matches[1]);
+            $content = $token->getContent();
+            $trimmedContent = rtrim($content);
 
-                if (isset($tokens[$index + 1]) && $tokens[$index + 1]->isGivenKind(T_WHITESPACE)) {
-                    $tokens[$index + 1]->setContent($matches[2].$tokens[$index + 1]->getContent());
-                } else {
-                    $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, $matches[2])));
-                }
+            // nothing trimmed, nothing to do
+            if ($content === $trimmedContent) {
+                continue;
+            }
+
+            $whitespaces = substr($content, strlen($trimmedContent));
+
+            $token->setContent($trimmedContent);
+
+            if (isset($tokens[$index + 1]) && $tokens[$index + 1]->isGivenKind(T_WHITESPACE)) {
+                $tokens[$index + 1]->setContent($whitespaces.$tokens[$index + 1]->getContent());
+            } else {
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, $whitespaces)));
             }
         }
     }


### PR DESCRIPTION
Separate trailing whitespacy chars after comment into separate, following T_WHITESPACE token.

Will help to fix #774 [see also](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/774#issuecomment-64912296).

Simplify few issues when changing FixerInterface (see #902)