### PR TITLE
Double arrow align failed on sub array proof

### DIFF
--- a/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
@@ -153,6 +153,16 @@ class AlignDoubleArrowFixerTest extends AbstractFixerTestBase
     }',
             ),
             array(
+                "<?php
+    return new JsonResponse([
+        'result' => 'OK',
+        'html'   => renderView('views/my_view.html.twig', [
+            'foo'    => 'bar',
+            'foofoo' => 42,
+        ]),
+    ]);",
+            ),
+            array(
                 '<?php
     $data = [
         "foo"  => "Bar",


### PR DESCRIPTION
Related to #1377.