### PR TITLE
Walk up directories searching for .php_cs file

### DIFF
--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -247,10 +247,24 @@ final class ConfigurationResolver
             $configDir = $path;
         }
 
-        return array(
-            $configDir.DIRECTORY_SEPARATOR.'.php_cs',
-            $configDir.DIRECTORY_SEPARATOR.'.php_cs.dist',
+        $configDir .= DIRECTORY_SEPARATOR;
+
+        $files = array(
+            $configDir.'.php_cs',
+            $configDir.'.php_cs.dist',
         );
+
+        while (is_dir($configDir)) {
+            foreach (array('.php_cs', '.php_cs.dist') as $fileName) {
+                if (file_exists($configDir.$fileName)) {
+                    return array(realpath($configDir.$fileName));
+                }
+            }
+
+            $configDir .= '..'.DIRECTORY_SEPARATOR;
+        }
+
+        return $files;
     }
 
     /**

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -257,7 +257,8 @@ final class ConfigurationResolver
         while (is_dir($configDir)) {
             foreach (array('.php_cs', '.php_cs.dist') as $fileName) {
                 if (file_exists($configDir.$fileName)) {
-                    return array(realpath($configDir.$fileName));
+                    $files = array(realpath($configDir.$fileName));
+                    break 2;
                 }
             }
 

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -396,7 +396,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveConfigFileByPathOfFile()
     {
-        $dir = __DIR__.'/../Fixtures/ConfigurationResolverConfigFile/case_1';
+        $dir = realpath(__DIR__.'/../Fixtures/ConfigurationResolverConfigFile/case_1');
 
         $this->resolver
             ->setOption('path', $dir.DIRECTORY_SEPARATOR.'foo.php')
@@ -408,7 +408,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveConfigFileSpecified()
     {
-        $file = __DIR__.'/../Fixtures/ConfigurationResolverConfigFile/case_4/my.php_cs';
+        $file = realpath(__DIR__.'/../Fixtures/ConfigurationResolverConfigFile/case_4/my.php_cs');
 
         $this->resolver
             ->setOption('config-file', $file)
@@ -433,7 +433,7 @@ class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
     public function provideResolveConfigFileDefaultCases()
     {
-        $dirBase = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'ConfigurationResolverConfigFile'.DIRECTORY_SEPARATOR;
+        $dirBase = realpath(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'ConfigurationResolverConfigFile').DIRECTORY_SEPARATOR;
 
         return array(
             array(


### PR DESCRIPTION
This makes the fix command walk up directories looking for `.php_cs` files until it finds one.
It doesn't change the current behaviour when none is found.