### PR TITLE
Added LogicalNotOperatorsWithSpacesFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -479,6 +479,10 @@ Choose from the list of available fixers:
 * **header_comment** [contrib]
                 Add, replace or remove header comment.
 
+* **logical_not_operators_with_spaces** [contrib]
+                Logical NOT operators (!) should have
+                leading and trailing whitespaces.
+
 * **long_array_syntax** [contrib]
                 Arrays should use the long syntax.
 

--- a/Symfony/CS/Fixer/Contrib/LogicalNotOperatorsWithSpacesFixer.php
+++ b/Symfony/CS/Fixer/Contrib/LogicalNotOperatorsWithSpacesFixer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class LogicalNotOperatorsWithSpacesFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if ($tokens->isUnaryPredecessorOperator($index) && $token->equals('!')) {
+                if (!$tokens[$index + 1]->isWhitespace()) {
+                    $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
+                }
+
+                if (!$tokens[$index - 1]->isWhitespace()) {
+                    $tokens->insertAt($index, new Token(array(T_WHITESPACE, ' ')));
+                }
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Logical NOT operators (!) should have leading and trailing whitespaces.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run after the UnaryOperatorsSpacesFixer
+        return -10;
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/LogicalNotOperatorsWithSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/LogicalNotOperatorsWithSpacesFixerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class LogicalNotOperatorsWithSpacesFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php $i = 0; $i++; ++$i; $foo = ! false || ( ! true);',
+                '<?php $i = 0; $i++; ++$i; $foo = !false || (!true);',
+            ),
+            array(
+                '<?php $i = 0; $i--; --$i; $foo = ! false || ($i && ! true);',
+                '<?php $i = 0; $i--; --$i; $foo = !false || ($i && !true);',
+            ),
+            array(
+                '<?php $i = 0; $i--; $foo = ! false || ($i && ! /* some comment */true);',
+                '<?php $i = 0; $i--; $foo = !false || ($i && !/* some comment */true);',
+            ),
+            array(
+                '<?php $i = 0; $i--; $foo = ! false || ($i && !    true);',
+                '<?php $i = 0; $i--; $foo = !false || ($i && !    true);',
+            ),
+            array(
+                '<?php $i = 0; $i--; $foo = ! false || ($i &&    !    true);',
+                '<?php $i = 0; $i--; $foo = !false || ($i &&    !    true);',
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -199,6 +199,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
             array($fixers['unused_use'], $fixers['line_after_namespace']),
             array($fixers['linefeed'], $fixers['eof_ending']),
+            array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_spaces']),
         );
 
         $docFixerNames = array_filter(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This rule is used in Doctrine CS
(https://github.com/doctrine/doctrine2/blob/14ff7f50cfea67d8a4dca37b8ca364d2a83b9864/CONTRIBUTING.md#coding-standard).