### PR TITLE
Enhancement: Allow to specifiy cache directory

### DIFF
--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -28,6 +28,7 @@ class Config implements ConfigInterface
     protected $level;
     protected $fixers;
     protected $dir;
+    protected $cacheDir;
     protected $customFixers;
     protected $usingCache = false;
     protected $usingLinter = true;
@@ -53,6 +54,13 @@ class Config implements ConfigInterface
         $this->dir = $dir;
     }
 
+    public function setCacheDir($cacheDir)
+    {
+        $this->cacheDir = $cacheDir;
+
+        return $this;
+    }
+
     public function setUsingCache($usingCache)
     {
         $this->usingCache = $usingCache;
@@ -69,6 +77,15 @@ class Config implements ConfigInterface
 
     public function getDir()
     {
+        return $this->dir;
+    }
+
+    public function getCacheDir()
+    {
+        if (null !== $this->cacheDir) {
+            return $this->cacheDir;
+        }
+
         return $this->dir;
     }
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -261,6 +261,17 @@ speed up further runs.
     ;
 
     ?>
+
+In addition, you can optionally specify a cache directory.
+
+    <?php
+
+    return Symfony\CS\Config\Config::create()
+        ->setUsingCache(true)
+        ->setCacheDir(__DIR__ . '/.cache')
+    ;
+
+    ?>
 EOF
             );
     }

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -134,7 +134,7 @@ class Fixer
             $this->stopwatch->openSection();
         }
 
-        $fileCacheManager = new FileCacheManager($config->usingCache(), $config->getDir(), $config->getFixers());
+        $fileCacheManager = new FileCacheManager($config->usingCache(), $config->getCacheDir(), $config->getFixers());
 
         foreach ($config->getFinder() as $file) {
             if ($file->isDir()) {

--- a/Symfony/CS/Tests/Config/ConfigTest.php
+++ b/Symfony/CS/Tests/Config/ConfigTest.php
@@ -28,6 +28,29 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('somefile.php', $iterator->current()->getFilename());
     }
 
+    public function testGetCacheDirDefaultsToDir()
+    {
+        $config = Config::create();
+
+        $dir = 'foo';
+
+        $config->setDir($dir);
+
+        $this->assertSame($dir, $config->getDir());
+        $this->assertSame($dir, $config->getCacheDir());
+    }
+
+    public function testCanSetCacheDir()
+    {
+        $config = Config::create();
+
+        $cacheDir = 'foo';
+
+        $config->setCacheDir($cacheDir);
+
+        $this->assertSame($cacheDir, $config->getCacheDir());
+    }
+
     public function testThatCustomDefaultFinderWorks()
     {
         $finder = DefaultFinder::create();


### PR DESCRIPTION
This PR

* [x] allows to specify a cache directory using `Config::setCacheDir()`

:bulb: This can be quite useful if you want to speed up the runs on Travis and cache `php_cs.cache` between runs.