### PR TITLE
ConfigInterface - add missing methods

### DIFF
--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -84,4 +84,11 @@ interface ConfigInterface
      * @return FixerInterface[]
      */
     public function getCustomFixers();
+
+    /**
+     * Returns true if caching should be enabled.
+     *
+     * @return bool
+     */
+    public function usingCache();
 }

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -72,6 +72,13 @@ interface ConfigInterface
     public function getDir();
 
     /**
+     * Returns true if progress should be hidden.
+     *
+     * @return bool
+     */
+    public function getHideProgress();
+
+    /**
      * Adds an instance of a custom fixer.
      *
      * @param FixerInterface $fixer
@@ -91,4 +98,11 @@ interface ConfigInterface
      * @return bool
      */
     public function usingCache();
+
+    /**
+     * Returns true if linter should be enabled.
+     *
+     * @return bool
+     */
+    public function usingLinter();
 }

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -256,4 +256,25 @@ class FixerTest extends \PHPUnit_Framework_TestCase
 
         return $cases;
     }
+
+    public function testCanFixWithConfigInterfaceImplementation()
+    {
+        $config = $this->getMockBuilder('Symfony\CS\ConfigInterface')->getMock();
+
+        $config
+            ->expects($this->any())
+            ->method('getFixers')
+            ->willReturn(array())
+        ;
+
+        $config
+            ->expects($this->any())
+            ->method('getFinder')
+            ->willReturn(array())
+        ;
+
+        $fixer = new Fixer();
+
+        $fixer->fix($config);
+    }
 }


### PR DESCRIPTION
This PR extracts

* [x] `usingCache()`
* [x] `usingLinter()`
* [x] `getHideProcess()`

 into the `ConfigInterface`.

See

* https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.6/Symfony/CS/Fixer.php#L128-L137

Replaces #1075.