### PR TITLE
Enhancement: Allow to specify cache file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -627,6 +627,46 @@ Cache can be disabled via ``--using-cache`` option or config file:
         ->setUsingCache(false)
     ;
 
+Cache file can be specified via ``--cache-file`` option or config file:
+
+.. code-block:: php
+
+    <?php
+
+    return Symfony\CS\Config\Config::create()
+        ->setCacheFile(__DIR__.'/.php_cs.cache')
+    ;
+
+Using PHP CS Fixer on Travis
+----------------------------
+
+Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
+
+.. code-block:: bash
+
+    $ ./composer.phar require --dev fabpot/php-cs-fixer
+
+Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
+for PHP CS Fixer cache files and have Travis cache it between builds.
+
+.. code-block:: bash
+
+    language: php
+    php:
+        - 5.5
+    sudo: false
+    cache:
+        directories:
+            - "$HOME/.composer/cache"
+            - "$HOME/.php-cs-fixer"
+    before_script:
+        - mkdir -p "$HOME/.php-cs-fixer"
+    script:
+        - vendor/bin/php-cs-fixer fix --cache-file "$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
+
+Note: This will only trigger a build if you have a subscription for Travis
+or are using their free open source plan.
+
 Helpers
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -649,7 +649,7 @@ Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
 Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
 for PHP CS Fixer cache files and have Travis cache it between builds.
 
-.. code-block:: bash
+.. code-block:: yml
 
     language: php
     php:

--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -32,6 +32,7 @@ class Config implements ConfigInterface
     protected $usingCache = true;
     protected $usingLinter = true;
     protected $hideProgress = false;
+    protected $cacheFile = '.php_cs.cache';
 
     public function __construct($name = 'default', $description = 'A default configuration')
     {
@@ -156,5 +157,23 @@ class Config implements ConfigInterface
     public function usingLinter()
     {
         return $this->usingLinter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCacheFile($cacheFile)
+    {
+        $this->cacheFile = $cacheFile;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheFile()
+    {
+        return $this->cacheFile;
     }
 }

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -105,4 +105,20 @@ interface ConfigInterface
      * @return bool
      */
     public function usingLinter();
+
+    /**
+     * Sets the path to the cache file.
+     *
+     * @param string $cacheFile
+     *
+     * @return ConfigInterface
+     */
+    public function setCacheFile($cacheFile);
+
+    /**
+     * Returns the path to the cache file.
+     *
+     * @return string
+     */
+    public function getCacheFile();
 }

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -105,6 +105,7 @@ class FixCommand extends Command
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified'),
                     new InputOption('level', '', InputOption::VALUE_REQUIRED, 'The level of fixes (can be psr0, psr1, psr2, or symfony (formerly all))', null),
                     new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no)', null),
+                    new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file'),
                     new InputOption('fixers', '', InputOption::VALUE_REQUIRED, 'A list of fixers to run'),
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
@@ -271,6 +272,42 @@ Cache can be disabled via ``--using-cache`` option or config file:
     ;
 
     ?>
+
+Cache file can be specified via ``--cache-file`` option or config file:
+
+    <?php
+
+    return Symfony\CS\Config\Config::create()
+        ->setCacheFile(__DIR__.'/.php_cs.cache')
+    ;
+
+    ?>
+
+Using PHP CS Fixer on Travis
+----------------------------
+
+Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
+
+    $ ./composer.phar require --dev fabpot/php-cs-fixer
+
+Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
+for PHP CS Fixer cache files and have Travis cache it between builds.
+
+    language: php
+    php:
+        - 5.5
+    sudo: false
+    cache:
+        directories:
+            - "\$HOME/.composer/cache"
+            - "\$HOME/.php-cs-fixer"
+    before_script:
+        - mkdir -p "\$HOME/.php-cs-fixer"
+    script:
+        - vendor/bin/php-cs-fixer fix --cache-file "\$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
+
+Note: This will only trigger a build if you have a subscription for Travis
+or are using their free open source plan.
 EOF
             );
     }
@@ -294,6 +331,7 @@ EOF
                 'path' => $input->getArgument('path'),
                 'progress' => $output->isVerbose() && 'txt' === $input->getOption('format'),
                 'using-cache' => $input->getOption('using-cache'),
+                'cache-file' => $input->getOption('cache-file'),
             ))
             ->resolve()
         ;

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -293,6 +293,8 @@ Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
 Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
 for PHP CS Fixer cache files and have Travis cache it between builds.
 
+    <?yml
+
     language: php
     php:
         - 5.5
@@ -305,6 +307,8 @@ for PHP CS Fixer cache files and have Travis cache it between builds.
         - mkdir -p "\$HOME/.php-cs-fixer"
     script:
         - vendor/bin/php-cs-fixer fix --cache-file "\$HOME/.php-cs-fixer/.php_cs.cache" --dry-run --diff --verbose
+
+    ?>
 
 Note: This will only trigger a build if you have a subscription for Travis
 or are using their free open source plan.

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -208,11 +208,19 @@ EOF;
         $help = preg_replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
         $help = preg_replace('#^ \* ``(.+)``#m', '* **$1**', $help);
         $help = preg_replace("#^\n( +)#m", "\n.. code-block:: bash\n\n$1", $help);
-        $help = preg_replace("#^\.\. code-block:: bash\n\n( +<\?php)#m", ".. code-block:: php\n\n$1", $help);
+        $help = preg_replace("#^\.\. code-block:: bash\n\n( +<\?(\w+))#m", ".. code-block:: $2\n\n$1", $help);
         $help = preg_replace_callback(
-            "#<\?php.*?\?>#s",
+            "#<\?(\w+).*?\?>#s",
             function ($matches) {
-                return preg_replace("#\n\n +\?>#", '', preg_replace("#^\.\. code-block:: bash\n\n#m", '', $matches[0]));
+                $result = preg_replace("#^\.\. code-block:: bash\n\n#m", '', $matches[0]);
+
+                if ('php' !== $matches[1]) {
+                    $result = preg_replace("#<\?{$matches[1]}\s*#", '', $result);
+                }
+
+                $result = preg_replace("#\n\n +\?>#", '', $result);
+
+                return $result;
             },
             $help
         );

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -47,10 +47,12 @@ class ConfigurationResolver
         'path' => null,
         'progress' => null,
         'using-cache' => null,
+        'cache-file' => null,
     );
     private $path;
     private $progress;
     private $usingCache;
+    private $cacheFile;
 
     /**
      * Returns config instance.
@@ -131,9 +133,11 @@ class ConfigurationResolver
 
         $this->resolveProgress();
         $this->resolveUsingCache();
+        $this->resolveCacheFile();
 
         $this->config->fixers($this->getFixers());
         $this->config->setUsingCache($this->usingCache);
+        $this->config->setCacheFile($this->cacheFile);
 
         return $this;
     }
@@ -471,5 +475,19 @@ class ConfigurationResolver
         }
 
         $this->usingCache = $this->config->usingCache();
+    }
+
+    /**
+     * Resolves cache file.
+     */
+    private function resolveCacheFile()
+    {
+        if (null !== $this->options['cache-file']) {
+            $this->cacheFile = $this->options['cache-file'];
+
+            return;
+        }
+
+        $this->cacheFile = $this->config->getCacheFile();
     }
 }

--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -29,18 +29,16 @@ namespace Symfony\CS;
  */
 class FileCacheManager
 {
-    const CACHE_FILE = '.php_cs.cache';
-
-    private $dir;
+    private $cacheFile;
     private $isEnabled;
     private $fixers;
     private $newHashes = array();
     private $oldHashes = array();
 
-    public function __construct($isEnabled, $dir, array $fixers)
+    public function __construct($isEnabled, $cacheFile, array $fixers)
     {
         $this->isEnabled = $isEnabled;
-        $this->dir = null !== $dir ? $dir.DIRECTORY_SEPARATOR : '';
+        $this->cacheFile = $cacheFile;
         $this->fixers = array_map(function (FixerInterface $f) {
             return $f->getName();
         }, $fixers);
@@ -114,11 +112,11 @@ class FileCacheManager
             return;
         }
 
-        if (!file_exists($this->dir.self::CACHE_FILE)) {
+        if (!file_exists($this->cacheFile)) {
             return;
         }
 
-        $content = file_get_contents($this->dir.self::CACHE_FILE);
+        $content = file_get_contents($this->cacheFile);
         $data = unserialize($content);
 
         // Set hashes only if the cache is fresh, otherwise we need to parse all files
@@ -141,6 +139,6 @@ class FileCacheManager
             )
         );
 
-        file_put_contents($this->dir.self::CACHE_FILE, $data, LOCK_EX);
+        file_put_contents($this->cacheFile, $data, LOCK_EX);
     }
 }

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -134,7 +134,11 @@ class Fixer
             $this->stopwatch->openSection();
         }
 
-        $fileCacheManager = new FileCacheManager($config->usingCache(), $config->getDir(), $config->getFixers());
+        $fileCacheManager = new FileCacheManager(
+            $config->usingCache(),
+            $config->getCacheFile(),
+            $config->getFixers()
+        );
 
         foreach ($config->getFinder() as $file) {
             if ($file->isDir() || $file->isLink()) {

--- a/Symfony/CS/Tests/Config/ConfigTest.php
+++ b/Symfony/CS/Tests/Config/ConfigTest.php
@@ -52,4 +52,28 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $iterator->rewind();
         $this->assertSame('somefile.php', $iterator->current()->getFilename());
     }
+
+    public function testThatCacheFileHasDefaultValue()
+    {
+        $config = new Config();
+
+        $this->assertSame('.php_cs.cache', $config->getCacheFile());
+    }
+
+    public function testThatCacheFileCanBeMutated()
+    {
+        $cacheFile = 'some-directory/some.file';
+
+        $config = new Config();
+        $config->setCacheFile($cacheFile);
+
+        $this->assertSame($cacheFile, $config->getCacheFile());
+    }
+
+    public function testThatMutatorHasFluentInterface()
+    {
+        $config = new Config();
+
+        $this->assertSame($config, $config->setCacheFile('some-directory/some.file'));
+    }
 }

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Console\Command;
+
+use Symfony\CS\Console\Command;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ */
+class FixCommandTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCommandHasCacheFileOption()
+    {
+        $command = new Command\FixCommand();
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('cache-file'));
+
+        $option = $definition->getOption('cache-file');
+
+        $this->assertNull($option->getShortcut());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertSame('The path to the cache file', $option->getDescription());
+        $this->assertNull($option->getDefault());
+    }
+}

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -566,4 +566,49 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->config->usingCache());
     }
+
+    public function testResolveCacheFileWithoutConfigAndOption()
+    {
+        $default = $this->config->getCacheFile();
+
+        $this->resolver->resolve();
+
+        $this->assertSame($default, $this->config->getCacheFile());
+    }
+
+    public function testResolveCacheFileWithConfig()
+    {
+        $cacheFile = 'foo/bar.baz';
+
+        $this->config->setCacheFile($cacheFile);
+
+        $this->resolver->resolve();
+
+        $this->assertSame($cacheFile, $this->config->getCacheFile());
+    }
+
+    public function testResolveCacheFileWithOption()
+    {
+        $cacheFile = 'bar.baz';
+
+        $this->config->setCacheFile($cacheFile);
+        $this->resolver->setOption('cache-file', $cacheFile);
+
+        $this->resolver->resolve();
+
+        $this->assertSame($cacheFile, $this->config->getCacheFile());
+    }
+
+    public function testResolveCacheFileWithConfigAndOption()
+    {
+        $configCacheFile = 'foo/bar.baz';
+        $optionCacheFile = 'bar.baz';
+
+        $this->config->setCacheFile($configCacheFile);
+        $this->resolver->setOption('cache-file', $optionCacheFile);
+
+        $this->resolver->resolve();
+
+        $this->assertSame($optionCacheFile, $this->config->getCacheFile());
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds a mutator and accessor for the cache file to `Config`
* [x] requires said mutators and accessors to be implemented when implementing `ConfigInterface`
* [x] injects `cacheFile` into `FileCacheManager` and adjust it to work with it
* [x] adds a `cache-file` option to the `FixCommand` to allow to specify it from the console
* [x] resolve the value for `cacheFile`, whether specified by config or option

:bulb: This can be quite useful if you want to speed up the runs on Travis and cache `php_cs.cache` between runs.

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1074#issuecomment-84415033.