### PR TITLE
line_after_namespace - multiple lines allowed.

### DIFF
--- a/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
@@ -45,7 +45,14 @@ class LineAfterNamespaceFixer extends AbstractFixer
                 if (!$nextToken->isWhitespace()) {
                     $tokens->insertAt($semicolonIndex + 1, new Token(array(T_WHITESPACE, "\n\n")));
                 } else {
-                    $nextToken->setContent("\n\n".ltrim($nextToken->getContent()));
+                    $linefeedsRequired = 2;
+                    if (substr($nextToken->getContent(), 0, 1) === "\n") {
+                        $linefeedsRequired--;
+                    }
+                    if (substr($nextToken->getContent(), 1, 1) === "\n") {
+                        $linefeedsRequired--;
+                    }
+                    $nextToken->setContent(str_repeat("\n", $linefeedsRequired) . ltrim($nextToken->getContent(), "\r "));
                 }
             }
         }

--- a/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LineAfterNamespaceFixer.php
@@ -52,7 +52,7 @@ class LineAfterNamespaceFixer extends AbstractFixer
                     if (substr($nextToken->getContent(), 1, 1) === "\n") {
                         $linefeedsRequired--;
                     }
-                    $nextToken->setContent(str_repeat("\n", $linefeedsRequired) . ltrim($nextToken->getContent(), "\r "));
+                    $nextToken->setContent(str_repeat("\n", $linefeedsRequired).ltrim($nextToken->getContent(), "\r "));
                 }
             }
         }

--- a/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LineAfterNamespaceFixerTest.php
@@ -35,20 +35,6 @@ namespace A\B;
 
 class C {}
 ',
-                '<?php
-namespace A\B;
-
-
-
-class C {}
-',
-            ),
-            array(
-                '<?php
-namespace A\B;
-
-class C {}
-',
             ),
             array(
                 '<?php


### PR DESCRIPTION
PSR-2 standards declare:
* there MUST be one blank line after the namespace declaration.
* blank lines MAY be added to improve readability and to indicate related blocks of code.

This implies multiple blank lines after a namespace declaration are acceptable. The existing line_after_namespace fixer doesn't currently allow for this, so I've made a minor change for this.
The test cases were updated (original test case #0 became irrelevant as a result, and so has been removed).