### PR TITLE
composer.json - Update description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "fabpot/php-cs-fixer",
     "type": "application",
-    "description": "A script to automatically fix Symfony Coding Standard",
+    "description": "A tool to automatically fix PHP code style",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
I think PHP-CS-Fixer has out grown the `script`-label and it doesn't fix the `Symfony Coding Standard` but PHP code style issues to a selected standard.