### PR TITLE
Added NamespaceOperatorTransformer

### DIFF
--- a/Symfony/CS/Tests/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -39,6 +39,7 @@ class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestBase
             array("<?php\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\nnamespace X;"),
             array("<?php\r\nnamespace X;", "<?php\r\n\r\n\r\n\r\nnamespace X;"),
+            array("<?php\n\nnamespace\\Sub\\Foo::bar();"),
         );
     }
 

--- a/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
@@ -97,6 +97,14 @@ namespace A\B {
 class C {}\r",
                 "<?php\rnamespace A\B;\r\r\r\r\r\rclass C {}\r",
             ),
+            array(
+                '<?php
+namespace A\B;
+
+namespace\C\func();
+foo();
+',
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -39,6 +39,7 @@ class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestBase
             array("<?php\n\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\n\r\nnamespace X;"),
             array("<?php\r\n\nnamespace X;", "<?php\r\n\r\n\r\n\r\nnamespace X;"),
+            array("<?php\n\nfoo();\nnamespace\\bar\\baz();"),
         );
     }
 

--- a/Symfony/CS/Tests/Tokenizer/Transformer/NamespaceOperatorTransformerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/NamespaceOperatorTransformerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Tokenizer\Transformer;
+
+use Symfony\CS\Tests\Tokenizer\AbstractTransformerTestBase;
+
+/**
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class NamespaceOperatorTransformerTest extends AbstractTransformerTestBase
+{
+    /**
+     * @dataProvider provideProcessCases
+     */
+    public function testProcess($source, array $expectedTokens)
+    {
+        $this->makeTest($source, $expectedTokens);
+    }
+
+    public function provideProcessCases()
+    {
+        return array(
+            array(
+                '<?php
+namespace Foo;
+namespace\Bar\baz();
+',
+                array(
+                    1 => 'T_NAMESPACE',
+                    6 => 'CT_NAMESPACE_OPERATOR',
+                ),
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+++ b/Symfony/CS/Tokenizer/Transformer/NamespaceOperatorTransformer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tokenizer\Transformer;
+
+use Symfony\CS\Tokenizer\AbstractTransformer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Transform `namespace` operator from T_NAMESPACE into CT_NAMESPACE_OPERATOR.
+ *
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class NamespaceOperatorTransformer extends AbstractTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokenNames()
+    {
+        return array('CT_NAMESPACE_OPERATOR');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens, Token $token, $index)
+    {
+        if (!$token->isGivenKind(T_NAMESPACE)) {
+            return;
+        }
+
+        $nextIndex = $tokens->getNextMeaningfulToken($index);
+        $nextToken = $tokens[$nextIndex];
+
+        if ($nextToken->equals(array(T_NS_SEPARATOR))) {
+            $token->override(array(CT_NAMESPACE_OPERATOR, $token->getContent()));
+        }
+    }
+}


### PR DESCRIPTION
Added failing test cases for [namespace operator](http://php.net/manual/en/language.namespaces.nsconstants.php#example-267) and a `NamespaceOperator` transformer to fix them.