### PR TITLE
Tokens::getImportUseIndexes - fix detection near comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for v1.4
 ------------------
 
 * feature #841 PhpdocParamsFixer: added aligning var/type annotations (GrahamCampbell)
+* bug #951 Tokens::getImportUseIndexes - fix detection near comments (keradus)
 * bug #949 Tokens::isShortArray - fix detection near comments (keradus)
 * bug #948 NewWithBracesFixer - fix case with multidimensional array (keradus)
 * bug #945 Skip files containing __halt_compiler() on PHP 5.3 (stof)

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -543,7 +543,7 @@ class Tokens extends \SplFixedArray
                 continue;
             }
 
-            $nextToken = $this[$this->getNextNonWhitespace($index)];
+            $nextToken = $this[$this->getNextMeaningfulToken($index)];
 
             // ignore function () use ($foo) {}
             if ($nextToken->equals('(')) {


### PR DESCRIPTION
need manually merge into 2.x due to new transformer