### PR TITLE
UnusedUseFixer - fix false positive when name is used as part of another namespace

### DIFF
--- a/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
@@ -73,7 +73,7 @@ class UnusedUseFixer extends AbstractFixer
         $usages = array();
 
         foreach ($useDeclarations as $shortName => $useDeclaration) {
-            $usages[$shortName] = (bool) preg_match('/(?<!\$)\b'.preg_quote($shortName).'\b/i', $content);
+            $usages[$shortName] = (bool) preg_match('/(?<![\$\\\\])\b'.preg_quote($shortName).'\b/i', $content);
         }
 
         return $usages;

--- a/Symfony/CS/Tests/Fixer/PSR2/ElseifFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/ElseifFixerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\CS\Tests\Fixer\PSR2;
 
-use Symfony\CS\Fixer;
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**

--- a/Symfony/CS/Tests/Fixer/Symfony/UnusedUseFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnusedUseFixerTest.php
@@ -377,6 +377,26 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
+    public function testNamespacePart()
+    {
+        $expected = <<<'EOF'
+<?php
+
+
+new \Baz\Bar();
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use Foo\Bar;
+
+new \Baz\Bar();
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
     /**
      * @dataProvider providerUseInString
      */


### PR DESCRIPTION
Example:

```php
use Foo\Bar;

new \Baz\Bar();
```