### PR TITLE
Fixer - fix handling of empty file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for v1.4
 ------------------
 
 * feature #841 PhpdocParamsFixer: added aligning var/type annotations (GrahamCampbell)
+* bug #961 Fixer - fix handling of empty file (keradus)
 * bug #960 IncludeFixer - fix bug when include is part of condition statement (keradus)
 * bug #954 AlignDoubleArrowFixer - fix new buggy case (keradus)
 * bug #955 ParenthesisFixer - fix case with list call with trailing comma (keradus)

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -165,7 +165,9 @@ class Fixer
     {
         $new = $old = file_get_contents($file->getRealpath());
 
-        if (!$fileCacheManager->needFixing($this->getFileRelativePathname($file), $old)
+        if (
+            '' === $old
+            || !$fileCacheManager->needFixing($this->getFileRelativePathname($file), $old)
             // PHP 5.3 has a broken implementation of token_get_all when the file uses __halt_compiler() starting in 5.3.6
             || (PHP_VERSION_ID >= 50306 && PHP_VERSION_ID < 50400 && false !== stripos($old, '__halt_compiler()'))
         ) {


### PR DESCRIPTION
If file is empty then many fixers crash during operating on empty collection.
What's more there is no need to lint empty file etc.