### PR TITLE
[2.x] Add integration tests using fixtures files.

### DIFF
--- a/Symfony/CS/Tests/AbstractIntegrationTest.php
+++ b/Symfony/CS/Tests/AbstractIntegrationTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\CS\Error\Error;
+use Symfony\CS\FileCacheManager;
+use Symfony\CS\Fixer;
+use Symfony\CS\FixerInterface;
+
+/**
+ * Integration test helper.
+ *
+ * @author SpacePossum
+ */
+abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getTests
+     */
+    public function testIntegration($testFileName, $testTitle, $fixers, $input, $expected = null)
+    {
+        $this->doTestIntegration($testFileName, $testTitle, $fixers, $input, $expected);
+    }
+
+    public function getTests()
+    {
+        $fixturesDir = realpath($this->getFixturesDir());
+        $this->assertTrue(is_dir($fixturesDir), sprintf('Given fixture dir "%s" is not a directory.', $fixturesDir));
+
+        $tests = array();
+
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($fixturesDir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+            if (!preg_match('/\.test$/', $file)) {
+                continue;
+            }
+
+            $test = file_get_contents($file->getRealpath());
+            $fileName = $file->getFileName();
+            if (preg_match('/--TEST--[\r\n](.*?)\s--CONFIG--[\r\n](.*?)\s--INPUT--[\r\n](.*?[\r\n]*)(?:[\r\n]--EXPECT--\s(.*)|$)/s', $test, $match)) {
+                $testTitle = $match[1];
+                $config = $this->getFixersFromConfig($fileName, $match[2]);
+                $input = $match[3];
+                $expected = isset($match[4]) ? $match[4] : null;
+                $tests[] = array($fileName, $testTitle, $config, $input, $expected);
+            } else {
+                throw new InvalidArgumentException(sprintf('Test "%s" is not valid.', $fileName));
+            }
+        }
+
+        $this->assertNotEmpty($tests, sprintf('No tests found in fixtures dir "%s".', $fixturesDir));
+
+        return $tests;
+    }
+
+    /**
+     * Returns the full path to directory which contains the tests.
+     *
+     * @return string
+     */
+    abstract protected function getFixturesDir();
+
+    /**
+     * Returns the full path to directory where the tests will writes the temporary file.
+     *
+     * @return string
+     */
+    abstract protected function getTempDir();
+
+    /**
+     * @param string           $testFileName
+     * @param string           $testTitle
+     * @param FixerInterface[] $fixers
+     * @param string           $input
+     * @param string|null      $expected
+     */
+    protected function doTestIntegration($testFileName, $testTitle, $fixers, $input, $expected = null)
+    {
+        $fixer = new Fixer();
+        $fs = new Filesystem();
+
+        $dir = $this->getTempDir();
+        $tmpDir = new \SplFileInfo($dir);
+        if (!$tmpDir->isDir()) {
+            $fs->mkdir($tmpDir);
+        }
+
+        $this->assertTrue($tmpDir->isDir(), sprintf('Given temp dir "%s" is not a directory.', $dir));
+        $this->assertTrue($tmpDir->isWritable(), sprintf('Given temp dir "%s" is not writable.', $dir));
+
+        $tmpFile = $tmpDir->getRealPath().'/tmp.php';
+        $this->assertNotFalse(@file_put_contents($tmpFile, $input), sprintf('Failed to write to tmp. file "%s".', $tmpFile));
+
+        $changed = $fixer->fixFile(new \SplFileInfo($tmpFile), $fixers, false, true, new FileCacheManager(false, null, $fixers));
+
+        if (null !== $expected) {
+            // read back the changed file content
+            $newContent = file_get_contents($tmpFile);
+        }
+
+        $fs->remove($tmpFile);
+
+        $errorsManager = $fixer->getErrorsManager();
+        if (!$errorsManager->isEmpty()) {
+            $errors = $errorsManager->getExceptionErrors();
+            $this->assertEmpty($errors, sprintf('Errors reported during fixing: %s', $this->implodeErrors($errors)));
+            $errors = $errorsManager->getInvalidErrors();
+            $this->assertEmpty($errors, sprintf('Errors reported during linting before fixing: %s.', $this->implodeErrors($errors)));
+            $errors = $errorsManager->getLintErrors();
+            $this->assertEmpty($errors, sprintf('Errors reported during linting after fixing: %s.', $this->implodeErrors($errors)));
+        }
+
+        if (null === $expected) {
+            if (null !== $changed) {
+                $this->assertEmpty($changed, sprintf("Expected no changes made to test \"%s\" in \"%s\".\nFixers applied:\n\"%s\".\nDiff.:\n\"%s\".", $testTitle, $testFileName, implode(',', $changed['appliedFixers']), $changed['diff']));
+            }
+
+            return;
+        }
+
+        $this->assertNotEmpty($changed, sprintf('Expected changes made to test "%s" in "%s".', $testTitle, $testFileName));
+        $this->assertSame($expected, $newContent, sprintf('Expected changes do not match result, for "%s" in "%s".', $testTitle, $testFileName));
+
+        // run the test again with the `expected` part, this should always stay the same
+        $this->testIntegration($testFileName, $testTitle.' "--EXPECT-- part run"', $fixers, $expected);
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $config
+     *
+     * @return FixerInterface[]
+     */
+    protected function getFixersFromConfig($fileName, $config)
+    {
+        static $levelMap = array(
+            'none' => FixerInterface::NONE_LEVEL,
+            'psr1' => FixerInterface::PSR1_LEVEL,
+            'psr2' => FixerInterface::PSR2_LEVEL,
+            'symfony' => FixerInterface::SYMFONY_LEVEL,
+        );
+
+        $lines = explode("\n", $config);
+        if (count($lines) < 1) {
+            throw new InvalidArgumentException(sprintf('No configuration options found in "%s".', $fileName));
+        }
+
+        $config = array('level' => null, 'fixers' => array(), '--fixers' => array());
+
+        foreach ($lines as $line) {
+            $labelValuePair = explode('=', $line);
+            if (2 !== count($labelValuePair)) {
+                throw new InvalidArgumentException(sprintf('Invalid configuration line "%s" in "%s".', $line, $fileName));
+            }
+
+            $label = strtolower(trim($labelValuePair[0]));
+            $value = trim($labelValuePair[1]);
+
+            switch ($label) {
+                case 'level' : {
+                    if (!array_key_exists($value, $levelMap)) {
+                        throw new InvalidArgumentException(sprintf('Unknown level "%s" set in configuration in "%s", expected any of "%s".', $value, $fileName, implode(', ', array_keys($levelMap))));
+                    }
+
+                    if (null !== $config['level']) {
+                        throw new InvalidArgumentException(sprintf('Cannot use multiple levels in configuration in "%s".', $fileName));
+                    }
+
+                    $config['level'] = $value;
+                    break;
+                }
+                case 'fixers' : {
+                    $fixers = explode(',', $value);
+                    foreach ($fixers as $fixer) {
+                        $config['fixers'][] = strtolower(trim($fixer));
+                    }
+
+                    break;
+                }
+                case '--fixers' : {
+                    $fixers = explode(',', $value);
+                    foreach ($fixers as $fixer) {
+                        $config['--fixers'][] = strtolower(trim($fixer));
+                    }
+
+                    break;
+                }
+                default : {
+                    throw new InvalidArgumentException(sprintf('Unknown configuration item "%s" in "%s".', $label, $fileName));
+                }
+            }
+        }
+
+        if (null === $config['level']) {
+            throw new InvalidArgumentException(sprintf('Level not set in configuration "%s".', $fileName));
+        }
+
+        $fixer = new Fixer();
+        $fixer->registerBuiltInFixers();
+        $allFixers = $fixer->getFixers();
+
+        $fixers = array();
+        for ($i = count($allFixers) - 1; $i >= 0; --$i) {
+            /** @var FixerInterface $fixer */
+            $fixer = $allFixers[$i];
+            $fixerName = $fixer->getName();
+            if ('psr0' === $fixer->getName()) {
+                // File based fixer won't work
+                continue;
+            }
+
+            if ($fixer->getLevel() !== ($fixer->getLevel() & $levelMap[$config['level']])) {
+                if (false !== $key = array_search($fixerName, $config['fixers'], true)) {
+                    $fixers[] = $fixer;
+                    unset($config['fixers'][$key]);
+                }
+                continue;
+            }
+
+            if (false !== $key = array_search($fixerName, $config['--fixers'], true)) {
+                unset($config['--fixers'][$key]);
+                continue;
+            }
+
+            if (in_array($fixerName, $config['fixers'], true)) {
+                throw new InvalidArgumentException(sprintf('Additional fixer "%s" configured, but is already part of the level.', $fixerName));
+            }
+
+            $fixers[] = $fixer;
+        }
+
+        if (!empty($config['fixers'])) {
+            throw new InvalidArgumentException(sprintf('Unknown "fixers" configured to be used "%s".', implode(',', $config['fixers'])));
+        }
+
+        if (!empty($config['--fixers'])) {
+            throw new InvalidArgumentException(sprintf('Unknown "--fixers" configured to be removed "%s".', implode(',', $config['--fixers'])));
+        }
+
+        return $fixers;
+    }
+
+    /**
+     * @param Error[] $errors
+     *
+     * @return string
+     */
+    private function implodeErrors(array $errors)
+    {
+        $errorStr = '';
+        foreach ($errors as $error) {
+            $errorStr .= sprintf("%d: %s\n", $error->getType(), $error->getFilePath());
+        }
+
+        return $errorStr;
+    }
+}

--- a/Symfony/CS/Tests/Fixtures/Integration/psr2.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/psr2.test
@@ -1,0 +1,52 @@
+--TEST--
+PSR2 integration
+--CONFIG--
+level=psr2
+--INPUT--
+<?php
+namespace Vendor\Package;
+use FooInterface;
+use BarClass as Bar;
+use OtherVendor\OtherPackage\BazClass;
+class Foo extends Bar implements FooInterface{
+    public function sampleFunction($a, $b = null)
+    {
+        if ($a === $b) {
+            bar();
+        } elseif ($a > $b) {
+            $foo->bar($arg1);
+        } else {
+                BazClass::bar($arg2, $arg3);
+        }
+    }
+
+    static public  final function bar() {
+    // method body
+    }
+}
+--EXPECT--
+<?php
+namespace Vendor\Package;
+
+use FooInterface;
+use BarClass as Bar;
+use OtherVendor\OtherPackage\BazClass;
+
+class Foo extends Bar implements FooInterface
+{
+    public function sampleFunction($a, $b = null)
+    {
+        if ($a === $b) {
+            bar();
+        } elseif ($a > $b) {
+            $foo->bar($arg1);
+        } else {
+            BazClass::bar($arg2, $arg3);
+        }
+    }
+
+    final public static function bar()
+    {
+        // method body
+    }
+}

--- a/Symfony/CS/Tests/Fixtures/Integration/symfony.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/symfony.test
@@ -1,0 +1,77 @@
+--TEST--
+Symfony test
+--CONFIG--
+level=symfony
+--INPUT--
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Acme;
+
+/**
+ * Coding standards demonstration.
+ */
+class FooBar
+{
+    const SOME_CONST = 42;
+
+    private $fooBar;
+
+    /**
+     * @param string $dummy Some argument description
+     */
+    public function __construct($dummy)
+    {
+        $this->fooBar = $this->transformText($dummy);
+    }
+
+    /**
+     * @param string $dummy   Some argument description
+     * @param array  $options
+     *
+     * @return string|null Transformed input
+     *
+     * @throws \RuntimeException
+     */
+    private function transformText($dummy, array $options = array())
+    {
+        $mergedOptions = array_merge(
+            array(
+                'some_default' => 'values',
+                'another_default' => 'more values',
+            ),
+            $options
+        );
+
+        if (true === $dummy) {
+            return;
+        }
+
+        if ('string' === $dummy) {
+            if ('values' === $mergedOptions['some_default']) {
+                return substr($dummy, 0, 5);
+            }
+
+            return ucwords($dummy);
+        }
+
+        throw new \RuntimeException(sprintf('Unrecognized dummy option "%s"', $dummy));
+    }
+
+    private function reverseBoolean($value = null, $theSwitch = false)
+    {
+        if (!$theSwitch) {
+            return;
+        }
+
+        return !$value;
+    }
+}

--- a/Symfony/CS/Tests/IntegrationTest.php
+++ b/Symfony/CS/Tests/IntegrationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+/**
+ * Test that parses and runs the fixture *.test files found in
+ * /Fixtures/Integration.
+ *
+ * @author SpacePossum
+ */
+class IntegrationTest extends AbstractIntegrationTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFixturesDir()
+    {
+        return __DIR__.'/Fixtures/Integration';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTempDir()
+    {
+        return $this->getFixturesDir().'/tmp';
+    }
+}


### PR DESCRIPTION
There are good unit tests for fixers (and other parts of the code),
but there is no easy way to make integration tests.
  
This PR adds integration tests to the PHP-CS-Fixer code base.
It aims to makes it easy to tests (whole) PHP code (files) using multiple fixers.

Inspired by the fixtures in Twig.

Limitations:
* it doesn't test/do linting (by design)
* file based fixers won't work (like PSR0 and possibly PSR4 if that fixer is made)

A `.test` has the following structure:
```
--TEST--
My test title
--CONFIG--
level=none|psr0|psr1|psr2|symfony
fixers=name1,name2 (additonal fixers)
--fixers=name3,name4 (fixers not to use)
--INPUT--
some code
--EXPECT--
expected code after fixing
```

config items `fixers` and `--fixers` are optional
`--EXPECT--` is optional, if omitted the input is expected to stay the same.

Examples can be seen here:
* https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1375/files#diff-e283518231c001f9337e0093560cb730R1
* https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1375/files#diff-acdfc6b1dc6d83c7a9ae915af8acb5a1R1