### PR TITLE
Fix not well-formed XML output

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -453,39 +453,6 @@ EOF
                     }
                 }
 
-                $fixEvent = $this->stopwatch->getEvent('fixFiles');
-
-                $timeXML = $dom->createElement('time');
-                $memoryXML = $dom->createElement('memory');
-                $filesXML->appendChild($timeXML);
-                $filesXML->appendChild($memoryXML);
-
-                $memoryXML->setAttribute('value', round($fixEvent->getMemory() / 1024 / 1024, 3));
-                $memoryXML->setAttribute('unit', 'MB');
-
-                $timeXML->setAttribute('unit', 's');
-                $timeTotalXML = $dom->createElement('total');
-                $timeTotalXML->setAttribute('value', round($fixEvent->getDuration() / 1000, 3));
-                $timeXML->appendChild($timeTotalXML);
-
-                if (OutputInterface::VERBOSITY_DEBUG <= $verbosity) {
-                    $timeFilesXML = $dom->createElement('files');
-                    $timeXML->appendChild($timeFilesXML);
-                    $eventCounter = 1;
-
-                    foreach ($this->stopwatch->getSectionEvents('fixFile') as $file => $event) {
-                        if ('__section__' === $file) {
-                            continue;
-                        }
-
-                        $timeFileXML = $dom->createElement('file');
-                        $timeFilesXML->appendChild($timeFileXML);
-                        $timeFileXML->setAttribute('id', $eventCounter++);
-                        $timeFileXML->setAttribute('name', $file);
-                        $timeFileXML->setAttribute('value', round($event->getDuration() / 1000, 3));
-                    }
-                }
-
                 $dom->formatOutput = true;
                 $output->write($dom->saveXML());
                 break;

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -457,8 +457,8 @@ EOF
 
                 $timeXML = $dom->createElement('time');
                 $memoryXML = $dom->createElement('memory');
-                $dom->appendChild($timeXML);
-                $dom->appendChild($memoryXML);
+                $filesXML->appendChild($timeXML);
+                $filesXML->appendChild($memoryXML);
 
                 $memoryXML->setAttribute('value', round($fixEvent->getMemory() / 1024 / 1024, 3));
                 $memoryXML->setAttribute('unit', 'MB');


### PR DESCRIPTION
PR for #1363 

Remove time and memory tags.

#### Command
`php-cs-fixer fix --no-ansi --verbose --dry-run --diff --format=xml --no-interaction /home/junichi11/Some.php`

#### PHP File
Some.php
```php
<?php
namespace Foo\Bar;
/**
 * Description of Some
 *
 * @author junichi11
 */
class Some2 {
}

```

#### Before
```xml
<?xml version="1.0" encoding="UTF-8"?>
<files>
  <file id="1" name="/home/junichi11/Some.php">
    <applied_fixers>
      <applied_fixer name="phpdoc_short_description"/>
      <applied_fixer name="blankline_after_open_tag"/>
      <applied_fixer name="psr0"/>
      <applied_fixer name="line_after_namespace"/>
      <applied_fixer name="braces"/>
    </applied_fixers>
    <diff><![CDATA[      --- Original
      +++ New
      @@ @@
       <?php
      +
       namespace Foo\Bar;
      +
       /**
      - * Description of Some
      + * Description of Some.
        *
        * @author junichi11
        */
      -class Some2 {
      +class Some
      +{
       }
       
      ]]></diff>
  </file>
</files>
<time unit="s">
  <total value="0.092"/>
</time>
<memory value="3.75" unit="MB"/>
```
#### After
```xml
<?xml version="1.0" encoding="UTF-8"?>
<files>
  <file id="1" name="/home/junichi11/NetBeansProjects/issue-254585/Some.php">
    <applied_fixers>
      <applied_fixer name="phpdoc_short_description"/>
      <applied_fixer name="blankline_after_open_tag"/>
      <applied_fixer name="psr0"/>
      <applied_fixer name="line_after_namespace"/>
      <applied_fixer name="braces"/>
    </applied_fixers>
    <diff><![CDATA[      --- Original
      +++ New
      @@ @@
       <?php
      +
       namespace Foo\Bar;
      +
       /**
      - * Description of Some
      + * Description of Some.
        *
        * @author junichi11
        */
      -class Some2 {
      +class Some
      +{
       }
       
      ]]></diff>
  </file>
</files>
```

Thanks.