### PR TITLE
WhitespacyLinesFixer - spaces on next valid line must not be fixed

### DIFF
--- a/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/WhitespacyLinesFixer.php
@@ -46,7 +46,13 @@ final class WhitespacyLinesFixer extends AbstractFixer
                 // and T_WHITESPACES with at least 2 lines at the end of file
                 || (count($lines) > 1 && !isset($tokens[$index + 1]))
             ) {
-                $token->setContent(preg_replace('/^\h+$/m', '', $content));
+                $newContent = preg_replace('/^\h+$/m', '', $content);
+
+                if (isset($tokens[$index + 1])) {
+                    $newContent .= end($lines);
+                }
+
+                $token->setContent($newContent);
             }
         }
     }

--- a/Symfony/CS/Tests/Fixer/Symfony/WhitespacyLinesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/WhitespacyLinesFixerTest.php
@@ -66,6 +66,10 @@ class WhitespacyLinesFixerTest extends AbstractFixerTestBase
     const FOO = "BAR";
 ',
             ),
+            array(
+                "<?php\n\n    \$a = 1;\n\n    \$b = 2;",
+                "<?php\n\n    \$a = 1;\n    \n    \$b = 2;",
+            ),
         );
     }
 }


### PR DESCRIPTION
The current `Whitespacy Lines` has this bug that is messing my code if I don't remember to clear Whitespacy Lines before
```php
<?php
// Every space is represented by a dot
....$a = 1;
....
....$b = 2;

// Becomes
....$a = 1;

$b = 2;
```
It clears the whitespace line, but also the legit code indentation.

This PR fixes it.