### PR TITLE
add transformer for namespace operator

### DIFF
--- a/Symfony/CS/Tests/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -39,6 +39,7 @@ class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestBase
             array("<?php\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\nnamespace X;"),
             array("<?php\r\nnamespace X;", "<?php\r\n\r\n\r\n\r\nnamespace X;"),
+            array("<?php\n\nnamespace\\Sub\\Foo::bar();"),
         );
     }
 

--- a/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
@@ -97,6 +97,14 @@ namespace A\B {
 class C {}\r",
                 "<?php\rnamespace A\B;\r\r\r\r\r\rclass C {}\r",
             ),
+            array(
+                '<?php
+namespace A\B;
+
+namespace\C\func();
+foo();
+',
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -39,6 +39,7 @@ class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestBase
             array("<?php\n\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\n\r\nnamespace X;"),
             array("<?php\r\n\nnamespace X;", "<?php\r\n\r\n\r\n\r\nnamespace X;"),
+            array("<?php\n\nfoo();\nnamespace\\bar\\baz();"),
         );
     }
 

--- a/Symfony/CS/Tests/Tokenizer/Transformer/NamespaceOperatorTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/NamespaceOperatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Tokenizer\Transformer;
+
+use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class NamespaceOperatorTest extends AbstractTransformerTestBase
+{
+    /**
+     * @dataProvider provideProcessCases
+     */
+    public function testProcess($source, array $expectedTokens)
+    {
+        $tokens = Tokens::fromCode($source);
+
+        foreach ($expectedTokens as $index => $name) {
+            $this->assertSame(constant($name), $tokens[$index]->getId());
+            $this->assertSame($name, $tokens[$index]->getName());
+        }
+    }
+
+    public function provideProcessCases()
+    {
+        return array(
+            array(
+                '<?php
+namespace Foo;
+namespace\Bar\baz();
+',
+                array(
+                    1 => 'T_NAMESPACE',
+                    6 => 'CT_NAMESPACE_OPERATOR',
+                ),
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tokenizer/Transformer/NamespaceOperator.php
+++ b/Symfony/CS/Tokenizer/Transformer/NamespaceOperator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tokenizer\Transformer;
+
+use Symfony\CS\Tokenizer\AbstractTransformer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Transform `namespace` operator from T_NAMESPACE into CT_NAMESPACE_OPERATOR.
+ *
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class NamespaceOperator extends AbstractTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens)
+    {
+        foreach ($tokens->findGivenKind(T_NAMESPACE) as $index => $token) {
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            $nextToken = $tokens[$nextIndex];
+
+            if ($nextToken->equals(array(T_NS_SEPARATOR))) {
+                $token->override(array(CT_NAMESPACE_OPERATOR, $token->getContent(), $token->getLine()));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokenNames()
+    {
+        return array('CT_NAMESPACE_OPERATOR');
+    }
+}


### PR DESCRIPTION
Added failing test cases for [namespace operator](http://php.net/manual/en/language.namespaces.nsconstants.php#example-267) and a `NamespaceOperator` transformer to fix them.