### PR TITLE
Linter - Prefer error output when throwing a linting exception

### DIFF
--- a/Symfony/CS/Linter/Linter.php
+++ b/Symfony/CS/Linter/Linter.php
@@ -87,7 +87,7 @@ final class Linter implements LinterInterface
     private function checkProcess(Process $process)
     {
         if (!$process->isSuccessful()) {
-            throw new LintingException($process->getErrorOutput(), $process->getExitCode());
+            throw new LintingException($process->getErrorOutput() ?: $process->getOutput(), $process->getExitCode());
         }
     }
 

--- a/Symfony/CS/Linter/Linter.php
+++ b/Symfony/CS/Linter/Linter.php
@@ -87,7 +87,7 @@ final class Linter implements LinterInterface
     private function checkProcess(Process $process)
     {
         if (!$process->isSuccessful()) {
-            // on some systems std error is used, but on others, it's not
+            // on some systems stderr is used, but on others, it's not
             throw new LintingException($process->getErrorOutput() ?: $process->getOutput(), $process->getExitCode());
         }
     }

--- a/Symfony/CS/Linter/Linter.php
+++ b/Symfony/CS/Linter/Linter.php
@@ -87,7 +87,7 @@ final class Linter implements LinterInterface
     private function checkProcess(Process $process)
     {
         if (!$process->isSuccessful()) {
-            throw new LintingException($process->getOutput(), $process->getExitCode());
+            throw new LintingException($process->getErrorOutput(), $process->getExitCode());
         }
     }
 

--- a/Symfony/CS/Linter/Linter.php
+++ b/Symfony/CS/Linter/Linter.php
@@ -87,6 +87,7 @@ final class Linter implements LinterInterface
     private function checkProcess(Process $process)
     {
         if (!$process->isSuccessful()) {
+            // on some systems std error is used, but on others, it's not
             throw new LintingException($process->getErrorOutput() ?: $process->getOutput(), $process->getExitCode());
         }
     }


### PR DESCRIPTION
The error output provides information that's actually useful to debug the error.