### PR TITLE
[1.11] Added optional more risky phpdoc scalar fixing

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
@@ -182,7 +182,7 @@ class PhpdocScalarFixer extends AbstractFixer
     private static function normalizeType($type)
     {
         if (!self::$caseSensitive) {
-            $lower = strtolower($type)
+            $lower = strtolower($type);
 
             if (in_array($lower, self::$standard, true)) {
                 $type = $lower;

--- a/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
@@ -49,6 +49,7 @@ class PhpdocScalarFixer extends AbstractFixer
         'array',
         'bool',
         'boolean',
+        'callable',
         'double',
         'float',
         'int',
@@ -57,6 +58,7 @@ class PhpdocScalarFixer extends AbstractFixer
         'null',
         'object',
         'real',
+        'resource',
         'string',
         'void',
     );

--- a/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
@@ -34,11 +34,49 @@ class PhpdocScalarFixer extends AbstractFixer
      * @var array
      */
     private static $types = array(
-        'integer' => 'int',
         'boolean' => 'bool',
-        'real' => 'float',
         'double' => 'float',
+        'integer' => 'int',
+        'real' => 'float',
     );
+
+    /**
+     * The supported types to process.
+     *
+     * @var array
+     */
+    private static $supported = array(
+        'array',
+        'bool',
+        'boolean',
+        'double',
+        'float',
+        'int',
+        'integer',
+        'mixed',
+        'null',
+        'object',
+        'real',
+        'string',
+        'void',
+    );
+
+    /**
+     * Are searches are case sensitive.
+     *
+     * @var bool
+     */
+    private static $caseSensitive = true;
+
+    /**
+     * Sets if searches are case sensitive.
+     *
+     * @param bool $caseSensitive
+     */
+    public static function setCaseSensitive($caseSensitive)
+    {
+        self::$caseSensitive = (bool) $caseSensitive;
+    }
 
     /**
      * {@inheritdoc}
@@ -143,6 +181,14 @@ class PhpdocScalarFixer extends AbstractFixer
      */
     private static function normalizeType($type)
     {
+        if (!self::$caseSensitive) {
+            $lower = strtolower($type)
+
+            if (in_array($lower, self::$standard, true)) {
+                $type = $lower;
+            }
+        }
+
         if (array_key_exists($type, self::$types)) {
             return self::$types[$type];
         }

--- a/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
@@ -184,7 +184,7 @@ class PhpdocScalarFixer extends AbstractFixer
         if (!self::$caseSensitive) {
             $lower = strtolower($type);
 
-            if (in_array($lower, self::$standard, true)) {
+            if (in_array($lower, self::$supported, true)) {
                 $type = $lower;
             }
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\CS\Tests\Fixer\Symfony;
 
+use Symfony\CS\Fixer\Symfony\PhpdocScalarFixer;
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
@@ -18,6 +19,13 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
  */
 class PhpdocScalarFixerTest extends AbstractFixerTestBase
 {
+    protected function makeTest($expected, $input = null, \SplFileInfo $file = null, $case = true)
+    {
+        PhpdocScalarFixer::setCaseSensitive($case);
+
+        parent::makeTest($expected, $input, $file);
+    }
+
     public function testBasicFix()
     {
         $expected = <<<'EOF'
@@ -269,5 +277,53 @@ EOF;
 
 EOF;
         $this->makeTest($expected);
+    }
+
+    public function testNotCaseSensitive()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param bool|array|Foo
+     *
+     * @return int|float
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param Boolean|Array|Foo $bar
+     *
+     * @return inTEger|Float
+     */
+
+EOF;
+        $this->makeTest($expected, $input, null, false);
+    }
+
+    public function testMoreNotCaseSensitive()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param mixed
+     *
+     * @return void
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param Mixed $foo
+     *
+     * @return Void
+     */
+
+EOF;
+        $this->makeTest($expected, $input, null, false);
     }
 }


### PR DESCRIPTION
Setting case sensitive to false means that things like "Integer" are now fixed to "int", where before, they were ignored. Also, "Int" will also be fixed to "int" if the user disables the case sensitive search.