### PR TITLE
Don't allow PHP 7 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
     - hhvm
 
 matrix:
+    fast_finish: true
     include:
         - php: 5.3
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,9 @@ php:
     - hhvm
 
 matrix:
-    fast_finish: true
     include:
         - php: 5.3
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-    allow_failures:
-        - php: 7.0
 
 sudo: false
 


### PR DESCRIPTION
PHP 7.0 is RC now. It's pretty much fixed. At this point, I'd say we really want to know if things start failing.