### PR TITLE
Tokens::isLambda - fix detection near comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for v1.4
 ------------------
 
 * feature #841 PhpdocParamsFixer: added aligning var/type annotations (GrahamCampbell)
+* bug #950 Tokens::isLambda - fix detection near comments (keradus)
 * bug #951 Tokens::getImportUseIndexes - fix detection near comments (keradus)
 * bug #949 Tokens::isShortArray - fix detection near comments (keradus)
 * bug #948 NewWithBracesFixer - fix case with multidimensional array (keradus)

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -62,4 +62,49 @@ PHP;
 
         $this->assertSame($countBefore, $tokens->count());
     }
+
+    /**
+     * @dataProvider provideIsLambdaCases
+     */
+    public function testIsLambda($source, array $expected)
+    {
+        $tokens = Tokens::fromCode($source);
+
+        foreach ($expected as $index => $expected) {
+            $this->assertSame($expected, $tokens->isLambda($index));
+        }
+    }
+
+    public function provideIsLambdaCases()
+    {
+        return array(
+            array(
+                '<?php function foo () {}',
+                array(1 => false),
+            ),
+            array(
+                '<?php function /** foo */ foo () {}',
+                array(1 => false),
+            ),
+            array(
+                '<?php $foo = function () {}',
+                array(5 => true),
+            ),
+            array(
+                '<?php $foo = function /** foo */ () {}',
+                array(5 => true),
+            ),
+            array(
+                '<?php
+preg_replace_callback(
+    "/(^|[a-z])/",
+    function (array $matches) {
+        return "a";
+    },
+    $string
+);',
+                array(7 => true),
+            ),
+        );
+    }
 }

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -292,7 +292,7 @@ class Tokens extends \SplFixedArray
 
         if ($token->isWhitespace()) {
             $removeLastCommentLine($this[$index - 1], $indexOffset);
-            $token->setContent($whitespace);
+            $token->override(array(T_WHITESPACE, $whitespace, $token->getLine()));
 
             return false;
         }
@@ -833,7 +833,7 @@ class Tokens extends \SplFixedArray
             throw new \LogicException('No T_FUNCTION at given index');
         }
 
-        $nextIndex = $this->getNextNonWhitespace($index);
+        $nextIndex = $this->getNextMeaningfulToken($index);
         $nextToken = $this[$nextIndex];
 
         if (!$nextToken->equals('(')) {
@@ -842,7 +842,7 @@ class Tokens extends \SplFixedArray
 
         $endParenthesisIndex = $this->findBlockEnd(self::BLOCK_TYPE_PARENTHESIS_BRACE, $nextIndex);
 
-        $nextIndex = $this->getNextNonWhitespace($endParenthesisIndex);
+        $nextIndex = $this->getNextMeaningfulToken($endParenthesisIndex);
         $nextToken = $this[$nextIndex];
 
         if (!$nextToken->equalsAny(array('{', array(T_USE)))) {


### PR DESCRIPTION
(After merge into 1.x) It should be manually merged into TokensAnalyzer at 2.x line.
Also watch on Token::getLine removal
