### PR TITLE
Fixed error handler to respect current error_reporting

### DIFF
--- a/Symfony/CS/Resources/phar-stub.php
+++ b/Symfony/CS/Resources/phar-stub.php
@@ -21,7 +21,9 @@ if (defined('HHVM_VERSION_ID')) {
 }
 
 set_error_handler(function ($severity, $message, $file, $line) {
-    throw new ErrorException($message, 0, $severity, $file, $line);
+    if ($severity & error_reporting()) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
 });
 
 Phar::mapPhar('php-cs-fixer.phar');

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -26,7 +26,9 @@ if (defined('HHVM_VERSION_ID')) {
 }
 
 set_error_handler(function ($severity, $message, $file, $line) {
-    throw new ErrorException($message, 0, $severity, $file, $line);
+    if ($severity & error_reporting()) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
 });
 
 // installed via composer?


### PR DESCRIPTION
Ignoring current error_reporting can break any code relying on the unfamous `@` operator. Lines like `@unlink($file) // @ - file may not exist` are very common.

Quoting from http://php.net/manual/en/language.operators.errorcontrol.php:
> If you have set a custom error handler function with set_error_handler() then it will still get called, but this custom error handler can (and should) call error_reporting() which will return 0 when the call that triggered the error was preceded by an @.