### PR TITLE
Test for clear empty tokens, allow range hinting for cleaning

### DIFF
--- a/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
+++ b/Symfony/CS/Fixer/Contrib/OrderedUseFixer.php
@@ -59,7 +59,7 @@ final class OrderedUseFixer extends AbstractFixer
             $declarationTokens = Tokens::fromCode('<?php use '.$use[0].';');
             $declarationTokens->clearRange(0, 2); // clear `<?php use `
             $declarationTokens[count($declarationTokens) - 1]->clear(); // clear `;`
-            $declarationTokens->clearEmptyTokens();
+            $declarationTokens->clearEmptyTokens(0, count($declarationTokens));
 
             $tokens->overrideRange($index, $mapStartToEnd[$index], $declarationTokens);
         }

--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -107,7 +107,7 @@ final class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 $newNamespace[0]->clear();
                 $newNamespace[1]->clear();
                 $newNamespace[2]->clear();
-                $newNamespace->clearEmptyTokens();
+                $newNamespace->clearEmptyTokens(0, 3);
 
                 $tokens->insertAt($namespaceIndex, $newNamespace);
             }

--- a/Symfony/CS/Fixer/PSR2/MultipleUseFixer.php
+++ b/Symfony/CS/Fixer/PSR2/MultipleUseFixer.php
@@ -62,7 +62,7 @@ final class MultipleUseFixer extends AbstractFixer
 
             $declarationTokens = Tokens::fromCode('<?php '.$declarationContent);
             $declarationTokens[0]->clear();
-            $declarationTokens->clearEmptyTokens();
+            $declarationTokens->clearEmptyTokens(0, 1);
 
             $tokens->insertAt($index, $declarationTokens);
         }

--- a/Symfony/CS/Fixer/Symfony/ListCommasFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ListCommasFixer.php
@@ -58,10 +58,9 @@ final class ListCommasFixer extends AbstractFixer
             }
 
             if (null !== $markIndex) {
-                $tokens->clearRange(
-                    $tokens->getPrevNonWhitespace($markIndex) + 1,
-                    $closeIndex - 1
-                );
+                $startIndex = $tokens->getPrevNonWhitespace($markIndex) + 1;
+                $tokens->clearRange($startIndex, $closeIndex - 1);
+                $tokens->clearEmptyTokens($startIndex, $closeIndex);
             }
         }
     }

--- a/Symfony/CS/Tests/AssertTokensTrait.php
+++ b/Symfony/CS/Tests/AssertTokensTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+trait AssertTokensTrait
+{
+    public function assertTokens(Tokens $expectedTokens, Tokens $inputTokens)
+    {
+        foreach ($expectedTokens as $index => $expectedToken) {
+            $this->assertTrue(isset($inputTokens[$index]), sprintf('Expected at index: %d token: "%s"', $index, $expectedToken->toJson()));
+            $inputToken = $inputTokens[$index];
+
+            $this->assertTrue(
+                $expectedToken->equals($inputToken),
+                sprintf('The token at index %d must be %s, got %s', $index, $expectedToken->toJson(), ($inputToken instanceof Token) ? $inputToken->toJson() : var_export($inputToken, true))
+            );
+        }
+
+        $this->assertEquals($expectedTokens->count(), $inputTokens->count(), 'The collection must have the same length than the expected one.');
+
+        $tokensReflection = new \ReflectionClass($expectedTokens);
+        $propertyReflection = $tokensReflection->getProperty('foundTokenKinds');
+        $propertyReflection->setAccessible(true);
+        $foundTokenKinds = array_keys($propertyReflection->getValue($expectedTokens));
+
+        foreach ($foundTokenKinds as $tokenKind) {
+            $this->assertTrue(
+                $inputTokens->isTokenKindFound($tokenKind),
+                sprintf('The token kind %s must be found in fixed tokens collection.', $tokenKind)
+            );
+        }
+    }
+}

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -12,6 +12,7 @@
 namespace Symfony\CS\Tests\Fixer;
 
 use Symfony\CS\FixerInterface;
+use Symfony\CS\Tests\AssertTokensTrait;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
@@ -19,6 +20,8 @@ use Symfony\CS\Tokenizer\Tokens;
  */
 abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
 {
+    use AssertTokensTrait;
+
     protected function getFixer()
     {
         $fixerName = 'Symfony\CS\Fixer'.substr(get_called_class(), strlen(__NAMESPACE__), -strlen('Test'));
@@ -76,31 +79,5 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($tokens->isChanged(), 'Tokens collection built on expected code must not be marked as changed after fixing.');
         $this->assertSame($expected, $tokens->generateCode(), 'Code build on expected code must not change.');
-    }
-
-    private function assertTokens(Tokens $expectedTokens, Tokens $inputTokens)
-    {
-        foreach ($expectedTokens as $index => $expectedToken) {
-            $inputToken = $inputTokens[$index];
-
-            $this->assertTrue(
-                $expectedToken->equals($inputToken),
-                sprintf('The token at index %d must be %s, got %s', $index, $expectedToken->toJson(), $inputToken->toJson())
-            );
-        }
-
-        $this->assertEquals($expectedTokens->count(), $inputTokens->count(), 'The collection must have the same length than the expected one.');
-
-        $tokensReflection = new \ReflectionClass($expectedTokens);
-        $propertyReflection = $tokensReflection->getProperty('foundTokenKinds');
-        $propertyReflection->setAccessible(true);
-        $foundTokenKinds = array_keys($propertyReflection->getValue($expectedTokens));
-
-        foreach ($foundTokenKinds as $tokenKind) {
-            $this->assertTrue(
-                $inputTokens->isTokenKindFound($tokenKind),
-                sprintf('The token kind %s must be found in fixed tokens collection.', $tokenKind)
-            );
-        }
     }
 }

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\CS\Tests\Tokenizer;
 
+use Symfony\CS\Tests\AssertTokensTrait;
 use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
@@ -19,6 +20,8 @@ use Symfony\CS\Tokenizer\Tokens;
  */
 class TokensTest extends \PHPUnit_Framework_TestCase
 {
+    use AssertTokensTrait;
+
     public function testReadFromCacheAfterClearing()
     {
         $code = '<?php echo 1;';
@@ -395,7 +398,6 @@ if (!function_exists('bar')) {
     }
 }
 EOF;
-
         $tokens = Tokens::fromCode($code);
 
         $this->assertTrue($tokens->isTokenKindFound(T_CLASS));
@@ -409,5 +411,69 @@ EOF;
         $this->assertTrue($tokens->isAnyTokenKindsFound(array(T_CLASS, T_RETURN)));
         $this->assertTrue($tokens->isAnyTokenKindsFound(array(T_CLASS, T_INTERFACE)));
         $this->assertFalse($tokens->isAnyTokenKindsFound(array(T_INTERFACE, T_ARRAY)));
+    }
+
+    /**
+     * @dataProvider provideClearEmptyTokens
+     */
+    public function testClearEmptyTokens(array $input, array $expected = null, $startIndex = 0, $endIndex = null)
+    {
+        $tokens = Tokens::fromArray($input);
+        $tokens->clearEmptyTokens($startIndex, $endIndex);
+        $this->assertTokens(null === $expected ? Tokens::fromArray($input) : Tokens::fromArray($expected), $tokens);
+    }
+
+    public function provideClearEmptyTokens()
+    {
+        $clearedToken = new Token('');
+        $clearedToken->clear();
+
+        return array(
+            array(
+                array(
+                    new Token(array(T_WHITESPACE, ' ')),
+                    $clearedToken,
+                    $clearedToken,
+                ),
+                array(
+                    new Token(array(T_WHITESPACE, ' ')),
+                ),
+            ),
+            array(
+                array(
+                    $clearedToken,
+                    new Token(array(T_WHITESPACE, ' ')),
+                    $clearedToken,
+                    $clearedToken,
+                    new Token(array(T_WHITESPACE, ' ')),
+                    $clearedToken,
+                ),
+                array(
+                    $clearedToken,
+                    new Token(array(T_WHITESPACE, ' ')),
+                    new Token(array(T_WHITESPACE, ' ')),
+                ),
+                1,
+            ),
+            array(
+                array(
+                    $clearedToken,
+                    new Token(array(T_WHITESPACE, ' ')),
+                    $clearedToken,
+                    $clearedToken,
+                ),
+                array(
+                    $clearedToken,
+                    new Token(array(T_WHITESPACE, ' ')),
+                    $clearedToken,
+                ),
+                1, 3,
+            ),
+            array(
+                array(
+                    new Token(array(T_WHITESPACE, ' ')),
+                ),
+            ),
+        );
     }
 }

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -305,27 +305,38 @@ class Tokens extends \SplFixedArray
      * Clear empty tokens.
      *
      * Empty tokens can occur e.g. after calling clear on item of collection.
+     *
+     * @param int $startIndex optional start index, default 0.
+     * @param int $endIndex   optional end index, default the size of this.
      */
-    public function clearEmptyTokens()
+    public function clearEmptyTokens($startIndex = 0, $endIndex = null)
     {
-        $limit = $this->count();
-        $index = 0;
+        if (null === $endIndex) {
+            $endIndex = $this->getSize();
+        } elseif ($endIndex <= $startIndex || $endIndex > $this->getSize()) {
+            throw new \InvalidArgumentException('Invalid param $endIndex');
+        }
 
-        for (; $index < $limit; ++$index) {
-            if ($this[$index]->isEmpty()) {
+        if ($startIndex < 0 || $startIndex > $this->getSize()) {
+            throw new \InvalidArgumentException('Invalid param $startIndex - not a proper start');
+        }
+
+        for (; $startIndex < $endIndex; ++$startIndex) {
+            if ($this[$startIndex]->isEmpty()) {
                 break;
             }
         }
 
         // no empty token found, therefore there is no need to override collection
-        if ($limit === $index) {
+        if ($endIndex === $startIndex) {
             return;
         }
 
-        for ($count = $index; $index < $limit; ++$index) {
-            $token = $this[$index];
+        $limit = $this->getSize();
+        for ($count = $startIndex; $startIndex < $limit; ++$startIndex) {
+            $token = $this[$startIndex];
 
-            if (!$token->isEmpty()) {
+            if ($startIndex >= $endIndex || !$token->isEmpty()) {
                 $this[$count++] = $token;
             }
         }
@@ -705,8 +716,8 @@ class Tokens extends \SplFixedArray
      * Find a sequence of meaningful tokens and returns the array of their locations.
      *
      * @param array      $sequence      an array of tokens (same format used by getNextTokenOfKind)
-     * @param int        $start         start index, defaulting to the start of the file
-     * @param int        $end           end index, defaulting to the end of the file
+     * @param int        $start         start index, defaulting to the start of the tokens
+     * @param int        $end           end index, defaulting to the end of the tokens
      * @param bool|array $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
      *                                  the ones used in $others. If any is missing, the default case-sensitive
      *                                  comparison is used.


### PR DESCRIPTION
Step one for optimizing the clearing of tokens. With the range options Fixers could do clear out the tokens they know the have changed. If this is done this call can go:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/Symfony/CS/Fixer.php#L241