### PR TITLE
[1.10] Fixed the var without name fixer for inline docs

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
@@ -38,7 +38,8 @@ class PhpdocVarWithoutNameFixer extends AbstractFixer
 
             $annotations = $doc->getAnnotationsOfType(array('var', 'type'));
 
-            if (empty($annotations)) {
+            // only process docblocks where there is exactly one occurrence
+            if (count($annotations) !== 1) {
                 continue;
             }
 

--- a/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
@@ -36,16 +36,15 @@ class PhpdocVarWithoutNameFixer extends AbstractFixer
                 continue;
             }
 
-            $annotations = $doc->getAnnotationsOfType(array('var', 'type'));
+            $annotations = $doc->getAnnotations();
 
-            // only process docblocks where there is exactly one occurrence
-            if (count($annotations) !== 1) {
+            // only process docblocks containing exactly one annotation
+            // also, require that annotation to be either @type or @var
+            if (count($annotations) !== 1 || in_array($annotations[0]->getTag()->getName(), ['type', 'var'], true)) {
                 continue;
             }
 
-            foreach ($annotations as $annotation) {
-                $this->fixLine($doc->getLine($annotation->getStart()));
-            }
+            $this->fixLine($doc->getLine($annotations[0]->getStart()));
 
             $token->setContent($doc->getContent());
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
@@ -96,4 +96,22 @@ EOF;
 
         $this->makeTest($expected);
     }
+
+    public function testInlineDoc()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Initializes this class with the given options.
+     *
+     * @param array $options {
+     *     @var bool   $required Whether this element is required
+     *     @var string $label    The display name for this element
+     * }
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
@@ -114,4 +114,21 @@ EOF;
 
         $this->makeTest($expected);
     }
+
+    public function testInlineDocAgain()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int[] $stuff {
+     *     @var int $foo
+     * }
+     *
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
 }


### PR DESCRIPTION
This fixer is already pretty heuristic as it is. As far as I can see, this simple change is good enough.

--

Closes #1352.