### PR TITLE
Fix: SingleBlankLineBeforeNamespaceFixer needs to add whitespace

### DIFF
--- a/Symfony/CS/AbstractLinesBeforeNamespaceFixer.php
+++ b/Symfony/CS/AbstractLinesBeforeNamespaceFixer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\CS;
 
+use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
@@ -40,6 +41,14 @@ abstract class AbstractLinesBeforeNamespaceFixer extends AbstractFixer
         }
 
         $previous = $tokens[$index - 1];
+
+        if ($previous->isGivenKind(T_OPEN_TAG)) {
+            if ($expected > 1) {
+                $previous->setContent(trim($previous->getContent(), ' ')."\n");
+                $tokens->insertAt($index, new Token(array(T_WHITESPACE, str_repeat("\n", $expected - 1))));
+            }
+        }
+
         if ($previous->isWhitespace()) {
             $content = $previous->getContent();
             if (substr_count($content, "\n") !== $expected) {

--- a/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -36,6 +36,7 @@ class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestBase
     {
         return array(
             array("<?php\n\nnamespace X;"),
+            array("<?php\n\nnamespace X;", '<?php namespace X;'),
             array("<?php\n\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\n\r\nnamespace X;"),
             array("<?php\r\n\nnamespace X;", "<?php\r\n\r\n\r\n\r\nnamespace X;"),


### PR DESCRIPTION
This PR

* [x] adds a failing test for `SingleBlankLineBeforeNamespaceFixer`
* [x] inserts whitespace token if necessary

:information_desk_person: I'd expect

```php
<?php namespace X;
```

to be fixed to

```php
<?php

namespace X;
```

What do you think?