### PR TITLE
Fix: Add failing test for IndentationFixer

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/IndentationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/IndentationFixerTest.php
@@ -173,6 +173,27 @@ class IndentationFixerTest extends AbstractFixerTestBase
 \t \t   echo QUEBEC;",
         );
 
+        $cases[] = array(
+'<?php
+
+class Foo
+{
+    const FOO = \'foo\';
+    const BAR = \'bar\';
+
+    protected $bar;
+}',
+'<?php
+
+class Foo
+{
+  const FOO = \'foo\';
+  const BAR = \'bar\';
+
+  protected $bar;
+}',
+        );
+
         return $cases;
     }
 


### PR DESCRIPTION
This PR adds a failing test to demonstrate that the `VisibilityFixer` fails to fix

```php
<?php
class Foo
{
  const FOO = 'foo';
  const BAR = 'bar';
  protected $bar;
}
```

to 

```php
<?php
class Foo
{
    const FOO = 'foo';
    const BAR = 'bar';
    protected $bar;
}
```

:bulb: Note that 4 spaces are expected, but the input is indented with 2 spaces. 