### PR TITLE
Enhancement: Add failing test for braces fixer

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -953,18 +953,6 @@ function foo()
             array(
                 '<?php
 if ($this->foo()) {
-    $this->bar();
-    $this->baz();
-}',
-                '<?php
-if ($this->foo()) {
-  $this->bar();
-  $this->baz();
-}',
-            ),
-            array(
-                '<?php
-if ($this->foo()) {
     // foo this
     $this->bar();
     $this->baz();

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -940,6 +940,46 @@ function foo()
     }
 
     /**
+     * @dataProvider provideFixCommentAfterBraceCases
+     */
+    public function testFixCommentAfterBrace($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixCommentAfterBraceCases()
+    {
+        return array(
+            array(
+                '<?php
+if ($this->foo()) {
+    $this->bar();
+    $this->baz();
+}',
+                '<?php
+if ($this->foo()) {
+  $this->bar();
+  $this->baz();
+}',
+            ),
+            array(
+                '<?php
+if ($this->foo()) {
+    // foo this
+    $this->bar();
+    $this->baz();
+}',
+                '<?php
+if ($this->foo()) {
+  // foo this
+  $this->bar();
+  $this->baz();
+}',
+            ),
+        );
+    }
+
+    /**
      * @dataProvider provideFixWhitespaceBeforeBraceCases
      */
     public function testFixWhitespaceBeforeBrace($expected, $input = null)


### PR DESCRIPTION
This PR

* [x] adds a failing test for the `braces` fixer for a case where we have a comment after the brace

:question: Not sure, should this be fixed by this fixer?

ref: #1196