### PR TITLE
Add buggy test for PhpdocSeparationFixer

### DIFF
--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSeparationFixerTest.php
@@ -40,6 +40,30 @@ EOF;
 EOF;
 
         $this->makeTest($expected, $input);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param string $name
+     *
+     * @access public
+     *
+     * @return string
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param string $name
+     * @access public
+     * @return string
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
     }
 
     public function testFixMoreTags()


### PR DESCRIPTION
Don't know why but PhpdocSeparationFixer stick `@param` with `@access`.

Could you take care of this @GrahamCampbell ?