### PR TITLE
Fix invalid UTF-8 char in docs

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -17,7 +17,7 @@ use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * @author Ceeram <ceeram@cakephp.org>
- * @author Dariusz Rumiñski <dariusz.ruminski@gmail.com>
+ * @author Dariusz RumiÅ„ski <dariusz.ruminski@gmail.com>
  */
 class PhpdocToCommentFixer extends AbstractFixer
 {


### PR DESCRIPTION
This file shows me a warning about UTF-8 encoding when opened in my IDE