### PR TITLE
PhpdocIndentFixer - fix error when there is a comment between docblock and next meaningful token

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -46,7 +46,10 @@ class PhpdocIndentFixer extends AbstractFixer
                 continue;
             }
 
-            $indent = Utils::calculateTrailingWhitespaceIndent($tokens[$nextIndex - 1]);
+            $indent = '';
+            if ($tokens[$nextIndex - 1]->isWhitespace()) {
+                $indent = Utils::calculateTrailingWhitespaceIndent($tokens[$nextIndex - 1]);
+            }
 
             $prevToken->setContent($this->fixWhitespaceBefore($prevToken->getContent(), $indent));
             $token->setContent($this->fixDocBlock($token->getContent(), $indent));

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
@@ -383,13 +383,6 @@ public function write(\$name) {}
 /**
  * docs
  */
-// comment
-$foo = $bar;
-',
-            '<?php
-/**
- * docs
- */
 
 // comment
 $foo = $bar;

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
@@ -378,6 +378,24 @@ public function write(\$name) {}
     }',
         );
 
+        $cases[] = array(
+            '<?php
+/**
+ * docs
+ */
+// comment
+$foo = $bar;
+',
+            '<?php
+/**
+ * docs
+ */
+
+// comment
+$foo = $bar;
+',
+        );
+
         return $cases;
     }
 }


### PR DESCRIPTION
Bug when between docs and documented code is a comment.

Could you take care of that @ceeram , please?