### PR TITLE
Warn on xdebug, tweak "Fixed all files" message 

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -340,6 +340,9 @@ EOF
         }
 
         $verbosity = $output->getVerbosity();
+        if (OutputInterface::VERBOSITY_VERY_VERBOSE <= $verbosity && extension_loaded('xdebug')) {
+            $output->writeln('<comment>xdebug is enabled</comment>, this might have a big impact on the performance of PHP-CS-Fixer.');
+        }
 
         // register custom fixers from config
         $this->fixer->registerCustomFixers($config->getCustomFixers());
@@ -422,7 +425,7 @@ EOF
                 }
 
                 $fixEvent = $this->stopwatch->getEvent('fixFiles');
-                $output->writeln(sprintf('Fixed all files in %.3f seconds, %.3f MB memory used', $fixEvent->getDuration() / 1000, $fixEvent->getMemory() / 1024 / 1024));
+                $output->writeln(sprintf('All files %s in %.3f seconds, %.3f MB memory used.', $resolver->isDryRun() ? 'checked' : 'fixed', $fixEvent->getDuration() / 1000, $fixEvent->getMemory() / 1024 / 1024));
                 break;
             case 'xml':
                 $dom = new \DOMDocument('1.0', 'UTF-8');


### PR DESCRIPTION
replacement of https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1245 for 1.9