### PR TITLE
[WIP] Split AlignEquals for constant and common code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -458,6 +458,10 @@ Choose from the list of available fixers:
                 Remove trailing whitespace at the end
                 of blank lines.
 
+* **align_constant_equals** [contrib]
+                Align constant equals symbols in
+                consecutive lines.
+
 * **align_double_arrow** [contrib]
                 Align double arrow symbols in
                 consecutive lines.

--- a/Symfony/CS/Fixer/Contrib/AlignConstantEqualsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AlignConstantEqualsFixer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractAlignFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class AlignConstantEqualsFixer extends AbstractAlignFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        list($tokens, $deepestLevel) = $this->injectAlignmentPlaceholders($content);
+
+        return $this->replacePlaceholder($tokens, $deepestLevel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Align constant equals symbols in consecutive lines.';
+    }
+
+    /**
+     * Inject into the text placeholders of candidates of vertical alignment.
+     *
+     * @param string $content
+     *
+     * @return array($code, $deepestLevel)
+     */
+    private function injectAlignmentPlaceholders($content)
+    {
+        $deepestLevel = 0;
+        $constantDetected = false;
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens as $token) {
+            $tokenContent = $token->getContent();
+
+            if ($tokenContent === 'const') {
+                $constantDetected = true;
+            }
+
+            if (true === $constantDetected && $token->equals('=')) {
+                $token->setContent(sprintf(self::ALIGNABLE_PLACEHOLDER, $deepestLevel).$tokenContent);
+                $constantDetected = false;
+                continue;
+            }
+
+            if ($token->isGivenKind(T_CLASS)) {
+                ++$deepestLevel;
+            }
+        }
+
+        return array($tokens, $deepestLevel);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/AlignConstantEqualsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AlignConstantEqualsFixerTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+class AlignConstantEqualsFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFixCases()
+    {
+        return array(
+            array(
+                '<?php
+                const FIRST_CONSTANT          = 1;
+                const SECOND_CONSTANT         = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+                ',
+                '<?php
+                const FIRST_CONSTANT = 1;
+                const SECOND_CONSTANT = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+                ',
+            ),
+            array(
+                '<?php
+                const FIRST_CONSTANT          = 1;
+                const SECOND_CONSTANT         = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+                ',
+                '<?php
+                const FIRST_CONSTANT            = 1;
+                const SECOND_CONSTANT           = 2;
+                const THIRD_AND_LAST_CONSTANT   = 3;
+                ',
+            ),
+            array(
+                '<?php
+                const FIRST_CONSTANT          = 1;
+                const SECOND_CONSTANT         = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+                ',
+                '<?php
+                const FIRST_CONSTANT          = 1;
+                const SECOND_CONSTANT         = 2;
+                const THIRD_AND_LAST_CONSTANT   = 3;
+                ',
+            ),
+            array(
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+            ),
+            array(
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT = 1;
+                    const SECOND_CONSTANT = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+            ),
+            array(
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT = 1;
+                    const SECOND_CONSTANT = 2;
+                    const THIRD_AND_LAST_CONSTANT   = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+            ),
+            array(
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT            = 1;
+                    const SECOND_CONSTANT           = 2;
+                    const THIRD_AND_LAST_CONSTANT   = 3;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+            ),
+            array(
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    const NEWLINE_BEFORE          = 42;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+                '<?php
+                class Foo
+                {
+                    const FIRST_CONSTANT          = 1;
+                    const SECOND_CONSTANT         = 2;
+                    const THIRD_AND_LAST_CONSTANT = 3;
+
+                    const NEWLINE_BEFORE = 42;
+
+                    public function bar($thing)
+                    {
+                        $myThing = $thing;
+                        $myOtherThing = $thing;
+                    }
+                }
+                ',
+            ),
+            array(
+                '<?php
+                const FIRST_CONSTANT          = 1;
+                const SECOND_CONSTANT         = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+
+                class Foo
+                {
+                    const CLASS_FIRST_CONSTANT          = 1;
+                    const CLASS_SECOND_CONSTANT         = 2;
+                    const CLASS_THIRD_AND_LAST_CONSTANT = 3;
+                }
+                ',
+                '<?php
+                const FIRST_CONSTANT = 1;
+                const SECOND_CONSTANT = 2;
+                const THIRD_AND_LAST_CONSTANT = 3;
+
+                class Foo
+                {
+                    const CLASS_FIRST_CONSTANT = 1;
+                    const CLASS_SECOND_CONSTANT = 2;
+                    const CLASS_THIRD_AND_LAST_CONSTANT = 3;
+                }
+                ',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Closes #1268 

To do list:

- [ ] Implement `AlignConstantEqualsFixer` for constants.
- [ ] Implement `AlignCodeEqualsFixer` for common code.
- [ ] Implement `UnalignConstantEqualsFixer` for constants.
- [ ] Implement `UnalignCodeEqualsFixer` for common code.
- [ ] Deprecate `AlignEqualsFixer`.
- [ ] Deprecate `UnalignEqualsFixer`.
- [ ] Write tests (of course!) and check code coverage.
- [ ] Update `README.rst` (`php php-cs-fixer readme > README.rst`).

Note: Once this PR got merged, make another one on `master` to remove deprecated `AlignEqualsFixer` and `UnalignEqualsFixer` classes.