### PR TITLE
NoEmptyLinesAfterPhpdocsFixer - fix only when documentation documents sth

### DIFF
--- a/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
@@ -26,13 +26,24 @@ class NoEmptyLinesAfterPhpdocsFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, $content)
     {
+        static $forbiddenSuccessors = array(
+            T_DOC_COMMENT,
+            T_COMMENT,
+            T_WHITESPACE,
+            T_RETURN,
+            T_THROW,
+            T_GOTO,
+            T_CONTINUE,
+            T_BREAK,
+        );
+
         $tokens = Tokens::fromCode($content);
 
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
             // get the next non-whitespace token inc comments, provided
             // that there is whitespace between it and the current token
             $next = $tokens->getNextNonWhitespace($index);
-            if ($index + 2 === $next && false === $tokens[$next]->isGivenKind(array(T_DOC_COMMENT, T_COMMENT, T_WHITESPACE))) {
+            if ($index + 2 === $next && false === $tokens[$next]->isGivenKind($forbiddenSuccessors)) {
                 $this->fixWhitespace($tokens[$index + 1]);
             }
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
@@ -212,4 +212,26 @@ EOF;
 
         $this->makeTest($expected, $input);
     }
+
+    // empty line between typehinting docs and return statement should be preserved
+    public function testInlineTypehintingDocsBeforeReturn()
+    {
+        $expected = <<<'EOF'
+<?php
+
+function parseTag($tag)
+{
+    $tagClass = get_class($tag);
+
+    if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+        /** @var DocBlock\Tag\VarTag $tag */
+
+        return $tag->getDescription();
+    }
+}
+
+EOF;
+
+        $this->makeTest($expected);
+    }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixerTest.php
@@ -213,12 +213,22 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
-    // empty line between typehinting docs and return statement should be preserved
-    public function testInlineTypehintingDocsBeforeReturn()
+    /**
+     * Empty line between typehinting docs and return statement should be preserved.
+     *
+     * @dataProvider provideInlineTypehintingDocsBeforeFlowBreakCases
+     */
+    public function testInlineTypehintingDocsBeforeFlowBreak($expected, $input = null)
     {
-        $expected = <<<'EOF'
-<?php
+        $this->makeTest($expected, $input);
+    }
 
+    public function provideInlineTypehintingDocsBeforeFlowBreakCases()
+    {
+        $cases = array();
+
+        $cases[] = array(<<<'EOF'
+<?php
 function parseTag($tag)
 {
     $tagClass = get_class($tag);
@@ -229,9 +239,73 @@ function parseTag($tag)
         return $tag->getDescription();
     }
 }
+EOF
+);
 
-EOF;
+        $cases[] = array(<<<'EOF'
+<?php
+function parseTag($tag)
+{
+    $tagClass = get_class($tag);
 
-        $this->makeTest($expected);
+    if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+        /** @var DocBlock\Tag\VarTag $tag */
+
+        throw new Exception($tag->getDescription());
+    }
+}
+EOF
+);
+
+        $cases[] = array(<<<'EOF'
+<?php
+function parseTag($tag)
+{
+    $tagClass = get_class($tag);
+
+    if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+        /** @var DocBlock\Tag\VarTag $tag */
+
+        goto FOO;
+    }
+}
+EOF
+);
+
+        $cases[] = array(<<<'EOF'
+<?php
+function parseTag($tag)
+{
+    while (true) {
+        $tagClass = get_class($tag);
+
+        if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+            /** @var DocBlock\Tag\VarTag $tag */
+
+            continue;
+        }
+    }
+}
+EOF
+);
+
+        $cases[] = array(<<<'EOF'
+<?php
+function parseTag($tag)
+{
+    while (true) {
+        $tagClass = get_class($tag);
+
+        if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+            /** @var DocBlock\Tag\VarTag $tag */
+
+            break;
+        }
+    }
+}
+EOF
+);
+
+        return $cases;
     }
 }


### PR DESCRIPTION
Empty line between typehinting docs and return statement should be preserved.

@GrahamCampbell , could you take care of this, please ?