### PR TITLE
Php4ConstructorFixer - fix invalid handling of subnamespaces

### DIFF
--- a/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
+++ b/Symfony/CS/Fixer/Contrib/Php4ConstructorFixer.php
@@ -41,7 +41,7 @@ class Php4ConstructorFixer extends AbstractFixer
                 // make sure it's not the global namespace, as PHP4 constructors are allowed in there
                 if (!$tokens[$nspIndex]->equals('{')) {
                     // unless it's the global namespace, the index currently points to the name
-                    $nspIndex = $tokens->getNextMeaningfulToken($nspIndex);
+                    $nspIndex = $tokens->getNextTokenOfKind($nspIndex, array(';', '{'));
 
                     if ($tokens[$nspIndex]->equals(';')) {
                         // the class is inside a (non-block) namespace, no PHP4-code should be in there

--- a/Symfony/CS/Tests/Fixer/Contrib/Php4ConstructorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/Php4ConstructorFixerTest.php
@@ -23,7 +23,7 @@ class Php4ConstructorFixerTest extends AbstractFixerTestBase
         $expected = <<<'EOF'
 <?php
 
-namespace Baz;
+namespace Baz\Qux;
 
 class Foo
 {
@@ -47,7 +47,7 @@ EOF;
         $expected = <<<'EOF'
 <?php
 
-namespace Baz
+namespace Baz\Qux
 {
     class Foo
     {
@@ -83,7 +83,7 @@ EOF;
         $input = <<<'EOF'
 <?php
 
-namespace Baz
+namespace Baz\Qux
 {
     class Foo
     {


### PR DESCRIPTION
Fixes #1197.