### PR TITLE
Make cache setting optional + docs and docs for --format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -516,8 +516,8 @@ only those exact fixers are enabled whether or not level is set.
 With the ``--config-file`` option you can specify the path to the
 ``.php_cs`` file.
 
-By using ``--using-cache`` option you can set if caching
-mechanism should be used.
+By using ``--using-cache`` option with ``yes`` or ``no`` you can set if caching
+mechanism should be used (enabled by default).
 
 Caching
 -------
@@ -527,7 +527,7 @@ fixing only files that were modified. Tool will fix all files if tool version
 changed or fixers list changed.
 Cache is supported only for tool downloaded as phar file or installed via
 composer.
-Cache can be disabled via ``--using-cache`` option or config file:
+Cache can be disabled via ``--using-cache`` option using ``no`` or config file:
 
 .. code-block:: php
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
     $ ./composer.phar global require fabpot/php-cs-fixer
 
-Then, make sure you have ``~/.composer/vendor/bin`` in your ``PATH``, and
+Then make sure you have ``~/.composer/vendor/bin`` in your ``PATH`` and
 you're good to go:
 
 .. code-block:: bash
@@ -117,16 +117,16 @@ Usage
 -----
 
 The ``fix`` command tries to fix as much coding standards
-problems as possible on a given file or directory:
+problems as possible on a given file or files in a given directory and its subdirectories:
 
 .. code-block:: bash
 
     php php-cs-fixer.phar fix /path/to/dir
     php php-cs-fixer.phar fix /path/to/file
 
-The ``--format`` option can be used to set the output format of the results; ``txt`` format (default one), ``xml`` or ``json``.
+The ``--format`` option can be used to set the output format of the results; ``txt`` (default one), ``xml`` or ``json``.
 
-The ``--verbose`` option show applied fixers. When using ``txt`` format it will also displays progress notification.
+The ``--verbose`` option will show the applied fixers. When using ``txt`` format it will also displays progress notifications.
 
 The ``--level`` option limits the fixers to apply on the
 project:
@@ -149,21 +149,26 @@ apply (the fixer names must be separated by a comma):
 
     php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,short_tag,indentation
 
+<<<<<<< HEAD
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using ``-name_of_fixer``:
+=======
+You can also blacklist the fixers you don't want when this is more convenient,
+using ``-name``:
+>>>>>>> fix cache default setting, fix some docs (minor)
 
 .. code-block:: bash
 
     php php-cs-fixer.phar fix /path/to/dir --fixers=-short_tag,-indentation
 
-When using combination with exact and blacklist fixers, apply exact fixers along with above blacklisted result:
+When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
 .. code-block:: bash
 
     php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag
 
 A combination of ``--dry-run`` and ``--diff`` will
-display summary of proposed fixes, leaving your files unchanged.
+display a summary of proposed fixes, leaving your files unchanged.
 
 The command can also read from standard input, in which case it won't
 automatically fix anything:
@@ -177,7 +182,7 @@ Choose from the list of available fixers:
 * **psr0** [PSR-0]
                 Classes must be in a path that matches
                 their namespace, be at least one
-                namespace deep, and the class name
+                namespace deep and the class name
                 should match the file name.
 
 * **encoding** [PSR-1]
@@ -462,7 +467,7 @@ The example below will add two contrib fixers to the default list of PSR2-level 
         ->finder($finder)
     ;
 
-If you want complete control over which fixers you use, you may use the empty level and
+If you want complete control over which fixers you use you can use the empty level and
 then specify all fixers to be used:
 
 .. code-block:: php
@@ -509,7 +514,7 @@ The ``psr2`` level is set by default, you can also change the default level:
 
 In combination with these config and command line options, you can choose various usage.
 
-For example, default level is ``psr2``, but if you also don't want to use
+For example, the default level is ``psr2``, but if you don't want to use
 the ``psr0`` fixer, you can specify the ``--fixers="-psr0"`` option.
 
 But if you use the ``--fixers`` option with only exact fixers,
@@ -525,11 +530,11 @@ Caching
 -------
 
 The caching mechanism is enabled by default. This will speed up further runs by
-fixing only files that were modified. Tool will fix all files if tool version
-changed or fixers list changed.
-Cache is supported only for tool downloaded as phar file or installed via
+fixing only files that were modified since the last run. The tool will fix all files if the
+tool version has changed or the list of fixers has changed.
+Cache is only supported when the tool is downloaded as phar file or installed via
 composer.
-Cache can be disabled via ``--using-cache`` option using ``no`` or config file:
+Cache can be disabled via ``--using-cache`` option using ``no`` or by config file:
 
 .. code-block:: php
 

--- a/README.rst
+++ b/README.rst
@@ -149,13 +149,8 @@ apply (the fixer names must be separated by a comma):
 
     php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,short_tag,indentation
 
-<<<<<<< HEAD
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using ``-name_of_fixer``:
-=======
-You can also blacklist the fixers you don't want when this is more convenient,
-using ``-name``:
->>>>>>> fix cache default setting, fix some docs (minor)
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,9 @@ problems as possible on a given file or directory:
     php php-cs-fixer.phar fix /path/to/dir
     php php-cs-fixer.phar fix /path/to/file
 
-The ``--verbose`` option show applied fixers. When using ``txt`` format (default one) it will also displays progress notification.
+The ``--format`` option can be used to set the output format of the results; ``txt`` format (default one), ``xml`` or ``json``.
+
+The ``--verbose`` option show applied fixers. When using ``txt`` format it will also displays progress notification.
 
 The ``--level`` option limits the fixers to apply on the
 project:

--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -100,7 +100,7 @@ class Config implements ConfigInterface
         return $this->level;
     }
 
-    public function fixers($fixers)
+    public function fixers(array $fixers)
     {
         $this->fixers = $fixers;
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -118,7 +118,9 @@ problems as possible on a given file or directory:
     <info>php %command.full_name% /path/to/dir</info>
     <info>php %command.full_name% /path/to/file</info>
 
-The <comment>--verbose</comment> option show applied fixers. When using ``txt`` format (default one) it will also displays progress notification.
+The <comment>--format</comment> option can be used to set the output format of the results; ``txt`` format (default one), ``xml`` or ``json``.
+
+The <comment>--verbose</comment> option show applied fixers. When using ``txt`` format it will also displays progress notification.
 
 The <comment>--level</comment> option limits the fixers to apply on the
 project:

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -139,13 +139,8 @@ apply (the fixer names must be separated by a comma):
 
     <info>php %command.full_name% /path/to/dir --fixers=linefeed,short_tag,indentation</info>
 
-<<<<<<< HEAD
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using <comment>-name_of_fixer</comment>:
-=======
-You can also blacklist the fixers you don't want when this is more convenient,
-using <comment>-name</comment>:
->>>>>>> fix cache default setting, fix some docs (minor)
 
     <info>php %command.full_name% /path/to/dir --fixers=-short_tag,-indentation</info>
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -104,7 +104,7 @@ class FixCommand extends Command
                     new InputOption('config-file', '', InputOption::VALUE_OPTIONAL, 'The path to a .php_cs file ', null),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified'),
                     new InputOption('level', '', InputOption::VALUE_REQUIRED, 'The level of fixes (can be psr0, psr1, psr2, or symfony (formerly all))', null),
-                    new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no)', null),
+                    new InputOption('using-cache', '', InputOption::VALUE_OPTIONAL, 'Set cache should be used (can be yes or no)', 'yes'),
                     new InputOption('fixers', '', InputOption::VALUE_REQUIRED, 'A list of fixers to run'),
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
@@ -251,8 +251,8 @@ only those exact fixers are enabled whether or not level is set.
 With the <comment>--config-file</comment> option you can specify the path to the
 <comment>.php_cs</comment> file.
 
-By using ``--using-cache`` option you can set if caching
-mechanism should be used.
+By using ``--using-cache`` option with ``yes`` or ``no`` you can set if caching
+mechanism should be used (enabled by default).
 
 Caching
 -------
@@ -262,7 +262,7 @@ fixing only files that were modified. Tool will fix all files if tool version
 changed or fixers list changed.
 Cache is supported only for tool downloaded as phar file or installed via
 composer.
-Cache can be disabled via ``--using-cache`` option or config file:
+Cache can be disabled via ``--using-cache`` option using ``no`` or config file:
 
     <?php
 
@@ -298,7 +298,7 @@ EOF
             ->resolve()
         ;
 
-        $config     = $resolver->getConfig();
+        $config = $resolver->getConfig();
         $configFile = $resolver->getConfigFile();
 
         if ($configFile && 'txt' === $input->getOption('format')) {

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -104,7 +104,7 @@ class FixCommand extends Command
                     new InputOption('config-file', '', InputOption::VALUE_OPTIONAL, 'The path to a .php_cs file ', null),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified'),
                     new InputOption('level', '', InputOption::VALUE_REQUIRED, 'The level of fixes (can be psr0, psr1, psr2, or symfony (formerly all))', null),
-                    new InputOption('using-cache', '', InputOption::VALUE_OPTIONAL, 'Set cache should be used (can be yes or no)', 'yes'),
+                    new InputOption('using-cache', '', InputOption::VALUE_OPTIONAL, 'Set cache should be used (can be yes or no)', null),
                     new InputOption('fixers', '', InputOption::VALUE_REQUIRED, 'A list of fixers to run'),
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
@@ -113,14 +113,14 @@ class FixCommand extends Command
             ->setDescription('Fixes a directory or a file')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command tries to fix as much coding standards
-problems as possible on a given file or directory:
+problems as possible on a given file or files in a given directory and its subdirectories:
 
     <info>php %command.full_name% /path/to/dir</info>
     <info>php %command.full_name% /path/to/file</info>
 
-The <comment>--format</comment> option can be used to set the output format of the results; ``txt`` format (default one), ``xml`` or ``json``.
+The <comment>--format</comment> option can be used to set the output format of the results; ``txt`` (default one), ``xml`` or ``json``.
 
-The <comment>--verbose</comment> option show applied fixers. When using ``txt`` format it will also displays progress notification.
+The <comment>--verbose</comment> option will show the applied fixers. When using ``txt`` format it will also displays progress notifications.
 
 The <comment>--level</comment> option limits the fixers to apply on the
 project:
@@ -139,17 +139,22 @@ apply (the fixer names must be separated by a comma):
 
     <info>php %command.full_name% /path/to/dir --fixers=linefeed,short_tag,indentation</info>
 
+<<<<<<< HEAD
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using <comment>-name_of_fixer</comment>:
+=======
+You can also blacklist the fixers you don't want when this is more convenient,
+using <comment>-name</comment>:
+>>>>>>> fix cache default setting, fix some docs (minor)
 
     <info>php %command.full_name% /path/to/dir --fixers=-short_tag,-indentation</info>
 
-When using combination with exact and blacklist fixers, apply exact fixers along with above blacklisted result:
+When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
     <info>php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag</info>
 
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
-display summary of proposed fixes, leaving your files unchanged.
+display a summary of proposed fixes, leaving your files unchanged.
 
 The command can also read from standard input, in which case it won't
 automatically fix anything:
@@ -197,7 +202,7 @@ The example below will add two contrib fixers to the default list of PSR2-level 
 
     ?>
 
-If you want complete control over which fixers you use, you may use the empty level and
+If you want complete control over which fixers you use you can use the empty level and
 then specify all fixers to be used:
 
     <?php
@@ -244,7 +249,7 @@ The ``psr2`` level is set by default, you can also change the default level:
 
 In combination with these config and command line options, you can choose various usage.
 
-For example, default level is ``psr2``, but if you also don't want to use
+For example, the default level is ``psr2``, but if you don't want to use
 the ``psr0`` fixer, you can specify the ``--fixers="-psr0"`` option.
 
 But if you use the ``--fixers`` option with only exact fixers,
@@ -260,11 +265,11 @@ Caching
 -------
 
 The caching mechanism is enabled by default. This will speed up further runs by
-fixing only files that were modified. Tool will fix all files if tool version
-changed or fixers list changed.
-Cache is supported only for tool downloaded as phar file or installed via
+fixing only files that were modified since the last run. The tool will fix all files if the
+tool version has changed or the list of fixers has changed.
+Cache is only supported when the tool is downloaded as phar file or installed via
 composer.
-Cache can be disabled via ``--using-cache`` option using ``no`` or config file:
+Cache can be disabled via ``--using-cache`` option using ``no`` or by config file:
 
     <?php
 

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -97,7 +97,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
     $ ./composer.phar global require fabpot/php-cs-fixer
 
-Then, make sure you have ``~/.composer/vendor/bin`` in your ``PATH``, and
+Then make sure you have ``~/.composer/vendor/bin`` in your ``PATH`` and
 you're good to go:
 
 .. code-block:: bash

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -134,7 +134,7 @@ class ConfigurationResolver
 
         $names = array();
         foreach ($this->getFixers() as $fixer) {
-        	$names[] = $fixer->getName();
+            $names[] = $fixer->getName();
         }
 
         $this->config->fixers($names);

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -132,7 +132,12 @@ class ConfigurationResolver
         $this->resolveProgress();
         $this->resolveUsingCache();
 
-        $this->config->fixers($this->getFixers());
+        $names = array();
+        foreach ($this->getFixers() as $fixer) {
+        	$names[] = $fixer->getName();
+        }
+
+        $this->config->fixers($names);
         $this->config->setUsingCache($this->usingCache);
 
         return $this;
@@ -175,7 +180,7 @@ class ConfigurationResolver
      */
     public function setFixer(Fixer $fixer)
     {
-        $this->fixer     = $fixer;
+        $this->fixer = $fixer;
         $this->allFixers = $fixer->getFixers();
 
         return $this;
@@ -331,7 +336,7 @@ class ConfigurationResolver
                     throw new \UnexpectedValueException(sprintf('The config file "%s" does not return an instance of Symfony\CS\Config\Config', $configFile));
                 }
 
-                $this->config     = $config;
+                $this->config = $config;
                 $this->configFile = $configFile;
 
                 return;

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -465,7 +465,7 @@ class ConfigurationResolver
     private function resolveUsingCache()
     {
         if (null !== $this->options['using-cache']) {
-            $this->usingCache = 'yes' === $this->options['using-cache'];
+            $this->usingCache = 0 === strcasecmp('yes', $this->options['using-cache']);
 
             return;
         }

--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -133,7 +133,7 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
      */
     public function getDescription()
     {
-        return 'Classes must be in a path that matches their namespace, be at least one namespace deep, and the class name should match the file name.';
+        return 'Classes must be in a path that matches their namespace, be at least one namespace deep and the class name should match the file name.';
     }
 
     /**

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -566,4 +566,17 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->config->usingCache());
     }
+
+    public function testResolveUsingCacheCaseInsensitiveOptionConfig()
+    {
+        foreach (array('Yes', 'YES', 'YEs', 'yEs') as $option) {
+            $this->config->setUsingCache(false);
+            $this->resolver
+                ->setOption('using-cache', $option)
+                ->resolve();
+
+        	$this->assertTrue($this->config->usingCache());
+    	}
+    }
+
 }

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -575,7 +575,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
                 ->setOption('using-cache', $option)
                 ->resolve();
 
-        	$this->assertTrue($this->config->usingCache());
+            $this->assertTrue($this->config->usingCache());
     	}
     }
 

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -576,7 +576,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
                 ->resolve();
 
             $this->assertTrue($this->config->usingCache());
-    	}
+        }
     }
 
 }

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -578,5 +578,4 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($this->config->usingCache());
         }
     }
-
 }


### PR DESCRIPTION
This PR adds a description of the possible values for the cache option since it wasn't in the docs.
It makes the value optional as is suggested in the current docs. The value `yes` is now checked case insensitive for DX reasons.

Btw. a lot of tests fail on master and if I run the fixer over the code base itself the comments are all messed up. Am I the only one with this problem?