### PR TITLE
Removed T_HEREDOC_END from isStructureAlternativeEnd

### DIFF
--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -374,7 +374,7 @@ class Token
      */
     public function isStructureAlternativeEnd()
     {
-        static $tokens = array(T_ENDDECLARE, T_ENDFOR, T_ENDFOREACH, T_ENDIF, T_ENDSWITCH, T_ENDWHILE, T_END_HEREDOC);
+        static $tokens = array(T_ENDDECLARE, T_ENDFOR, T_ENDFOREACH, T_ENDIF, T_ENDSWITCH, T_ENDWHILE);
 
         return $this->isGivenKind($tokens);
     }


### PR DESCRIPTION
I think `T_HEREDOC_END` is not an alternative end. Alternative to what?