### PR TITLE
Added NewlineAfterOpenTagFixer and BlanklineAfterOpenTagFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,6 +267,11 @@ Choose from the list of available fixers:
                 visibility; static MUST be declared
                 after the visibility.
 
+* **blankline_after_open_tag** [symfony]
+                Ensure there is no code on the same
+                line as the PHP open tag and it is
+                followed by a blankline.
+
 * **concat_without_spaces** [symfony]
                 Concatenation should be used without
                 spaces.
@@ -453,6 +458,10 @@ Choose from the list of available fixers:
 * **multiline_spaces_before_semicolon** [contrib]
                 Multi-line whitespace before closing
                 semicolon are prohibited.
+
+* **newline_after_open_tag** [contrib]
+                Ensure there is no code on the same
+                line as the PHP open tag.
 
 * **no_blank_lines_before_namespace** [contrib]
                 There should be no blank lines before

--- a/Symfony/CS/Fixer/Contrib/NewlineAfterOpenTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NewlineAfterOpenTagFixer.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Ceeram <ceeram@cakephp.org>
+ */
+class NewlineAfterOpenTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_OPEN_TAG)) {
+                break;
+            }
+
+            if (false !== strpos($token->getContent(), "\n")) {
+                break;
+            }
+
+            $newlines = 0;
+            $whitespaceTokens = $tokens->findGivenKind(T_WHITESPACE);
+            foreach ($whitespaceTokens as $whitespaceToken) {
+                if ($whitespaceToken->isWhitespace(array('whitespaces' => "\n"))) {
+                    ++$newlines;
+                }
+            }
+            if (0 === $newlines) {
+                break;
+            }
+
+            $token->setContent(rtrim($token->getContent())."\n");
+            break;
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Ensure there is no code on the same line as the PHP open tag.';
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
+++ b/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Ceeram <ceeram@cakephp.org>
+ */
+class BlanklineAfterOpenTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_OPEN_TAG)) {
+                break;
+            }
+
+            $newlines = 0;
+            $whitespaceTokens = $tokens->findGivenKind(T_WHITESPACE);
+            foreach ($whitespaceTokens as $whitespaceToken) {
+                if ($whitespaceToken->isWhitespace(array('whitespaces' => "\n"))) {
+                    ++$newlines;
+                }
+            }
+            if (0 === $newlines) {
+                break;
+            }
+
+            if (false === strpos($token->getContent(), "\n")) {
+                $token->setContent(rtrim($token->getContent())."\n");
+            }
+
+            if (!$tokens[$index + 1]->isWhitespace(array('whitespaces' => "\n"))) {
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, "\n")));
+            }
+            break;
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Ensure there is no code on the same line as the PHP open tag and it is followed by a blankline.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/NewlineAfterOpenTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NewlineAfterOpenTagFixerTest.php
@@ -15,6 +15,7 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
  * @author Ceeram <ceeram@cakephp.org>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
 class NewlineAfterOpenTagFixerTest extends AbstractFixerTestBase
 {
@@ -47,6 +48,8 @@ class NewlineAfterOpenTagFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
+
+
 $foo = true;
 ?>',
             ),
@@ -60,9 +63,7 @@ $bar = false;
 ?>',
             ),
             array(
-                '<?php
-$foo = true;
-?>
+                '<?php $foo = true; ?>
 Html here
 <?php $bar = false; ?>',
             ),

--- a/Symfony/CS/Tests/Fixer/Contrib/NewlineAfterOpenTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NewlineAfterOpenTagFixerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Ceeram <ceeram@cakephp.org>
+ */
+class NewlineAfterOpenTagFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @requires PHP 5.4
+     * @dataProvider provideCases54
+     */
+    public function testFix54($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php $foo = true; ?>',
+            ),
+            array(
+                '<?php $foo = true; ?>
+',
+            ),
+            array(
+                '<?php
+$foo = true;
+?>',
+            ),
+            array(
+                '<?php
+$foo = true;
+$bar = false;
+?>',
+                '<?php $foo = true;
+$bar = false;
+?>',
+            ),
+            array(
+                '<?php
+$foo = true;
+?>
+Html here
+<?php $bar = false; ?>',
+            ),
+        );
+    }
+
+    public function provideCases54()
+    {
+        return array(
+            array(
+                '<?= $bar;
+$foo = $bar;
+?>',
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
@@ -15,6 +15,7 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
  * @author Ceeram <ceeram@cakephp.org>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
 class BlanklineAfterOpenTagFixerTest extends AbstractFixerTestBase
 {
@@ -38,7 +39,6 @@ class BlanklineAfterOpenTagFixerTest extends AbstractFixerTestBase
     public function provideCases()
     {
         return array(
-
             array(
                 '<?php $foo = true; ?>',
             ),
@@ -80,13 +80,6 @@ Html here
 <?php $bar = false;',
             ),
             array(
-                '<?php
-
-$foo = true;
-?>
-Html here
-<?php $bar = false;
-',
                 '<?php
 $foo = true;
 ?>

--- a/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Ceeram <ceeram@cakephp.org>
+ */
+class BlanklineAfterOpenTagFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @requires PHP 5.4
+     * @dataProvider provideCases54
+     */
+    public function testFix54($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+
+            array(
+                '<?php $foo = true; ?>',
+            ),
+            array(
+                '<?php $foo = true; ?>
+',
+            ),
+            array(
+                '<?php
+
+$foo = true;
+?>',
+            ),
+            array(
+                '<?php
+
+$foo = true;
+?>',
+                '<?php
+$foo = true;
+?>',
+            ),
+            array(
+                '<?php
+
+$foo = true;
+$bar = false;
+',
+                '<?php $foo = true;
+$bar = false;
+',
+            ),
+            array(
+                '<?php
+
+$foo = true;
+?>
+Html here
+<?php $bar = false;',
+            ),
+            array(
+                '<?php
+
+$foo = true;
+?>
+Html here
+<?php $bar = false;
+',
+                '<?php
+$foo = true;
+?>
+Html here
+<?php $bar = false;
+',
+            ),
+        );
+    }
+
+    public function provideCases54()
+    {
+        return array(
+            array(
+                '<?= $bar;
+$foo = $bar;
+?>',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Replaces #1030 and #1032
Now these new fixers support only monolithic files (no templates), it also allows to simplify flow. And just for fun little performance optimizations.