### PR TITLE
Ease inherting from OrderedUseFixer

### DIFF
--- a/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
@@ -132,7 +132,7 @@ class OrderedUseFixer extends AbstractFixer
             }
         }
 
-        uasort($indexes, 'self::sortingCallBack');
+        uasort($indexes, 'static::sortingCallBack');
 
         $i = -1;
 


### PR DESCRIPTION
To ease inheriting from `OrderedUseFixer` (e.g. to implement a custom sorting algorithm) it would be convenient if `sortingCallBack` was invoked by late static binding.
This way an inheriting class just has to overwrite a single method to change the sort order.