### PR TITLE
ShortTagFixer - fix false positive

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,7 +22,6 @@ return Symfony\CS\Config\Config::create()
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()
             ->exclude('Symfony/CS/Tests/Fixtures')
-            ->notName('ShortTagFixerTest.php')
             ->in(__DIR__)
     )
 ;

--- a/Symfony/CS/Fixer/PSR1/ShortTagFixer.php
+++ b/Symfony/CS/Fixer/PSR1/ShortTagFixer.php
@@ -54,7 +54,7 @@ class ShortTagFixer extends AbstractFixer
             if ($token->isGivenKind(array(T_COMMENT, T_DOC_COMMENT, T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_STRING))) {
                 $tokenContent = '';
                 $tokenContentLength = 0;
-                $parts = explode('<?php ', $token->getContent());
+                $parts = explode('<?php', $token->getContent());
                 $iLast = count($parts) - 1;
 
                 foreach ($parts as $i => $part) {
@@ -63,11 +63,11 @@ class ShortTagFixer extends AbstractFixer
 
                     if ($i !== $iLast) {
                         if ('<?php' === substr($content, $tokensOldContentLength + $tokenContentLength, 5)) {
-                            $tokenContent .= '<?php ';
-                            $tokenContentLength += 6;
+                            $tokenContent .= '<?php';
+                            $tokenContentLength += 5;
                         } else {
-                            $tokenContent .= '<? ';
-                            $tokenContentLength += 3;
+                            $tokenContent .= '<?';
+                            $tokenContentLength += 2;
                         }
                     }
                 }

--- a/Symfony/CS/Tests/Fixer/PSR1/ShortTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR1/ShortTagFixerTest.php
@@ -51,6 +51,11 @@ echo \'Foo\';
                 'foo <?  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <? echo "<? ";',
             ),
             array(
+                "<?php
+'<?
+';",
+            ),
+            array(
                 '<?php
 // Replace all <? with <?php !',
             ),


### PR DESCRIPTION
before this bugfix this

```php
<?php
'<?
';
```

was "fixed" to:

```php
<?php
'<?php
';
```