### PR TITLE
VisibilityFixer - fix T_VAR with multiple props

### DIFF
--- a/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
@@ -37,13 +37,9 @@ class VisibilityFixer extends AbstractFixer
                 // force whitespace between function keyword and function name to be single space char
                 $tokens[++$index]->setContent(' ');
             } elseif ('property' === $element['type']) {
-                $prevIndex = $tokens->getPrevTokenOfKind($index, array(';', ','));
-                $nextIndex = $tokens->getNextTokenOfKind($index, array(';', ',', '='));
+                $prevIndex = $tokens->getPrevTokenOfKind($index, array(';', ',', '{'));
 
-                if (
-                    (!$prevIndex || !$tokens[$prevIndex]->equals(',')) &&
-                    (!$nextIndex || !$tokens[$nextIndex]->equals(','))
-                ) {
+                if (!$prevIndex || !$tokens[$prevIndex]->equals(',')) {
                     $this->applyAttribs($tokens, $index, $this->grabAttribsBeforePropertyToken($tokens, $index));
                 }
             }

--- a/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
@@ -379,13 +379,13 @@ EOF;
     /**
      * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
      */
-    public function testLeaveCommaSeparatedPropertyAlone()
+    public function testFixCommaSeparatedProperty()
     {
         $expected = <<<'EOF'
 <?php
 class Foo
 {
-    public $foo;
+    public $foo1;
     private $foo2;
     protected $bar1, $bar2;
     public $baz1 = null, $baz2, $baz3 = false;
@@ -397,7 +397,7 @@ EOF;
 <?php
 class Foo
 {
-    $foo;
+    $foo1;
     private $foo2;
     protected $bar1, $bar2;
     public $baz1 = null, $baz2, $baz3 = false;

--- a/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/VisibilityFixerTest.php
@@ -389,6 +389,7 @@ class Foo
     private $foo2;
     protected $bar1, $bar2;
     public $baz1 = null, $baz2, $baz3 = false;
+    public $foo, $bar;
 }
 EOF;
 
@@ -400,6 +401,7 @@ class Foo
     private $foo2;
     protected $bar1, $bar2;
     public $baz1 = null, $baz2, $baz3 = false;
+    var $foo, $bar;
 }
 EOF;
 


### PR DESCRIPTION
This PR

* [x] adds a failing test that shows 

```php
class Foo
{
    var $foo, $bar;
}
```

doesn't get fixed to 

```php
class Foo
{
    public $foo, $bar;
}
```

Follows #1054.
