### PR TITLE
EofEndingFixer - do not add an empty line at EOF if the PHP tags have been closed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,8 +199,8 @@ Choose from the list of available fixers:
                 keywords looks like single words.
 
 * **eof_ending** [PSR-2]
-                A file must always end with an empty
-                line feed.
+                A file must always end with a single
+                empty line feed.
 
 * **function_call_space** [PSR-2]
                 When making a method or function call,

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -12,6 +12,8 @@
 namespace Symfony\CS\Fixer\PSR2;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -23,15 +25,26 @@ class EofEndingFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, $content)
     {
-        // [Structure] A file must always end with a linefeed character
+        $tokens = Tokens::fromCode($content);
 
-        $content = rtrim($content);
-
-        if ('' !== $content) {
-            return $content."\n";
+        $count = $tokens->count();
+        if (0 === $count) {
+            return '';
         }
 
-        return $content;
+        $token = $tokens[$count - 1];
+        if ($token->isGivenKind(array(T_INLINE_HTML, T_CLOSE_TAG, T_OPEN_TAG))) {
+            return $content;
+        }
+
+        if ($token->isWhitespace()) {
+            $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
+            $token->setContent($lineBreak);
+        } else {
+            $tokens->insertAt($count, new Token(array(T_WHITESPACE, "\n")));
+        }
+
+        return $tokens->generateCode();
     }
 
     /**
@@ -39,7 +52,7 @@ class EofEndingFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'A file must always end with an empty line feed.';
+        return 'A file must always end with a single empty line feed.';
     }
 
     /**

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -30,6 +30,9 @@ class EofEndingFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                "<?php\n",
+            ),
+            array(
                 '<?php
 $a = 1;
 ',
@@ -52,17 +55,49 @@ $a = 3;
 ',
             ),
             array(
-                "<?php\r\$a = 1;\n",
-                "<?php\r\$a = 1;",
+                "<?php\r\n\$a = 4;\n",
+                "<?php\r\n\$a = 4;",
             ),
             array(
-                "<?php\r\$a = 1;\n",
-                "<?php\r\$a = 1;\r",
+                // test not changing line break characters,
+                // this is not the responsibility of this fixer
+                "<?php\r\n\$a = 5;\r\n",
+                "<?php\r\n\$a = 5;\r\n    \r\n",
             ),
             array(
-                // test for not adding an empty line in empty file
-                '',
-            ),
+                '<?php
+$a = 6;
+
+//test
+
+?>
+  ', ),
+            array(
+                // test for not adding an empty line after PHP tag has been closed
+                '<?php
+$a = 7;
+
+//test
+
+?>', ),
+            array(
+                // test for not adding an empty line after PHP tag has been closed
+                '<?php
+$a = 8;
+//test
+?>
+Outside of PHP tags rendering
+
+', ),
+array(
+                // test for not adding an empty line after PHP tag has been closed
+                "<?php
+//test
+?>
+inline 1
+<?php
+
+?>Inline2\r\n", ),
         );
     }
 }

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -198,6 +198,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
             array($fixers['unused_use'], $fixers['line_after_namespace']),
+            array($fixers['linefeed'], $fixers['eof_ending']),
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -390,11 +390,11 @@ class Token
      */
     public function isWhitespace(array $opts = array())
     {
-        $whitespaces = isset($opts['whitespaces']) ? $opts['whitespaces'] : " \t\n\r\0\x0B";
-
         if ($this->isArray && !$this->isGivenKind(T_WHITESPACE)) {
             return false;
         }
+
+        $whitespaces = isset($opts['whitespaces']) ? $opts['whitespaces'] : " \t\n\r\0\x0B";
 
         return '' === trim($this->content, $whitespaces);
     }


### PR DESCRIPTION
When a PHP file has content at the end of the file outside of PHP tag (`?>`) do not add a single line break.