### PR TITLE
Added ShortEchoTagFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -494,6 +494,10 @@ Choose from the list of available fixers:
                 PHP arrays should use the PHP 5.4
                 short-syntax.
 
+* **short_echo_tag** [contrib]
+                Replace short-echo <?= with long
+                format <?php echo syntax.
+
 * **strict** [contrib]
                 Comparison should be strict. Warning!
                 This could change code behavior.

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -208,7 +208,7 @@ EOF;
         $help = preg_replace("#^\n( +)#m", "\n.. code-block:: bash\n\n$1", $help);
         $help = preg_replace("#^\.\. code-block:: bash\n\n( +<\?php)#m", ".. code-block:: php\n\n$1", $help);
         $help = preg_replace_callback(
-            "#<\?php.*?\?>#s",
+            "#^\s*<\?php.*?\?>#ms",
             function ($matches) {
                 return preg_replace("#\n\n +\?>#", '', preg_replace("#^\.\. code-block:: bash\n\n#m", '', $matches[0]));
             },

--- a/Symfony/CS/Fixer/Contrib/ShortEchoTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortEchoTagFixer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+class ShortEchoTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        $i = count($tokens);
+
+        while ($i--) {
+            $token = $tokens[$i];
+            $nextIndex = $i + 1;
+
+            if (!$token->isGivenKind(T_OPEN_TAG_WITH_ECHO)) {
+                continue;
+            }
+
+            $token->override(array(T_OPEN_TAG, '<?php ', $token->getLine()));
+
+            if (!$tokens[$nextIndex]->isWhitespace()) {
+                $tokens->insertAt($nextIndex, new Token(array(T_WHITESPACE, ' ')));
+            }
+
+            $tokens->insertAt($nextIndex, new Token(array(T_ECHO, 'echo')));
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Replace short-echo <?= with long format <?php echo syntax.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/ShortEchoTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ShortEchoTagFixerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+class ShortEchoTagFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideClosingTagExamples
+     * @requires PHP 5.4
+     */
+    public function testOneLineFix($expected, $input = null)
+    {
+        /*
+         * short_echo_tag setting is ignored by HHVM
+         * @see https://github.com/facebook/hhvm/issues/4809
+         */
+        if (!defined('HHVM_VERSION')) {
+            $this->makeTest($expected, $input);
+        }
+    }
+
+    public function provideClosingTagExamples()
+    {
+        return array(
+            array('<?php echo \'Foo\';', '<?= \'Foo\';'),
+            array('<?php echo \'Foo\'; ?> PLAIN TEXT', '<?= \'Foo\'; ?> PLAIN TEXT'),
+            array('PLAIN TEXT<?php echo \'Foo\'; ?>', 'PLAIN TEXT<?= \'Foo\'; ?>'),
+            array('<?php echo \'Foo\'; ?> <?php echo \'Bar\'; ?>', '<?= \'Foo\'; ?> <?= \'Bar\'; ?>'),
+            array('<?php echo foo();', '<?=foo();'),
+        );
+    }
+}


### PR DESCRIPTION
Replace short-eco `<?=` syntax with long format `<?php echo` syntax. As discussed in #1095. 

This is my first try at creating a fixer and any help would be a lot appreciated! What can I do more to make this fixer better? 
