### PR TITLE
Fixer - ignore symlinks

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -137,7 +137,7 @@ class Fixer
         $fileCacheManager = new FileCacheManager($config->usingCache(), $config->getDir(), $config->getFixers());
 
         foreach ($config->getFinder() as $file) {
-            if ($file->isDir()) {
+            if ($file->isDir() || $file->isLink()) {
                 continue;
             }
 


### PR DESCRIPTION
Previously, having symlinks ending in `.php` (a common case is Doctrine's `bin/doctrine.php`) in the path passed to `fix` command lead to `file_get_contents()` and `file_put_contents()` errors being output.