### PR TITLE
Fixers - no need to search for tokens of given kind in extra loop

### DIFF
--- a/COOKBOOK-FIXERS.md
+++ b/COOKBOOK-FIXERS.md
@@ -277,9 +277,11 @@ class RemoveCommentsFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        $foundComments = $tokens->findGivenKind(T_COMMENT);
+        foreach($tokens as $index => $token){
+            if (!$token->isGivenKind(T_COMMENT)) {
+                continue;
+            }
 
-        foreach($foundComments as $index => $token){
             // need to figure out what to do here!
         }
     }
@@ -297,9 +299,11 @@ class RemoveCommentsFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        $foundComments = $tokens->findGivenKind(T_COMMENT);
+        foreach($tokens as $index => $token){
+            if (!$token->isGivenKind(T_COMMENT)) {
+                continue;
+            }
 
-        foreach($foundComments as $index => $token){
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevTokenIndex];
 
@@ -336,9 +340,11 @@ class RemoveCommentsFixer extends AbstractFixer {
      * {@inheritdoc}
      */
     public function fix(\SplFileInfo $file, Tokens $tokens) {
-        $foundComments = $tokens->findGivenKind(T_COMMENT);
+        foreach($tokens as $index => $token){
+            if (!$token->isGivenKind(T_COMMENT)) {
+                continue;
+            }
 
-        foreach ($foundComments as $index => $token) {
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevTokenIndex];
 

--- a/Symfony/CS/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixer.php
@@ -24,7 +24,13 @@ class NoBlankLinesBeforeNamespaceFixer extends AbstractLinesBeforeNamespaceFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach (array_keys($tokens->findGivenKind(T_NAMESPACE)) as $index) {
+        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
+            $token = $tokens[$index];
+
+            if (!$token->isGivenKind(T_NAMESPACE)) {
+                continue;
+            }
+
             $this->fixLinesBeforeNamespace($tokens, $index, 1);
         }
     }

--- a/Symfony/CS/Fixer/Contrib/PhpdocOrderFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpdocOrderFixer.php
@@ -25,7 +25,11 @@ class PhpdocOrderFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $content = $token->getContent();
             // move param to start, return to end, leave throws in the middle
             $content = $this->moveParamAnnotations($content);

--- a/Symfony/CS/Fixer/Contrib/PhpdocVarToTypeFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpdocVarToTypeFixer.php
@@ -25,7 +25,11 @@ class PhpdocVarToTypeFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $annotations = $doc->getAnnotationsOfType('var');
 

--- a/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
@@ -25,7 +25,11 @@ class ShortArraySyntaxFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_ARRAY) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_ARRAY)) {
+                continue;
+            }
+
             $openIndex = $tokens->getNextTokenOfKind($index, array('('));
             $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openIndex);
 

--- a/Symfony/CS/Fixer/PSR2/ElseifFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ElseifFixer.php
@@ -28,7 +28,11 @@ class ElseifFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_ELSE) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_ELSE)) {
+                continue;
+            }
+
             $nextIndex = $tokens->getNextNonWhitespace($index);
             $nextToken = $tokens[$nextIndex];
 

--- a/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
@@ -30,21 +30,23 @@ class LineAfterNamespaceFixer extends AbstractFixer
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
             $token = $tokens[$index];
 
-            if (T_NAMESPACE === $token->getId()) {
-                $semicolonIndex = $tokens->getNextTokenOfKind($index, array(';', '{'));
-                $semicolonToken = $tokens[$semicolonIndex];
+            if (!$token->isGivenKind(T_NAMESPACE)) {
+                continue;
+            }
 
-                if (!$semicolonToken->equals(';') || !isset($tokens[$semicolonIndex + 1])) {
-                    continue;
-                }
+            $semicolonIndex = $tokens->getNextTokenOfKind($index, array(';', '{'));
+            $semicolonToken = $tokens[$semicolonIndex];
 
-                $nextToken = $tokens[$semicolonIndex + 1];
+            if (!$semicolonToken->equals(';') || !isset($tokens[$semicolonIndex + 1])) {
+                continue;
+            }
 
-                if (!$nextToken->isWhitespace()) {
-                    $tokens->insertAt($semicolonIndex + 1, new Token(array(T_WHITESPACE, "\n\n")));
-                } else {
-                    $nextToken->setContent("\n\n".ltrim($nextToken->getContent()));
-                }
+            $nextToken = $tokens[$semicolonIndex + 1];
+
+            if (!$nextToken->isWhitespace()) {
+                $tokens->insertAt($semicolonIndex + 1, new Token(array(T_WHITESPACE, "\n\n")));
+            } else {
+                $nextToken->setContent("\n\n".ltrim($nextToken->getContent()));
             }
         }
     }

--- a/Symfony/CS/Fixer/Symfony/ConcatWithoutSpacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ConcatWithoutSpacesFixer.php
@@ -27,14 +27,16 @@ class ConcatWithoutSpacesFixer extends AbstractFixer
         $whitespaces = array('whitespaces' => " \t");
 
         foreach ($tokens as $index => $token) {
-            if ($token->equals('.')) {
-                if (!$tokens[$tokens->getPrevNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
-                    $tokens->removeLeadingWhitespace($index, $whitespaces);
-                }
+            if (!$token->equals('.')) {
+                continue;
+            }
 
-                if (!$tokens[$tokens->getNextNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
-                    $tokens->removeTrailingWhitespace($index, $whitespaces);
-                }
+            if (!$tokens[$tokens->getPrevNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
+                $tokens->removeLeadingWhitespace($index, $whitespaces);
+            }
+
+            if (!$tokens[$tokens->getNextNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
+                $tokens->removeTrailingWhitespace($index, $whitespaces);
             }
         }
     }

--- a/Symfony/CS/Fixer/Symfony/DoubleArrowMultilineWhitespacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/DoubleArrowMultilineWhitespacesFixer.php
@@ -27,7 +27,11 @@ class DoubleArrowMultilineWhitespacesFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOUBLE_ARROW) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOUBLE_ARROW)) {
+                continue;
+            }
+
             $this->fixWhitespace($tokens[$index - 1]);
             // do not move anything about if there is a comment following the whitespace
             if (!$tokens[$index + 2]->isComment()) {

--- a/Symfony/CS/Fixer/Symfony/EmptyReturnFixer.php
+++ b/Symfony/CS/Fixer/Symfony/EmptyReturnFixer.php
@@ -24,7 +24,11 @@ class EmptyReturnFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_RETURN) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_RETURN)) {
+                continue;
+            }
+
             if ($this->needFixing($tokens, $index)) {
                 $this->clear($tokens, $index);
             }

--- a/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
@@ -24,7 +24,11 @@ class ExtraEmptyLinesFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_WHITESPACE) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_WHITESPACE)) {
+                continue;
+            }
+
             $content = '';
             $count = 0;
             $parts = explode("\n", $token->getContent());

--- a/Symfony/CS/Fixer/Symfony/JoinFunctionFixer.php
+++ b/Symfony/CS/Fixer/Symfony/JoinFunctionFixer.php
@@ -24,7 +24,11 @@ class JoinFunctionFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_STRING) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_STRING)) {
+                continue;
+            }
+
             if ('join' !== $token->getContent()) {
                 continue;
             }

--- a/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
@@ -37,7 +37,10 @@ class NoEmptyLinesAfterPhpdocsFixer extends AbstractFixer
             T_BREAK,
         );
 
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
             // get the next non-whitespace token inc comments, provided
             // that there is whitespace between it and the current token
             $next = $tokens->getNextNonWhitespace($index);

--- a/Symfony/CS/Fixer/Symfony/ObjectOperatorFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ObjectOperatorFixer.php
@@ -26,7 +26,11 @@ class ObjectOperatorFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
         // [Structure] there should not be space before or after T_OBJECT_OPERATOR
-        foreach ($tokens->findGivenKind(T_OBJECT_OPERATOR) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_OBJECT_OPERATOR)) {
+                continue;
+            }
+
             // clear whitespace before ->
             if ($tokens[$index - 1]->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isComment()) {
                 $tokens[$index - 1]->clear();

--- a/Symfony/CS/Fixer/Symfony/PhpdocAlignFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocAlignFixer.php
@@ -44,8 +44,10 @@ class PhpdocAlignFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
-            $token->setContent($this->fixDocBlock($token->getContent()));
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_DOC_COMMENT)) {
+                $tokens[$index]->setContent($this->fixDocBlock($token->getContent()));
+            }
         }
     }
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -26,7 +26,11 @@ class PhpdocIndentFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $nextIndex = $tokens->getNextMeaningfulToken($index);
 
             // skip if there is no next token or if next token is block end `}`

--- a/Symfony/CS/Fixer/Symfony/PhpdocNoEmptyReturnFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocNoEmptyReturnFixer.php
@@ -26,7 +26,11 @@ class PhpdocNoEmptyReturnFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $annotations = $doc->getAnnotationsOfType('return');
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocNoPackageFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocNoPackageFixer.php
@@ -26,7 +26,11 @@ class PhpdocNoPackageFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $annotations = $doc->getAnnotationsOfType(array('package', 'subpackage'));
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocSeparationFixer.php
@@ -27,10 +27,15 @@ class PhpdocSeparationFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $this->fixDescription($doc);
             $this->fixAnnotations($doc);
+
             $token->setContent($doc->getContent());
         }
     }

--- a/Symfony/CS/Fixer/Symfony/PhpdocShortDescriptionFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocShortDescriptionFixer.php
@@ -25,7 +25,11 @@ class PhpdocShortDescriptionFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $end = $this->findShortDescriptionEnd($doc->getLines());
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -47,7 +47,11 @@ class PhpdocToCommentFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $nextIndex = $tokens->getNextMeaningfulToken($index);
             $nextToken = null !== $nextIndex ? $tokens[$nextIndex] : null;
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
@@ -25,7 +25,11 @@ class PhpdocTrimFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $content = $token->getContent();
             $content = $this->fixStart($content);
             // we need re-parse the docblock after fixing the start before

--- a/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
@@ -25,7 +25,11 @@ class PhpdocTypeToVarFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $annotations = $doc->getAnnotationsOfType('type');
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
@@ -26,7 +26,11 @@ class PhpdocVarWithoutNameFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
 
             // don't process single line docblocks

--- a/Symfony/CS/Fixer/Symfony/RemoveLinesBetweenUsesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/RemoveLinesBetweenUsesFixer.php
@@ -25,7 +25,18 @@ class RemoveLinesBetweenUsesFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        $this->removeLineBreaksBetweenUseStatements($tokens);
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        $namespacesImports = $tokensAnalyzer->getImportUseIndexes(true);
+
+        if (!count($namespacesImports)) {
+            return;
+        }
+
+        foreach ($namespacesImports as $uses) {
+            $uses = array_reverse($uses);
+            $this->fixLineBreaksPerImportGroup($tokens, $uses);
+        }
     }
 
     /**
@@ -43,22 +54,6 @@ class RemoveLinesBetweenUsesFixer extends AbstractFixer
     public function getDescription()
     {
         return 'Removes line breaks between use statements.';
-    }
-
-    private function removeLineBreaksBetweenUseStatements(Tokens $tokens)
-    {
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
-
-        $namespacesImports = $tokensAnalyzer->getImportUseIndexes(true);
-
-        if (!count($namespacesImports)) {
-            return;
-        }
-
-        foreach ($namespacesImports as $uses) {
-            $uses = array_reverse($uses);
-            $this->fixLineBreaksPerImportGroup($tokens, $uses);
-        }
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixer.php
@@ -24,8 +24,12 @@ class SingleBlankLineBeforeNamespaceFixer extends AbstractLinesBeforeNamespaceFi
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach (array_keys($tokens->findGivenKind(T_NAMESPACE)) as $index) {
-            $this->fixLinesBeforeNamespace($tokens, $index, 2);
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if ($token->isGivenKind(T_NAMESPACE)) {
+                $this->fixLinesBeforeNamespace($tokens, $index, 2);
+            }
         }
     }
 


### PR DESCRIPTION
```bash
[keradus@keradus 00:10 ~/github/PHP-CS-Fixer]$ . benchmark.sh master 2.0-fix_find
master mean:2.9462 total:29.462 rounds:10
2.0-fix_find mean:2.9255 total:29.255 rounds:10
```

Proposed long time ago, not sure but perhaps by @ceeram 

~1 percent performance gain. One by one...