### PR TITLE
PhpdocToCommentFixer - Add static as valid keyword for structural element

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -110,6 +110,7 @@ class PhpdocToCommentFixer extends AbstractFixer
             T_INCLUDE,
             T_INCLUDE_ONCE,
             T_FINAL,
+            T_STATIC,
         );
 
         return $token->isClassy() || $token->isGivenKind($skip);

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
@@ -304,6 +304,16 @@ static $formatter;
 ',
         );
 
+        $cases[] = array(
+            '<?php
+function getNumberFormatter()
+{
+    /** @var \NumberFormatter $formatter */
+    static $formatter;
+}
+',
+        );
+
         return $cases;
     }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
@@ -297,6 +297,13 @@ echo "Some string";
 ',
         );
 
+        $cases[] = array(
+            '<?php
+/** @var \NumberFormatter $formatter */
+static $formatter;
+',
+        );
+
         return $cases;
     }
 


### PR DESCRIPTION
Added tests and fix for #1034