### PR TITLE
Added MethodSeparationFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,10 @@ Choose from the list of available fixers:
                         Remove trailing commas in list
                         function calls.
 
+* **method_separation** [symfony]
+                        Methods must be separated with
+                        one blank line.
+
 * **multiline_array_trailing_comma** [symfony]
                         PHP multi-line arrays should
                         have a trailing comma.

--- a/Symfony/CS/Fixer/Symfony/MethodSeparationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/MethodSeparationFixer.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use SplFileInfo;
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+use Symfony\CS\Tokenizer\TokensAnalyzer;
+
+/**
+ * Make sure there is one blank line above and below a method.
+ * The exception is when a method is the last item in a 'classy'.
+ *
+ * @author SpacePossum
+ */
+final class MethodSeparationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Methods must be separated with one blank line.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // Must run before braces and indentation fixers because this fixer
+        // might add line breaks to the code without indenting.
+        return 55;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        for ($index = $tokens->getSize() - 1; $index > 0;--$index) {
+            if (!$tokens[$index]->isClassy()) {
+                continue;
+            }
+
+            // figure out where the classy starts
+            $classStart = $tokens->getNextTokenOfKind($index, array('{'));
+
+            // figure out where the classy ends
+            $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classStart);
+
+            if ($tokens[$index]->isGivenKind(T_INTERFACE)) {
+                $this->fixInterface($tokens, $classStart, $classEnd);
+            } else {
+                // classes and traits can be fixed the same way
+                $this->fixClass($tokens, $tokensAnalyzer, $classStart, $classEnd);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens         $tokens
+     * @param TokensAnalyzer $tokensAnalyzer
+     * @param int            $classStart
+     * @param int            $classEnd
+     */
+    private function fixClass(Tokens $tokens, TokensAnalyzer $tokensAnalyzer, $classStart, $classEnd)
+    {
+        for ($index = $classEnd; $index > $classStart; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION) || $tokensAnalyzer->isLambda($index)) {
+                continue;
+            }
+
+            $attributes = $tokensAnalyzer->getMethodAttributes($index);
+            if (true === $attributes['abstract']) {
+                $methodEnd = $tokens->getNextTokenOfKind($index, array(';'));
+            } else {
+                $methodStart = $tokens->getNextTokenOfKind($index, array('{'));
+                $methodEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $methodStart, true);
+            }
+
+            $this->fixSpaceBelowMethod($tokens, $classEnd, $methodEnd);
+            $this->fixSpaceAboveMethod($tokens, $classStart, $index);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $classStart
+     * @param int    $classEnd
+     */
+    private function fixInterface(Tokens $tokens, $classStart, $classEnd)
+    {
+        for ($index = $classEnd; $index > $classStart; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $methodEnd = $tokens->getNextTokenOfKind($index, array(';'));
+
+            $this->fixSpaceBelowMethod($tokens, $classEnd, $methodEnd);
+            $this->fixSpaceAboveMethod($tokens, $classStart, $index);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $classEnd
+     * @param int    $methodEnd
+     */
+    private function fixSpaceBelowMethod(Tokens $tokens, $classEnd, $methodEnd)
+    {
+        $nextNotWhite = $tokens->getNextNonWhitespace($methodEnd);
+        $this->correctLineBreaks($tokens, $methodEnd, $nextNotWhite, $nextNotWhite === $classEnd ? 1 : 2);
+    }
+
+    /**
+     * Fix spacing above a method signature. Deal with comments, PHPDocs and spaces above the method.
+     *
+     * @param Tokens $tokens
+     * @param int    $classStart  index of the class Token the method is in
+     * @param int    $methodIndex index of the method to fix
+     */
+    private function fixSpaceAboveMethod(Tokens $tokens, $classStart, $methodIndex)
+    {
+        static $methodAttr = array(T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC);
+
+        // find out where the method signature starts
+        $firstMethodAttrIndex = $methodIndex;
+        for ($i = $methodIndex; $i > $classStart; --$i) {
+            $nonWhiteAbove = $tokens->getNonWhitespaceSibling($i, -1);
+            if (null !== $nonWhiteAbove && $tokens[$nonWhiteAbove]->isGivenKind($methodAttr)) {
+                $firstMethodAttrIndex = $nonWhiteAbove;
+            } else {
+                break;
+            }
+        }
+
+        if (false === $tokens[$nonWhiteAbove]->isGivenKind(T_DOC_COMMENT)) {
+            $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstMethodAttrIndex, $nonWhiteAbove === $classStart ? 1 : 2);
+
+            return;
+        }
+
+        // there should be one linebreak between the method signature and the PHPDoc above it
+        $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstMethodAttrIndex, 1);
+
+        // there should be one blank line between the PHPDoc and whatever is above
+        $nonWhiteAbovePHPDoc = $tokens->getNonWhitespaceSibling($nonWhiteAbove, -1);
+        $this->correctLineBreaks($tokens, $nonWhiteAbovePHPDoc, $nonWhiteAbove, $nonWhiteAbovePHPDoc === $classStart ? 1 : 2);
+    }
+
+    private function correctLineBreaks(Tokens $tokens, $startIndex, $endIndex, $reqLineCount = 2)
+    {
+        $startIndex += 1;
+        $numbOfWhiteTokens = $endIndex - $startIndex;
+        if (0 === $numbOfWhiteTokens) {
+            $tokens->insertAt($startIndex, new Token(array(T_WHITESPACE, str_repeat("\n", $reqLineCount))));
+
+            return;
+        }
+
+        $lineBreakCount = $this->getLineBreakCount($tokens, $startIndex, $endIndex);
+        if ($reqLineCount === $lineBreakCount) {
+            return;
+        }
+
+        if ($lineBreakCount < $reqLineCount) {
+            $tokens[$startIndex]->setContent(str_repeat("\n", $reqLineCount - $lineBreakCount).$tokens[$startIndex]->getContent());
+
+            return;
+        }
+
+        // $lineCount = > $reqLineCount : check the one Token case first since this one will be true most of the time
+        if (1 === $numbOfWhiteTokens) {
+            $tokens[$startIndex]->setContent(preg_replace('/[\r\n]/', '', $tokens[$startIndex]->getContent(), $lineBreakCount - $reqLineCount));
+
+            return;
+        }
+
+        // $numbOfWhiteTokens = > 1
+        $toReplaceCount = $lineBreakCount - $reqLineCount;
+        for ($i = $startIndex; $i < $endIndex && $toReplaceCount > 0; ++$i) {
+            $tokenLineCount = substr_count($tokens[$i]->getContent(), "\n");
+            if ($tokenLineCount > 0) {
+                $tokens[$i]->setContent(preg_replace('/[\r\n]/', '', $tokens[$i]->getContent(), min($toReplaceCount, $tokenLineCount)));
+                $toReplaceCount -= $tokenLineCount;
+            }
+        }
+    }
+
+    private function getLineBreakCount(Tokens $tokens, $whiteStart, $whiteEnd)
+    {
+        $lineCount = 0;
+        for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
+            $lineCount += substr_count($tokens[$i]->getContent(), "\n");
+        }
+
+        return $lineCount;
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/MethodSeparationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/MethodSeparationFixer.php
@@ -172,7 +172,7 @@ final class MethodSeparationFixer extends AbstractFixer
 
     private function correctLineBreaks(Tokens $tokens, $startIndex, $endIndex, $reqLineCount = 2)
     {
-        $startIndex += 1;
+        ++$startIndex;
         $numbOfWhiteTokens = $endIndex - $startIndex;
         if (0 === $numbOfWhiteTokens) {
             $tokens->insertAt($startIndex, new Token(array(T_WHITESPACE, str_repeat("\n", $reqLineCount))));

--- a/Symfony/CS/Tests/Fixer/Symfony/MethodSeparationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/MethodSeparationFixerTest.php
@@ -1,0 +1,528 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+class MethodSeparationFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideFixClassesCases
+     */
+    public function testFixClasses($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixClassesCases()
+    {
+        $cases = array();
+        $cases[] = array(
+            '<?php
+abstract class MethodTest2
+{
+    public function method045()
+    {
+        $files = null;
+            if (!empty($files)) {
+            $this->filter(
+                function (\SplFileInfo $file) use ($files) {
+                    return !in_array($file->getRelativePathname(), $files, true);
+                }
+            );
+        }
+    }
+
+     private $a;
+
+     public static function method145()
+     {
+     }
+
+       abstract protected function method245();
+
+    // comment
+
+    final private function method345()
+    {
+    }
+}
+function test1(){ echo 1;}
+function test1(){ echo 2;}',
+            '<?php
+abstract class MethodTest2
+{
+    public function method045()
+    {
+        $files = null;
+            if (!empty($files)) {
+            $this->filter(
+                function (\SplFileInfo $file) use ($files) {
+                    return !in_array($file->getRelativePathname(), $files, true);
+                }
+            );
+        }
+    }
+     private $a;
+
+     public static function method145()
+     {
+     }
+       abstract protected function method245();
+    // comment
+
+    final private function method345()
+    {
+    }
+}
+function test1(){ echo 1;}
+function test1(){ echo 2;}',
+        );
+
+        $cases[] = array(
+            '<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Linter;
+
+/**
+ * Dummy linter. No linting is performed. No error is raised.
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class NullLinter implements LinterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function lintFile($path)
+    {
+        unset($path);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lintSource($source)
+    {
+        unset($source);
+    }
+}
+',
+        );
+
+        // do not touch anonymous functions (since PHP doesn't allow
+        // for class attributes being functions :(, we only have to test
+        // those used within methods)
+        $cases[] = array(
+            '<?php
+class MethodTestAnonymous
+{
+    public function method444a()
+    {
+        $text = "hello";
+        $example = function ($arg) use ($message) {
+            var_dump($arg . " " . $message);
+        };
+        $example($text);
+        $example = function($arg) use ($message) {
+            var_dump($arg . " " . $message);
+        };
+        $example = function /*test*/ ($arg) use ($message) {
+            var_dump($arg . " " . $message);
+        };
+    }
+}',
+        );
+
+        $cases[] = array(
+            '<?php
+class MethodTest1
+{
+    private $c; //
+
+    public function method444a()
+    {
+    }
+
+    /**
+     *
+     */
+    public function method444b()
+    {
+    }
+
+    //
+
+    public function method444c()
+    {
+    }
+
+    private $a;
+
+    public function method444d()
+    {
+    }
+
+    private $b;
+    //
+
+    public function method444e()
+    {
+    }
+
+    public function method444f()
+    {
+    }
+
+    private $d; //
+
+    public function method444f1()
+    {
+    }
+
+    /**/
+
+    public function method444g()
+    {
+    }
+}',
+            '<?php
+class MethodTest1
+{
+    private $c; //
+    public function method444a()
+    {
+    }
+    /**
+     *
+     */
+    public function method444b()
+    {
+    }
+
+    //
+
+
+    public function method444c()
+    {
+    }
+
+    private $a;
+    public function method444d()
+    {
+    }
+    private $b;
+    //
+    public function method444e()
+    {
+    }
+
+    public function method444f()
+    {
+    }
+
+    private $d; //
+    public function method444f1()
+    {
+    }
+
+    /**/
+    public function method444g()
+    {
+    }
+}',
+        );
+
+        // spaces between methods
+        $cases[] = array(
+            '<?php
+abstract class MethodTest3
+{
+    public function method021()
+    {
+    }
+
+    public static function method121()
+    {
+    }
+
+    abstract protected function method221();	
+
+    final private function method321a()
+    {
+    }
+}'
+        ,
+            '<?php
+abstract class MethodTest3
+{
+    public function method021()
+    {
+    }
+
+    public static function method121()
+    {
+    }
+
+
+    abstract protected function method221();
+
+
+
+	
+
+
+
+
+    final private function method321a()
+    {
+    }
+}', );
+        // don't change correct code
+        $cases[] = array(
+            '<?php
+class SmallHelperException extends \Exception
+{
+    public function getId111()
+    {
+        return 1;
+    }
+
+    public function getMessage111()
+    {
+        return \'message\';
+    }
+}
+
+class MethodTest123124124
+{
+    public function method111a(){}
+
+    public function method211a(){}
+}',
+        );
+
+        // do not touch function out of class scope
+        $cases[] = array(
+            '<?php
+function test0() {
+
+}
+class MethodTest4
+{
+    public function method122b()
+    {
+    }
+
+    public function method222b()
+    {
+    }
+}
+function test() {
+
+}
+function test2() {
+
+}
+',
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @requires PHP 5.4
+     * @dataProvider provideFixTraitsCases
+     */
+    public function testFixTraits($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixTraitsCases()
+    {
+        $cases = array();
+
+        // do not touch well formatted traits
+        $cases[] = array('<?php
+trait OkTrait
+{
+    function getReturnTypeOk()
+    {
+    }
+
+    /**
+     *
+     */
+    function getReturnDescriptionOk()
+    {
+    }
+}',
+        );
+
+        $cases[] = array('<?php
+trait ezcReflectionReturnInfo {
+    public $x = 1;
+
+    protected function getA(){echo 1;}
+
+function getB(){echo 2;}
+
+    protected function getC(){echo 3;}
+
+/** Description */
+function getD(){echo 4;}
+
+    protected function getE(){echo 3;}
+
+private $a;
+
+function getF(){echo 4;}
+}'
+        , '<?php
+trait ezcReflectionReturnInfo {
+    public $x = 1;
+    protected function getA(){echo 1;}function getB(){echo 2;}
+    protected function getC(){echo 3;}/** Description */function getD(){echo 4;}
+    protected function getE(){echo 3;}private $a;function getF(){echo 4;}
+}',
+        );
+
+        $cases[] = array('<?php
+trait SomeReturnInfo {
+    function getReturnType()
+    {
+    }
+
+    function getReturnDescription()
+    {
+    }
+
+ function getReturnDescription2()
+    {
+    }
+
+    abstract public function getWorld();
+}'
+        , '<?php
+trait SomeReturnInfo {
+    function getReturnType()
+    {
+    }
+    function getReturnDescription()
+    {
+    } function getReturnDescription2()
+    {
+    }
+
+    abstract public function getWorld();
+}',
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideFixInterfaces
+     */
+    public function testFixInterfaces($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixInterfaces()
+    {
+        $cases = array();
+        $cases[] = array(
+            '<?php
+interface TestInterface
+{
+    public function testInterfaceMethod4();
+
+    public function testInterfaceMethod5();
+
+    /**
+     * {@link}
+     */           
+    public function testInterfaceMethod6();
+
+    public function testInterfaceMethod7();
+
+ public function testInterfaceMethod8();
+}'
+            ,
+            '<?php
+interface TestInterface
+{    public function testInterfaceMethod4();
+    public function testInterfaceMethod5();
+
+
+    /**
+     * {@link}
+     */           
+    public function testInterfaceMethod6();
+
+
+    public function testInterfaceMethod7(); public function testInterfaceMethod8();
+}',
+        );
+
+        // do not touch well formatted interfaces
+        $cases[] = array(
+            '<?php
+interface TestInterfaceOK
+{
+    public function testMethod1();
+
+    public function testMethod2();
+}',
+        );
+
+        // method after trait use
+        $cases[] = array(
+            '<?php
+trait ezcReflectionReturnInfo {
+    function getReturnDescription() {}
+}
+class ezcReflectionMethod extends ReflectionMethod {
+    use ezcReflectionReturnInfo;
+
+function afterUseTrait(){}
+
+function afterUseTrait2(){}
+}',
+'<?php
+trait ezcReflectionReturnInfo {
+    function getReturnDescription() {}
+}
+class ezcReflectionMethod extends ReflectionMethod {
+    use ezcReflectionReturnInfo;function afterUseTrait(){}function afterUseTrait2(){}
+
+
+
+}',
+        );
+
+        return $cases;
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -238,6 +238,8 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['php_unit_strict'], $fixers['php_unit_construct']),
             array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_spaces']),
             array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_successor_space']),
+            array($fixers['method_separation'], $fixers['braces']),
+            array($fixers['method_separation'], $fixers['indentation']),
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Tokenizer/TokensAnalyzerTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensAnalyzerTest.php
@@ -553,4 +553,73 @@ $b;',
 
         return $cases;
     }
+
+    /**
+     * @dataProvider provideGetFunctionProperties
+     */
+    public function testGetFunctionProperties($source, $index, $expected)
+    {
+        $tokens = Tokens::fromCode($source);
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        $attributes = $tokensAnalyzer->getMethodAttributes($index);
+        $this->assertSame($expected, $attributes);
+    }
+
+    public function provideGetFunctionProperties()
+    {
+        $defaultAttributes = array(
+            'visibility' => null,
+            'static' => false,
+            'abstract' => false,
+            'final' => false,
+        );
+
+        $template = '
+<?php
+class TestClass {
+    %s function a() {
+        //
+    }
+}
+';
+        $cases = array();
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = T_PRIVATE;
+        $cases[] = array(sprintf($template, 'private'), 10, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = T_PUBLIC;
+        $cases[] = array(sprintf($template, 'public'), 10, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = T_PROTECTED;
+        $cases[] = array(sprintf($template, 'protected'), 10, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = null;
+        $attributes['static'] = true;
+        $cases[] = array(sprintf($template, 'static'), 10, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = T_PUBLIC;
+        $attributes['static'] = true;
+        $attributes['final'] = true;
+        $cases[] = array(sprintf($template, 'final public static'), 14, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = null;
+        $attributes['abstract'] = true;
+        $cases[] = array(sprintf($template, 'abstract'), 10, $attributes);
+
+        $attributes = $defaultAttributes;
+        $attributes['visibility'] = T_PUBLIC;
+        $attributes['abstract'] = true;
+        $cases[] = array(sprintf($template, 'abstract public'), 12, $attributes);
+
+        $attributes = $defaultAttributes;
+        $cases[] = array(sprintf($template, ''), 8, $attributes);
+
+        return $cases;
+    }
 }

--- a/Symfony/CS/Tests/UtilsTest.php
+++ b/Symfony/CS/Tests/UtilsTest.php
@@ -135,7 +135,7 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The given token must be whitespace.
+     * @expectedExceptionMessage The given token must be whitespace, got "T_STRING".
      */
     public function testCalculateTrailingWhitespaceIndentFail()
     {

--- a/Symfony/CS/Tokenizer/TokensAnalyzer.php
+++ b/Symfony/CS/Tokenizer/TokensAnalyzer.php
@@ -212,11 +212,12 @@ final class TokensAnalyzer
 
     /**
      * Returns the attributes of the method under the given index.
+     *
      * The array has the following items:
      * 'visibility' int|null  T_PRIVATE, T_PROTECTED or T_PUBLIC
      * 'static'     bool
      * 'abstract'   bool
-     * 'final'      bool.
+     * 'final'      bool
      *
      * @param int $index Token index of the method (T_FUNCTION)
      *

--- a/Symfony/CS/Tokenizer/TokensAnalyzer.php
+++ b/Symfony/CS/Tokenizer/TokensAnalyzer.php
@@ -38,7 +38,7 @@ final class TokensAnalyzer
     /**
      * Get indexes of methods and properties in classy code (classes, interfaces and traits).
      *
-     * @return array
+     * @return array[]
      */
     public function getClassyElements()
     {
@@ -211,7 +211,84 @@ final class TokensAnalyzer
     }
 
     /**
-     * Check if there is a lambda function under given index.
+     * Returns the attributes of the method under the given index.
+     * The array has the following items:
+     * 'visibility' int|null  T_PRIVATE, T_PROTECTED or T_PUBLIC
+     * 'static'     bool
+     * 'abstract'   bool
+     * 'final'      bool
+     *
+     * @param int $index Token index of the method (T_FUNCTION)
+     *
+     * @return array
+     */
+    public function getMethodAttributes($index)
+    {
+        $tokens = $this->tokens;
+        $token = $tokens[$index];
+
+        if (!$token->isGivenKind(T_FUNCTION)) {
+            throw new \LogicException(sprintf('No T_FUNCTION at given index %d, got %s', $index, $token->getName()));
+        }
+
+        $attributes = array(
+            'visibility' => null,
+            'static' => false,
+            'abstract' => false,
+            'final' => false,
+        );
+
+        for ($i = $index; $i >= 0; --$i) {
+            $tokenIndex = $tokens->getPrevMeaningfulToken($i);
+            if (null === $tokenIndex) {
+                break;
+            }
+
+            $i = $tokenIndex;
+            $token = $tokens[$tokenIndex];
+
+            if ($token->isGivenKind(array(T_STATIC))) {
+                $attributes['static'] = true;
+                continue;
+            }
+
+            if ($token->isGivenKind(array(T_FINAL))) {
+                $attributes['final'] = true;
+                continue;
+            }
+
+            if ($token->isGivenKind(array(T_ABSTRACT))) {
+                $attributes['abstract'] = true;
+                continue;
+            }
+
+            // visibility
+
+            if ($token->isGivenKind(array(T_PRIVATE))) {
+                $attributes['visibility'] = T_PRIVATE;
+                continue;
+            }
+
+            if ($token->isGivenKind(array(T_PROTECTED))) {
+                $attributes['visibility'] = T_PROTECTED;
+                continue;
+            }
+
+            if ($token->isGivenKind(array(T_PUBLIC))) {
+                $attributes['visibility'] = T_PUBLIC;
+                continue;
+            }
+
+            // found a meaningful token that is not part of
+            // the function signature; stop looking
+            break;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Check if the function under given index is a lambda.
      *
      * @param int $index
      *
@@ -223,7 +300,7 @@ final class TokensAnalyzer
         $token = $tokens[$index];
 
         if (!$token->isGivenKind(T_FUNCTION)) {
-            throw new \LogicException('No T_FUNCTION at given index');
+            throw new \LogicException(sprintf('No T_FUNCTION at given index %d, got %s', $index, $token->getName()));
         }
 
         $startParenthesisIndex = $tokens->getNextMeaningfulToken($index);
@@ -459,7 +536,7 @@ final class TokensAnalyzer
     }
 
     /**
-     * Check if Token at given index is `T_WHILE` token for `do { ... } while ();` syntax
+     * Check if `T_WHILE` token at given index is `do { ... } while ();` syntax
      * and not `while () { ...}`.
      *
      * @param int $index
@@ -472,7 +549,7 @@ final class TokensAnalyzer
         $token = $tokens[$index];
 
         if (!$token->isGivenKind(T_WHILE)) {
-            throw new \LogicException('No T_WHILE at given index');
+            throw new \LogicException(sprintf('No T_WHILE at given index %d, got %s', $index, $token->getName()));
         }
 
         $startParenthesisIndex = $tokens->getNextMeaningfulToken($index);

--- a/Symfony/CS/Tokenizer/TokensAnalyzer.php
+++ b/Symfony/CS/Tokenizer/TokensAnalyzer.php
@@ -216,7 +216,7 @@ final class TokensAnalyzer
      * 'visibility' int|null  T_PRIVATE, T_PROTECTED or T_PUBLIC
      * 'static'     bool
      * 'abstract'   bool
-     * 'final'      bool
+     * 'final'      bool.
      *
      * @param int $index Token index of the method (T_FUNCTION)
      *

--- a/Symfony/CS/Utils.php
+++ b/Symfony/CS/Utils.php
@@ -111,7 +111,7 @@ final class Utils
     public static function calculateTrailingWhitespaceIndent(Token $token)
     {
         if (!$token->isWhitespace()) {
-            throw new \InvalidArgumentException('The given token must be whitespace.');
+            throw new \InvalidArgumentException(sprintf('The given token must be whitespace, got "%s".', $token->getName()));
         }
 
         return ltrim(strrchr(str_replace(array("\r\n", "\r"), "\n", $token->getContent()), 10), "\n");


### PR DESCRIPTION
This fixer adds and removes linebreaks to ensure there is a blank line above a method, or above the methods' PHPDoc (in this case there will a linebreak between the method signature and the PHPDoc) and makes sure there is a blank line below a method. 
The exception is when the method is the last item in a 'classy' then there should a single line break but not a blank line.
Works for classes, interfaces and traits. It doesn't touch anything outside of a 'classy', it does not fix indenting, just linebreaks.
@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/723

Example:
From:

```php
<?php
class MethodTest1
{
    private $c; //
    public function method444a()
    {
    }
    /**
     *
     */
    public function method444b()
    {
    }

    //


    public function method444c()
    {
    }

    private $a;
    public function method444d()
    {
    }
    private $b;
    //
    public function method444e()
    {
    }

    public function method444f()
    {
    }

    private $d; //
    public function method444f1()
    {
    }

    /**/
    public function method444g()
    {
    }
}'
```

To:


```php
<?php
class MethodTest1
{
    private $c; //

    public function method444a()
    {
    }

    /**
     *
     */
    public function method444b()
    {
    }

    //

    public function method444c()
    {
    }

    private $a;

    public function method444d()
    {
    }

    private $b;
    //

    public function method444e()
    {
    }

    public function method444f()
    {
    }

    private $d; //

    public function method444f1()
    {
    }

    /**/

    public function method444g()
    {
    }
}
```
