### PR TITLE
VisibilityFixer - fix var with array value assigned

### DIFF
--- a/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
@@ -38,7 +38,7 @@ class VisibilityFixer extends AbstractFixer
                 $tokens[++$index]->setContent(' ');
             } elseif ('property' === $element['type']) {
                 $prevIndex = $tokens->getPrevTokenOfKind($index, array(';', ','));
-                $nextIndex = $tokens->getNextTokenOfKind($index, array(';', ','));
+                $nextIndex = $tokens->getNextTokenOfKind($index, array(';', ',', '='));
 
                 if (
                     (!$prevIndex || !$tokens[$prevIndex]->equals(',')) &&

--- a/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
@@ -406,13 +406,19 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
-    public function testFixesVarDeclarationWhereValueIsArrayWithOneValue()
+    public function testFixesVarDeclarationsWithArrayValue()
     {
         $expected = <<<'EOF'
 <?php
 class Foo
 {
-  public $foo = array('foo');
+    public $foo1 = 1;
+    public $foo2a = array('foo');
+    public $foo2b = ['foo'];
+    public $foo3a = array('foo', 'bar');
+    public $foo3b = ['foo', 'bar'];
+    public $foo4a = 1a, $foo5a = array(1, 2, 3), $foo6a = 10;
+    public $foo4b = 1b, $foo5b = array(1, 2, 3), $foo6b = 10;
 }
 EOF;
 
@@ -420,70 +426,13 @@ EOF;
 <?php
 class Foo
 {
-  var $foo = array('foo');
-}
-EOF;
-
-        $this->makeTest($expected, $input);
-    }
-
-    public function testFixesVarDeclarationWhereValueIsArrayWithMoreThanOneValue()
-    {
-        $expected = <<<'EOF'
-<?php
-class Foo
-{
-  public $foo = array('foo', 'bar');
-}
-EOF;
-
-        $input = <<<'EOF'
-<?php
-class Foo
-{
-  var $foo = array('foo', 'bar');
-}
-EOF;
-
-        $this->makeTest($expected, $input);
-    }
-
-    public function testFixesVarDeclarationWhereValueIsShortArrayWithOneValue()
-    {
-        $expected = <<<'EOF'
-<?php
-class Foo
-{
-  public $foo = ['foo'];
-}
-EOF;
-
-        $input = <<<'EOF'
-<?php
-class Foo
-{
-  var $foo = array('foo');
-}
-EOF;
-
-        $this->makeTest($expected, $input);
-    }
-
-    public function testFixesVarDeclarationWhereValueIsShortArrayWithMoreThanOneValue()
-    {
-        $expected = <<<'EOF'
-<?php
-class Foo
-{
-  public $foo = ['foo', 'bar'];
-}
-EOF;
-
-        $input = <<<'EOF'
-<?php
-class Foo
-{
-  var $foo = ['foo', 'bar'];
+    var $foo1 = 1;
+    var $foo2a = array('foo');
+    var $foo2b = ['foo'];
+    var $foo3a = array('foo', 'bar');
+    var $foo3b = ['foo', 'bar'];
+    var $foo4a = 1a, $foo5a = array(1, 2, 3), $foo6a = 10;
+    var $foo4b = 1b, $foo5b = array(1, 2, 3), $foo6b = 10;
 }
 EOF;
 

--- a/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
@@ -405,4 +405,88 @@ EOF;
 
         $this->makeTest($expected, $input);
     }
+
+    public function testFixesVarDeclarationWhereValueIsArrayWithOneValue()
+    {
+        $expected = <<<'EOF'
+<?php
+class Foo
+{
+  public $foo = array('foo');
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+class Foo
+{
+  var $foo = array('foo');
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixesVarDeclarationWhereValueIsArrayWithMoreThanOneValue()
+    {
+        $expected = <<<'EOF'
+<?php
+class Foo
+{
+  public $foo = array('foo', 'bar');
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+class Foo
+{
+  var $foo = array('foo', 'bar');
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixesVarDeclarationWhereValueIsShortArrayWithOneValue()
+    {
+        $expected = <<<'EOF'
+<?php
+class Foo
+{
+  public $foo = ['foo'];
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+class Foo
+{
+  var $foo = array('foo');
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixesVarDeclarationWhereValueIsShortArrayWithMoreThanOneValue()
+    {
+        $expected = <<<'EOF'
+<?php
+class Foo
+{
+  public $foo = ['foo', 'bar'];
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+class Foo
+{
+  var $foo = ['foo', 'bar'];
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
 }

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -26,26 +26,33 @@ class TokensTest extends \PHPUnit_Framework_TestCase
 <?php
 class Foo
 {
-    public function bar()
+    public $prop0;
+    protected $prop1;
+    private $prop2 = 1;
+    var $prop3 = array(1,2,3);
+
+    public function bar4()
     {
         $a = 5;
 
         return " ({$a})";
     }
-    public function baz($data)
+    public function bar5($data)
     {
     }
 }
 PHP;
 
         $tokens = Tokens::fromCode($source);
-        $elements = $tokens->getClassyElements();
+        $elements = array_values($tokens->getClassyElements());
 
-        $this->assertCount(2, $elements);
-
-        foreach ($elements as $element) {
-            $this->assertSame('method', $element['type']);
-        }
+        $this->assertCount(6, $elements);
+        $this->assertSame('property', $elements[0]['type']);
+        $this->assertSame('property', $elements[1]['type']);
+        $this->assertSame('property', $elements[2]['type']);
+        $this->assertSame('property', $elements[3]['type']);
+        $this->assertSame('method', $elements[4]['type']);
+        $this->assertSame('method', $elements[5]['type']);
     }
 
     public function testReadFromCacheAfterClearing()


### PR DESCRIPTION
This PR

* [x] adds a failing test for `Symfony\CS\Fixer\PSR2\VisibilityFixer`, which fails to fix a `var` declaration when the value assigned is an array with more than one value

Hoping to submit a patch, but wanted to point this out as we're currently working on a code base where we encountered this error.

Replaces #1052.