### PR TITLE
Tests - Do not run makeTest twice if input has been given.

### DIFF
--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -55,6 +55,8 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
             Tokens::clearCache();
             $expectedTokens = Tokens::fromCode($fixedCode); // Load the expected collection based on PHP parsing
             $this->assertTokens($expectedTokens, $tokens);
+
+            return;
         }
 
         $this->assertSame($expected, $fileIsSupported ? $fixer->fix($file, $expected) : $expected);


### PR DESCRIPTION
Assuming that when `$input` has been given the test should also pass like if it wasn't given seems a bit to optimistic to me.
I ran into this when trying to write a new fixer, so maybe I'm missing something here?
