### PR TITLE
feature: #1270 add information about processed file to event

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -95,6 +95,14 @@ final class FixCommand extends Command
     }
 
     /**
+     * @return EventDispatcher
+     */
+    public function getEventDispatcher()
+    {
+        return $this->eventDispatcher;
+    }
+
+    /**
      * @see Command
      */
     protected function configure()

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -199,7 +199,7 @@ class Fixer
         ) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,
-                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_SKIPPED)
+                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_SKIPPED)->setFileInfo($file)
             );
 
             return;
@@ -210,7 +210,7 @@ class Fixer
         } catch (LintingException $e) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,
-                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_INVALID)
+                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_INVALID)->setFileInfo($file)
             );
 
             $this->errorsManager->report(new Error(
@@ -247,7 +247,7 @@ class Fixer
         } catch (\Exception $e) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,
-                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_EXCEPTION)
+                FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_EXCEPTION)->setFileInfo($file)
             );
 
             $this->errorsManager->report(new Error(
@@ -275,7 +275,7 @@ class Fixer
             } catch (LintingException $e) {
                 $this->dispatchEvent(
                     FixerFileProcessedEvent::NAME,
-                    FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_LINT)
+                    FixerFileProcessedEvent::create()->setStatus(FixerFileProcessedEvent::STATUS_LINT)->setFileInfo($file)
                 );
 
                 $this->errorsManager->report(new Error(
@@ -305,7 +305,7 @@ class Fixer
 
         $this->dispatchEvent(
             FixerFileProcessedEvent::NAME,
-            FixerFileProcessedEvent::create()->setStatus($fixInfo ? FixerFileProcessedEvent::STATUS_FIXED : FixerFileProcessedEvent::STATUS_NO_CHANGES)
+            FixerFileProcessedEvent::create()->setStatus($fixInfo ? FixerFileProcessedEvent::STATUS_FIXED : FixerFileProcessedEvent::STATUS_NO_CHANGES)->setFileInfo($file)
         );
 
         return $fixInfo;

--- a/Symfony/CS/FixerFileProcessedEvent.php
+++ b/Symfony/CS/FixerFileProcessedEvent.php
@@ -35,6 +35,11 @@ final class FixerFileProcessedEvent extends Event
     const STATUS_EXCEPTION = 5;
     const STATUS_LINT = 6;
 
+    /**            
+     * @var \SplFileInfo|null
+     */
+    private $fileInfo;
+
     /**
      * File status.
      *
@@ -73,6 +78,25 @@ final class FixerFileProcessedEvent extends Event
     {
         $this->status = $status;
 
+        return $this;
+    }
+
+    /**
+     * @return null|\SplFileInfo
+     */
+    public function getFileInfo()
+    {
+        return $this->fileInfo;
+    }
+  
+    /**
+     * @param null|\SplFileInfo $fileInfo
+     * @return $this
+     */
+    public function setFileInfo(\SplFileInfo $fileInfo)
+    {
+        $this->fileInfo = $fileInfo;
+  
         return $this;
     }
 }

--- a/Symfony/CS/FixerFileProcessedEvent.php
+++ b/Symfony/CS/FixerFileProcessedEvent.php
@@ -88,15 +88,16 @@ final class FixerFileProcessedEvent extends Event
     {
         return $this->fileInfo;
     }
-  
+
     /**
      * @param null|\SplFileInfo $fileInfo
+     *
      * @return $this
      */
     public function setFileInfo(\SplFileInfo $fileInfo)
     {
         $this->fileInfo = $fileInfo;
-  
+
         return $this;
     }
 }

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Ivan Scherbak <dev@funivan.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Symfony\CS\Tests\FixerFileProcessedEvent;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the PHP CS utility.
  *
- * (c) Ivan Scherbak <dev@funivan.com>
+ * (c) Fabien Potencier <fabien@symfony.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\CS\Tests\FixerFileProcessedEvent;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\CS\FixerFileProcessedEvent;
+
+/**
+ * Custom logger implementation. Used only for test
+ */
+class CustomFixerLogger
+{
+    /**
+     * Event dispatcher instance.
+     *
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+    
+    /**
+     *
+     * @var array
+     */
+    private $filesStatuses = array();
+    
+    /**
+     * @param EventDispatcher $dispatcher
+     */
+    public function __construct(EventDispatcher $dispatcher)
+    {
+        $this->eventDispatcher = $dispatcher;
+        $this->eventDispatcher->addListener(FixerFileProcessedEvent::NAME, array($this, 'onFixerFileProcessed'));
+    }
+    
+    /**
+     * @param FixerFileProcessedEvent $event
+     */
+    public function onFixerFileProcessed(FixerFileProcessedEvent $event)
+    {
+        $name = $event->getFileInfo() ? $event->getFileInfo()->getFilename() : null;
+        $this->filesStatuses[$event->getStatus()][] = $name;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getFileStatuses()
+    {
+        return $this->filesStatuses;
+    }
+    
+    /**
+     * 
+     */
+    public function __destruct()
+    {
+        $this->eventDispatcher->removeListener(FixerFileProcessedEvent::NAME, array($this, 'onFixerFileProcessed'));
+    }
+}

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/CustomFixerLogger.php
@@ -6,7 +6,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\CS\FixerFileProcessedEvent;
 
 /**
- * Custom logger implementation. Used only for test
+ * Custom logger implementation. Used only for test.
  */
 class CustomFixerLogger
 {
@@ -16,13 +16,12 @@ class CustomFixerLogger
      * @var EventDispatcher
      */
     private $eventDispatcher;
-    
+
     /**
-     *
      * @var array
      */
     private $filesStatuses = array();
-    
+
     /**
      * @param EventDispatcher $dispatcher
      */
@@ -31,7 +30,7 @@ class CustomFixerLogger
         $this->eventDispatcher = $dispatcher;
         $this->eventDispatcher->addListener(FixerFileProcessedEvent::NAME, array($this, 'onFixerFileProcessed'));
     }
-    
+
     /**
      * @param FixerFileProcessedEvent $event
      */
@@ -40,7 +39,7 @@ class CustomFixerLogger
         $name = $event->getFileInfo() ? $event->getFileInfo()->getFilename() : null;
         $this->filesStatuses[$event->getStatus()][] = $name;
     }
-    
+
     /**
      * @return array
      */
@@ -48,7 +47,7 @@ class CustomFixerLogger
     {
         return $this->filesStatuses;
     }
-    
+
     /**
      * 
      */

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-  namespace Symfony\CS\Tests\FixerFileProcessedEvent;
+namespace Symfony\CS\Tests\FixerFileProcessedEvent;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\CS\Config\Config;
@@ -15,19 +15,17 @@ class FixerFileProcessedEventTest extends \PHPUnit_Framework_TestCase
 
         $eventDispatcher = new EventDispatcher();
         $fixer->setEventDispatcher($eventDispatcher);
-      
+
         $fixer->addFixer(new \Symfony\CS\Fixer\PSR2\VisibilityFixer());
 
-        $config = Config::create()->finder(new \DirectoryIterator(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'FixerTest' . DIRECTORY_SEPARATOR . 'fix'));
+        $config = Config::create()->finder(new \DirectoryIterator(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix'));
         $config->fixers($fixer->getFixers());
         $config->setUsingCache(false);
-
 
         $logger = new CustomFixerLogger($eventDispatcher);
         $changed = $fixer->fix($config, true, true);
 
         $this->assertCount(1, $changed);
-
 
         $fixedFilesByStatuses = $logger->getFileStatuses();
         $this->assertCount(1, $fixedFilesByStatuses);

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Ivan Scherbak <dev@funivan.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Symfony\CS\Tests\FixerFileProcessedEvent;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
@@ -1,0 +1,43 @@
+<?php
+
+  namespace Symfony\CS\Tests\FixerFileProcessedEvent;
+
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\CS\Config\Config;
+use Symfony\CS\Fixer;
+use Symfony\CS\FixerFileProcessedEvent;
+
+class FixerFileProcessedEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFixerEventData()
+    {
+        $fixer = new Fixer();
+
+        $eventDispatcher = new EventDispatcher();
+        $fixer->setEventDispatcher($eventDispatcher);
+      
+        $fixer->addFixer(new \Symfony\CS\Fixer\PSR2\VisibilityFixer());
+
+        $config = Config::create()->finder(new \DirectoryIterator(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . 'FixerTest' . DIRECTORY_SEPARATOR . 'fix'));
+        $config->fixers($fixer->getFixers());
+        $config->setUsingCache(false);
+
+
+        $logger = new CustomFixerLogger($eventDispatcher);
+        $changed = $fixer->fix($config, true, true);
+
+        $this->assertCount(1, $changed);
+
+
+        $fixedFilesByStatuses = $logger->getFileStatuses();
+        $this->assertCount(1, $fixedFilesByStatuses);
+
+        $this->assertArrayHasKey(FixerFileProcessedEvent::STATUS_FIXED, $fixedFilesByStatuses);
+
+        $fixedFiles = $fixedFilesByStatuses[FixerFileProcessedEvent::STATUS_FIXED];
+        $this->assertCount(1, $fixedFiles);
+
+        $this->assertNotEmpty($fixedFiles[0]);
+        $this->assertEquals('somefile.php', $fixedFiles[0]);
+    }
+}

--- a/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
+++ b/Symfony/CS/Tests/FixerFileProcessedEvent/FixerFileProcessedEventTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the PHP CS utility.
  *
- * (c) Ivan Scherbak <dev@funivan.com>
+ * (c) Fabien Potencier <fabien@symfony.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.


### PR DESCRIPTION
Get more information about file fix. 
Now it is possible to subscribe for `FixerFileProcessedEvent` outside of the library. 
Developers can handle more verbose information about fixed/ignored files. 

```php
$fixCommand = new FixCommand(null, $config);  

$fixCommand->getEventDispatcher()
->addListener(FixerFileProcessedEvent::NAME, function (FixerFileProcessedEvent $event) {
  // you can log information, make custom output or do other stuff
    if ($event->getStatus() == FixerFileProcessedEvent::STATUS_INVALID) {
      echo 'Invalid file:' . $event->getFileInfo()->getFilename() ;
    }
});
```
