### PR TITLE
BracesFixer - fix missing braces for nested if elseif else

### DIFF
--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -438,7 +438,7 @@ class BracesFixer extends AbstractFixer
 
             $endIndex = $this->findStatementEnd($tokens, $parenthesisEndIndex);
 
-            if ($nextToken->isGivenKind([T_IF, T_TRY])) {
+            if ($nextToken->isGivenKind(array(T_IF, T_TRY))) {
                 $openingTokenKind = $nextToken->getId();
 
                 while (true) {

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -439,14 +439,20 @@ class BracesFixer extends AbstractFixer
             $endIndex = $this->findStatementEnd($tokens, $parenthesisEndIndex);
 
             if ($nextToken->isGivenKind(T_IF)) {
-                $nextIndex = $tokens->getNextNonWhitespace($endIndex);
-                $nextToken = $tokens[$nextIndex];
+                do {
+                    $nextIndex = $tokens->getNextNonWhitespace($endIndex);
+                    $nextToken = $tokens[$nextIndex];
 
-                if ($nextToken && $nextToken->isGivenKind($this->getControlContinuationTokens())) {
-                    $parenthesisEndIndex = $this->findParenthesisEnd($tokens, $nextIndex);
+                    if ($nextToken && $nextToken->isGivenKind($this->getControlContinuationTokens())) {
+                        $parenthesisEndIndex = $this->findParenthesisEnd($tokens, $nextIndex);
 
-                    return $this->findStatementEnd($tokens, $parenthesisEndIndex);
-                }
+                        $endIndex = $this->findStatementEnd($tokens, $parenthesisEndIndex);
+
+                        if ($nextToken->isGivenKind($this->getFinalControlContinuationTokens())) {
+                            return $endIndex;
+                        }
+                    }
+                } while ($nextToken);
             }
 
             return $endIndex;
@@ -526,6 +532,23 @@ class BracesFixer extends AbstractFixer
                 T_ELSE,
                 T_ELSEIF,
                 T_CATCH,
+            );
+
+            if (defined('T_FINALLY')) {
+                $tokens[] = T_FINALLY;
+            }
+        }
+
+        return $tokens;
+    }
+
+    private function getFinalControlContinuationTokens()
+    {
+        static $tokens = null;
+
+        if (null === $tokens) {
+            $tokens = array(
+                T_ELSE,
             );
 
             if (defined('T_FINALLY')) {

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -569,13 +569,13 @@ class BracesFixer extends AbstractFixer
     private function getFinalControlContinuationTokensForOpeningToken($openingTokenKind)
     {
         if ($openingTokenKind === T_IF) {
-            return [T_ELSE];
+            return array(T_ELSE);
         }
 
         if ($openingTokenKind === T_TRY && defined('T_FINALLY')) {
-            return [T_FINALLY];
+            return array(T_FINALLY);
         }
 
-        return [];
+        return array();
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -717,34 +717,6 @@ if (true)
 else
     echo 4;',
             ),
-            array(
-                '<?php
-try {
-    try {
-        echo 1;
-    } catch (Exception $e) {
-        echo 2;
-    } catch (Exception $e) {
-        echo 3;
-    } finally {
-        echo 4;
-    }
-} catch (Exception $e) {
-    echo 5;
-}',
-                '<?php
-try
-    try
-        echo 1;
-    catch(Exception $e)
-        echo 2;
-    catch(Exception $e)
-        echo 3;
-    finally
-        echo 4;
-catch(Exception $e)
-    echo 5;',
-            ),
         );
     }
 
@@ -1214,6 +1186,34 @@ while (true) {
     finally     {
         echo "finish!";
     }',
+            ),
+            array(
+                '<?php
+try {
+    try {
+        echo 1;
+    } catch (Exception $e) {
+        echo 2;
+    } catch (Exception $e) {
+        echo 3;
+    } finally {
+        echo 4;
+    }
+} catch (Exception $e) {
+    echo 5;
+}',
+                '<?php
+try
+    try
+        echo 1;
+    catch(Exception $e)
+        echo 2;
+    catch(Exception $e)
+        echo 3;
+    finally
+        echo 4;
+catch(Exception $e)
+    echo 5;',
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -619,6 +619,80 @@ function mixedComplex()
         }
     }',
             ),
+            array(
+                '<?php
+if (true) {
+    if (true) {
+        echo 1;
+    } elseif (true) {
+        echo 2;
+    } else {
+        echo 3;
+    }
+}
+',
+                '<?php
+if(true)
+    if(true)
+        echo 1;
+    elseif(true)
+        echo 2;
+    else
+        echo 3;
+',
+            ),
+            array(
+                '<?php
+if (true) {
+    if (true) {
+        echo 1;
+    } elseif (true) {
+        echo 2;
+    } else {
+        echo 3;
+    }
+}
+echo 4;
+',
+                '<?php
+if(true)
+    if(true)
+        echo 1;
+    elseif(true)
+        echo 2;
+    else
+        echo 3;
+echo 4;
+',
+            ),
+            array(
+                '<?php
+if (true) {
+    if (true) {
+        echo 1;
+    } elseif (true) {
+        echo 2;
+    } else {
+        echo 3;
+    }
+}',
+                '<?php
+if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
+            ),
+            array(
+                '<?php
+if (true) {
+    if (true) {
+        echo 1;
+    } else {
+        echo 2;
+    }
+} else {
+    echo 3;
+}',
+                '<?php
+if(true) if(true) echo 1; else echo 2; else echo 3;',
+            ),
         );
     }
 

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -693,6 +693,58 @@ if (true) {
                 '<?php
 if(true) if(true) echo 1; else echo 2; else echo 3;',
             ),
+            array(
+                '<?php
+if (true) {
+    try {
+        echo 1;
+    } catch (Exception $e) {
+        echo 2;
+    } catch (Exception $e) {
+        echo 3;
+    }
+} else {
+    echo 4;
+}',
+                '<?php
+if (true)
+    try
+        echo 1;
+    catch(Exception $e)
+        echo 2;
+    catch(Exception $e)
+        echo 3;
+else
+    echo 4;',
+            ),
+            array(
+                '<?php
+try {
+    try {
+        echo 1;
+    } catch (Exception $e) {
+        echo 2;
+    } catch (Exception $e) {
+        echo 3;
+    } finally {
+        echo 4;
+    }
+} catch (Exception $e) {
+    echo 5;
+}',
+                '<?php
+try
+    try
+        echo 1;
+    catch(Exception $e)
+        echo 2;
+    catch(Exception $e)
+        echo 3;
+    finally
+        echo 4;
+catch(Exception $e)
+    echo 5;',
+            ),
         );
     }
 


### PR DESCRIPTION
Hi,

```php
if (true)
    if (false)
        echo 1;
    elseif (false)
        echo 2;
    else
        echo 3;
```
is currently rewritten as:

```php
if (true) {
    if (false) {
        echo 1;
    } elseif (false) {
        echo 2;
    }
} else {
        echo 3;
    }
```

Braces are misplaced, it should be:

```php
if (true) {
    if (false) {
        echo 1;
    } elseif (false) {
        echo 2;
    } else {
        echo 3;
    }
}
```

I've tried to fix this issue in this pull request.