### PR TITLE
Fix: Extract usingCache() into ConfigInterface

### DIFF
--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -82,4 +82,11 @@ interface ConfigInterface
      * @return FixerInterface[]
      */
     public function getCustomFixers();
+
+    /**
+     * Returns true if caching should be enabled.
+     *
+     * @return string
+     */
+    public function usingCache();
 }

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -255,4 +255,25 @@ class FixerTest extends \PHPUnit_Framework_TestCase
 
         return $cases;
     }
+
+    public function testCanFixWithConfigInterfaceImplementation()
+    {
+        $config = $this->getMockBuilder('Symfony\CS\ConfigInterface')->getMock();
+
+        $config
+            ->expects($this->any())
+            ->method('getFixers')
+            ->willReturn([])
+        ;
+
+        $config
+            ->expects($this->any())
+            ->method('getFinder')
+            ->willReturn([])
+        ;
+
+        $fixer = new Fixer();
+
+        $fixer->fix($config);
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds a failing test
* [x] extracts the method `usingCache()` into the `ConfigInterface`

See

* https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.6/Symfony/CS/Fixer.php#L128-L137