### PR TITLE
ToolInfo - Fix way to find script dir

### DIFF
--- a/Symfony/CS/ToolInfo.php
+++ b/Symfony/CS/ToolInfo.php
@@ -51,7 +51,14 @@ class ToolInfo
             $script = $_SERVER['SCRIPT_NAME'];
 
             if (is_link($script)) {
-                $script = dirname($script).'/'.readlink($script);
+                $linkTarget = readlink($script);
+
+                // If the link target is relative to the link
+                if (false === realpath($linkTarget)) {
+                    $linkTarget = dirname($script).'/'.$linkTarget;
+                }
+
+                $script = $linkTarget;
             }
 
             $result = dirname($script);


### PR DESCRIPTION
I don't know if the PR has to be over branch ```1.8``` or other branch.

The bug is that the function ```readlink``` returns the absolute path to the linked script (http://php.net/manual/en/function.readlink.php). Then this concatenation is not needed.