### PR TITLE
Fix: Remove comments in return annotations

### DIFF
--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -21,7 +21,7 @@ interface ConfigInterface
      *
      * The name must be all lowercase and without any spaces.
      *
-     * @return string The name of the configuration
+     * @return string
      */
     public function getName();
 
@@ -30,7 +30,7 @@ interface ConfigInterface
      *
      * A short one-line description for the configuration.
      *
-     * @return string The description of the configuration
+     * @return string
      */
     public function getDescription();
 
@@ -44,14 +44,14 @@ interface ConfigInterface
     /**
      * Returns the level to run.
      *
-     * @return int A level
+     * @return int
      */
     public function getLevel();
 
     /**
      * Returns the fixers to run.
      *
-     * @return array A list of fixer names
+     * @return array
      */
     public function getFixers();
 
@@ -60,14 +60,14 @@ interface ConfigInterface
      *
      * @param string $dir The project root directory
      *
-     * @return ConfigInterface The same instance
+     * @return ConfigInterface
      */
     public function setDir($dir);
 
     /**
      * Returns the root directory of the project.
      *
-     * @return string The project root directory
+     * @return string
      */
     public function getDir();
 

--- a/Symfony/CS/Fixer/Contrib/EregToPregFixer.php
+++ b/Symfony/CS/Fixer/Contrib/EregToPregFixer.php
@@ -122,7 +122,7 @@ class EregToPregFixer extends AbstractFixer
      *
      * @param string $pattern the regular expression
      *
-     * @return string the preg delimiter
+     * @return string
      */
     private function getBestDelimiter($pattern)
     {

--- a/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
+++ b/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
@@ -243,7 +243,7 @@ class Php4ConstructorFixer extends AbstractFixer
      * @param int    $startIndex function/method start index
      * @param int    $bodyIndex  function/method body index
      *
-     * @return array an array containing the sequence and case sensitiveness [ 0 => $seq, 1 => $case ]
+     * @return array
      */
     private function getWrapperMethodSequence(Tokens $tokens, $method, $startIndex, $bodyIndex)
     {

--- a/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
+++ b/Symfony/CS/Fixer/PSR2/VisibilityFixer.php
@@ -100,7 +100,7 @@ class VisibilityFixer extends AbstractFixer
      * @param Tokens $tokens Tokens collection
      * @param int    $index  token index
      *
-     * @return array map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array
      */
     private function grabAttribsBeforeMethodToken(Tokens $tokens, $index)
     {
@@ -134,7 +134,7 @@ class VisibilityFixer extends AbstractFixer
      * @param Tokens $tokens Tokens collection
      * @param int    $index  token index
      *
-     * @return array map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array
      */
     private function grabAttribsBeforePropertyToken(Tokens $tokens, $index)
     {
@@ -165,7 +165,7 @@ class VisibilityFixer extends AbstractFixer
      * @param array  $tokenAttribsMap token to attribute name map
      * @param array  $attribs         array of token attributes
      *
-     * @return array map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array
      */
     private function grabAttribsBeforeToken(Tokens $tokens, $index, array $tokenAttribsMap, array $attribs)
     {

--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -88,7 +88,7 @@ class PhpdocIndentFixer extends AbstractFixer
      * @param string $content Docblock contents
      * @param string $indent  Indentation to apply
      *
-     * @return string Dockblock contents including correct indentation
+     * @return string
      */
     private function fixDocBlock($content, $indent)
     {
@@ -101,7 +101,7 @@ class PhpdocIndentFixer extends AbstractFixer
      * @param string $content Whitespace before Docblock
      * @param string $indent  Indentation of the documented subject
      *
-     * @return string Whitespace including correct indentation for Dockblock after this whitespace
+     * @return string
      */
     private function fixWhitespaceBefore($content, $indent)
     {

--- a/Symfony/CS/FixerInterface.php
+++ b/Symfony/CS/FixerInterface.php
@@ -38,7 +38,7 @@ interface FixerInterface
      *
      * A short one-line description of what the fixer does.
      *
-     * @return string The description of the fixer
+     * @return string
      */
     public function getDescription();
 
@@ -59,7 +59,7 @@ interface FixerInterface
      *
      * The name must be all lowercase and without any spaces.
      *
-     * @return string The name of the fixer
+     * @return string
      */
     public function getName();
 
@@ -75,7 +75,7 @@ interface FixerInterface
     /**
      * Returns true if the file is supported by this fixer.
      *
-     * @return bool true if the file is supported by this fixer, false otherwise
+     * @return bool
      */
     public function supports(\SplFileInfo $file);
 }

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -266,7 +266,7 @@ class Token
     /**
      * Check if token prototype is an array.
      *
-     * @return bool is array
+     * @return bool
      */
     public function isArray()
     {

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -341,7 +341,7 @@ class Tokens extends \SplFixedArray
      * @param int    $indexOffset index offset for Token insertion
      * @param string $whitespace  whitespace to set
      *
-     * @return bool if new Token was added
+     * @return bool
      */
     public function ensureWhitespaceAtIndex($index, $indexOffset, $whitespace)
     {
@@ -384,7 +384,7 @@ class Tokens extends \SplFixedArray
      * @param int  $searchIndex index of opening brace
      * @param bool $findEnd     if method should find block's end, default true, otherwise method find block's start
      *
-     * @return int index of closing brace
+     * @return int
      */
     public function findBlockEnd($type, $searchIndex, $findEnd = true)
     {
@@ -444,7 +444,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int|array $possibleKind kind or array of kind
      *
-     * @return array array of tokens of given kinds or assoc array of arrays
+     * @return array
      */
     public function findGivenKind($possibleKind)
     {

--- a/Symfony/CS/Tokenizer/TransformerInterface.php
+++ b/Symfony/CS/Tokenizer/TransformerInterface.php
@@ -51,7 +51,7 @@ interface TransformerInterface
      *
      * The name must be all lowercase and without any spaces.
      *
-     * @return string The name of the fixer
+     * @return string
      */
     public function getName();
 }


### PR DESCRIPTION
This PR

* [x] removes comments in `@return` annotations

/cc @GrahamCampbell 