### PR TITLE
Php4ConstructorFixer - fix detection of a PHP4 parent constructor variant

### DIFF
--- a/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
+++ b/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
@@ -159,20 +159,24 @@ class Php4ConstructorFixer extends AbstractFixer
             $parentIndex = $tokens->getNextMeaningfulToken($index);
             $parentClass = $tokens[$parentIndex]->getContent();
 
-            // using parent::ParentClassName()
+            // using parent::ParentClassName() or ParentClassName::ParentClassName()
             $parentSeq = $tokens->findSequence(array(
-                array(T_STRING, 'parent'),
+                array(T_STRING),
                 array(T_DOUBLE_COLON),
                 array(T_STRING, $parentClass),
                 '(',
-            ), $classStart, $classEnd, array(false, true, false, true));
+            ), $classStart, $classEnd, array(2 => false));
 
             if (null !== $parentSeq) {
                 // we only need indexes
                 $parentSeq = array_keys($parentSeq);
 
-                // replace method name with __construct
-                $tokens[$parentSeq[2]]->setContent('__construct');
+                // match either of the possibilities
+                if ($tokens[$parentSeq[0]]->equalsAny(array(array(T_STRING, 'parent'), array(T_STRING, $parentClass)), false)) {
+                    // replace with parent::__construct
+                    $tokens[$parentSeq[0]]->setContent('parent');
+                    $tokens[$parentSeq[2]]->setContent('__construct');
+                }
             }
 
             // using $this->ParentClassName()

--- a/Symfony/CS/Tests/Fixer/Contrib/Php4ConstructorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/Php4ConstructorFixerTest.php
@@ -677,6 +677,53 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
+    public function testParentOther2()
+    {
+        $expected = <<<'EOF'
+<?php
+
+class Foo extends FooParent
+{
+    /**
+     * Constructor
+     */
+    function __construct($bar)
+    {
+        parent::__construct(1);
+        var_dump(9);
+    }
+
+    function bar()
+    {
+        var_dump(3);
+    }
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+class Foo extends FooParent
+{
+    /**
+     * Constructor
+     */
+    function Foo($bar)
+    {
+        FooParent::FooParent(1);
+        var_dump(9);
+    }
+
+    function bar()
+    {
+        var_dump(3);
+    }
+}
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
     public function testClassWithAnonymous()
     {
         $expected = <<<'EOF'


### PR DESCRIPTION
This one gave me a few headaches the other day, e.g.

```php
function __constructor() {
    parentClass::parentClass();
}
```