### PR TITLE
Enhancement: Add failing test for VisibilityFixer

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
@@ -407,4 +407,27 @@ EOF;
 
         $this->makeTest($expected, $input);
     }
+
+    public function testFixesVarDeclarationWhereValueIsArrayWithMoreThanOneValue()
+    {
+        $expected = <<<'EOF'
+<?php
+class Foo
+{
+  public $foo = array('foo');
+  public $bar = array('bar', 'baz');
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+class Foo
+{
+  var $foo = array('foo');
+  var $bar = array('bar', 'baz');
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds a failing test for `Symfony\CS\Fixer\PSR2\VisibilityFixer`, which fails to fix a `var` declaration when the value assigned is an array with more than one value

Hoping to submit a patch, but wanted to point this out as we're currently working on a code base where we encountered this error.