### PR TITLE
Utils::camelCaseToUnderscore - fix regexp

### DIFF
--- a/Symfony/CS/Tests/UtilsTest.php
+++ b/Symfony/CS/Tests/UtilsTest.php
@@ -17,27 +17,42 @@ use Symfony\CS\Utils;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Graham Campbell <graham@mineuk.com>
+ * @author Odín del Río <odin.drp@gmail.com>
  */
 class UtilsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider provideCamelCaseToUnderscoreCases
+     *
+     * @param string $expected Camel case string.
+     * @param string $input    Input string.
      */
-    public function testCamelCaseToUnderscore($expected, $input = null)
+    public function testCamelCaseToUnderscore($expected, $input)
     {
-        if (null !== $input) {
-            $this->assertSame($expected, Utils::camelCaseToUnderscore($input));
-        }
-
-        $this->assertSame($expected, Utils::camelCaseToUnderscore($expected));
+        $this->assertSame($expected, Utils::camelCaseToUnderscore($input));
     }
 
+    /**
+     * @return array
+     */
     public function provideCamelCaseToUnderscoreCases()
     {
         return array(
             array(
                 'dollar_close_curly_braces',
                 'DollarCloseCurlyBraces',
+            ),
+            array(
+                'utf8_encoder_fixer',
+                'utf8EncoderFixer',
+            ),
+            array(
+                'utf8_encoder_fixer',
+                'utf8_encoder_fixer',
+            ),
+            array(
+                'terminated_with_number10',
+                'TerminatedWithNumber10',
             ),
         );
     }

--- a/Symfony/CS/Tests/UtilsTest.php
+++ b/Symfony/CS/Tests/UtilsTest.php
@@ -27,9 +27,12 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
      * @param string $expected Camel case string.
      * @param string $input    Input string.
      */
-    public function testCamelCaseToUnderscore($expected, $input)
+    public function testCamelCaseToUnderscore($expected, $input = null)
     {
-        $this->assertSame($expected, Utils::camelCaseToUnderscore($input));
+        if (null !== $input) {
+            $this->assertSame($expected, Utils::camelCaseToUnderscore($input));
+        }
+        $this->assertSame($expected, Utils::camelCaseToUnderscore($expected));
     }
 
     /**
@@ -47,13 +50,13 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
                 'utf8EncoderFixer',
             ),
             array(
-                'utf8_encoder_fixer',
-                'utf8_encoder_fixer',
-            ),
-            array(
                 'terminated_with_number10',
                 'TerminatedWithNumber10',
             ),
+            array(
+                'utf8_encoder_fixer',
+            ),
+
         );
     }
 

--- a/Symfony/CS/Tests/UtilsTest.php
+++ b/Symfony/CS/Tests/UtilsTest.php
@@ -32,6 +32,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         if (null !== $input) {
             $this->assertSame($expected, Utils::camelCaseToUnderscore($input));
         }
+
         $this->assertSame($expected, Utils::camelCaseToUnderscore($expected));
     }
 

--- a/Symfony/CS/Utils.php
+++ b/Symfony/CS/Utils.php
@@ -51,7 +51,7 @@ class Utils
     public static function camelCaseToUnderscore($string)
     {
         return preg_replace_callback(
-            '/(^|[a-z])([A-Z])/',
+            '/(^|[a-z0-9])([A-Z])/',
             function (array $matches) {
                 return strtolower(strlen($matches[1]) ? $matches[1].'_'.$matches[2] : $matches[2]);
             },

--- a/Symfony/CS/Utils.php
+++ b/Symfony/CS/Utils.php
@@ -16,6 +16,7 @@ use Symfony\CS\Tokenizer\Token;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Graham Campbell <graham@mineuk.com>
+ * @author Odín del Río <odin.drp@gmail.com>
  *
  * @internal
  */


### PR DESCRIPTION
I want to add a "contrib fixer" with the keyword **utf8** in the class name and I noticed that the **camelCaseToUnderscore** wasn't working for my "fixer" name.
Fixed by modifying the used regular expression (and added the related tests).