### PR TITLE
OrderedUseFixer - fix namespace order for trailing digits

### DIFF
--- a/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
@@ -89,6 +89,10 @@ class OrderedUseFixer extends AbstractFixer
         $a = trim(preg_replace('%/\*(.*)\*/%s', '', $first[0]));
         $b = trim(preg_replace('%/\*(.*)\*/%s', '', $second[0]));
 
+        // Replace backslashes by spaces before sorting for correct sort order
+        $a = str_replace('\\', ' ', $a);
+        $b = str_replace('\\', ' ', $b);
+
         return strcasecmp($a, $b);
     }
 

--- a/Symfony/CS/Tests/Fixer/Contrib/OrderedUseFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/OrderedUseFixerTest.php
@@ -544,4 +544,39 @@ EOF
 
         $this->makeTest($expected);
     }
+
+    public function testOrderWithTrailingDigit()
+    {
+        $expected = <<<'EOF'
+<?php
+
+use abc\Bar;
+use abc2\Bar;
+use xyz\abc\Bar;
+use xyz\abc2\Bar;
+use xyz\xyz\Bar;
+use xyz\xyz\Bar2;
+
+class Test
+{
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use abc2\Bar;
+use abc\Bar;
+use xyz\abc2\Bar;
+use xyz\abc\Bar;
+use xyz\xyz\Bar2;
+use xyz\xyz\Bar;
+
+class Test
+{
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Check the test case - this is also how IntelliJ IDEA sorts on "Organize Imports".