### PR TITLE
Add Tokens::findSequence

### DIFF
--- a/Symfony/CS/Tests/Tokenizer/TokenTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokenTest.php
@@ -341,9 +341,35 @@ class TokenTest extends \PHPUnit_Framework_TestCase
             array(false, array(array(T_FUNCTION, 'Function'), array(T_VARIABLE, 'function')), array(true, true)),
 
             array(true, array(',', '}', array(T_FUNCTION, 'Function')), array(2 => false)),
-            array(true, array('a' => ',', 'b' => '}', 'c' => array(T_FUNCTION, 'Function')), array('c' => false)),
 
             array(false, array(array(T_VARIABLE, 'junction'), array(T_FUNCTION, 'junction')), false),
+        );
+    }
+
+    /**
+     * @dataProvider provideIsKeyCaseSensitive
+     */
+    public function testIsKeyCaseSensitive($isKeyCaseSensitive, $caseSensitive, $key)
+    {
+        $this->assertSame($isKeyCaseSensitive, Token::isKeyCaseSensitive($caseSensitive, $key));
+    }
+
+    public function provideIsKeyCaseSensitive()
+    {
+        return array(
+            array(true, true, 0),
+            array(true, true, 1),
+            array(true, array(), 0),
+            array(true, array(true), 0),
+            array(true, array(false, true), 1),
+            array(true, array(false, true, false), 1),
+            array(true, array(false), 10),
+
+            array(false, false, 10),
+            array(false, array(false), 0),
+            array(false, array(true, false), 1),
+            array(false, array(true, false, true), 1),
+            array(false, array(1 => false), 1),
         );
     }
 }

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -134,11 +134,7 @@ class Token
     public function equalsAny(array $others, $caseSensitive = true)
     {
         foreach ($others as $key => $other) {
-            if (is_array($caseSensitive)) {
-                $cs = isset($caseSensitive[$key]) ? $caseSensitive[$key] : true;
-            } else {
-                $cs = $caseSensitive;
-            }
+            $cs = self::isKeyCaseSensitive($caseSensitive, $key);
 
             if ($this->equals($other, $cs)) {
                 return true;
@@ -146,6 +142,25 @@ class Token
         }
 
         return false;
+    }
+
+    /**
+     * A helper method used to find out whether or not a certain input token has to be case-sensitively matched.
+     *
+     * @param bool|bool[] $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                   the ones used in $others. If any is missing, the default case-sensitive
+     *                                   comparison is used.
+     * @param int         $key           the key of the token that has to be looked up
+     *
+     * @return bool
+     */
+    public static function isKeyCaseSensitive($caseSensitive, $key)
+    {
+        if (is_array($caseSensitive)) {
+            return isset($caseSensitive[$key]) ? $caseSensitive[$key] : true;
+        }
+
+        return $caseSensitive;
     }
 
     /**

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -751,6 +751,94 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * Find a sequence of meaningful tokens and returns the array of their locations.
+     *
+     * @param array      $sequence      an array of tokens (same format used by getNextTokenOfKind)
+     * @param int        $start         start index, defaulting to the start of the file
+     * @param int        $end           end index, defaulting to the end of the file
+     * @param bool|array $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     *                                  the ones used in $others. If any is missing, the default case-sensitive
+     *                                  comparison is used.
+     *
+     * @return array|null an array containing the tokens matching the sequence elements, indexed by their position
+     */
+    public function findSequence(array $sequence, $start = 0, $end = null, $caseSensitive = true)
+    {
+        // $end defaults to the end of the collection
+        if (null === $end) {
+            $end = count($this) - 1;
+        }
+
+        if (!count($sequence)) {
+            throw new \InvalidArgumentException('Invalid sequence');
+        }
+
+        // make sure the sequence content is "meaningful"
+        foreach ($sequence as $key => $token) {
+            // if not a Token instance already, we convert it to verify the meaningfulness
+            if (!$token instanceof Token) {
+                if (is_array($token) && !isset($token[1])) {
+                    // fake some content as it is required by the Token constructor,
+                    // although optional for search purposes
+                    $token[1] = '';
+                }
+                $token = new Token($token);
+            }
+            if ($token->isWhitespace() || $token->isComment() || $token->isEmpty()) {
+                throw new \InvalidArgumentException('Non-meaningful token at position: '.$key);
+            }
+        }
+
+        // remove the first token from the sequence, so we can freely iterate through the sequence after a match to
+        // the first one is found
+        $key = key($sequence);
+        $firstCs = Token::isKeyCaseSensitive($caseSensitive, $key);
+        $firstToken = $sequence[$key];
+        unset($sequence[$key]);
+
+        // begin searching for the first token in the sequence (start included)
+        $index = $start - 1;
+        while (null !== $index && $index <= $end) {
+            $index = $this->getNextTokenOfKind($index, array($firstToken), $firstCs);
+
+            // ensure we found a match and didn't get past the end index
+            if (null === $index || $index > $end) {
+                return;
+            }
+
+            // initialise the result array with the current index
+            $result = array($index => $this[$index]);
+
+            // advance cursor to the current position
+            $currIdx = $index;
+
+            // iterate through the remaining tokens in the sequence
+            foreach ($sequence as $key => $token) {
+                $currIdx = $this->getNextMeaningfulToken($currIdx);
+
+                // ensure we didn't go too far
+                if (null === $currIdx || $currIdx > $end) {
+                    return;
+                }
+
+                if (!$this[$currIdx]->equals($token, Token::isKeyCaseSensitive($caseSensitive, $key))) {
+                    // not a match, restart the outer loop
+                    continue 2;
+                }
+
+                // append index to the result array
+                $result[$currIdx] = $this[$currIdx];
+            }
+
+            // do we have a complete match?
+            // hint: $result is bigger than $sequence since the first token has been removed from the latter
+            if (count($sequence) < count($result)) {
+                return $result;
+            }
+        }
+    }
+
+    /**
      * Insert instances of Token inside collection.
      *
      * @param int                  $index start inserting index


### PR DESCRIPTION
A new utility method to match a sequence of meaningful tokens in the code. Comments and whitespace are ignored.

This PR is based on #972