### PR TITLE
DuplicateSemicolonFixer - ignore duplicated semicolons inside T_FOR

### DIFF
--- a/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
@@ -25,9 +25,17 @@ class DuplicateSemicolonFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
+        $limit = $tokens->count();
 
-        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+        for ($index = 0; $index < $limit; ++$index) {
             $token = $tokens[$index];
+
+            // skip T_FOR parenthesis to ignore duplicated `;` like `for ($i = 1; ; ++$i) {...}`
+            if ($token->isGivenKind(T_FOR)) {
+                $index = $tokens->getNextMeaningfulToken($index);
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+                continue;
+            }
 
             if (!$token->equals(';')) {
                 continue;

--- a/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
@@ -47,6 +47,9 @@ class DuplicateSemicolonFixerTest extends AbstractFixerTestBase
                 '<?php $foo = 1; ',
                 '<?php $foo = 1;; ',
             ),
+            array(
+                '<?php for ($i = 0; ; ++$i) {}',
+            ),
         );
     }
 }


### PR DESCRIPTION
bug from #992