### PR TITLE
Exit with non-zero if invalid files were detected prior to fixing

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -545,7 +545,7 @@ EOF
             $this->listErrors($output, 'linting after fixing', $lintErrors);
         }
 
-        return !$resolver->isDryRun() || empty($changed) ? 0 : 3;
+        return !$resolver->isDryRun() || (empty($changed) && empty($invalidErrors)) ? 0 : 3;
     }
 
     /**

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -37,8 +37,8 @@ use Symfony\CS\Utils;
  */
 class FixCommand extends Command
 {
-    const FLAG_HAS_INVALID_FILES = 4;
-    const FLAG_HAS_CHANGED_FILES = 8;
+    const EXIT_STATUS_FLAG_HAS_INVALID_FILES = 4;
+    const EXIT_STATUS_FLAG_HAS_CHANGED_FILES = 8;
 
     /**
      * EventDispatcher instance.
@@ -552,11 +552,11 @@ EOF
 
         if ($resolver->isDryRun()) {
             if (!empty($invalidErrors)) {
-                $exitStatus |= self::FLAG_HAS_INVALID_FILES;
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_INVALID_FILES;
             }
 
             if (!empty($changed)) {
-                $exitStatus |= self::FLAG_HAS_CHANGED_FILES;
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_CHANGED_FILES;
             }
         }
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -548,10 +548,9 @@ EOF
             $this->listErrors($output, 'linting after fixing', $lintErrors);
         }
 
+        $exitStatus = 0;
+
         if ($resolver->isDryRun()) {
-
-            $exitStatus = 0;
-
             if (!empty($invalidErrors)) {
                 $exitStatus |= self::FLAG_HAS_INVALID_FILES;
             }
@@ -559,11 +558,9 @@ EOF
             if (!empty($changed)) {
                 $exitStatus |= self::FLAG_HAS_CHANGED_FILES;
             }
-
-            return $exitStatus;
         }
 
-        return 0;
+        return $exitStatus;
     }
 
     /**

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -545,7 +545,11 @@ EOF
             $this->listErrors($output, 'linting after fixing', $lintErrors);
         }
 
-        return !$resolver->isDryRun() || (empty($changed) && empty($invalidErrors)) ? 0 : 3;
+        if (($resolver->isDryRun() && !empty($changed)) || !empty($invalidErrors)) {
+            return 3;
+        }
+
+        return 0;
     }
 
     /**

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -37,6 +37,9 @@ use Symfony\CS\Utils;
  */
 class FixCommand extends Command
 {
+    const FLAG_HAS_INVALID_FILES = 4;
+    const FLAG_HAS_CHANGED_FILES = 8;
+
     /**
      * EventDispatcher instance.
      *
@@ -550,11 +553,11 @@ EOF
             $exitStatus = 0;
 
             if (!empty($invalidErrors)) {
-                $exitStatus |= 4;
+                $exitStatus |= self::FLAG_HAS_INVALID_FILES;
             }
 
             if (!empty($changed)) {
-                $exitStatus |= 8;
+                $exitStatus |= self::FLAG_HAS_CHANGED_FILES;
             }
 
             return $exitStatus;

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -545,8 +545,19 @@ EOF
             $this->listErrors($output, 'linting after fixing', $lintErrors);
         }
 
-        if (($resolver->isDryRun() && !empty($changed)) || !empty($invalidErrors)) {
-            return 3;
+        if ($resolver->isDryRun()) {
+
+            $exitStatus = 0;
+
+            if (!empty($invalidErrors)) {
+                $exitStatus |= 4;
+            }
+
+            if (!empty($changed)) {
+                $exitStatus |= 8;
+            }
+
+            return $exitStatus;
         }
 
         return 0;

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -183,8 +183,6 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
                 if (array_key_exists($name, $arguments)) {
                     return $arguments[$name];
                 }
-
-                return;
             })
         ;
 
@@ -203,8 +201,6 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
                 if (array_key_exists($name, $options)) {
                     return $options[$name];
                 }
-
-                return;
             })
         ;
 

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -11,7 +11,13 @@
 
 namespace Symfony\CS\Tests\Console\Command;
 
-use Symfony\CS\Console\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\CS\Console\Command\FixCommand;
+use Symfony\CS\Error\Error;
+use Symfony\CS\Error\ErrorsManager;
+use Symfony\CS\Fixer;
 
 /**
  * @author Andreas Möller <am@localheinz.com>
@@ -20,7 +26,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
 {
     public function testCommandHasCacheFileOption()
     {
-        $command = new Command\FixCommand();
+        $command = new FixCommand();
         $definition = $command->getDefinition();
 
         $this->assertTrue($definition->hasOption('cache-file'));
@@ -31,5 +37,226 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($option->isValueRequired());
         $this->assertSame('The path to the cache file', $option->getDescription());
         $this->assertNull($option->getDefault());
+    }
+
+    public function testExitCodeDryRunWithoutChangedFiles()
+    {
+        $command = new FixCommand();
+
+        $input = $this->getInputMock(array(
+            'dry-run' => true,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function testExitCodeActualRunWithoutChangedFiles()
+    {
+        $fixer = $this->getFixerMock();
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => false,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function testExitCodeDryRunWithChangedFiles()
+    {
+        $fixer = $this->getFixerMock(array(
+            'Changed.php',
+        ));
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => true,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(3, $exitCode);
+    }
+
+    public function testExitCodeActualRunWithChangedFiles()
+    {
+        $fixer = $this->getFixerMock(array(
+            'Changed.php',
+        ));
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => false,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function testExitCodeDryRunWithInvalidFiles()
+    {
+        $errorsManager = new ErrorsManager();
+
+        $errorsManager->report(new Error(
+            Error::TYPE_INVALID,
+            'Invalid.php'
+        ));
+
+        $fixer = $this->getFixerMock(array(), $errorsManager);
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => true,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function testExitCodeActualRunWithInvalidFiles()
+    {
+        $errorsManager = new ErrorsManager();
+
+        $errorsManager->report(new Error(
+            Error::TYPE_INVALID,
+            'Invalid.php'
+        ));
+
+        $fixer = $this->getFixerMock(array(), $errorsManager);
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => true,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return InputInterface
+     */
+    private function getInputMock(array $options = array())
+    {
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->getMock();
+
+        $arguments = array(
+            'path' => __DIR__.'/../../Fixtures/FixCommand',
+        );
+
+        $input
+            ->expects($this->any())
+            ->method('getArgument')
+            ->willReturnCallback(function ($name) use ($arguments) {
+                if (array_key_exists($name, $arguments)) {
+                    return $arguments[$name];
+                }
+
+                return;
+            })
+        ;
+
+        $options = array_merge(
+            array(
+                'config-file' => __DIR__.'/../../Fixtures/FixCommand/.phpcs',
+                'format' => 'txt',
+            ),
+            $options
+        );
+
+        $input
+            ->expects($this->any())
+            ->method('getOption')
+            ->willReturnCallback(function ($name) use ($options) {
+                if (array_key_exists($name, $options)) {
+                    return $options[$name];
+                }
+
+                return;
+            })
+        ;
+
+        return $input;
+    }
+
+    /**
+     * @param array         $changed
+     * @param ErrorsManager $errorsManager
+     *
+     * @return Fixer
+     */
+    private function getFixerMock(array $changed = array(), ErrorsManager $errorsManager = null)
+    {
+        $fixer = $this->getMockBuilder('Symfony\CS\Fixer')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $fixer
+            ->expects($this->once())
+            ->method('fix')
+            ->with($this->anything())
+            ->willReturn($changed)
+        ;
+
+        $fixer
+            ->expects($this->any())
+            ->method('getConfigs')
+            ->willReturn(array())
+        ;
+
+        $fixer
+            ->expects($this->any())
+            ->method('getFixers')
+            ->willReturn(array())
+        ;
+
+        $fixer
+            ->expects($this->any())
+            ->method('getStopwatch')
+            ->willReturn(new Stopwatch())
+        ;
+
+        $errorsManager = $errorsManager ?: new ErrorsManager();
+
+        $fixer
+            ->expects($this->any())
+            ->method('getErrorsManager')
+            ->willReturn($errorsManager)
+        ;
+
+        return $fixer;
     }
 }

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -152,7 +152,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
         $command = new FixCommand($fixer);
 
         $input = $this->getInputMock(array(
-            'dry-run' => true,
+            'dry-run' => false,
         ));
 
         $exitCode = $command->run(

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -39,7 +39,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($option->getDefault());
     }
 
-    public function testExitCodeDryRunWithoutChangedFiles()
+    public function testExitCodeDryRun()
     {
         $command = new FixCommand();
 
@@ -55,7 +55,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $exitCode);
     }
 
-    public function testExitCodeActualRunWithoutChangedFiles()
+    public function testExitCodeActualRun()
     {
         $fixer = $this->getFixerMock();
 
@@ -90,7 +90,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
             new NullOutput()
         );
 
-        $this->assertSame(3, $exitCode);
+        $this->assertSame(8, $exitCode);
     }
 
     public function testExitCodeActualRunWithChangedFiles()
@@ -135,7 +135,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
             new NullOutput()
         );
 
-        $this->assertSame(3, $exitCode);
+        $this->assertSame(4, $exitCode);
     }
 
     public function testExitCodeActualRunWithInvalidFiles()
@@ -160,7 +160,67 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
             new NullOutput()
         );
 
-        $this->assertSame(3, $exitCode);
+        $this->assertSame(0, $exitCode);
+    }
+
+    public function testExitCodeDryRunWithChangedAndInvalidFiles()
+    {
+        $errorsManager = new ErrorsManager();
+
+        $errorsManager->report(new Error(
+            Error::TYPE_INVALID,
+            'Invalid.php'
+        ));
+
+        $fixer = $this->getFixerMock(
+            array(
+                'Changed.php',
+            ),
+            $errorsManager
+        );
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => true,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(12, $exitCode);
+    }
+
+    public function testExitCodeActualRunWithChangedAndInvalidFiles()
+    {
+        $errorsManager = new ErrorsManager();
+
+        $errorsManager->report(new Error(
+            Error::TYPE_INVALID,
+            'Invalid.php'
+        ));
+
+        $fixer = $this->getFixerMock(
+            array(
+                'Changed.php',
+            ),
+            $errorsManager
+        );
+
+        $command = new FixCommand($fixer);
+
+        $input = $this->getInputMock(array(
+            'dry-run' => false,
+        ));
+
+        $exitCode = $command->run(
+            $input,
+            new NullOutput()
+        );
+
+        $this->assertSame(0, $exitCode);
     }
 
     /**

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -135,7 +135,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
             new NullOutput()
         );
 
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(3, $exitCode);
     }
 
     public function testExitCodeActualRunWithInvalidFiles()
@@ -160,7 +160,7 @@ class FixCommandTest extends \PHPUnit_Framework_TestCase
             new NullOutput()
         );
 
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(3, $exitCode);
     }
 
     /**

--- a/Symfony/CS/Tests/Fixtures/FixCommand/.phpcs
+++ b/Symfony/CS/Tests/Fixtures/FixCommand/.phpcs
@@ -1,0 +1,14 @@
+<?php
+
+$config = Symfony\CS\Config\Config::create();
+
+$finder = $config->getFinder()->in(__DIR__);
+
+return $config
+    ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
+    ->setUsingCache(false)
+    ->setUsingLinter(true)
+    ->fixers(array(
+        'psr0',
+    ))
+;


### PR DESCRIPTION
This PR

* [x] asserts current exit codes for runs with and without `--dry-run` option for scenarios where
  * fixers were applied
  * no fixers were applied 
  * invalid files were found prior to fixing
* [x] adjusts the `FixCommand` to exit with non-zero if invalid files were found prior to fixing

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1102.
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1100. 
Ref #1211