### PR TITLE
Added PhpdocInlineTagFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,6 +343,10 @@ Choose from the list of available fixers:
                 Docblocks should have the same
                 indentation as the documented subject.
 
+* **phpdoc_inline_tag** [symfony]
+                Fix PHPDoc inline tags, make
+                inheritdoc always inline.
+
 * **phpdoc_no_access** [symfony]
                 @access annotations should be omitted
                 from phpdocs.

--- a/Symfony/CS/Fixer/Symfony/PhpdocInlineTagFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocInlineTagFixer.php
@@ -44,14 +44,15 @@ final class PhpdocInlineTagFixer extends AbstractFixer
             // Make sure the tags are written in lower case, remove white space between end
             // of text and closing bracket and between the tag and inline comment.
             $content = preg_replace_callback(
-                '#(@{+|{+[ \t]*@)[ \t]*(example|id|internal|inheritdoc|link|source|toc|tutorial)s*([^}]*)(}*)#i',
+                '#(?:@{+|{+[ \t]*@)[ \t]*(example|id|internal|inheritdoc|link|source|toc|tutorial)s?([^}]*)(?:}*)#i',
                 function (array $matches) {
-                    $doc = trim($matches[3]);
+                    $doc = trim($matches[2]);
+
                     if ('' === $doc) {
-                        return '{@'.strtolower($matches[2]).'}';
+                        return '{@'.strtolower($matches[1]).'}';
                     }
 
-                    return '{@'.strtolower($matches[2]).' '.$doc.'}';
+                    return '{@'.strtolower($matches[1]).' '.$doc.'}';
                 },
                 $content
             );

--- a/Symfony/CS/Fixer/Symfony/PhpdocInlineTagFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocInlineTagFixer.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Fix inline tags and make inheritdoc tag always inline.
+ */
+final class PhpdocInlineTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+
+            // Move `@` inside tag, for example @{tag} -> {@tag}, replace multiple curly brackets,
+            // remove spaces between '{' and '@', remove 's' at the end of tag.
+            // Make sure the tags are written in lower case, remove white space between end
+            // of text and closing bracket and between the tag and inline comment.
+            $content = preg_replace_callback(
+                '#(@{+|{+[ \t]*@)[ \t]*(example|id|internal|inheritdoc|link|source|toc|tutorial)s*([^}]*)(}*)#i',
+                function (array $matches) {
+                    $doc = trim($matches[3]);
+                    if ('' === $doc) {
+                        return '{@'.strtolower($matches[2]).'}';
+                    }
+
+                    return '{@'.strtolower($matches[2]).' '.$doc.'}';
+                },
+                $content
+            );
+
+            // Always make inheritdoc inline using with '{' '}' when needed, remove trailing 's',
+            // make sure lowercase.
+            $content = preg_replace(
+                '#(?<!{)@inheritdocs?(?!})#i',
+                '{@inheritdoc}',
+                $content
+            );
+
+            $token->setContent($content);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Fix PHPDoc inline tags, make inheritdoc always inline.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocInlineTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocInlineTagFixerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * Test PhpdocInlineTagFixer.
+ */
+class PhpdocInlineTagFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideTestFixInlineDocCases
+     */
+    public function testFixInlineDoc($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideTestFixInlineDocCases()
+    {
+        $cases = array(
+            array(
+                '<?php
+    /**
+     * {link} { LINK }
+     * { test }
+     * {@inheritdoc rire éclatant des écoliers qui décontenança®¶ñ¿}
+     * test other comment
+     * {@inheritdoc test} a
+     * {@inheritdoc test} b
+     * {@inheritdoc test} c
+     * {@inheritdoc foo bar.} d
+     * {@inheritdoc foo bar.} e
+     * {@inheritdoc test} f
+     * end comment {@inheritdoc here we are done} @spacepossum {1}
+     */
+',
+                '<?php
+    /**
+     * {link} { LINK }
+     * { test }
+     * {@inheritDoc rire éclatant des écoliers qui décontenança®¶ñ¿ }
+     * test other comment
+     * @{inheritdoc test} a
+     * {{@inheritdoc    test}} b
+     * {@ inheritdoc   test} c
+     * { @inheritdoc 	foo bar.  } d
+     * {@ 	inheritdoc foo bar.	} e
+     * @{{inheritdoc test}} f
+     * end comment {@inheritdoc here we are done} @spacepossum {1}
+     */
+',
+            ),
+        );
+
+        foreach (array('example','id', 'internal', 'inheritdoc', 'link', 'source', 'toc', 'tutorial') as $tag) {
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * {@%s}a\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * @{%s}a\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * {@%s} b\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * {{@%s}} b\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c @{{%s}}\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c @{{%s test}}\n      */\n", $tag),
+            );
+            // test unbalanced { tags
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c {@%s test}}\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c {{@%s test}\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c {@%s test}}\n      */\n", $tag),
+            );
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * c {@%s test}\n      */\n", $tag),
+                sprintf("<?php\n     /**\n      * c @{{%s test}}}\n      */\n", $tag),
+            );
+        }
+
+        // don't touch custom tags
+        $tag = 'foo';
+        $cases[] = array(
+            sprintf("<?php\n     /**\n      * @{%s}a\n      */\n", $tag),
+        );
+        $cases[] = array(
+            sprintf("<?php\n     /**\n      * {{@%s}} b\n      */\n", $tag),
+        );
+        $cases[] = array(
+            sprintf("<?php\n     /**\n      * c @{{%s}}\n      */\n", $tag),
+        );
+
+        // don't auto inline tags with the exception of inheritdoc
+        foreach (array('example','id', 'internal', 'foo', 'link', 'source', 'toc', 'tutorial') as $tag) {
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * @%s\n      */\n", $tag),
+            );
+        }
+
+        // don't touch well formatted tags
+
+        foreach (array('example','id', 'internal', 'inheritdoc', 'link', 'source', 'toc', 'tutorial') as $tag) {
+            $cases[] = array(
+                sprintf("<?php\n     /**\n      * {@%s}\n      */\n", $tag),
+            );
+        }
+
+        // common typos
+        $cases[] = array(
+            '<?php
+    /**
+     * Typo {@inheritdoc} {@example} {@id} {@source} {@tutorial} {links}
+     * inheritdocs
+     */
+',
+            '<?php
+    /**
+     * Typo {@inheritdocs} {@exampleS} { @ids} { @sources } {{{ @tutorials }} {links}
+     * inheritdocs
+     */
+',
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideTestFixInheritDocCases
+     */
+    public function testFixInheritDoc($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideTestFixInheritDocCases()
+    {
+        return array(
+            array(
+                '<?php
+    /**
+     * {@inheritdoc} should this be inside the tag?
+     * {@inheritdoc}
+     * {@inheritdoc}
+     * inheritdoc
+     */
+',
+                // missing { } test for inheritdoc
+                '<?php
+    /**
+     * @inheritdoc should this be inside the tag?
+     * @inheritdoc
+     * @inheritdocs
+     * inheritdoc
+     */
+',
+                ),
+        );
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocInlineTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocInlineTagFixerTest.php
@@ -162,6 +162,7 @@ class PhpdocInlineTagFixerTest extends AbstractFixerTestBase
      * {@inheritdoc} should this be inside the tag?
      * {@inheritdoc}
      * {@inheritdoc}
+     * {@inheritdoc}
      * inheritdoc
      */
 ',
@@ -171,6 +172,7 @@ class PhpdocInlineTagFixerTest extends AbstractFixerTestBase
      * @inheritdoc should this be inside the tag?
      * @inheritdoc
      * @inheritdocs
+     * {@inheritdocs}
      * inheritdoc
      */
 ',


### PR DESCRIPTION
@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1208

This fixer will do the following:
@inheritdoc     -> {@inheritdoc}
{{@inheritdoc}} -> {@inheritdoc}
@{inheritdoc}   -> {@inheritdoc}