### PR TITLE
Tokens: added typehint for Iterator elements

### DIFF
--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -19,6 +19,8 @@ use Symfony\CS\Utils;
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Gregor Harlan <gharlan@web.de>
+ *
+ * @method Token current()
  */
 class Tokens extends \SplFixedArray
 {


### PR DESCRIPTION
I'm not sure if it is acceptable for you, but it would be very helpful.

Before:

![screenshot 2015-07-27 23 14 28](https://cloud.githubusercontent.com/assets/330436/8918127/76bccfda-34b6-11e5-96b7-675e259d70cc.png)

![screenshot 2015-07-27 23 18 22](https://cloud.githubusercontent.com/assets/330436/8918130/7b08fdb6-34b6-11e5-8f7e-bbbea848c339.png)

After:

![screenshot 2015-07-27 23 15 09](https://cloud.githubusercontent.com/assets/330436/8918136/855d3f98-34b6-11e5-8207-ab4e14fabf04.png)

![screenshot 2015-07-27 23 18 46](https://cloud.githubusercontent.com/assets/330436/8918182/bfd718ba-34b6-11e5-82e4-2d3abc6b47e1.png)

/cc @kalessil 