### PR TITLE
Psr0Fixer - fix bug for fixing file with long extension like .class.php

### DIFF
--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -147,7 +147,7 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
     {
         $filenameParts = explode('.', $file->getBasename(), 2);
 
-        if ('php' !== $filenameParts[1]) {
+        if (!isset($filenameParts[1]) || 'php' !== $filenameParts[1]) {
             return false;
         }
 

--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -84,8 +84,7 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 $dir = '';
             }
 
-            $filenameParts = explode('.', $file->getBasename(), 2);
-            $filename = array_shift($filenameParts);
+            $filename = basename($path, '.php');
 
             if ($classyName !== $filename) {
                 $tokens[$classyIndex]->setContent($filename);
@@ -146,7 +145,9 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
      */
     public function supports(\SplFileInfo $file)
     {
-        if ('php' !== pathinfo($file->getFilename(), PATHINFO_EXTENSION)) {
+        $filenameParts = explode('.', $file->getBasename(), 2);
+
+        if ('php' !== $filenameParts[1]) {
             return false;
         }
 

--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -83,7 +83,9 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
             if (false === $dir) {
                 $dir = '';
             }
-            $filename = basename($path, '.php');
+
+            $filenameParts = explode('.', $file->getBasename(), 2);
+            $filename = array_shift($filenameParts);
 
             if ($classyName !== $filename) {
                 $tokens[$classyIndex]->setContent($filename);

--- a/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
@@ -149,14 +149,9 @@ EOF;
         $expected = <<<'EOF'
 <?php
 namespace Aaa;
-class Foo {}
-EOF;
-        $input = <<<'EOF'
-<?php
-namespace Aaa;
 class Bar {}
 EOF;
 
-        $this->makeTest($expected, $input, $file);
+        $this->makeTest($expected, $expected, $file);
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
@@ -141,4 +141,22 @@ EOF;
 
         $this->assertSame($expected, $fixer->fix($file, $input));
     }
+
+    public function testIgnoreLongExtension()
+    {
+        $file = $this->getTestFile('Foo.class.php');
+
+        $expected = <<<'EOF'
+<?php
+namespace Aaa;
+class Foo {}
+EOF;
+        $input = <<<'EOF'
+<?php
+namespace Aaa;
+class Bar {}
+EOF;
+
+        $this->makeTest($expected, $input, $file);
+    }
 }


### PR DESCRIPTION
Reported [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/995#issuecomment-83944377)