### PR TITLE
Readme - Add spaces around PHP-CS-Fixer headers

### DIFF
--- a/COOKBOOK-FIXERS.md
+++ b/COOKBOOK-FIXERS.md
@@ -49,6 +49,7 @@ Create a new file in
 Put this content inside:
 ```php
 <?php
+
 /*
  * This file is part of the PHP CS utility.
  *
@@ -57,6 +58,7 @@ Put this content inside:
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
 namespace Symfony\CS\Fixer\Contrib;
 
 use Symfony\CS\AbstractFixer;
@@ -81,6 +83,7 @@ content inside:
 
 ```php
 <?php
+
 /*
  * This file is part of the PHP CS utility.
  *
@@ -89,6 +92,7 @@ content inside:
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
 namespace Symfony\CS\Tests\Fixer\Contrib;
 
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
@@ -160,6 +164,7 @@ like:
 `Symfony/CS/Tests/Fixer/Contrib/RemoveCommentsFixerTest.php`
 ```php
 <?php
+
 /*
  * This file is part of the PHP CS utility.
  *
@@ -168,6 +173,7 @@ like:
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
  */
+
 namespace Symfony\CS\Tests\Fixer\Contrib;
 
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
@@ -336,6 +342,7 @@ class RemoveCommentsFixer extends AbstractFixer
 So the fixer in the end looks like this:
 ```php
 <?php
+
 /*
  * This file is part of the PHP CS utility.
  *
@@ -345,6 +352,7 @@ So the fixer in the end looks like this:
  * with this source code in the file LICENSE.
  *
  */
+
 namespace Symfony\CS\Fixer\Contrib;
 
 use Symfony\CS\AbstractFixer;


### PR DESCRIPTION
Because it's not really standard compliant AFAIK. :-)