### PR TITLE
[WIP] Config resolver should rely on the ConfigInterface

### DIFF
--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -104,7 +104,7 @@ class Config implements ConfigInterface
         return $this->level;
     }
 
-    public function fixers($fixers)
+    public function fixers(array $fixers)
     {
         $this->fixers = $fixers;
 

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\CS;
 
+use Traversable;
+
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -37,7 +39,7 @@ interface ConfigInterface
     /**
      * Returns an iterator of files to scan.
      *
-     * @return \Traversable A \Traversable instance that returns \SplFileInfo instances
+     * @return Traversable A \Traversable instance that returns \SplFileInfo instances
      */
     public function getFinder();
 
@@ -49,9 +51,18 @@ interface ConfigInterface
     public function getLevel();
 
     /**
-     * Returns the fixers to run.
+     * Set the fixers to be used.
      *
-     * @return array A list of fixer names
+     * @param string[] $fixers
+     *
+     * @return ConfigInterface
+     */
+    public function fixers(array $fixers);
+
+    /**
+     * Returns the fixers.
+     *
+     * @return FixerInterface[] A list of fixers
      */
     public function getFixers();
 
@@ -139,11 +150,11 @@ interface ConfigInterface
     public function getPhpExecutable();
 
     /**
-     * Set the fixers to be used.
+     * Set the finder to be used.
      *
-     * @param FixerInterface[] $fixers
+     * @param Traversable $finder
      *
      * @return ConfigInterface
      */
-    public function fixers(array $fixers);
+    public function finder(Traversable $finder);
 }

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -116,6 +116,15 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
+     * Sets if caching should be enabled.
+     *
+     * @param bool $usingCache
+     *
+     * @return ConfigInterface
+     */
+    public function setUsingCache($usingCache);
+
+    /**
      * Returns the path to the cache file.
      *
      * @return string
@@ -128,4 +137,13 @@ interface ConfigInterface
      * @return string|null
      */
     public function getPhpExecutable();
+
+    /**
+     * Set the fixers to be used.
+     *
+     * @param FixerInterface[] $fixers
+     *
+     * @return ConfigInterface
+     */
+    public function fixers(array $fixers);
 }

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -141,7 +141,7 @@ class ConfigurationResolver
         $this->resolveUsingCache();
         $this->resolveCacheFile();
 
-        $this->config->fixers($this->getFixers());
+        $this->config->fixers($this->getFixers()); // FIXME this should be done in another way
         $this->config->setUsingCache($this->usingCache);
         $this->config->setCacheFile($this->cacheFile);
 
@@ -417,6 +417,20 @@ class ConfigurationResolver
         foreach ($this->allFixers as $fixer) {
             if (isset($addNames[$fixer->getName()]) && !in_array($fixer, $this->fixers, true)) {
                 $this->fixers[] = $fixer;
+            }
+        }
+
+        foreach ($addNames as $addName => $add) {
+            $found = false;
+            foreach ($this->fixers as $fixer) {
+                if ($addName === $fixer->getName()) {
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (false === $found) {
+                throw new \UnexpectedValueException(sprintf('Fixer to add not found "%s"', $addName));
             }
         }
     }

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -12,7 +12,6 @@
 namespace Symfony\CS\Console;
 
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\CS\Config\Config;
 use Symfony\CS\ConfigInterface;
 use Symfony\CS\Fixer;
 use Symfony\CS\FixerInterface;
@@ -30,7 +29,14 @@ use Symfony\CS\StdinFileInfo;
 class ConfigurationResolver
 {
     private $allFixers;
+
+    /**
+     * The config instance.
+     *
+     * @var ConfigInterface
+     */
     private $config;
+
     private $configFile;
     private $cwd;
     private $defaultConfig;
@@ -330,9 +336,9 @@ class ConfigurationResolver
             if (file_exists($configFile)) {
                 $config = include $configFile;
 
-                // verify that the config has an instance of Config
-                if (!$config instanceof Config) {
-                    throw new \UnexpectedValueException(sprintf('The config file: "%s" does not return a "Symfony\CS\Config\Config" instance. Got: "%s".', $configFile, is_object($config) ? get_class($config) : gettype($config)));
+                // verify that the config has an instance of ConfigInterface
+                if (!$config instanceof ConfigInterface) {
+                    throw new \UnexpectedValueException(sprintf('The config file "%s" does not return an instance of Symfony\CS\ConfigInterface. Got: "%s".', $configFile, is_object($config) ? get_class($config) : gettype($config)));
                 }
 
                 $this->config = $config;

--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -35,6 +35,11 @@ class FileCacheManager
     private $newHashes = array();
     private $oldHashes = array();
 
+    /**
+     * @param bool             $isEnabled
+     * @param string           $cacheFile
+     * @param FixerInterface[] $fixers
+     */
     public function __construct($isEnabled, $cacheFile, array $fixers)
     {
         $this->isEnabled = $isEnabled;

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -460,7 +460,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException              \UnexpectedValueException
-     * @expectedExceptionMessageRegExp /The config file: ".+\/Tests\/Fixtures\/ConfigurationResolverConfigFile\/case_5\/.php_cs.dist" does not return a "Symfony\\CS\\Config\\Config" instance. Got: "string"./
+     * @expectedExceptionMessageRegExp /The config file ".+\/Tests\/Fixtures\/ConfigurationResolverConfigFile\/case_5\/.php_cs.dist" does not return an instance of Symfony\\CS\\ConfigInterface. Got: "string"./
      */
     public function testResolveConfigFileChooseFileWithInvalidFile()
     {
@@ -610,5 +610,19 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->resolve();
 
         $this->assertSame($optionCacheFile, $this->config->getCacheFile());
+    }
+
+    public function testResolveCustomConfigClass()
+    {
+        $file = __DIR__.'/../Fixtures/ConfigurationResolverConfigFile/case_7/my.php_cs.php';
+
+        $this->resolver->setOption('config-file', $file)->resolve();
+
+        $this->assertSame($file, $this->resolver->getConfigFile());
+        $this->assertSame(array(), $this->resolver->getFixers());
+
+        $config = $this->resolver->getConfig();
+        $this->assertSame('TestCase7', $config->getName());
+        $this->assertSame('Test config for PHPUnit test case 7', $config->getDescription());
     }
 }

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -112,7 +112,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', $property);
     }
 
-    protected function makeFixersTest($expectedFixers, $resolvedFixers)
+    protected function makeFixersTest(array $expectedFixers, array $resolvedFixers)
     {
         $this->assertCount(count($expectedFixers), $resolvedFixers);
 
@@ -624,5 +624,16 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $config = $this->resolver->getConfig();
         $this->assertSame('TestCase7', $config->getName());
         $this->assertSame('Test config for PHPUnit test case 7', $config->getDescription());
+    }
+
+    /**
+     * @expectedException              \UnexpectedValueException
+     * @expectedExceptionMessageRegExp /Fixer to add not found "not_existing_fixer"/
+     */
+    public function testResolveUnknownFixer()
+    {
+        $this->config->fixers(array('encoding', 'not_existing_fixer'));
+        $this->resolver
+            ->resolve();
     }
 }

--- a/Symfony/CS/Tests/Fixtures/ConfigurationResolverConfigFile/case_7/my.php_cs.php
+++ b/Symfony/CS/Tests/Fixtures/ConfigurationResolverConfigFile/case_7/my.php_cs.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Symfony\CS\ConfigInterface;
+use Symfony\CS\Finder\DefaultFinder;
+use Symfony\CS\FixerInterface;
+
+/**
+ * Test configuration class for a PHPUnit test.
+ */
+class CustomConfig implements ConfigInterface
+{
+    private $fixers = array();
+
+    public function getName()
+    {
+        return 'TestCase7';
+    }
+
+    public function getDescription()
+    {
+        return 'Test config for PHPUnit test case 7';
+    }
+
+    public function getFinder()
+    {
+        return new DefaultFinder();
+    }
+
+    public function getLevel()
+    {
+        return FixerInterface::NONE_LEVEL;
+    }
+
+    public function getFixers()
+    {
+        return $this->fixers;
+    }
+
+    public function setDir($dir)
+    {
+        return $this;
+    }
+
+    public function getDir()
+    {
+        return __DIR__;
+    }
+
+    public function getHideProgress()
+    {
+        return true;
+    }
+
+    public function addCustomFixer(\Symfony\CS\FixerInterface $fixer)
+    {
+        return $this;
+    }
+
+    public function getCustomFixers()
+    {
+        return array();
+    }
+
+    public function usingCache()
+    {
+        return false;
+    }
+
+    public function usingLinter()
+    {
+        return false;
+    }
+
+    public function setCacheFile($cacheFile)
+    {
+        return $this;
+    }
+
+    public function getCacheFile()
+    {
+        return __DIR__.'/test.cache';
+    }
+
+    public function getPhpExecutable()
+    {
+        return;
+    }
+
+    public function fixers(array $fixers)
+    {
+        $this->fixers = $fixers;
+
+        return $this;
+    }
+
+    public function setUsingCache($usingCache)
+    {
+        return false;
+    }
+}
+
+return new CustomConfig();

--- a/Symfony/CS/Tests/Fixtures/ConfigurationResolverConfigFile/case_7/my.php_cs.php
+++ b/Symfony/CS/Tests/Fixtures/ConfigurationResolverConfigFile/case_7/my.php_cs.php
@@ -106,6 +106,11 @@ class CustomConfig implements ConfigInterface
     {
         return false;
     }
+
+    public function finder(Traversable $finder)
+    {
+        return $this;
+    }
 }
 
 return new CustomConfig();


### PR DESCRIPTION
In the docs it states people can provide their our instance of a ConfigInterface and the fixer will use it to run. However the ConfigResolver depends on the Config class. The diversion of the Config class with the ConfigInterface causes the resolver not being able to deal with an implementation of the ConfigInterface.
