### PR TITLE
AliasFunctionsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -422,6 +422,10 @@ Choose from the list of available fixers:
                 Remove trailing whitespace at the end
                 of blank lines.
 
+* **alias_functions** [contrib]
+                Master functions shall be used instead
+                of aliases.
+
 * **align_double_arrow** [contrib]
                 Align double arrow symbols in
                 consecutive lines.

--- a/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
@@ -55,7 +55,7 @@ class AliasFunctionsFixer extends AbstractFixer
 
         foreach ($tokens->findGivenKind(T_STRING) as $index => $token) {
             $tokenContent = $token->getContent();
-            if (!array_key_exists($tokenContent, static::$aliases)) {
+            if (!array_key_exists($tokenContent, self::$aliases)) {
                 continue;
             }
 
@@ -69,7 +69,7 @@ class AliasFunctionsFixer extends AbstractFixer
                 continue;
             }
 
-            $token->setContent(static::$aliases[$tokenContent]);
+            $token->setContent(self::$aliases[$tokenContent]);
         }
 
         return $tokens->generateCode();

--- a/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
@@ -15,9 +15,11 @@ use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
- * @author Vladimir Reznichenko <kalessil@gmail.com>
+ * Fixes AliasFunctionsUsageInspection inspection warnings from Php Inspections (EA Extended).
+ * This fixer is based on JoinFunctionFixer code from Dariusz Rumiński.
  *
- * Fixes AliasFunctionsUsageInspection inspection warnings from Php Inspections (EA Extended)
+ * @author Vladimir Reznichenko <kalessil@gmail.com>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
 class AliasFunctionsFixer extends AbstractFixer
 {
@@ -34,7 +36,6 @@ class AliasFunctionsFixer extends AbstractFixer
         'fputs' => 'fwrite',
         'join' => 'implode',
         'key_exists' => 'array_key_exists',
-
         'chop' => 'rtrim',
         'close' => 'closedir',
         'ini_alter' => 'ini_set',
@@ -45,6 +46,14 @@ class AliasFunctionsFixer extends AbstractFixer
         'show_source' => 'highlight_file',
         'strchr' => 'strstr',
     );
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases()
+    {
+        return self::$aliases;
+    }
 
     /**
      * {@inheritdoc}
@@ -65,7 +74,7 @@ class AliasFunctionsFixer extends AbstractFixer
             }
 
             $nextToken = $tokens[$tokens->getNextMeaningfulToken($index)];
-            if ($nextToken->isGivenKind(array(T_DOUBLE_COLON, T_NS_SEPARATOR))) {
+            if (!$nextToken->equals('(')) {
                 continue;
             }
 

--- a/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
@@ -22,7 +22,7 @@ use Symfony\CS\Tokenizer\Tokens;
 class AliasFunctionsFixer extends AbstractFixer
 {
     /**
-     * @var array|string[]
+     * @var string[]
      */
     private static $aliases = array(
         'is_double' => 'is_float',

--- a/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
@@ -54,7 +54,7 @@ class AliasFunctionsFixer extends AbstractFixer
         $tokens = Tokens::fromCode($content);
 
         foreach ($tokens->findGivenKind(T_STRING) as $index => $token) {
-            $tokenContent = $token->getContent();
+            $tokenContent = strtolower($token->getContent());
             if (!array_key_exists($tokenContent, self::$aliases)) {
                 continue;
             }

--- a/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AliasFunctionsFixer.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * Fixes AliasFunctionsUsageInspection inspection warnings from Php Inspections (EA Extended)
+ */
+class AliasFunctionsFixer extends AbstractFixer
+{
+    /**
+     * @var array|string[]
+     */
+    private static $aliases = array(
+        'is_double' => 'is_float',
+        'is_integer' => 'is_int',
+        'is_long' => 'is_int',
+        'is_real' => 'is_float',
+        'sizeof' => 'count',
+        'doubleval' => 'floatval',
+        'fputs' => 'fwrite',
+        'join' => 'implode',
+        'key_exists' => 'array_key_exists',
+
+        'chop' => 'rtrim',
+        'close' => 'closedir',
+        'ini_alter' => 'ini_set',
+        'is_writeable' => 'is_writable',
+        'magic_quotes_runtime' => 'set_magic_quotes_runtime',
+        'pos' => 'current',
+        'rewind' => 'rewinddir',
+        'show_source' => 'highlight_file',
+        'strchr' => 'strstr',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens->findGivenKind(T_STRING) as $index => $token) {
+            $tokenContent = $token->getContent();
+            if (!array_key_exists($tokenContent, static::$aliases)) {
+                continue;
+            }
+
+            $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
+            if ($prevToken->isGivenKind(array(T_DOUBLE_COLON, T_NEW, T_NS_SEPARATOR, T_OBJECT_OPERATOR, T_FUNCTION))) {
+                continue;
+            }
+
+            $nextToken = $tokens[$tokens->getNextMeaningfulToken($index)];
+            if ($nextToken->isGivenKind(array(T_DOUBLE_COLON, T_NS_SEPARATOR))) {
+                continue;
+            }
+
+            $token->setContent(static::$aliases[$tokenContent]);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Master functions shall be used instead of aliases.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
@@ -21,7 +21,7 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 class AliasFunctionsFixerTest extends AbstractFixerTestBase
 {
     /**
-     * @var array|string[]
+     * @var string[]
      */
     private static $aliases = array(
         'is_double' => 'is_float',

--- a/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * Fixes AliasFunctionsUsageInspection warnings from Php Inspections (EA Extended)
+ */
+class AliasFunctionsFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @var array|string[]
+     */
+    private static $aliases = array(
+        'is_double' => 'is_float',
+        'is_integer' => 'is_int',
+        'is_long' => 'is_int',
+        'is_real' => 'is_float',
+        'sizeof' => 'count',
+        'doubleval' => 'floatval',
+        'fputs' => 'fwrite',
+        'join' => 'implode',
+        'key_exists' => 'array_key_exists',
+
+        'chop' => 'rtrim',
+        'close' => 'closedir',
+        'ini_alter' => 'ini_set',
+        'is_writeable' => 'is_writable',
+        'magic_quotes_runtime' => 'set_magic_quotes_runtime',
+        'pos' => 'current',
+        'rewind' => 'rewinddir',
+        'show_source' => 'highlight_file',
+        'strchr' => 'strstr',
+        );
+
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        $validCases = array();
+        $fixCases = array();
+        foreach (static::$aliases as $alias => $master) {
+            $validCases [] = array('<?php $smth->'.$alias.'($a);');
+            $validCases [] = array('<?php '.$alias.'Smth($a);');
+            $validCases [] = array('<?php smth_'.$alias.'($a);');
+            $validCases [] = array('<?php new '.$alias.'($a);');
+            $validCases [] = array('<?php Smth::'.$alias.'($a);');
+            $validCases [] = array('<?php new '.$alias.'\smth($a);');
+            $validCases [] = array('<?php '.$alias.'::smth($a);');
+            $validCases [] = array('<?php '.$alias.'\smth($a);');
+            $validCases [] = array('<?php "SELECT ... '.$alias.'($a) ...";');
+            $validCases [] = array('<?php "SELECT ... '.strtoupper($alias).'($a) ...";');
+            $validCases [] = array("<?php 'test'.'".$alias."' . 'in concatenation';");
+            $validCases [] = array('<?php "test" . "'.$alias.'"."in concatenation";');
+            $validCases [] = array(
+                '<?php
+class '.ucfirst($alias).'ing
+{
+    public function '.$alias.'($'.$alias.')
+    {
+        //expressions here
+    }
+}',
+            );
+
+            $fixCases [] = array(
+                '<?php '.$master.'($a);',
+                '<?php '.$alias.'($a);',
+            );
+            $fixCases [] = array(
+                '<?php $a = &'.$master.'($a);',
+                '<?php $a = &'.$alias.'($a);',
+            );
+            $fixCases [] = array(
+                '<?php '.$master.'
+                            ($a);',
+                '<?php '.$alias.'
+                            ($a);',
+            );
+            $fixCases [] = array(
+                '<?php /* foo */ '.$master.' /** bar */ ($a);',
+                '<?php /* foo */ '.$alias.' /** bar */ ($a);',
+            );
+            $fixCases [] = array(
+                '<?php a('.$master.'());',
+                '<?php a('.$alias.'());',
+            );
+        }
+
+        return array_merge($validCases, $fixCases);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
@@ -58,19 +58,19 @@ class AliasFunctionsFixerTest extends AbstractFixerTestBase
         $validCases = array();
         $fixCases = array();
         foreach (static::$aliases as $alias => $master) {
-            $validCases [] = array('<?php $smth->'.$alias.'($a);');
-            $validCases [] = array('<?php '.$alias.'Smth($a);');
-            $validCases [] = array('<?php smth_'.$alias.'($a);');
-            $validCases [] = array('<?php new '.$alias.'($a);');
-            $validCases [] = array('<?php Smth::'.$alias.'($a);');
-            $validCases [] = array('<?php new '.$alias.'\smth($a);');
-            $validCases [] = array('<?php '.$alias.'::smth($a);');
-            $validCases [] = array('<?php '.$alias.'\smth($a);');
-            $validCases [] = array('<?php "SELECT ... '.$alias.'($a) ...";');
-            $validCases [] = array('<?php "SELECT ... '.strtoupper($alias).'($a) ...";');
-            $validCases [] = array("<?php 'test'.'".$alias."' . 'in concatenation';");
-            $validCases [] = array('<?php "test" . "'.$alias.'"."in concatenation";');
-            $validCases [] = array(
+            $validCases[] = array('<?php $smth->'.$alias.'($a);');
+            $validCases[] = array('<?php '.$alias.'Smth($a);');
+            $validCases[] = array('<?php smth_'.$alias.'($a);');
+            $validCases[] = array('<?php new '.$alias.'($a);');
+            $validCases[] = array('<?php Smth::'.$alias.'($a);');
+            $validCases[] = array('<?php new '.$alias.'\smth($a);');
+            $validCases[] = array('<?php '.$alias.'::smth($a);');
+            $validCases[] = array('<?php '.$alias.'\smth($a);');
+            $validCases[] = array('<?php "SELECT ... '.$alias.'($a) ...";');
+            $validCases[] = array('<?php "SELECT ... '.strtoupper($alias).'($a) ...";');
+            $validCases[] = array("<?php 'test'.'".$alias."' . 'in concatenation';");
+            $validCases[] = array('<?php "test" . "'.$alias.'"."in concatenation";');
+            $validCases[] = array(
                 '<?php
 class '.ucfirst($alias).'ing
 {
@@ -81,25 +81,25 @@ class '.ucfirst($alias).'ing
 }',
             );
 
-            $fixCases [] = array(
+            $fixCases[] = array(
                 '<?php '.$master.'($a);',
                 '<?php '.$alias.'($a);',
             );
-            $fixCases [] = array(
+            $fixCases[] = array(
                 '<?php $a = &'.$master.'($a);',
                 '<?php $a = &'.$alias.'($a);',
             );
-            $fixCases [] = array(
+            $fixCases[] = array(
                 '<?php '.$master.'
                             ($a);',
                 '<?php '.$alias.'
                             ($a);',
             );
-            $fixCases [] = array(
+            $fixCases[] = array(
                 '<?php /* foo */ '.$master.' /** bar */ ($a);',
                 '<?php /* foo */ '.$alias.' /** bar */ ($a);',
             );
-            $fixCases [] = array(
+            $fixCases[] = array(
                 '<?php a('.$master.'());',
                 '<?php a('.$alias.'());',
             );

--- a/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AliasFunctionsFixerTest.php
@@ -57,7 +57,7 @@ class AliasFunctionsFixerTest extends AbstractFixerTestBase
     {
         $validCases = array();
         $fixCases = array();
-        foreach (static::$aliases as $alias => $master) {
+        foreach (self::$aliases as $alias => $master) {
             $validCases[] = array('<?php $smth->'.$alias.'($a);');
             $validCases[] = array('<?php '.$alias.'Smth($a);');
             $validCases[] = array('<?php smth_'.$alias.'($a);');


### PR DESCRIPTION
Fixes AliasFunctionsUsageInspection inspection warnings from Php Inspections (EA Extended) - to use master functions instead of aliases.

PS: recent <a href="https://github.com/symfony/symfony/pull/13862">symfony PR</a> as reference.