### PR TITLE
Added SelfAccessorFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -397,6 +397,10 @@ Choose from the list of available fixers:
                 An empty line feed should precede a
                 return statement.
 
+* **self_accessor** [symfony]
+                Inside a classy element "self" should
+                be preferred to the class name itself.
+
 * **single_array_no_trailing_comma** [symfony]
                 PHP single-line arrays should not have
                 trailing comma.

--- a/Symfony/CS/Fixer/Symfony/SelfAccessorFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SelfAccessorFixer.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class SelfAccessorFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($i = 0, $c = $tokens->count(); $i < $c; ++$i) {
+            if (!$tokens[$i]->isClassy()) {
+                continue;
+            }
+
+            $nameIndex = $tokens->getNextTokenOfKind($i, array(array(T_STRING)));
+            $startIndex = $tokens->getNextTokenOfKind($nameIndex, array('{'));
+            $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $startIndex);
+
+            $name = $tokens[$nameIndex]->getContent();
+
+            $this->replaceNameOccurrences($tokens, $name, $startIndex, $endIndex);
+
+            // continue after the class declaration
+            $i = $endIndex;
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Inside a classy element "self" should be preferred to the class name itself.';
+    }
+
+    /**
+     * Replace occurrences of the name of the classy element by "self" (if possible).
+     *
+     * @param Tokens $tokens
+     * @param string $name
+     * @param int    $startIndex
+     * @param int    $endIndex
+     */
+    private function replaceNameOccurrences(Tokens $tokens, $name, $startIndex, $endIndex)
+    {
+        for ($i = $startIndex; $i < $endIndex; ++$i) {
+            $token = $tokens[$i];
+
+            // skip lambda functions (PHP < 5.4 compatibility)
+            if ($token->isGivenKind(T_FUNCTION) && $tokens->isLambda($i)) {
+                $i = $tokens->getNextTokenOfKind($i, array('{'));
+                $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $i);
+                continue;
+            }
+
+            if (!$token->equals(array(T_STRING, $name), false)) {
+                continue;
+            }
+
+            $prevToken = $tokens[$tokens->getPrevMeaningfulToken($i)];
+            $nextToken = $tokens[$tokens->getNextMeaningfulToken($i)];
+
+            // skip tokens that are part of a fully qualified name
+            if ($prevToken->isGivenKind(T_NS_SEPARATOR) || $nextToken->isGivenKind(T_NS_SEPARATOR)) {
+                continue;
+            }
+
+            if (
+                $prevToken->isGivenKind(array(T_INSTANCEOF, T_NEW)) ||
+                $nextToken->isGivenKind(T_PAAMAYIM_NEKUDOTAYIM)
+            ) {
+                $token->setContent('self');
+            }
+        }
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/SelfAccessorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SelfAccessorFixerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Gregor Harlan <gharlan@web.de>
+ */
+class SelfAccessorFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideExamples()
+    {
+        return array(
+            array(
+                '<?php class Foo { const BAR = self::BAZ; }',
+                '<?php class Foo { const BAR = Foo::BAZ; }',
+            ),
+            array(
+                '<?php class Foo { private $bar = self::BAZ; }',
+                '<?php class Foo { private $bar = fOO::BAZ; }', // case insensitive
+            ),
+            array(
+                '<?php class Foo { function bar($a = self::BAR) {} }',
+                '<?php class Foo { function bar($a = Foo::BAR) {} }',
+            ),
+            array(
+                '<?php class Foo { function bar() { self::baz(); } }',
+                '<?php class Foo { function bar() { Foo::baz(); } }',
+            ),
+            array(
+                '<?php class Foo { function bar() { self::class; } }',
+                '<?php class Foo { function bar() { Foo::class; } }',
+            ),
+            array(
+                '<?php class Foo { function bar() { $x instanceof self; } }',
+                '<?php class Foo { function bar() { $x instanceof Foo; } }',
+            ),
+            array(
+                '<?php class Foo { function bar() { new self(); } }',
+                '<?php class Foo { function bar() { new Foo(); } }',
+            ),
+            array(
+                '<?php interface Foo { const BAR = self::BAZ; function bar($a = self::BAR); }',
+                '<?php interface Foo { const BAR = Foo::BAZ; function bar($a = Foo::BAR); }',
+            ),
+
+            array(
+                '<?php class Foo { const Foo = 1; }',
+            ),
+            array(
+                '<?php class Foo { function foo() { } }',
+            ),
+            array(
+                '<?php class Foo { function bar() { new \Baz\Foo(); } }',
+            ),
+            array(
+                '<?php class Foo { function bar() { new Foo\Baz(); } }',
+            ),
+            array(
+                // PHP < 5.4 compatibility: "self" is not available in closures
+                '<?php class Foo { function bar() { function ($a = Foo::BAZ) { new Foo(); }; } }',
+            ),
+        );
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testFix54()
+    {
+        $expected = '<?php trait Foo { function bar() { self::bar(); } }';
+        $input = '<?php trait Foo { function bar() { Foo::bar(); } }';
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -89,7 +89,7 @@ class Token
      */
     public function equals($other, $caseSensitive = true)
     {
-        $otherPrototype = $other instanceof Token ? $other->getPrototype() : $other;
+        $otherPrototype = $other instanceof self ? $other->getPrototype() : $other;
 
         if ($this->isArray() !== is_array($otherPrototype)) {
             return false;

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -91,7 +91,7 @@ class Tokens extends \SplFixedArray
      */
     public static function fromArray($array, $saveIndexes = null)
     {
-        $tokens = new Tokens(count($array));
+        $tokens = new self(count($array));
 
         if (null === $saveIndexes || $saveIndexes) {
             foreach ($array as $key => $val) {
@@ -1322,7 +1322,7 @@ class Tokens extends \SplFixedArray
              *
              * @see https://github.com/facebook/hhvm/issues/4810
              */
-            $tokens = Tokens::fromCode("#!/usr/bin/env php\n");
+            $tokens = self::fromCode("#!/usr/bin/env php\n");
             if (!$tokens[0]->isGivenKind(T_INLINE_HTML)) {
                 $hashBangId = $tokens[0]->getId();
                 $hhvmHashBangs = $this->findGivenKind($hashBangId);


### PR DESCRIPTION
The fixer converts class names to `self` (if possible).

```php
class Foo 
{
    public function baz($a = Foo::BAR) // self::BAR
    {
        if ($b instanceof Foo) { // $b instanceof self
            new Foo(); // new self();
            Foo::baz(); // self::baz();
        }
    }
}
```