### PR TITLE
Enable caching of composer downloads on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ php:
 
 sudo: false
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 install:
-    - travis_retry composer install --no-interaction --prefer-source
+    - travis_retry composer install --no-interaction
 
 script:
     - phpunit --verbose --coverage-clover build/logs/clover.xml


### PR DESCRIPTION
This is possible thanks to 2 changes:

- the new docker-based infrastructure allows to use the cache for public repos too.
- since several months, Composer is smart enough to fallback to a source install in case it cannot download the dist, avoiding to break the build in case the Github API rate limit is reached on the Travis VM

And thanks to the usage of the cache, most downloads will not count in the API rate limit because they will never reach Github (only new versions will be downloaded when one of the dependencies makes a new release).

Note that the PR build will not show any improvement yet, because PR builds are loading the cache of their target branch, and the target branch does not have a cache yet of course.

The target of this PR is 1.4 so that all maintained branches will get this improvement.