### PR TITLE
Skip files containing __halt_compiler() on PHP 5.3

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -165,7 +165,10 @@ class Fixer
     {
         $new = $old = file_get_contents($file->getRealpath());
 
-        if (!$fileCacheManager->needFixing($this->getFileRelativePathname($file), $old)) {
+        if (!$fileCacheManager->needFixing($this->getFileRelativePathname($file), $old)
+            // PHP 5.3 has a broken implementation of token_get_all when the file uses __halt_compiler() starting in 5.3.6
+            || (PHP_VERSION_ID >= 50306 && PHP_VERSION_ID < 50400 && false !== stripos($old, '__halt_compiler()'))
+        ) {
             if ($this->eventDispatcher) {
                 $this->eventDispatcher->dispatch(
                     FixerFileProcessedEvent::NAME,


### PR DESCRIPTION
Closes #760

Files will be reported as skipped here (I figured it was better than hiding them entirely from the output)