### PR TITLE
Add options to generate file header as a docblock and on the first line in…

### DIFF
--- a/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
+++ b/Symfony/CS/Fixer/Contrib/HeaderCommentFixer.php
@@ -22,6 +22,8 @@ class HeaderCommentFixer extends AbstractFixer
 {
     private static $header = '';
     private static $headerComment = '';
+    private static $useLeadingNewLine = true;
+    private static $useDocBlockComment = false;
 
     /**
      * Sets the desired header text.
@@ -48,6 +50,36 @@ class HeaderCommentFixer extends AbstractFixer
     public static function getHeader()
     {
         return self::$header;
+    }
+
+    /**
+     * Sets the newline mode.
+     *
+     * The multiline comment will appear with a leading newline by default.
+     * This setting will control whether the newline appears or not.
+     *
+     * @param bool $new Should the newline appear?
+     */
+    public static function setUseLeadingNewLine($new)
+    {
+        self::$useLeadingNewLine = (bool) $new;
+    }
+
+    /**
+     * Sets the comment mode.
+     *
+     * The multiline comment is by-default rendered with /*. This setting
+     * allows for the usage of docblock comments /**.
+     *
+     * @param bool $new Should the comment be a docblock comment?
+     */
+    public static function setUseDocBlockComment($new)
+    {
+        self::$useDocBlockComment = (bool) $new;
+        if ('' !== self::$headerComment) {
+            $leading = self::$useDocBlockComment ? '/**' : '/*';
+            self::$headerComment = $leading.strstr(self::$headerComment, "\n");
+        }
     }
 
     /**
@@ -86,7 +118,7 @@ class HeaderCommentFixer extends AbstractFixer
      */
     private static function encloseTextInComment($header)
     {
-        $comment = "/*\n";
+        $comment = self::$useDocBlockComment ? "/**\n" : "/*\n";
         $lines = explode("\n", str_replace("\r", '', $header));
         foreach ($lines as $line) {
             $comment .= rtrim(' * '.$line)."\n";
@@ -104,7 +136,8 @@ class HeaderCommentFixer extends AbstractFixer
     private function removeHeaderComment(Tokens $tokens)
     {
         $index = $tokens->getNextNonWhitespace(0);
-        if (null !== $index && $tokens[$index]->isGivenKind(T_COMMENT)) {
+        $token = self::$useDocBlockComment ? T_DOC_COMMENT : T_COMMENT;
+        if (null !== $index && $tokens[$index]->isGivenKind($token)) {
             $tokens[$index]->clear();
         }
     }
@@ -136,12 +169,14 @@ class HeaderCommentFixer extends AbstractFixer
      */
     private function insertHeaderComment(Tokens $tokens, $index)
     {
-        $headCommentTokens = array(
-            new Token(array(T_WHITESPACE, "\n")),
-        );
+        $headCommentTokens = array();
+        if (self::$useLeadingNewLine) {
+            $headCommentTokens[] = new Token(array(T_WHITESPACE, "\n"));
+        }
 
         if ('' !== self::$headerComment) {
-            $headCommentTokens[] = new Token(array(T_COMMENT, self::$headerComment));
+            $token = self::$useDocBlockComment ? T_DOC_COMMENT : T_COMMENT;
+            $headCommentTokens[] = new Token(array($token, self::$headerComment));
             $headCommentTokens[] = new Token(array(T_WHITESPACE, "\n\n"));
         }
 

--- a/Symfony/CS/Tests/Fixer/Contrib/HeaderCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/HeaderCommentFixerTest.php
@@ -30,6 +30,8 @@ EOH;
     {
         parent::setUp();
         self::$savedHeader = HeaderCommentFixer::getHeader();
+        HeaderCommentFixer::setUseDocBlockComment(false);
+        HeaderCommentFixer::setUseLeadingNewLine(true);
         HeaderCommentFixer::setHeader(self::$testHeader);
     }
 
@@ -195,6 +197,94 @@ EOH;
 EOH;
 
         $input = "<?php\n";
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithoutNewLine()
+    {
+        $expected = <<<'EOH'
+<?php
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+EOH;
+
+        $input = "<?php\n";
+        HeaderCommentFixer::setUseLeadingNewLine(false);
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixWithExplicitNewLine()
+    {
+        $expected = <<<'EOH'
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+EOH;
+
+        $input = "<?php\n";
+        HeaderCommentFixer::setUseLeadingNewLine(true);
+        $this->makeTest($expected, $input);
+    }
+
+    public function testUseDocBlockComment()
+    {
+        $expected = <<<'EOH'
+<?php
+
+/**
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+EOH;
+
+        $input = "<?php\n";
+        HeaderCommentFixer::setUseDocBlockComment(true);
+        $this->makeTest($expected, $input);
+    }
+
+    public function testUseDocBlockCommentExplicitFalse()
+    {
+        $expected = <<<'EOH'
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+EOH;
+
+        $input = "<?php\n";
+        HeaderCommentFixer::setUseDocBlockComment(true);
+        HeaderCommentFixer::setUseDocBlockComment(false);
         $this->makeTest($expected, $input);
     }
 }


### PR DESCRIPTION
…stead of second line.

This provides two new methods: `HeaderCommentFixer::setUseLeadingNewLine(bool $new)` and `HeaderCommentFixer::setUseDocBlockComment(bool $new)`
The methods should be self-explanatory in their function, and they will have the appropriate affect