### PR TITLE
PhpdocTrimFixer - fix doc typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -377,7 +377,7 @@ Choose from the list of available fixers:
 
 * **phpdoc_trim** [symfony]
                 Phpdocs should start and end with
-                content, excluding the very fist and
+                content, excluding the very first and
                 last line of the docblocks.
 
 * **phpdoc_type_to_var** [symfony]

--- a/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTrimFixer.php
@@ -44,7 +44,7 @@ class PhpdocTrimFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Phpdocs should start and end with content, excluding the very fist and last line of the docblocks.';
+        return 'Phpdocs should start and end with content, excluding the very first and last line of the docblocks.';
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] fixes a minor spelling issue