### PR TITLE
Add class to exception message, use sprintf for exceptions

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -311,13 +311,13 @@ EOF
             }
 
             if (null === $config) {
-                throw new \InvalidArgumentException(sprintf('The configuration "%s" is not defined', $input->getOption('config')));
+                throw new \InvalidArgumentException(sprintf('The configuration "%s" is not defined.', $input->getOption('config')));
             }
         } elseif (file_exists($configFile)) {
             $config = include $configFile;
             // verify that the config has an instance of Config
             if (!$config instanceof Config) {
-                throw new \UnexpectedValueException(sprintf('The config file "%s" does not return an instance of Symfony\CS\Config\Config', $configFile));
+                throw new \UnexpectedValueException(sprintf('The config file "%s" does not return a "Symfony\CS\Config\Config" instance. Got: "%s".', $configFile, is_object($config) ? get_class($config) : gettype($config)));
             }
 
             if ('txt' === $input->getOption('format')) {

--- a/Symfony/CS/Tests/Tokenizer/AbstractTransformerTestBase.php
+++ b/Symfony/CS/Tests/Tokenizer/AbstractTransformerTestBase.php
@@ -49,7 +49,7 @@ abstract class AbstractTransformerTestBase extends \PHPUnit_Framework_TestCase
             }
         }
 
-        throw new \RuntimeException("Transformer $transformerClass not found.");
+        throw new \RuntimeException(sprintf('Transformer class "%s" not found.', $transformerClass));
     }
 
     protected static function getTransformers()

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -190,7 +190,7 @@ class Tokens extends \SplFixedArray
     private static function getCache($key)
     {
         if (!self::hasCache($key)) {
-            throw new \OutOfBoundsException('Unknown cache key: '.$key);
+            throw new \OutOfBoundsException(sprintf('Unknown cache key: %s', $key));
         }
 
         return self::$cache[$key];
@@ -329,7 +329,7 @@ class Tokens extends \SplFixedArray
         $blockEdgeDefinitions = self::getBlockEdgeDefinitions();
 
         if (!isset($blockEdgeDefinitions[$type])) {
-            throw new \InvalidArgumentException('Invalid param $type');
+            throw new \InvalidArgumentException(sprintf('Invalid param type: %s', $type));
         }
 
         $startEdge = $blockEdgeDefinitions[$type]['start'];
@@ -791,7 +791,7 @@ class Tokens extends \SplFixedArray
                 $token = new Token($token);
             }
             if ($token->isWhitespace() || $token->isComment() || $token->isEmpty()) {
-                throw new \InvalidArgumentException('Non-meaningful token at position: '.$key);
+                throw new \InvalidArgumentException(sprintf('Non-meaningful token at position: %s', $key));
             }
         }
 

--- a/Symfony/CS/Tokenizer/Transformers.php
+++ b/Symfony/CS/Tokenizer/Transformers.php
@@ -69,7 +69,7 @@ class Transformers
     public function getCustomToken($value)
     {
         if (!$this->hasCustomToken($value)) {
-            throw new \InvalidArgumentException("No custom token was found for $value");
+            throw new \InvalidArgumentException(sprintf('No custom token was found for: %s', $value));
         }
 
         return $this->customTokens[$value];
@@ -131,7 +131,12 @@ class Transformers
     private function addCustomToken($value, $name)
     {
         if ($this->hasCustomToken($value)) {
-            throw new \LogicException("Trying to register token $name ($value), token with this value was already defined: ".$this->getCustomToken($value));
+            throw new \LogicException(
+                sprintf(
+                    'Trying to register token %s (%s), token with this value was already defined: %s',
+                    $name, $value, $this->getCustomToken($value)
+                )
+            );
         }
 
         $this->customTokens[$value] = $name;


### PR DESCRIPTION
From the project's standards:
-> Symfony Coding Standards

http://symfony.com/doc/current/contributing/code/standards.html
* Exception message strings should be concatenated using sprintf.
