### PR TITLE
Add case sensitive option to the tokenizer

### DIFF
--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -80,11 +80,12 @@ class Token
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param Token|array|string $other token or it's prototype
+     * @param Token|array|string $other         token or it's prototype
+     * @param bool               $caseSensitive perform a case sensitive comparison
      *
      * @return bool
      */
-    public function equals($other)
+    public function equals($other, $caseSensitive = true)
     {
         $otherPrototype = $other instanceof Token ? $other->getPrototype() : $other;
 
@@ -99,8 +100,21 @@ class Token
         $selfPrototype = $this->getPrototype();
 
         foreach ($otherPrototype as $key => $val) {
-            if ($selfPrototype[$key] !== $val) {
+            // make sure the token has such key
+            if (!isset($selfPrototype[$key])) {
                 return false;
+            }
+
+            if (1 === $key && !$caseSensitive) {
+                // case-insensitive comparison only applies to the content (key 1)
+                if (0 !== strcasecmp($val, $selfPrototype[1])) {
+                    return false;
+                }
+            } else {
+                // regular comparison
+                if ($selfPrototype[$key] !== $val) {
+                    return false;
+                }
             }
         }
 
@@ -110,14 +124,23 @@ class Token
     /**
      * Check if token is equals to one of given.
      *
-     * @param array $others array of tokens or token prototypes
+     * @param array       $others        array of tokens or token prototypes
+     * @param bool|bool[] $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                   the ones used in $others. If any is missing, the default case-sensitive
+     *                                   comparison is used.
      *
      * @return bool
      */
-    public function equalsAny(array $others)
+    public function equalsAny(array $others, $caseSensitive = true)
     {
-        foreach ($others as $other) {
-            if ($this->equals($other)) {
+        foreach ($others as $key => $other) {
+            if (is_array($caseSensitive)) {
+                $cs = isset($caseSensitive[$key]) ? $caseSensitive[$key] : true;
+            } else {
+                $cs = $caseSensitive;
+            }
+
+            if ($this->equals($other, $cs)) {
                 return true;
             }
         }

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -577,14 +577,17 @@ class Tokens extends \SplFixedArray
      *
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param int   $index  token index
-     * @param array $tokens possible tokens
+     * @param int         $index         token index
+     * @param array       $tokens        possible tokens
+     * @param bool|bool[] $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                   the ones used in $others. If any is missing, the default case-sensitive
+     *                                   comparison is used.
      *
      * @return int|null
      */
-    public function getNextTokenOfKind($index, array $tokens = array())
+    public function getNextTokenOfKind($index, array $tokens = array(), $caseSensitive = true)
     {
-        return $this->getTokenOfKindSibling($index, 1, $tokens);
+        return $this->getTokenOfKindSibling($index, 1, $tokens, $caseSensitive);
     }
 
     /**
@@ -632,26 +635,32 @@ class Tokens extends \SplFixedArray
      * Get index for closest previous token of given kind.
      * This method is shorthand for getTokenOfKindSibling method.
      *
-     * @param int   $index  token index
-     * @param array $tokens possible tokens
+     * @param int         $index         token index
+     * @param array       $tokens        possible tokens
+     * @param bool|bool[] $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                   the ones used in $others. If any is missing, the default case-sensitive
+     *                                   comparison is used.
      *
      * @return int|null
      */
-    public function getPrevTokenOfKind($index, array $tokens = array())
+    public function getPrevTokenOfKind($index, array $tokens = array(), $caseSensitive = true)
     {
-        return $this->getTokenOfKindSibling($index, -1, $tokens);
+        return $this->getTokenOfKindSibling($index, -1, $tokens, $caseSensitive);
     }
 
     /**
      * Get index for closest sibling token of given kind.
      *
-     * @param int   $index     token index
-     * @param int   $direction direction for looking, +1 or -1
-     * @param array $tokens    possible tokens
+     * @param int         $index         token index
+     * @param int         $direction     direction for looking, +1 or -1
+     * @param array       $tokens        possible tokens
+     * @param bool|bool[] $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                   the ones used in $others. If any is missing, the default case-sensitive
+     *                                   comparison is used.
      *
      * @return int|null
      */
-    public function getTokenOfKindSibling($index, $direction, array $tokens = array())
+    public function getTokenOfKindSibling($index, $direction, array $tokens = array(), $caseSensitive = true)
     {
         while (true) {
             $index += $direction;
@@ -662,7 +671,7 @@ class Tokens extends \SplFixedArray
 
             $token = $this[$index];
 
-            if ($token->equalsAny($tokens)) {
+            if ($token->equalsAny($tokens, $caseSensitive)) {
                 return $index;
             }
         }


### PR DESCRIPTION
> MARK FOR MERGE INTO 2.0 by @keradus
> Remove Token line usages !

Token equality now can optionally be case insensitive. Implemented in such a way that there is no BC break.

