### PR TITLE
ParenthesisFixer - fix case with list call with trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for v1.4
 ------------------
 
 * feature #841 PhpdocParamsFixer: added aligning var/type annotations (GrahamCampbell)
+* bug #952 ParenthesisFixer - fix case with list call with trailing comma (keradus)
 * bug #950 Tokens::isLambda - fix detection near comments (keradus)
 * bug #951 Tokens::getImportUseIndexes - fix detection near comments (keradus)
 * bug #949 Tokens::isShortArray - fix detection near comments (keradus)

--- a/Symfony/CS/Fixer/PSR2/ParenthesisFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ParenthesisFixer.php
@@ -35,7 +35,7 @@ class ParenthesisFixer extends AbstractFixer
                 continue;
             }
 
-            $prevIndex = $tokens->getPrevNonWhitespace($index);
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
 
             // ignore parenthesis for T_ARRAY
             if (null !== $prevIndex && $tokens[$prevIndex]->isGivenKind(T_ARRAY)) {
@@ -44,8 +44,13 @@ class ParenthesisFixer extends AbstractFixer
 
             $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 
+            // remove space after opening `(`
             $this->removeSpaceAroundToken($tokens, $index, 1);
-            $this->removeSpaceAroundToken($tokens, $endIndex, -1);
+
+            // remove space after closing `)` if it is not `list($a, $b, )` case
+            if (!$tokens[$tokens->getPrevMeaningfulToken($endIndex)]->equals(',')) {
+                $this->removeSpaceAroundToken($tokens, $endIndex, -1);
+            }
         }
 
         return $tokens->generateCode();

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -53,6 +53,11 @@ class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
             array(
                 '<?php array(10 , 20 ,30);',
             ),
+            // list call with trailing comma
+            array(
+                '<?php list($path, $mode, ) = foo();',
+                '<?php list($path, $mode,) = foo();',
+            ),
             // multi line testing method arguments
             array(
                 '<?php function xyz(

--- a/Symfony/CS/Tests/Fixer/PSR2/ParenthesisFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/ParenthesisFixerTest.php
@@ -53,6 +53,10 @@ EOF;
     {
         return array(
             array(
+                '<?php foo();',
+                '<?php foo( );',
+            ),
+            array(
                 '<?php
 if (true) {
     // if body
@@ -99,6 +103,13 @@ $var = array( 1, 2, 3 );
                 '<?php
 $var = [ 1, 2, 3 ];
 ',
+            ),
+            // list call with trailing comma - need to leave alone
+            array(
+                '<?php list($path, $mode, ) = foo();',
+            ),
+            array(
+                '<?php list($path, $mode,) = foo();',
             ),
         );
     }


### PR DESCRIPTION
Fix #930
Note: Should be merged into 1.4 branch as setted in milestone, not master as setted in PR.

Consider following code:
`<?php list($path, $mode,) = foo();`

If we run MethodArgumentSpaceFixer on it, it will add a space after comma:
`<?php list($path, $mode, ) = foo();`

Then if we run ParenthesisFixer it will remove that space:
`<?php list($path, $mode,) = foo();`


This PR change behavior of ParenthesisFixer - stop removing space if there is trailing comma.
Also added a tests for it in both fixers.