### PR TITLE
Do not add an empty line at EOF if the PHP tags have been closed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,8 @@ Choose from the list of available fixers:
                 keywords looks like single words.
 
 * **eof_ending** [PSR-2]
-                A file must always end with an empty
-                line feed.
+                A PHP file must always end with a
+                single empty line feed.
 
 * **function_call_space** [PSR-2]
                 When making a method or function call,

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -12,6 +12,7 @@
 namespace Symfony\CS\Fixer\PSR2;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -25,13 +26,25 @@ class EofEndingFixer extends AbstractFixer
     {
         // [Structure] A file must always end with a linefeed character
 
-        $content = rtrim($content);
-
-        if ('' !== $content) {
-            return $content."\n";
+        if (empty($content)) {
+            return $content;
         }
 
-        return $content;
+        $tokens = Tokens::fromCode($content);
+        $count = $tokens->count();
+        if (0 === $count) {
+            return;
+        }
+
+        $token = $tokens[$count - 1];
+        switch ($token->getId()) {
+            case T_CLOSE_TAG:
+            case T_INLINE_HTML: {
+                return $content;
+            }
+        }
+
+        return rtrim($content)."\n";
     }
 
     /**
@@ -39,7 +52,7 @@ class EofEndingFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'A file must always end with an empty line feed.';
+        return 'A PHP file must always end with a single empty line feed.';
     }
 
     /**

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -63,6 +63,34 @@ $a = 3;
                 // test for not adding an empty line in empty file
                 '',
             ),
+            array(
+                '<?php
+$a = 4;
+
+//test
+
+?>
+  ', ),
+            array(
+                // test for not adding an empty line after PHP tag has been closed
+                '<?php
+$a = 5;
+
+//test
+
+?>', ),
+            array(
+                // test for not adding an empty line after PHP tag has been closed
+                '<?php
+$a = 6;
+
+//test
+
+?>
+Outside of PHP tags rendering
+
+
+', ),
         );
     }
 }


### PR DESCRIPTION
When a PHP file has content at the end of the file outside of PHP tag (`?>`) do not add a single line break.