### PR TITLE
SingleQuoteFixer - made fixer more accurate

### DIFF
--- a/Symfony/CS/Fixer/Symfony/SingleQuoteFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SingleQuoteFixer.php
@@ -35,9 +35,12 @@ class SingleQuoteFixer extends AbstractFixer
             if (
                 '"' === $content[0] &&
                 false === strpos($content, "'") &&
-                false === strpos($content, '\\')
+                // regex: odd number of backslashes, not followed by double quote
+                !preg_match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["\\\\])/', $content, $m)
             ) {
-                $token->setContent("'".substr($content, 1, -1)."'");
+                $content = substr($content, 1, -1);
+                $content = str_replace('\\"', '"', $content);
+                $token->setContent("'".$content."'");
             }
         }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/SingleQuoteFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SingleQuoteFixerTest.php
@@ -47,6 +47,17 @@ class SingleQuoteFixerTest extends AbstractFixerTestBase
                 '<?php $a = \'foo\'.\'bar\'."$baz";',
                 '<?php $a = \'foo\'."bar"."$baz";',
             ),
+            array(
+                '<?php $a = \'foo "bar"\';',
+                '<?php $a = "foo \"bar\"";',
+            ),
+            array(<<<'EOF'
+<?php $a = '\\foo\\bar\\\\';
+EOF
+                , <<<'EOF'
+<?php $a = "\\foo\\bar\\\\";
+EOF
+            ),
 
             array('<?php $a = \'foo bar\';'),
             array('<?php $a = \'foo "bar"\';'),
@@ -54,6 +65,10 @@ class SingleQuoteFixerTest extends AbstractFixerTestBase
             array('<?php $a = "foo $bar";'),
             array('<?php $a = "foo ${bar}";'),
             array('<?php $a = "foo\n bar";'),
+            array(<<<'EOF'
+<?php $a = "\\\n";
+EOF
+            ),
         );
     }
 }


### PR DESCRIPTION
New cases where double quotes are converted:

```php
$a = "foo\\bar";
// converted to
$a = 'foo\\bar';

$a = "foo \"bar\"";
// converted to
$a = 'foo "bar"';
```