### PR TITLE
Prevent token collection corruption by fixers

### DIFF
--- a/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
+++ b/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
@@ -91,7 +91,7 @@ class HeaderCommentFixer extends AbstractFixer
         foreach ($lines as $line) {
             $comment .= rtrim(' * '.$line)."\n";
         }
-        $comment .= " */\n";
+        $comment .= ' */';
 
         return $comment;
     }
@@ -136,13 +136,14 @@ class HeaderCommentFixer extends AbstractFixer
      */
     private function insertHeaderComment(Tokens $tokens, $index)
     {
-        $headCommentTokens = Tokens::fromArray(
-            array(
-                new Token(array(T_WHITESPACE, "\n")),
-                new Token(array(T_COMMENT, self::$headerComment)),
-                new Token(array(T_WHITESPACE, strlen(self::$headerComment) ? "\n" : '')),
-            )
+        $headCommentTokens = array(
+            new Token(array(T_WHITESPACE, "\n")),
         );
+
+        if ('' !== self::$headerComment) {
+            $headCommentTokens[] = new Token(array(T_COMMENT, self::$headerComment));
+            $headCommentTokens[] = new Token(array(T_WHITESPACE, "\n\n"));
+        }
 
         $tokens->insertAt($index, $headCommentTokens);
     }

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -37,7 +37,12 @@ class BracesFixer extends AbstractFixer
         $this->fixDoWhile($tokens);
         $this->fixLambdas($tokens);
 
-        return $tokens->generateCode();
+        // Set code to itself to redo tokenizer work, that will guard as against token collection corruption.
+        // TODO: This MUST be removed on 2.0-dev version, where we add more transformers (and lack of them causes corruption on 1.x line).
+        $code = $tokens->generateCode();
+        $tokens->setCode($code);
+
+        return $code;
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/NamespaceNoLeadingWhitespaceFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NamespaceNoLeadingWhitespaceFixer.php
@@ -50,7 +50,7 @@ class NamespaceNoLeadingWhitespaceFixer extends AbstractFixer
                 $beforeBeforeNamespace = $tokens[$index - 2];
 
                 if (self::endsWithWhitespace($beforeBeforeNamespace->getContent())) {
-                    $beforeNamespace->setContent('');
+                    $beforeNamespace->clear();
                 } else {
                     $beforeNamespace->setContent(' ');
                 }

--- a/Symfony/CS/Fixer/Symfony/SpacesCastFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SpacesCastFixer.php
@@ -46,7 +46,7 @@ class SpacesCastFixer extends AbstractFixer
                     $tokens[$index + 1]->setContent(' ');
                 } elseif (!$tokens[$index + 1]->isWhitespace()) {
                     // - if next token is not whitespaces that contains spaces, tabs and new lines - append single space to current token
-                    $tokens->insertAt($index + 1, new Token(' '));
+                    $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
                 }
             }
         }

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\CS\Tests\Fixer;
 
+use Symfony\CS\Tokenizer\Tokens;
+
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
@@ -45,9 +47,32 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
         $fileIsSupported = $fixer->supports($file);
 
         if (null !== $input) {
-            $this->assertSame($expected, $fileIsSupported ? $fixer->fix($file, $input) : $input);
+            $fixedCode = $fileIsSupported ? $fixer->fix($file, $input) : $input;
+
+            $this->assertSame($expected, $fixedCode);
+
+            $tokens = Tokens::fromCode($fixedCode); // Load cached collection (used by the fixer)
+            Tokens::clearCache();
+            $expectedTokens = Tokens::fromCode($fixedCode); // Load the expected collection based on PHP parsing
+            $this->assertTokens($expectedTokens, $tokens);
         }
 
         $this->assertSame($expected, $fileIsSupported ? $fixer->fix($file, $expected) : $expected);
+    }
+
+    private function assertTokens(Tokens $expectedTokens, Tokens $tokens)
+    {
+        foreach ($expectedTokens as $index => $expectedToken) {
+            $token = $tokens[$index];
+
+            $expectedPrototype = $expectedToken->getPrototype();
+            if (is_array($expectedPrototype)) {
+                unset($expectedPrototype[2]); // don't compare token lines as our token mutations don't deal with line numbers
+            }
+
+            $this->assertTrue($token->equals($expectedPrototype), sprintf('The token at index %d should be %s, got %s', $index, json_encode($expectedPrototype), $token->toJson()));
+        }
+
+        $this->assertEquals($expectedTokens->count(), $tokens->count(), 'The collection should have the same length than the expected one');
     }
 }

--- a/Symfony/CS/Tests/Tokenizer/TokenTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokenTest.php
@@ -140,7 +140,7 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($whitespaceToken->isEmpty());
 
         $whitespaceToken->setContent('');
-        $this->assertFalse($whitespaceToken->isEmpty());
+        $this->assertTrue($whitespaceToken->isEmpty());
 
         $whitespaceToken->override(array(null, ''));
         $this->assertTrue($whitespaceToken->isEmpty());

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -428,6 +428,13 @@ class Token
      */
     public function setContent($content)
     {
+        // setting empty content is clearing the token
+        if ('' === $content) {
+            $this->clear();
+
+            return;
+        }
+
         $this->content = $content;
     }
 


### PR DESCRIPTION
This prevents replacing token content with unrelated content (hacky fix) in places which should override tokens. Given that the Tokens collection is cached and will be reused by the following fixer, a corrupted collection could break the following fixer as it expects token types to be valid.

The goal is to prevent having to deal with cases like that: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1097#discussion_r27307639

Replaces #1098 