### PR TITLE
UnusedUseFixer - must be run before LineAfterNamespaceFixer, fix token collection corruption

### DIFF
--- a/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
@@ -60,4 +60,13 @@ class LineAfterNamespaceFixer extends AbstractFixer
     {
         return 'There MUST be one blank line after the namespace declaration.';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run after the UnusedUseFixer
+        return -20;
+    }
 }

--- a/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
@@ -179,26 +179,31 @@ class UnusedUseFixer extends AbstractFixer
             $tokens[$index]->clear();
         }
 
-        $token = $tokens[$useDeclaration['start'] - 1];
+        $prevToken = $tokens[$useDeclaration['start'] - 1];
 
-        if ($token->isWhitespace()) {
-            $token->setContent(rtrim($token->getContent(), " \t"));
+        if ($prevToken->isWhitespace()) {
+            $prevToken->setContent(rtrim($prevToken->getContent(), " \t"));
         }
 
         if (!isset($tokens[$useDeclaration['end'] + 1])) {
             return;
         }
 
-        $token = $tokens[$useDeclaration['end'] + 1];
+        $nextToken = $tokens[$useDeclaration['end'] + 1];
 
-        if ($token->isWhitespace()) {
-            $content = ltrim($token->getContent(), " \t");
+        if ($nextToken->isWhitespace()) {
+            $content = ltrim($nextToken->getContent(), " \t");
 
             if ($content && "\n" === $content[0]) {
                 $content = substr($content, 1);
             }
 
-            $token->setContent($content);
+            $nextToken->setContent($content);
+        }
+
+        if ($prevToken->isWhitespace() && $nextToken->isWhitespace()) {
+            $nextToken->setContent($prevToken->getContent().$nextToken->getContent());
+            $prevToken->clear();
         }
     }
 

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -194,6 +194,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_short_description'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
+            array($fixers['unused_use'], $fixers['line_after_namespace']),
         );
 
         $docFixerNames = array_filter(


### PR DESCRIPTION
Closes #1124

Change priority to run in correct order.
No direct test to check fixing corruption of collection, this test is in #1098

cc @navitronic


