### PR TITLE
Introduce rules and sets

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -12,17 +12,15 @@ EOF;
 Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
 
 return Symfony\CS\Config\Config::create()
-    // use SYMFONY_LEVEL:
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    // and extra fixers:
-    ->fixers(array(
-        'header_comment',
-        'long_array_syntax',
-        'ordered_use',
-        'php_unit_construct',
-        'php_unit_strict',
-        'strict',
-        'strict_param',
+    ->setRules(array(
+        '@Symfony' => true,
+        'header_comment' => true,
+        'long_array_syntax' => true,
+        'ordered_use' => true,
+        'php_unit_construct' => true,
+        'php_unit_strict' => true,
+        'strict' => true,
+        'strict_param' => true,
     ))
     ->finder(
         Symfony\CS\Finder\DefaultFinder::create()

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -9,12 +9,10 @@ This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 EOF;
 
-Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
-
 return Symfony\CS\Config\Config::create()
     ->setRules(array(
         '@Symfony' => true,
-        'header_comment' => true,
+        'header_comment' => array('header' => $header),
         'long_array_syntax' => true,
         'ordered_use' => true,
         'php_unit_construct' => true,

--- a/README.rst
+++ b/README.rst
@@ -128,38 +128,34 @@ The ``--format`` option can be used to set the output format of the results; ``t
 
 The ``--verbose`` option will show the applied fixers. When using the ``txt`` format it will also displays progress notifications.
 
-The ``--level`` option limits the fixers to apply on the
+The ``--rules`` option limits the rules to apply on the
 project:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/project --level=psr1
-    php php-cs-fixer.phar fix /path/to/project --level=psr2
-    php php-cs-fixer.phar fix /path/to/project --level=symfony
+    php php-cs-fixer.phar fix /path/to/project --rules=@PSR2
 
-By default, all PSR fixers are run. The "contrib
-level" fixers cannot be enabled via this option; you should instead set them
-manually by their name via the ``--fixers`` option.
+By default, all PSR fixers are run.
 
-The ``--fixers`` option lets you choose the exact fixers to
+The ``--rules`` option lets you choose the exact fixers to
 apply (the fixer names must be separated by a comma):
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,short_tag,indentation
+    php php-cs-fixer.phar fix /path/to/dir --rules=linefeed,short_tag,indentation
 
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using ``-name_of_fixer``:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=-short_tag,-indentation
+    php php-cs-fixer.phar fix /path/to/dir --rules=-short_tag,-indentation
 
 When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=return,-short_tag
+    php php-cs-fixer.phar fix /path/to/project --rules=@Symfony,-@PSR1,-return,strict
 
 A combination of ``--dry-run`` and ``--diff`` will
 display a summary of proposed fixes, leaving your files unchanged.
@@ -173,406 +169,229 @@ automatically fix anything:
 
 Choose from the list of available fixers:
 
-* **encoding** [PSR-1]
-                        PHP code MUST use only UTF-8
-                        without BOM (remove BOM).
+* **alias_functions** [@Symfony]
+                        Master functions shall be used
+                        instead of aliases.
 
-* **short_tag** [PSR-1]
-                        PHP code must use the long
-                        <?php ?> tags or the
-                        short-echo <?= ?> tags; it
-                        must not use the other tag
-                        variations.
+* **align_double_arrow**
+                        Align double arrow symbols in
+                        consecutive lines.
 
-* **braces** [PSR-2]
+* **align_equals**
+                        Align equals symbols in
+                        consecutive lines.
+
+* **blankline_after_open_tag** [@Symfony]
+                        Ensure there is no code on the
+                        same line as the PHP open tag
+                        and it is followed by a
+                        blankline.
+
+* **braces** [@PSR2, @Symfony]
                         The body of each structure
                         MUST be enclosed by braces.
                         Braces should be properly
                         placed. Body of braces should
                         be properly indented.
 
-* **elseif** [PSR-2]
+* **concat_with_spaces**
+                        Concatenation should be used
+                        with at least one whitespace
+                        around.
+
+* **concat_without_spaces** [@Symfony]
+                        Concatenation should be used
+                        without spaces.
+
+* **double_arrow_multiline_whitespaces** [@Symfony]
+                        Operator => should not be
+                        arounded by multi-line
+                        whitespaces.
+
+* **duplicate_semicolon** [@Symfony]
+                        Remove duplicated semicolons.
+
+* **elseif** [@PSR2, @Symfony]
                         The keyword elseif should be
                         used instead of else if so
                         that all control keywords look
                         like single words.
 
-* **eof_ending** [PSR-2]
+* **empty_return** [@Symfony]
+                        A return statement wishing to
+                        return nothing should be
+                        simply "return".
+
+* **encoding** [@PSR1, @PSR2, @Symfony]
+                        PHP code MUST use only UTF-8
+                        without BOM (remove BOM).
+
+* **eof_ending** [@PSR2, @Symfony]
                         A file must always end with a
                         single empty line feed.
 
-* **function_call_space** [PSR-2]
+* **ereg_to_preg**
+                        Replace deprecated ereg
+                        regular expression functions
+                        with preg. Warning! This could
+                        change code behavior.
+
+* **extra_empty_lines** [@Symfony]
+                        Removes extra empty lines.
+
+* **function_call_space** [@PSR2, @Symfony]
                         When making a method or
                         function call, there MUST NOT
                         be a space between the method
                         or function name and the
                         opening parenthesis.
 
-* **function_declaration** [PSR-2]
+* **function_declaration** [@PSR2, @Symfony]
                         Spaces should be properly
                         placed in a function
                         declaration.
 
-* **indentation** [PSR-2]
+* **function_typehint_space**
+                        Add missing space between
+                        function's argument and its
+                        typehint.
+
+* **header_comment**
+                        Add, replace or remove header
+                        comment.
+
+* **include** [@Symfony]
+                        Include and file path should
+                        be divided with a single
+                        space. File path should not be
+                        placed under brackets.
+
+* **indentation** [@PSR2, @Symfony]
                         Code MUST use an indent of 4
                         spaces, and MUST NOT use tabs
                         for indenting.
 
-* **line_after_namespace** [PSR-2]
+* **line_after_namespace** [@PSR2, @Symfony]
                         There MUST be one blank line
                         after the namespace
                         declaration.
 
-* **linefeed** [PSR-2]
+* **linefeed** [@PSR2, @Symfony]
                         All PHP files must use the
                         Unix LF (linefeed) line
                         ending.
 
-* **lowercase_constants** [PSR-2]
+* **list_commas** [@Symfony]
+                        Remove trailing commas in list
+                        function calls.
+
+* **logical_not_operators_with_spaces**
+                        Logical NOT operators (!)
+                        should have leading and
+                        trailing whitespaces.
+
+* **logical_not_operators_with_successor_space**
+                        Logical NOT operators (!)
+                        should have one trailing
+                        whitespace.
+
+* **long_array_syntax**
+                        Arrays should use the long
+                        syntax.
+
+* **lowercase_constants** [@PSR2, @Symfony]
                         The PHP constants true, false,
                         and null MUST be in lower
                         case.
 
-* **lowercase_keywords** [PSR-2]
+* **lowercase_keywords** [@PSR2, @Symfony]
                         PHP keywords MUST be in lower
                         case.
 
-* **method_argument_space** [PSR-2]
+* **method_argument_space** [@PSR2, @Symfony]
                         In method arguments and method
                         call, there MUST NOT be a
                         space before each comma and
                         there MUST be one space after
                         each comma.
 
-* **multiple_use** [PSR-2]
+* **method_separation** [@Symfony]
+                        Methods must be separated with
+                        one blank line.
+
+* **multiline_array_trailing_comma** [@Symfony]
+                        PHP multi-line arrays should
+                        have a trailing comma.
+
+* **multiline_spaces_before_semicolon**
+                        Multi-line whitespace before
+                        closing semicolon are
+                        prohibited.
+
+* **multiple_use** [@PSR2, @Symfony]
                         There MUST be one use keyword
                         per declaration.
 
-* **parenthesis** [PSR-2]
+* **namespace_no_leading_whitespace** [@Symfony]
+                        The namespace declaration line
+                        shouldn't contain leading
+                        whitespace.
+
+* **new_with_braces** [@Symfony]
+                        All instances created with new
+                        keyword must be followed by
+                        braces.
+
+* **newline_after_open_tag**
+                        Ensure there is no code on the
+                        same line as the PHP open tag.
+
+* **no_blank_lines_after_class_opening** [@Symfony]
+                        There should be no empty lines
+                        after class opening brace.
+
+* **no_blank_lines_before_namespace**
+                        There should be no blank lines
+                        before a namespace
+                        declaration.
+
+* **no_empty_lines_after_phpdocs** [@Symfony]
+                        There should not be blank
+                        lines between docblock and the
+                        documented element.
+
+* **object_operator** [@Symfony]
+                        There should not be space
+                        before or after object
+                        T_OBJECT_OPERATOR.
+
+* **operators_spaces** [@Symfony]
+                        Binary operators should be
+                        arounded by at least one
+                        space.
+
+* **ordered_use**
+                        Ordering use statements.
+
+* **parenthesis** [@PSR2, @Symfony]
                         There MUST NOT be a space
                         after the opening parenthesis.
                         There MUST NOT be a space
                         before the closing
                         parenthesis.
 
-* **php_closing_tag** [PSR-2]
-                        The closing ?> tag MUST be
-                        omitted from files containing
-                        only PHP.
-
-* **single_line_after_imports** [PSR-2]
-                        Each namespace use MUST go on
-                        its own line and there MUST be
-                        one blank line after the use
-                        statements block.
-
-* **trailing_spaces** [PSR-2]
-                        Remove trailing whitespace at
-                        the end of non-blank lines.
-
-* **visibility** [PSR-2]
-                        Visibility MUST be declared on
-                        all properties and methods;
-                        abstract and final MUST be
-                        declared before the
-                        visibility; static MUST be
-                        declared after the visibility.
-
-* **alias_functions** [symfony]
-                        Master functions shall be used
-                        instead of aliases.
-
-* **blankline_after_open_tag** [symfony]
-                        Ensure there is no code on the
-                        same line as the PHP open tag
-                        and it is followed by a
-                        blankline.
-
-* **concat_without_spaces** [symfony]
-                        Concatenation should be used
-                        without spaces.
-
-* **double_arrow_multiline_whitespaces** [symfony]
-                        Operator => should not be
-                        arounded by multi-line
-                        whitespaces.
-
-* **duplicate_semicolon** [symfony]
-                        Remove duplicated semicolons.
-
-* **empty_return** [symfony]
-                        A return statement wishing to
-                        return nothing should be
-                        simply "return".
-
-* **extra_empty_lines** [symfony]
-                        Removes extra empty lines.
-
-* **function_typehint_space** [symfony]
-                        Add missing space between
-                        function's argument and its
-                        typehint.
-
-* **include** [symfony]
-                        Include and file path should
-                        be divided with a single
-                        space. File path should not be
-                        placed under brackets.
-
-* **list_commas** [symfony]
-                        Remove trailing commas in list
-                        function calls.
-
-* **method_separation** [symfony]
-                        Methods must be separated with
-                        one blank line.
-
-* **multiline_array_trailing_comma** [symfony]
-                        PHP multi-line arrays should
-                        have a trailing comma.
-
-* **namespace_no_leading_whitespace** [symfony]
-                        The namespace declaration line
-                        shouldn't contain leading
-                        whitespace.
-
-* **new_with_braces** [symfony]
-                        All instances created with new
-                        keyword must be followed by
-                        braces.
-
-* **no_blank_lines_after_class_opening** [symfony]
-                        There should be no empty lines
-                        after class opening brace.
-
-* **no_empty_lines_after_phpdocs** [symfony]
-                        There should not be blank
-                        lines between docblock and the
-                        documented element.
-
-* **object_operator** [symfony]
-                        There should not be space
-                        before or after object
-                        T_OBJECT_OPERATOR.
-
-* **operators_spaces** [symfony]
-                        Binary operators should be
-                        arounded by at least one
-                        space.
-
-* **phpdoc_align** [symfony]
-                        All items of the @param,
-                        @throws, @return, @var, and
-                        @type phpdoc tags must be
-                        aligned vertically.
-
-* **phpdoc_indent** [symfony]
-                        Docblocks should have the same
-                        indentation as the documented
-                        subject.
-
-* **phpdoc_inline_tag** [symfony]
-                        Fix PHPDoc inline tags, make
-                        inheritdoc always inline.
-
-* **phpdoc_no_access** [symfony]
-                        @access annotations should be
-                        omitted from phpdocs.
-
-* **phpdoc_no_empty_return** [symfony]
-                        @return void and @return null
-                        annotations should be omitted
-                        from phpdocs.
-
-* **phpdoc_no_package** [symfony]
-                        @package and @subpackage
-                        annotations should be omitted
-                        from phpdocs.
-
-* **phpdoc_scalar** [symfony]
-                        Scalar types should always be
-                        written in the same form.
-                        "int", not "integer"; "bool",
-                        not "boolean"; "float", not
-                        "real" or "double".
-
-* **phpdoc_separation** [symfony]
-                        Annotations in phpdocs should
-                        be grouped together so that
-                        annotations of the same type
-                        immediately follow each other,
-                        and annotations of a different
-                        type are separated by a single
-                        blank line.
-
-* **phpdoc_short_description** [symfony]
-                        Phpdocs short descriptions
-                        should end in either a full
-                        stop, exclamation mark, or
-                        question mark.
-
-* **phpdoc_to_comment** [symfony]
-                        Docblocks should only be used
-                        on structural elements.
-
-* **phpdoc_trim** [symfony]
-                        Phpdocs should start and end
-                        with content, excluding the
-                        very first and last line of
-                        the docblocks.
-
-* **phpdoc_type_to_var** [symfony]
-                        @type should always be written
-                        as @var.
-
-* **phpdoc_types** [symfony]
-                        The correct case must be used
-                        for standard PHP types in
-                        phpdoc.
-
-* **phpdoc_var_without_name** [symfony]
-                        @var and @type annotations
-                        should not contain the
-                        variable name.
-
-* **pre_increment** [symfony]
-                        Pre
-                        incrementation/decrementation
-                        should be used if possible.
-
-* **remove_leading_slash_use** [symfony]
-                        Remove leading slashes in use
-                        clauses.
-
-* **remove_lines_between_uses** [symfony]
-                        Removes line breaks between
-                        use statements.
-
-* **return** [symfony]
-                        An empty line feed should
-                        precede a return statement.
-
-* **self_accessor** [symfony]
-                        Inside a classy element "self"
-                        should be preferred to the
-                        class name itself.
-
-* **single_array_no_trailing_comma** [symfony]
-                        PHP single-line arrays should
-                        not have trailing comma.
-
-* **single_blank_line_before_namespace** [symfony]
-                        There should be exactly one
-                        blank line before a namespace
-                        declaration.
-
-* **single_quote** [symfony]
-                        Convert double quotes to
-                        single quotes for simple
-                        strings.
-
-* **spaces_before_semicolon** [symfony]
-                        Single-line whitespace before
-                        closing semicolon are
-                        prohibited.
-
-* **spaces_cast** [symfony]
-                        A single space should be
-                        between cast and variable.
-
-* **standardize_not_equal** [symfony]
-                        Replace all <> with !=.
-
-* **ternary_spaces** [symfony]
-                        Standardize spaces around
-                        ternary operator.
-
-* **trim_array_spaces** [symfony]
-                        Arrays should be formatted
-                        like function/method
-                        arguments, without leading or
-                        trailing single line space.
-
-* **unalign_double_arrow** [symfony]
-                        Unalign double arrow symbols.
-
-* **unalign_equals** [symfony]
-                        Unalign equals symbols.
-
-* **unary_operators_spaces** [symfony]
-                        Unary operators should be
-                        placed adjacent to their
-                        operands.
-
-* **unused_use** [symfony]
-                        Unused use statements must be
-                        removed.
-
-* **whitespacy_lines** [symfony]
-                        Remove trailing whitespace at
-                        the end of blank lines.
-
-* **align_double_arrow** [contrib]
-                        Align double arrow symbols in
-                        consecutive lines.
-
-* **align_equals** [contrib]
-                        Align equals symbols in
-                        consecutive lines.
-
-* **concat_with_spaces** [contrib]
-                        Concatenation should be used
-                        with at least one whitespace
-                        around.
-
-* **ereg_to_preg** [contrib]
-                        Replace deprecated ereg
-                        regular expression functions
-                        with preg. Warning! This could
-                        change code behavior.
-
-* **header_comment** [contrib]
-                        Add, replace or remove header
-                        comment.
-
-* **logical_not_operators_with_spaces** [contrib]
-                        Logical NOT operators (!)
-                        should have leading and
-                        trailing whitespaces.
-
-* **logical_not_operators_with_successor_space** [contrib]
-                        Logical NOT operators (!)
-                        should have one trailing
-                        whitespace.
-
-* **long_array_syntax** [contrib]
-                        Arrays should use the long
-                        syntax.
-
-* **multiline_spaces_before_semicolon** [contrib]
-                        Multi-line whitespace before
-                        closing semicolon are
-                        prohibited.
-
-* **newline_after_open_tag** [contrib]
-                        Ensure there is no code on the
-                        same line as the PHP open tag.
-
-* **no_blank_lines_before_namespace** [contrib]
-                        There should be no blank lines
-                        before a namespace
-                        declaration.
-
-* **ordered_use** [contrib]
-                        Ordering use statements.
-
-* **php4_constructor** [contrib]
+* **php4_constructor**
                         Convert PHP4-style
                         constructors to __construct.
                         Warning! This could change
                         code behavior.
 
-* **php_unit_construct** [contrib]
+* **php_closing_tag** [@PSR2, @Symfony]
+                        The closing ?> tag MUST be
+                        omitted from files containing
+                        only PHP.
+
+* **php_unit_construct**
                         PHPUnit assertion method calls
                         like "->assertSame(true,
                         $foo)" should be written with
@@ -581,25 +400,105 @@ Choose from the list of available fixers:
                         This could change code
                         behavior.
 
-* **php_unit_strict** [contrib]
+* **php_unit_strict**
                         PHPUnit methods like
                         "assertSame" should be used
                         instead of "assertEquals".
                         Warning! This could change
                         code behavior.
 
-* **phpdoc_order** [contrib]
+* **phpdoc_align** [@Symfony]
+                        All items of the @param,
+                        @throws, @return, @var, and
+                        @type phpdoc tags must be
+                        aligned vertically.
+
+* **phpdoc_indent** [@Symfony]
+                        Docblocks should have the same
+                        indentation as the documented
+                        subject.
+
+* **phpdoc_inline_tag** [@Symfony]
+                        Fix PHPDoc inline tags, make
+                        inheritdoc always inline.
+
+* **phpdoc_no_access** [@Symfony]
+                        @access annotations should be
+                        omitted from phpdocs.
+
+* **phpdoc_no_empty_return** [@Symfony]
+                        @return void and @return null
+                        annotations should be omitted
+                        from phpdocs.
+
+* **phpdoc_no_package** [@Symfony]
+                        @package and @subpackage
+                        annotations should be omitted
+                        from phpdocs.
+
+* **phpdoc_order**
                         Annotations in phpdocs should
                         be ordered so that param
                         annotations come first, then
                         throws annotations, then
                         return annotations.
 
-* **phpdoc_var_to_type** [contrib]
+* **phpdoc_scalar** [@Symfony]
+                        Scalar types should always be
+                        written in the same form.
+                        "int", not "integer"; "bool",
+                        not "boolean"; "float", not
+                        "real" or "double".
+
+* **phpdoc_separation** [@Symfony]
+                        Annotations in phpdocs should
+                        be grouped together so that
+                        annotations of the same type
+                        immediately follow each other,
+                        and annotations of a different
+                        type are separated by a single
+                        blank line.
+
+* **phpdoc_short_description** [@Symfony]
+                        Phpdocs short descriptions
+                        should end in either a full
+                        stop, exclamation mark, or
+                        question mark.
+
+* **phpdoc_to_comment** [@Symfony]
+                        Docblocks should only be used
+                        on structural elements.
+
+* **phpdoc_trim** [@Symfony]
+                        Phpdocs should start and end
+                        with content, excluding the
+                        very first and last line of
+                        the docblocks.
+
+* **phpdoc_type_to_var** [@Symfony]
+                        @type should always be written
+                        as @var.
+
+* **phpdoc_types**
+                        The correct case must be used
+                        for standard PHP types in
+                        phpdoc.
+
+* **phpdoc_var_to_type**
                         @var should always be written
                         as @type.
 
-* **psr0** [contrib]
+* **phpdoc_var_without_name** [@Symfony]
+                        @var and @type annotations
+                        should not contain the
+                        variable name.
+
+* **pre_increment** [@Symfony]
+                        Pre
+                        incrementation/decrementation
+                        should be used if possible.
+
+* **psr0**
                         Classes must be in a path that
                         matches their namespace, be at
                         least one namespace deep and
@@ -607,23 +506,120 @@ Choose from the list of available fixers:
                         the file name. Warning: This
                         could change code behavior.
 
-* **short_array_syntax** [contrib]
+* **remove_leading_slash_use** [@Symfony]
+                        Remove leading slashes in use
+                        clauses.
+
+* **remove_lines_between_uses** [@Symfony]
+                        Removes line breaks between
+                        use statements.
+
+* **return** [@Symfony]
+                        An empty line feed should
+                        precede a return statement.
+
+* **self_accessor** [@Symfony]
+                        Inside a classy element "self"
+                        should be preferred to the
+                        class name itself.
+
+* **short_array_syntax**
                         PHP arrays should use the PHP
                         5.4 short-syntax.
 
-* **short_echo_tag** [contrib]
+* **short_echo_tag**
                         Replace short-echo <?= with
                         long format <?php echo syntax.
 
-* **strict** [contrib]
+* **short_tag** [@PSR1, @PSR2, @Symfony]
+                        PHP code must use the long
+                        <?php ?> tags or the
+                        short-echo <?= ?> tags; it
+                        must not use the other tag
+                        variations.
+
+* **single_array_no_trailing_comma** [@Symfony]
+                        PHP single-line arrays should
+                        not have trailing comma.
+
+* **single_blank_line_before_namespace** [@Symfony]
+                        There should be exactly one
+                        blank line before a namespace
+                        declaration.
+
+* **single_line_after_imports** [@PSR2, @Symfony]
+                        Each namespace use MUST go on
+                        its own line and there MUST be
+                        one blank line after the use
+                        statements block.
+
+* **single_quote** [@Symfony]
+                        Convert double quotes to
+                        single quotes for simple
+                        strings.
+
+* **spaces_before_semicolon** [@Symfony]
+                        Single-line whitespace before
+                        closing semicolon are
+                        prohibited.
+
+* **spaces_cast** [@Symfony]
+                        A single space should be
+                        between cast and variable.
+
+* **standardize_not_equal** [@Symfony]
+                        Replace all <> with !=.
+
+* **strict**
                         Comparison should be strict.
                         Warning! This could change
                         code behavior.
 
-* **strict_param** [contrib]
+* **strict_param**
                         Functions should be used with
                         $strict param. Warning! This
                         could change code behavior.
+
+* **ternary_spaces** [@Symfony]
+                        Standardize spaces around
+                        ternary operator.
+
+* **trailing_spaces** [@PSR2, @Symfony]
+                        Remove trailing whitespace at
+                        the end of non-blank lines.
+
+* **trim_array_spaces** [@Symfony]
+                        Arrays should be formatted
+                        like function/method
+                        arguments, without leading or
+                        trailing single line space.
+
+* **unalign_double_arrow** [@Symfony]
+                        Unalign double arrow symbols.
+
+* **unalign_equals** [@Symfony]
+                        Unalign equals symbols.
+
+* **unary_operators_spaces** [@Symfony]
+                        Unary operators should be
+                        placed adjacent to their
+                        operands.
+
+* **unused_use** [@Symfony]
+                        Unused use statements must be
+                        removed.
+
+* **visibility** [@PSR2, @Symfony]
+                        Visibility MUST be declared on
+                        all properties and methods;
+                        abstract and final MUST be
+                        declared before the
+                        visibility; static MUST be
+                        declared after the visibility.
+
+* **whitespacy_lines** [@Symfony]
+                        Remove trailing whitespace at
+                        the end of blank lines.
 
 
 The ``--config`` option customizes the files to analyse, based
@@ -652,14 +648,14 @@ fixed but without actually modifying them:
 Instead of using command line options to customize the fixer, you can save the
 project configuration in a ``.php_cs.dist`` file in the root directory
 of your project. The file must return an instance of ``Symfony\CS\ConfigInterface``,
-which lets you configure the fixers, the level, the files and directories that
+which lets you configure the rules, the files and directories that
 need to be analyzed. You may also create ``.php_cs`` file, which is
 the local configuration that will be used instead of the project configuration. It
 is a good practice to add that file into your ``.gitignore`` file.
 With the ``--config-file`` option you can specify the path to the
 ``.php_cs`` file.
 
-The example below will add two contrib fixers to the default list of PSR2-level fixers:
+The example below will add two fixers to the default list of PSR2 set fixers:
 
 .. code-block:: php
 
@@ -671,30 +667,16 @@ The example below will add two contrib fixers to the default list of PSR2-level 
     ;
 
     return Symfony\CS\Config\Config::create()
-        ->fixers(array('strict_param', 'short_array_syntax'))
-        ->finder($finder)
-    ;
-
-If you want complete control over which fixers you use, you can use the empty level and
-then specify all fixers to be used:
-
-.. code-block:: php
-
-    <?php
-
-    $finder = Symfony\CS\Finder\DefaultFinder::create()
-        ->in(__DIR__)
-    ;
-
-    return Symfony\CS\Config\Config::create()
-        ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
-        ->fixers(array('trailing_spaces', 'encoding'))
+        ->setRules(array(
+            '@PSR2' => true,
+            'strict_param' => true,
+            'short_array_syntax' => true,
+        ))
         ->finder($finder)
     ;
 
 You may also use a blacklist for the Fixers instead of the above shown whitelist approach.
-The following example shows how to use all ``symfony`` Fixers but the ``short_tag`` fixer.
-Note the additional ``-`` in front of the Fixer name.
+The following example shows how to use all ``Symfony`` Fixers but the ``short_tag`` Fixer.
 
 .. code-block:: php
 
@@ -706,24 +688,12 @@ Note the additional ``-`` in front of the Fixer name.
     ;
 
     return Symfony\CS\Config\Config::create()
-        ->fixers(array('-short_tag'))
+        ->setRules(array(
+            '@Symfony' => true,
+            'short_tag' => false,
+        ))
         ->finder($finder)
     ;
-
-The ``psr2`` level is set by default, you can also change the default level:
-
-.. code-block:: php
-
-    <?php
-
-    return Symfony\CS\Config\Config::create()
-        ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ;
-
-In combination with these config and command line options, you can choose various usage.
-
-For example, the default level is ``psr2``, but if you don't want to use
-the ``short_tag`` fixer, you can specify the ``--level=psr2 --fixers=-short_tag`` options.
 
 By using ``--using-cache`` option with yes or no you can set if the caching
 mechanism should be used.
@@ -813,7 +783,7 @@ implement ``FixerInterface``).
 Configs
 ~~~~~~~
 
-A *config* knows about the CS level and the files and directories that must be
+A *config* knows about the CS rules and the files and directories that must be
 scanned by the tool when run in the directory of your project. It is useful for
 projects that follow a well-known directory structures (like for Symfony
 projects for instance).

--- a/Symfony/CS/AbstractFixer.php
+++ b/Symfony/CS/AbstractFixer.php
@@ -21,27 +21,6 @@ abstract class AbstractFixer implements FixerInterface
     /**
      * {@inheritdoc}
      */
-    public function getLevel()
-    {
-        static $map = array(
-            'PSR1' => FixerInterface::PSR1_LEVEL,
-            'PSR2' => FixerInterface::PSR2_LEVEL,
-            'Symfony' => FixerInterface::SYMFONY_LEVEL,
-            'Contrib' => FixerInterface::CONTRIB_LEVEL,
-        );
-
-        $level = current(explode('\\', substr(get_called_class(), strlen(__NAMESPACE__.'\\Fixer\\'))));
-
-        if (!isset($map[$level])) {
-            throw new \LogicException(sprintf('Can not determine Fixer level: "%s".', $level));
-        }
-
-        return $map[$level];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         $nameParts = explode('\\', get_called_class());

--- a/Symfony/CS/AbstractFixer.php
+++ b/Symfony/CS/AbstractFixer.php
@@ -21,6 +21,14 @@ abstract class AbstractFixer implements FixerInterface
     /**
      * {@inheritdoc}
      */
+    public function configure(array $configuration = null)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         $nameParts = explode('\\', get_called_class());

--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -25,24 +25,21 @@ class Config implements ConfigInterface
     protected $name;
     protected $description;
     protected $finder;
-    protected $level;
-    protected $fixers;
+    protected $fixers = array();
     protected $dir;
-    protected $customFixers;
+    protected $customFixers = array();
     protected $usingCache = true;
     protected $usingLinter = true;
     protected $hideProgress = false;
     protected $cacheFile = '.php_cs.cache';
     protected $phpExecutable;
+    protected $rules = array('@PSR2' => true);
 
     public function __construct($name = 'default', $description = 'A default configuration')
     {
         $this->name = $name;
         $this->description = $description;
-        $this->level = FixerInterface::PSR2_LEVEL;
-        $this->fixers = array();
         $this->finder = new DefaultFinder();
-        $this->customFixers = array();
     }
 
     public static function create()
@@ -92,19 +89,14 @@ class Config implements ConfigInterface
         return $this->finder;
     }
 
-    public function level($level)
-    {
-        $this->level = $level;
-
-        return $this;
-    }
-
-    public function getLevel()
-    {
-        return $this->level;
-    }
-
-    public function fixers($fixers)
+    /**
+     * Set fixers.
+     *
+     * @param FixerInterface[] $fixers
+     *
+     * @return $this
+     */
+    public function fixers(array $fixers)
     {
         $this->fixers = $fixers;
 
@@ -198,5 +190,23 @@ class Config implements ConfigInterface
     public function getPhpExecutable()
     {
         return $this->phpExecutable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRules(array $rules)
+    {
+        $this->rules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules()
+    {
+        return $this->rules;
     }
 }

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -42,16 +42,9 @@ interface ConfigInterface
     public function getFinder();
 
     /**
-     * Returns the level to run.
-     *
-     * @return int A level
-     */
-    public function getLevel();
-
-    /**
      * Returns the fixers to run.
      *
-     * @return array A list of fixer names
+     * @return FixerInterface[]
      */
     public function getFixers();
 
@@ -128,4 +121,24 @@ interface ConfigInterface
      * @return string|null
      */
     public function getPhpExecutable();
+
+    /**
+     * Get rules.
+     *
+     * Keys of array are names of fixers/sets, values are true/false.
+     *
+     * @return array
+     */
+    public function getRules();
+
+    /**
+     * Set rules.
+     *
+     * Keys of array are names of fixers/sets, values are true/false.
+     *
+     * @param array $rules
+     *
+     * @return ConfigInterface The same instance
+     */
+    public function setRules(array $rules);
 }

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -53,7 +53,7 @@ interface ConfigInterface
      *
      * @param string $dir The project root directory
      *
-     * @return ConfigInterface The same instance
+     * @return $this
      */
     public function setDir($dir);
 
@@ -134,11 +134,14 @@ interface ConfigInterface
     /**
      * Set rules.
      *
-     * Keys of array are names of fixers/sets, values are true/false.
+     * Keys of array are names of fixers or sets.
+     * Value for set must be bool (turn it on or off).
+     * Value for fixer may be bool (turn it on or off) or array of configuration
+     * (turn it on and contains configuration for FixerInterface::configure method).
      *
      * @param array $rules
      *
-     * @return ConfigInterface The same instance
+     * @return $this
      */
     public function setRules(array $rules);
 }

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -29,7 +29,7 @@ use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Linter\Linter;
 use Symfony\CS\Linter\UnavailableLinterException;
-use Symfony\CS\Utils;
+use Symfony\CS\RuleSet;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -107,10 +107,9 @@ final class FixCommand extends Command
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration name', null),
                     new InputOption('config-file', '', InputOption::VALUE_OPTIONAL, 'The path to a .php_cs file ', null),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified'),
-                    new InputOption('level', '', InputOption::VALUE_REQUIRED, 'The level of fixes (can be psr1, psr2, or symfony (formerly all))', null),
+                    new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'The rules', null),
                     new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no)', null),
                     new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file'),
-                    new InputOption('fixers', '', InputOption::VALUE_REQUIRED, 'A list of fixers to run'),
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
                 )
@@ -127,30 +126,26 @@ The <comment>--format</comment> option can be used to set the output format of t
 
 The <comment>--verbose</comment> option will show the applied fixers. When using the ``txt`` format it will also displays progress notifications.
 
-The <comment>--level</comment> option limits the fixers to apply on the
+The <comment>--rules</comment> option limits the rules to apply on the
 project:
 
-    <info>php %command.full_name% /path/to/project --level=psr1</info>
-    <info>php %command.full_name% /path/to/project --level=psr2</info>
-    <info>php %command.full_name% /path/to/project --level=symfony</info>
+    <info>php %command.full_name% /path/to/project --rules=@PSR2</info>
 
-By default, all PSR fixers are run. The "contrib
-level" fixers cannot be enabled via this option; you should instead set them
-manually by their name via the <comment>--fixers</comment> option.
+By default, all PSR fixers are run.
 
-The <comment>--fixers</comment> option lets you choose the exact fixers to
+The <comment>--rules</comment> option lets you choose the exact fixers to
 apply (the fixer names must be separated by a comma):
 
-    <info>php %command.full_name% /path/to/dir --fixers=linefeed,short_tag,indentation</info>
+    <info>php %command.full_name% /path/to/dir --rules=linefeed,short_tag,indentation</info>
 
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using <comment>-name_of_fixer</comment>:
 
-    <info>php %command.full_name% /path/to/dir --level=psr2 --fixers=-short_tag,-indentation</info>
+    <info>php %command.full_name% /path/to/dir --rules=-short_tag,-indentation</info>
 
 When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
-    <info>php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=return,-short_tag</info>
+    <info>php %command.full_name% /path/to/project --rules=@Symfony,-@PSR1,-return,strict</info>
 
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
 display a summary of proposed fixes, leaving your files unchanged.
@@ -181,14 +176,14 @@ fixed but without actually modifying them:
 Instead of using command line options to customize the fixer, you can save the
 project configuration in a <comment>.php_cs.dist</comment> file in the root directory
 of your project. The file must return an instance of ``Symfony\CS\ConfigInterface``,
-which lets you configure the fixers, the level, the files and directories that
+which lets you configure the rules, the files and directories that
 need to be analyzed. You may also create <comment>.php_cs</comment> file, which is
 the local configuration that will be used instead of the project configuration. It
 is a good practice to add that file into your <comment>.gitignore</comment> file.
 With the <comment>--config-file</comment> option you can specify the path to the
 <comment>.php_cs</comment> file.
 
-The example below will add two contrib fixers to the default list of PSR2-level fixers:
+The example below will add two fixers to the default list of PSR2 set fixers:
 
     <?php
 
@@ -198,32 +193,18 @@ The example below will add two contrib fixers to the default list of PSR2-level 
     ;
 
     return Symfony\CS\Config\Config::create()
-        ->fixers(array('strict_param', 'short_array_syntax'))
-        ->finder(\$finder)
-    ;
-
-    ?>
-
-If you want complete control over which fixers you use, you can use the empty level and
-then specify all fixers to be used:
-
-    <?php
-
-    \$finder = Symfony\CS\Finder\DefaultFinder::create()
-        ->in(__DIR__)
-    ;
-
-    return Symfony\CS\Config\Config::create()
-        ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
-        ->fixers(array('trailing_spaces', 'encoding'))
+        ->setRules(array(
+            '@PSR2' => true,
+            'strict_param' => true,
+            'short_array_syntax' => true,
+        ))
         ->finder(\$finder)
     ;
 
     ?>
 
 You may also use a blacklist for the Fixers instead of the above shown whitelist approach.
-The following example shows how to use all ``symfony`` Fixers but the ``short_tag`` fixer.
-Note the additional <comment>-</comment> in front of the Fixer name.
+The following example shows how to use all ``Symfony`` Fixers but the ``short_tag`` Fixer.
 
     <?php
 
@@ -233,26 +214,14 @@ Note the additional <comment>-</comment> in front of the Fixer name.
     ;
 
     return Symfony\CS\Config\Config::create()
-        ->fixers(array('-short_tag'))
+        ->setRules(array(
+            '@Symfony' => true,
+            'short_tag' => false,
+        ))
         ->finder(\$finder)
     ;
 
     ?>
-
-The ``psr2`` level is set by default, you can also change the default level:
-
-    <?php
-
-    return Symfony\CS\Config\Config::create()
-        ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ;
-
-    ?>
-
-In combination with these config and command line options, you can choose various usage.
-
-For example, the default level is ``psr2``, but if you don't want to use
-the ``short_tag`` fixer, you can specify the ``--level=psr2 --fixers=-short_tag`` options.
 
 By using ``--using-cache`` option with yes or no you can set if the caching
 mechanism should be used.
@@ -334,8 +303,7 @@ EOF
                 'config' => $input->getOption('config'),
                 'config-file' => $input->getOption('config-file'),
                 'dry-run' => $input->getOption('dry-run'),
-                'level' => $input->getOption('level'),
-                'fixers' => $input->getOption('fixers'),
+                'rules' => $input->getOption('rules'),
                 'path' => $input->getArgument('path'),
                 'progress' => (OutputInterface::VERBOSITY_VERBOSE <= $verbosity) && 'txt' === $input->getOption('format'),
                 'using-cache' => $input->getOption('using-cache'),
@@ -586,16 +554,10 @@ EOF
         $fixerFactory = new FixerFactory();
         $fixers = $fixerFactory->registerBuiltInFixers()->getFixers();
 
-        // sort fixers by level and name
+        // sort fixers by name
         usort(
             $fixers,
             function (FixerInterface $a, FixerInterface $b) {
-                $cmp = Utils::cmpInt($a->getLevel(), $b->getLevel());
-
-                if (0 !== $cmp) {
-                    return $cmp;
-                }
-
                 return strcmp($a->getName(), $b->getName());
             }
         );
@@ -606,10 +568,35 @@ EOF
             }
         }
 
+        $ruleSets = array();
+        foreach (RuleSet::create()->getSetDefinitionNames() as $setName) {
+            $ruleSets[$setName] = new RuleSet(array($setName => true));
+        }
+
+        $getSetsWithRule = function ($rule) use ($ruleSets) {
+            $sets = array();
+
+            foreach ($ruleSets as $setName => $ruleSet) {
+                if ($ruleSet->hasRule($rule)) {
+                    $sets[] = $setName;
+                }
+            }
+
+            return $sets;
+        };
+
         $count = count($fixers) - 1;
         foreach ($fixers as $i => $fixer) {
-            $chunks = explode("\n", wordwrap(sprintf("[%s]\n%s", $this->fixer->getLevelAsString($fixer), $fixer->getDescription()), 72 - $maxName, "\n"));
-            $help .= sprintf(" * <comment>%s</comment>%s %s\n", $fixer->getName(), str_repeat(' ', $maxName - strlen($fixer->getName())), array_shift($chunks));
+            $sets = $getSetsWithRule($fixer->getName());
+
+            if (!empty($sets)) {
+                $chunks = explode("\n", wordwrap(sprintf("[%s]\n%s", implode(', ', $sets), $fixer->getDescription()), 72 - $maxName, "\n"));
+                $help .= sprintf(" * <comment>%s</comment>%s %s\n", $fixer->getName(), str_repeat(' ', $maxName - strlen($fixer->getName())), array_shift($chunks));
+            } else {
+                $chunks = explode("\n", wordwrap(sprintf("\n%s", $fixer->getDescription()), 72 - $maxName, "\n"));
+                $help .= sprintf(" * <comment>%s</comment>%s\n", $fixer->getName(), array_shift($chunks));
+            }
+
             while ($c = array_shift($chunks)) {
                 $help .= str_repeat(' ', $maxName + 4).$c."\n";
             }

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -25,6 +25,7 @@ use Symfony\CS\Console\Output\ProcessOutput;
 use Symfony\CS\Error\Error;
 use Symfony\CS\Error\ErrorsManager;
 use Symfony\CS\Fixer;
+use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Linter\Linter;
 use Symfony\CS\Linter\UnavailableLinterException;
@@ -85,7 +86,6 @@ final class FixCommand extends Command
         $this->eventDispatcher = new EventDispatcher();
 
         $this->fixer = $fixer ?: new Fixer();
-        $this->fixer->registerBuiltInFixers();
         $this->fixer->registerBuiltInConfigs();
 
         $this->errorsManager = $this->fixer->getErrorsManager();
@@ -351,8 +351,6 @@ EOF
             $output->writeln(sprintf('Loaded config from "%s"', $configFile));
         }
 
-        // register custom fixers from config
-        $this->fixer->registerCustomFixers($config->getCustomFixers());
         if ($config->usingLinter()) {
             try {
                 $this->fixer->setLinter(new Linter($config->getPhpExecutable()));
@@ -585,7 +583,8 @@ EOF
     {
         $help = '';
         $maxName = 0;
-        $fixers = $this->fixer->getFixers();
+        $fixerFactory = new FixerFactory();
+        $fixers = $fixerFactory->registerBuiltInFixers()->getFixers();
 
         // sort fixers by level and name
         usort(

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -187,7 +187,7 @@ implement ``FixerInterface``).
 Configs
 ~~~~~~~
 
-A *config* knows about the CS level and the files and directories that must be
+A *config* knows about the CS rules and the files and directories that must be
 scanned by the tool when run in the directory of your project. It is useful for
 projects that follow a well-known directory structures (like for Symfony
 projects for instance).

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -167,6 +167,7 @@ final class ConfigurationResolver
         $this->resolveCacheFile();
 
         $this->config->fixers($this->getFixers());
+        $this->config->setRules($this->getRules());
         $this->config->setUsingCache($this->usingCache);
         $this->config->setCacheFile($this->cacheFile);
 

--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -21,7 +21,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
  * File will be processed by PHP CS Fixer only if any of the following conditions is fulfilled:
  *  - cache is not available,
  *  - fixer version changed,
- *  - fixers list is changed,
+ *  - rules changed,
  *  - file is new,
  *  - file changed.
  *
@@ -33,25 +33,22 @@ final class FileCacheManager
 {
     private $cacheFile;
     private $isEnabled;
-    private $fixers;
+    private $rules;
     private $newHashes = array();
     private $oldHashes = array();
 
     /**
      * Create instance.
      *
-     * @param bool             $isEnabled is cache enabled
-     * @param string           $cacheFile cache file
-     * @param FixerInterface[] $fixers
+     * @param bool   $isEnabled is cache enabled
+     * @param string $cacheFile cache file
+     * @param array  $rules     array defining rules, format like one for ConfigInterface::setRules
      */
-    public function __construct($isEnabled, $cacheFile, array $fixers)
+    public function __construct($isEnabled, $cacheFile, array $rules)
     {
         $this->isEnabled = $isEnabled;
         $this->cacheFile = $cacheFile;
-        $this->fixers = array_map(function (FixerInterface $f) {
-            return $f->getName();
-        }, $fixers);
-        sort($this->fixers);
+        $this->rules = $rules;
 
         $this->readFromFile();
     }
@@ -106,13 +103,13 @@ final class FileCacheManager
         return $result;
     }
 
-    private function isCacheStale($cacheVersion, $fixers)
+    private function isCacheStale($cacheVersion, $rules)
     {
         if (!$this->isCacheAvailable()) {
             return true;
         }
 
-        return ToolInfo::getVersion() !== $cacheVersion || $this->fixers !== $fixers;
+        return ToolInfo::getVersion() !== $cacheVersion || $this->rules !== $rules;
     }
 
     private function readFromFile()
@@ -128,8 +125,12 @@ final class FileCacheManager
         $content = file_get_contents($this->cacheFile);
         $data = unserialize($content);
 
+        if (!isset($data['version']) || !isset($data['rules'])) {
+            return;
+        }
+
         // Set hashes only if the cache is fresh, otherwise we need to parse all files
-        if (!$this->isCacheStale($data['version'], $data['fixers'])) {
+        if (!$this->isCacheStale($data['version'], $data['rules'])) {
             $this->oldHashes = $data['hashes'];
         }
     }
@@ -143,7 +144,7 @@ final class FileCacheManager
         $data = serialize(
             array(
                 'version' => ToolInfo::getVersion(),
-                'fixers' => $this->fixers,
+                'rules' => $this->rules,
                 'hashes' => $this->newHashes,
             )
         );

--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -37,6 +37,13 @@ final class FileCacheManager
     private $newHashes = array();
     private $oldHashes = array();
 
+    /**
+     * Create instance.
+     *
+     * @param bool             $isEnabled is cache enabled
+     * @param string           $cacheFile cache file
+     * @param FixerInterface[] $fixers
+     */
     public function __construct($isEnabled, $cacheFile, array $fixers)
     {
         $this->isEnabled = $isEnabled;

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -136,7 +136,7 @@ class Fixer
         $fileCacheManager = new FileCacheManager(
             $config->usingCache(),
             $config->getCacheFile(),
-            $fixers
+            $config->getRules()
         );
 
         foreach ($config->getFinder() as $file) {

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -291,29 +291,6 @@ class Fixer
         return $file->getPathname();
     }
 
-    public function getLevelAsString(FixerInterface $fixer)
-    {
-        $level = $fixer->getLevel();
-
-        if (($level & FixerInterface::NONE_LEVEL) === $level) {
-            return 'none';
-        }
-
-        if (($level & FixerInterface::PSR1_LEVEL) === $level) {
-            return 'PSR-1';
-        }
-
-        if (($level & FixerInterface::PSR2_LEVEL) === $level) {
-            return 'PSR-2';
-        }
-
-        if (($level & FixerInterface::CONTRIB_LEVEL) === $level) {
-            return 'contrib';
-        }
-
-        return 'symfony';
-    }
-
     protected function stringDiff($old, $new)
     {
         $diff = $this->diff->diff($old, $new);

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -33,7 +33,6 @@ class Fixer
 {
     const VERSION = '2.0-DEV';
 
-    protected $fixers = array();
     protected $configs = array();
 
     /**
@@ -77,37 +76,6 @@ class Fixer
         $this->errorsManager = new ErrorsManager();
         $this->linter = new NullLinter();
         $this->stopwatch = new Stopwatch();
-    }
-
-    public function registerBuiltInFixers()
-    {
-        foreach (Finder::create()->files()->in(__DIR__.'/Fixer') as $file) {
-            $relativeNamespace = $file->getRelativePath();
-            $class = 'Symfony\\CS\\Fixer\\'.($relativeNamespace ? $relativeNamespace.'\\' : '').$file->getBasename('.php');
-            $this->addFixer(new $class());
-        }
-    }
-
-    public function registerCustomFixers($fixers)
-    {
-        foreach ($fixers as $fixer) {
-            $this->addFixer($fixer);
-        }
-    }
-
-    public function addFixer(FixerInterface $fixer)
-    {
-        $this->fixers[] = $fixer;
-    }
-
-    /**
-     * @return FixerInterface[]
-     */
-    public function getFixers()
-    {
-        $this->sortFixers();
-
-        return $this->fixers;
     }
 
     public function registerBuiltInConfigs()
@@ -160,15 +128,15 @@ class Fixer
      */
     public function fix(ConfigInterface $config, $dryRun = false, $diff = false)
     {
-        $fixers = $this->prepareFixers($config);
         $changed = array();
+        $fixers = $config->getFixers();
 
         $this->stopwatch->openSection();
 
         $fileCacheManager = new FileCacheManager(
             $config->usingCache(),
             $config->getCacheFile(),
-            $config->getFixers()
+            $fixers
         );
 
         foreach ($config->getFinder() as $file) {
@@ -369,26 +337,6 @@ class Fixer
         );
 
         return $diff;
-    }
-
-    private function sortFixers()
-    {
-        usort($this->fixers, function (FixerInterface $a, FixerInterface $b) {
-            return Utils::cmpInt($b->getPriority(), $a->getPriority());
-        });
-    }
-
-    private function prepareFixers(ConfigInterface $config)
-    {
-        $fixers = $config->getFixers();
-
-        foreach ($fixers as $fixer) {
-            if ($fixer instanceof ConfigAwareInterface) {
-                $fixer->setConfig($config);
-            }
-        }
-
-        return $fixers;
     }
 
     /**

--- a/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
@@ -33,8 +33,15 @@ final class PhpUnitConstructFixer extends AbstractFixer
         'assertNotSame' => 'fixAssertNegative',
     );
 
-    public function configure(array $usingMethods)
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $usingMethods = null)
     {
+        if (null === $usingMethods) {
+            return;
+        }
+
         foreach ($usingMethods as $method => $fix) {
             if (!isset($this->configuration[$method])) {
                 throw new \InvalidArgumentException();

--- a/Symfony/CS/Fixer/Contrib/PhpUnitStrictFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitStrictFixer.php
@@ -26,8 +26,15 @@ final class PhpUnitStrictFixer extends AbstractFixer
         'assertNotEquals' => 'assertNotSame',
     );
 
-    public function configure(array $usingMethods)
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $usingMethods = null)
     {
+        if (null === $usingMethods) {
+            return;
+        }
+
         foreach (array_keys($this->configuration) as $method) {
             if (!in_array($method, $usingMethods, true)) {
                 unset($this->configuration[$method]);

--- a/Symfony/CS/FixerFactory.php
+++ b/Symfony/CS/FixerFactory.php
@@ -139,14 +139,18 @@ final class FixerFactory
      */
     public function useRuleSet(RuleSetInterface $ruleSet)
     {
-        $names = array_keys($ruleSet->getRules());
+        $fixers = array();
 
-        $this->fixers = array_filter(
-            $this->fixers,
-            function ($fixer) use ($names) {
-                return in_array($fixer->getName(), $names, true);
+        foreach ($this->fixers as $fixer) {
+            $name = $fixer->getName();
+
+            if ($ruleSet->hasRule($name)) {
+                $fixer->configure($ruleSet->getRuleConfiguration($name));
+                $fixers[] = $fixer;
             }
-        );
+        }
+
+        $this->fixers = $fixers;
 
         return $this;
     }

--- a/Symfony/CS/FixerFactory.php
+++ b/Symfony/CS/FixerFactory.php
@@ -139,15 +139,22 @@ final class FixerFactory
      */
     public function useRuleSet(RuleSetInterface $ruleSet)
     {
-        $fixers = array();
+        $fixersByName = array();
 
         foreach ($this->fixers as $fixer) {
-            $name = $fixer->getName();
+            $fixersByName[$fixer->getName()] = $fixer;
+        }
 
-            if ($ruleSet->hasRule($name)) {
-                $fixer->configure($ruleSet->getRuleConfiguration($name));
-                $fixers[] = $fixer;
+        $fixers = array();
+
+        foreach (array_keys($ruleSet->getRules()) as $name) {
+            if (!array_key_exists($name, $fixersByName)) {
+                throw new \UnexpectedValueException(sprintf('Rule "%s" does not exist.', $name));
             }
+
+            $fixer = $fixersByName[$name];
+            $fixer->configure($ruleSet->getRuleConfiguration($name));
+            $fixers[] = $fixer;
         }
 
         $this->fixers = $fixers;

--- a/Symfony/CS/FixerFactory.php
+++ b/Symfony/CS/FixerFactory.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Class provides a way to create a group of fixers.
+ *
+ * Fixers may be registered (made the factory aware of them) by
+ * registering a custom fixer and default, built in fixers.
+ * Then, one can attach Config instance to fixer instances.
+ *
+ * Finally factory creates a ready to use group of fixers.
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class FixerFactory
+{
+    /**
+     * Fixers.
+     *
+     * @var FixerInterface[]
+     */
+    private $fixers = array();
+
+    /**
+     * Create instance.
+     *
+     * @return FixerFactory
+     */
+    public static function create()
+    {
+        return new self();
+    }
+
+    /**
+     * Attach config into all fixers that are aware of it.
+     *
+     * @param ConfigInterface $config
+     *
+     * @return $this
+     */
+    public function attachConfig(ConfigInterface $config)
+    {
+        foreach ($this->fixers as $fixer) {
+            if ($fixer instanceof ConfigAwareInterface) {
+                $fixer->setConfig($config);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get fixers.
+     *
+     * @return FixerInterface[]
+     */
+    public function getFixers()
+    {
+        $this->sortFixers();
+
+        return $this->fixers;
+    }
+
+    /**
+     * Register all built in fixers.
+     *
+     * @return $this
+     */
+    public function registerBuiltInFixers()
+    {
+        static $builtInFixers = null;
+
+        if (null === $builtInFixers) {
+            $builtInFixers = array();
+
+            foreach (Finder::create()->files()->in(__DIR__.'/Fixer') as $file) {
+                $relativeNamespace = $file->getRelativePath();
+                $builtInFixers[] = 'Symfony\\CS\\Fixer\\'.($relativeNamespace ? $relativeNamespace.'\\' : '').$file->getBasename('.php');
+            }
+        }
+
+        foreach ($builtInFixers as $class) {
+            $this->registerFixer(new $class());
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register fixers.
+     *
+     * @param FixerInterface[] $fixers
+     *
+     * @return $this
+     */
+    public function registerCustomFixers(array $fixers)
+    {
+        foreach ($fixers as $fixer) {
+            $this->registerFixer($fixer);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register fixer.
+     *
+     * @param FixerInterface $fixer
+     *
+     * @return $this
+     */
+    public function registerFixer(FixerInterface $fixer)
+    {
+        $this->fixers[] = $fixer;
+
+        return $this;
+    }
+
+    /**
+     * Sort fixers by their priorities.
+     *
+     * @return $this
+     */
+    private function sortFixers()
+    {
+        usort($this->fixers, function (FixerInterface $a, FixerInterface $b) {
+            return Utils::cmpInt($b->getPriority(), $a->getPriority());
+        });
+
+        return $this;
+    }
+}

--- a/Symfony/CS/FixerFactory.php
+++ b/Symfony/CS/FixerFactory.php
@@ -131,6 +131,27 @@ final class FixerFactory
     }
 
     /**
+     * Apply RuleSet on fixers to filter out all unwanted fixers.
+     *
+     * @param RuleSetInteface $ruleSet
+     *
+     * @return $this
+     */
+    public function useRuleSet(RuleSetInterface $ruleSet)
+    {
+        $names = array_keys($ruleSet->getRules());
+
+        $this->fixers = array_filter(
+            $this->fixers,
+            function ($fixer) use ($names) {
+                return in_array($fixer->getName(), $names, true);
+            }
+        );
+
+        return $this;
+    }
+
+    /**
      * Sort fixers by their priorities.
      *
      * @return $this

--- a/Symfony/CS/FixerInterface.php
+++ b/Symfony/CS/FixerInterface.php
@@ -19,6 +19,18 @@ use Symfony\CS\Tokenizer\Tokens;
 interface FixerInterface
 {
     /**
+     * Set configuration.
+     *
+     * Some fixers may have no configuration, then - simply pass null.
+     * Other ones may have configuration that will change behavior of fixer,
+     * eg `php_unit_strict` fixer allows to configure which methods should be fixed.
+     * Finally, some fixers need configuration to work, eg `header_comment`.
+     *
+     * @param array|null $configuration configuration depends on Fixer
+     */
+    public function configure(array $configuration = null);
+
+    /**
      * Check if the fixer is a candidate for given Tokens collection.
      *
      * Fixer is a candidate when the collection contains tokens that may be fixed

--- a/Symfony/CS/FixerInterface.php
+++ b/Symfony/CS/FixerInterface.php
@@ -18,12 +18,6 @@ use Symfony\CS\Tokenizer\Tokens;
  */
 interface FixerInterface
 {
-    const NONE_LEVEL = 0;
-    const PSR1_LEVEL = 3;
-    const PSR2_LEVEL = 7;
-    const SYMFONY_LEVEL = 15;
-    const CONTRIB_LEVEL = 32;
-
     /**
      * Check if the fixer is a candidate for given Tokens collection.
      *
@@ -55,17 +49,6 @@ interface FixerInterface
      * @return string The description of the fixer
      */
     public function getDescription();
-
-    /**
-     * Returns the level of CS standard.
-     *
-     * Can be one of:
-     *  - self::PSR1_LEVEL,
-     *  - self::PSR2_LEVEL,
-     *  - self::SYMFONY_LEVEL,
-     *  - self::CONTRIB_LEVEL.
-     */
-    public function getLevel();
 
     /**
      * Returns the name of the fixer.

--- a/Symfony/CS/RuleSet.php
+++ b/Symfony/CS/RuleSet.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+/**
+ * Set of rules to be used by fixer.
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class RuleSet implements RuleSetInterface
+{
+    private $setDefinitions = array(
+        '@PSR1' => array(
+            'encoding' => true,
+            'short_tag' => true,
+        ),
+        '@PSR2' => array(
+            '@PSR1' => true,
+            'braces' => true,
+            'elseif' => true,
+            'eof_ending' => true,
+            'function_call_space' => true,
+            'function_declaration' => true,
+            'indentation' => true,
+            'line_after_namespace' => true,
+            'linefeed' => true,
+            'lowercase_constants' => true,
+            'lowercase_keywords' => true,
+            'method_argument_space' => true,
+            'multiple_use' => true,
+            'parenthesis' => true,
+            'php_closing_tag' => true,
+            'single_line_after_imports' => true,
+            'trailing_spaces' => true,
+            'visibility' => true,
+        ),
+        '@Symfony' => array(
+            '@PSR2' => true,
+            'alias_functions' => true,
+            'blankline_after_open_tag' => true,
+            'concat_without_spaces' => true,
+            'double_arrow_multiline_whitespaces' => true,
+            'duplicate_semicolon' => true,
+            'empty_return' => true,
+            'extra_empty_lines' => true,
+            'include' => true,
+            'list_commas' => true,
+            'method_separation' => true,
+            'multiline_array_trailing_comma' => true,
+            'namespace_no_leading_whitespace' => true,
+            'new_with_braces' => true,
+            'no_blank_lines_after_class_opening' => true,
+            'no_empty_lines_after_phpdocs' => true,
+            'object_operator' => true,
+            'operators_spaces' => true,
+            'phpdoc_align' => true,
+            'phpdoc_indent' => true,
+            'phpdoc_inline_tag' => true,
+            'phpdoc_no_access' => true,
+            'phpdoc_no_empty_return' => true,
+            'phpdoc_no_package' => true,
+            'phpdoc_scalar' => true,
+            'phpdoc_separation' => true,
+            'phpdoc_short_description' => true,
+            'phpdoc_to_comment' => true,
+            'phpdoc_trim' => true,
+            'phpdoc_type_to_var' => true,
+            'phpdoc_var_without_name' => true,
+            'pre_increment' => true,
+            'remove_leading_slash_use' => true,
+            'remove_lines_between_uses' => true,
+            'return' => true,
+            'self_accessor' => true,
+            'single_array_no_trailing_comma' => true,
+            'single_blank_line_before_namespace' => true,
+            'single_quote' => true,
+            'spaces_before_semicolon' => true,
+            'spaces_cast' => true,
+            'standardize_not_equal' => true,
+            'ternary_spaces' => true,
+            'trim_array_spaces' => true,
+            'unalign_double_arrow' => true,
+            'unalign_equals' => true,
+            'unary_operators_spaces' => true,
+            'unused_use' => true,
+            'whitespacy_lines' => true,
+        ),
+    );
+
+    /**
+     * Set that was used to generate group of rules.
+     *
+     * The key is name of rule or set, value is bool if the rule/set should be used.
+     *
+     * @var array
+     */
+    private $set;
+
+    /**
+     * Group of rules generated from input set.
+     *
+     * The key is name of rule, value is bool if the rule/set should be used.
+     * The key must not point to any set.
+     *
+     * @var array
+     */
+    private $rules;
+
+    public function __construct(array $set = array())
+    {
+        $this->set = $set;
+        $this->resolveSet();
+    }
+
+    public static function create(array $set = array())
+    {
+        return new self($set);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasRule($rule)
+    {
+        return array_key_exists($rule, $this->rules);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules()
+    {
+        return $this->rules;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSetDefinitionNames()
+    {
+        return array_keys($this->setDefinitions);
+    }
+
+    /**
+     * Get definition of set.
+     *
+     * @param string $name name of set
+     *
+     * @return array
+     */
+    private function getSetDefinition($name)
+    {
+        if (!isset($this->setDefinitions[$name])) {
+            throw new \UnexpectedValueException(sprintf('Set "%s" does not exist.', $name));
+        }
+
+        return $this->setDefinitions[$name];
+    }
+
+    /**
+     * Resolve input set into group of rules.
+     *
+     * @return $this
+     */
+    private function resolveSet()
+    {
+        $rules = $this->set;
+        $hasSet = null;
+
+        // expand sets
+        do {
+            $hasSet = false;
+
+            $tmpRules = $rules;
+            $rules = array();
+
+            foreach ($tmpRules as $name => $value) {
+                if (!$hasSet && '@' === $name[0]) {
+                    $hasSet = true;
+                    $set = $this->getSetDefinition($name);
+
+                    foreach ($set as $nestedName => $nestedValue) {
+                        // if set value is falsy then disable all fixers in set, if not then get value from set item
+                        $rules[$nestedName] = $value ? $nestedValue : false;
+                    }
+
+                    continue;
+                }
+
+                $rules[$name] = $value;
+            }
+        } while ($hasSet);
+
+        // filter out all rules that are off
+        $rules = array_filter($rules);
+
+        $this->rules = $rules;
+
+        return $this;
+    }
+}

--- a/Symfony/CS/RuleSet.php
+++ b/Symfony/CS/RuleSet.php
@@ -139,6 +139,22 @@ final class RuleSet implements RuleSetInterface
     /**
      * {@inheritdoc}
      */
+    public function getRuleConfiguration($rule)
+    {
+        if (!$this->hasRule($rule)) {
+            throw new \UnexpectedValueException(sprintf('Rule "%s" is not in the set.', $rule));
+        }
+
+        if ($this->rules[$rule] === true) {
+            return;
+        }
+
+        return $this->rules[$rule];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRules()
     {
         return $this->rules;

--- a/Symfony/CS/RuleSetInterface.php
+++ b/Symfony/CS/RuleSetInterface.php
@@ -34,6 +34,15 @@ interface RuleSetInterface
     public function hasRule($rule);
 
     /**
+     * Get configuration for given rule.
+     *
+     * @param string $rule name of rule
+     *
+     * @return array|null
+     */
+    public function getRuleConfiguration($rule);
+
+    /**
      * Get all rules from rules set.
      *
      * @return array

--- a/Symfony/CS/RuleSetInterface.php
+++ b/Symfony/CS/RuleSetInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+/**
+ * Set of rules to be used by fixer.
+ *
+ * Example of set: ["@PSR2" => true, "@PSR1" => false, "strict" => true].
+ *
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ */
+interface RuleSetInterface
+{
+    public function __construct(array $set = array());
+
+    public static function create(array $set = array());
+
+    /**
+     * Check given rule is in rules set.
+     *
+     * @param string $rule name of rule
+     *
+     * @return bool
+     */
+    public function hasRule($rule);
+
+    /**
+     * Get all rules from rules set.
+     *
+     * @return array
+     */
+    public function getRules();
+
+    /**
+     * Get names of all set definitions.
+     *
+     * @return string[]
+     */
+    public function getSetDefinitionNames();
+}

--- a/Symfony/CS/Tests/AbstractFixerTest.php
+++ b/Symfony/CS/Tests/AbstractFixerTest.php
@@ -18,16 +18,6 @@ namespace Symfony\CS\Tests;
  */
 final class AbstractFixerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage Can not determine Fixer level
-     */
-    public function testLevelThatNotExists()
-    {
-        $mockup = $this->getMockForAbstractClass('\\Symfony\\CS\\AbstractFixer');
-        $mockup->getLevel();
-    }
-
     public function testSupports()
     {
         $mockup = $this->getMockForAbstractClass('\\Symfony\\CS\\AbstractFixer');

--- a/Symfony/CS/Tests/AbstractIntegrationTest.php
+++ b/Symfony/CS/Tests/AbstractIntegrationTest.php
@@ -18,6 +18,7 @@ use Symfony\CS\FileCacheManager;
 use Symfony\CS\Fixer;
 use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
+use Symfony\CS\RuleSet;
 
 /**
  * Integration test base class.
@@ -30,17 +31,13 @@ use Symfony\CS\FixerInterface;
  * --TEST--
  * Example test description
  * --CONFIG--
- * level=symfony|none|psr0|psr1|psr2|symfony
- * fixers=fixer1,fixer2,...*
- * --fixers=fixer3,fixer4,...**
+ * {"@PSR2": true, "strict": true}
  * --INPUT--
  * Code to fix
  * --EXPECT--
- * Expected code after fixing***
+ * Expected code after fixing*
  *
- *   * Additional fixers may be omitted.
- *  ** Black listed filters may be omitted.
- * *** When the expected block is omitted the input is expected not to
+ * * When the expected block is omitted the input is expected not to
  *     be changed by the fixers.
  *
  * @author SpacePossum <possumfromspace@gmail.com>
@@ -49,8 +46,6 @@ use Symfony\CS\FixerInterface;
  */
 abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
 {
-    private static $builtInFixers;
-
     public static function setUpBeforeClass()
     {
         $tmpFile = static::getTempFile();
@@ -180,6 +175,16 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Create fixer factory with all needed fixers registered.
+     *
+     * @return FixerFactory
+     */
+    protected function createFixerFactory()
+    {
+        return FixerFactory::create()->registerBuiltInFixers();
+    }
+
+    /**
      * Parses the '--CONFIG--' block of a '.test' file and determines what fixers should be used.
      *
      * @param string $fileName
@@ -189,97 +194,16 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
      */
     protected function getFixersFromConfig($fileName, $config)
     {
-        static $levelMap = array(
-            'none' => FixerInterface::NONE_LEVEL,
-            'psr1' => FixerInterface::PSR1_LEVEL,
-            'psr2' => FixerInterface::PSR2_LEVEL,
-            'symfony' => FixerInterface::SYMFONY_LEVEL,
-        );
+        $ruleSet = json_decode($config, true);
 
-        $lines = explode("\n", $config);
-        if (count($lines) < 1) {
-            throw new \InvalidArgumentException(sprintf('No configuration options found in "%s".', $fileName));
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new \InvalidArgumentException(sprintf('Malformed JSON configuration "%s".', $fileName));
         }
 
-        $config = array('level' => null, 'fixers' => array(), '--fixers' => array());
-
-        foreach ($lines as $line) {
-            $labelValuePair = explode('=', $line);
-            if (2 !== count($labelValuePair)) {
-                throw new \InvalidArgumentException(sprintf('Invalid configuration line "%s" in "%s".', $line, $fileName));
-            }
-
-            $label = strtolower(trim($labelValuePair[0]));
-            $value = trim($labelValuePair[1]);
-
-            switch ($label) {
-                case 'level':
-                    if (!array_key_exists($value, $levelMap)) {
-                        throw new \InvalidArgumentException(sprintf('Unknown level "%s" set in configuration in "%s", expected any of "%s".', $value, $fileName, implode(', ', array_keys($levelMap))));
-                    }
-
-                    if (null !== $config['level']) {
-                        throw new \InvalidArgumentException(sprintf('Cannot use multiple levels in configuration in "%s".', $fileName));
-                    }
-
-                    $config['level'] = $value;
-                    break;
-                case 'fixers':
-                case '--fixers':
-                    foreach (explode(',', $value) as $fixer) {
-                        $config[$label][] = strtolower(trim($fixer));
-                    }
-
-                    break;
-                default:
-                    throw new \InvalidArgumentException(sprintf('Unknown configuration item "%s" in "%s".', $label, $fileName));
-            }
-        }
-
-        if (null === $config['level']) {
-            throw new \InvalidArgumentException(sprintf('Level not set in configuration "%s".', $fileName));
-        }
-
-        if (null === self::$builtInFixers) {
-            $fixer = new FixerFactory();
-            $fixer->registerBuiltInFixers();
-            self::$builtInFixers = $fixer->getFixers();
-        }
-
-        $fixers = array();
-        for ($i = count(self::$builtInFixers) - 1; $i >= 0; --$i) {
-            $fixer = self::$builtInFixers[$i];
-            $fixerName = $fixer->getName();
-            if ('psr0' === $fixer->getName()) {
-                // File based fixer won't work
-                continue;
-            }
-
-            if ($fixer->getLevel() !== ($fixer->getLevel() & $levelMap[$config['level']])) {
-                if (false !== $key = array_search($fixerName, $config['fixers'], true)) {
-                    $fixers[] = $fixer;
-                    unset($config['fixers'][$key]);
-                }
-                continue;
-            }
-
-            if (false !== $key = array_search($fixerName, $config['--fixers'], true)) {
-                unset($config['--fixers'][$key]);
-                continue;
-            }
-
-            if (in_array($fixerName, $config['fixers'], true)) {
-                throw new \InvalidArgumentException(sprintf('Additional fixer "%s" configured, but is already part of the level.', $fixerName));
-            }
-
-            $fixers[] = $fixer;
-        }
-
-        if (!empty($config['fixers']) || !empty($config['--fixers'])) {
-            throw new \InvalidArgumentException(sprintf('Unknown fixers in configuration "%s".', implode(',', empty($config['fixers']) ? $config['--fixers'] : $config['fixers'])));
-        }
-
-        return $fixers;
+        return $this->createFixerFactory()
+            ->useRuleSet(new RuleSet($ruleSet))
+            ->getFixers()
+        ;
     }
 
     /**

--- a/Symfony/CS/Tests/AbstractIntegrationTest.php
+++ b/Symfony/CS/Tests/AbstractIntegrationTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\CS\Error\Error;
 use Symfony\CS\FileCacheManager;
 use Symfony\CS\Fixer;
+use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
 
 /**
@@ -240,7 +241,7 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null === self::$builtInFixers) {
-            $fixer = new Fixer();
+            $fixer = new FixerFactory();
             $fixer->registerBuiltInFixers();
             self::$builtInFixers = $fixer->getFixers();
         }

--- a/Symfony/CS/Tests/Console/Command/FixCommandTest.php
+++ b/Symfony/CS/Tests/Console/Command/FixCommandTest.php
@@ -297,12 +297,6 @@ final class FixCommandTest extends \PHPUnit_Framework_TestCase
 
         $fixer
             ->expects($this->any())
-            ->method('getFixers')
-            ->willReturn(array())
-        ;
-
-        $fixer
-            ->expects($this->any())
             ->method('getStopwatch')
             ->willReturn(new Stopwatch())
         ;

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -14,7 +14,6 @@ namespace Symfony\CS\Tests\Console;
 use Symfony\CS\Config\Config;
 use Symfony\CS\Console\ConfigurationResolver;
 use Symfony\CS\Fixer;
-use Symfony\CS\FixerInterface;
 
 /**
  * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
@@ -26,7 +25,6 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 {
     protected $config;
     protected $resolver;
-    protected $fixersMap;
 
     protected function setUp()
     {
@@ -39,26 +37,11 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ->setDefaultConfig($this->config)
             ->setFixer($fixer)
         ;
-
-        $fixersMap = array();
-
-        foreach ($this->resolver->getFixerFactory()->getFixers() as $singleFixer) {
-            $level = $singleFixer->getLevel();
-
-            if (!isset($fixersMap[$level])) {
-                $fixersMap[$level] = array();
-            }
-
-            $fixersMap[$level][$singleFixer->getName()] = $singleFixer;
-        }
-
-        $this->fixersMap = $fixersMap;
     }
 
     protected function tearDown()
     {
         unset(
-            $this->fixersMap,
             $this->config,
             $this->resolver
         );
@@ -125,178 +108,6 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolveFixersReturnsEmptyArrayByDefault()
     {
         $this->makeFixersTest(array(), $this->resolver->getFixers());
-    }
-
-    public function testResolveFixersWithLevelConfig()
-    {
-        $this->config->level(FixerInterface::PSR2_LEVEL);
-
-        $this->resolver->resolve();
-
-        $this->makeFixersTest(
-            array_merge($this->fixersMap[FixerInterface::PSR1_LEVEL], $this->fixersMap[FixerInterface::PSR2_LEVEL]),
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithPositiveFixersConfig()
-    {
-        $this->config->level(FixerInterface::SYMFONY_LEVEL);
-        $this->config->fixers(array('strict', 'strict_param'));
-
-        $this->resolver->resolve();
-
-        $expectedFixers = array_merge(
-            $this->fixersMap[FixerInterface::PSR1_LEVEL],
-            $this->fixersMap[FixerInterface::PSR2_LEVEL],
-            $this->fixersMap[FixerInterface::SYMFONY_LEVEL],
-            array($this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'], $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'])
-        );
-
-        $this->makeFixersTest(
-            $expectedFixers,
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithNegativeFixersConfig()
-    {
-        $this->config->level(FixerInterface::SYMFONY_LEVEL);
-        $this->config->fixers(array('strict', '-include', 'strict_param'));
-
-        $this->resolver->resolve();
-
-        $expectedFixers = array_merge(
-            $this->fixersMap[FixerInterface::PSR1_LEVEL],
-            $this->fixersMap[FixerInterface::PSR2_LEVEL],
-            $this->fixersMap[FixerInterface::SYMFONY_LEVEL],
-            array($this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'], $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'])
-        );
-
-        foreach ($expectedFixers as $key => $fixer) {
-            if ('include' === $fixer->getName()) {
-                unset($expectedFixers[$key]);
-                break;
-            }
-        }
-
-        $this->makeFixersTest(
-            $expectedFixers,
-            $this->resolver->getFixers()
-        );
-    }
-
-    /**
-     * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /The level "foo" is not defined./
-     */
-    public function testResolveFixersWithInvalidLevelOption()
-    {
-        $this->resolver
-            ->setOption('level', 'foo')
-            ->resolve()
-        ;
-    }
-
-    public function testResolveFixersWithLevelOption()
-    {
-        $this->resolver
-            ->setOption('level', 'psr2')
-            ->resolve()
-        ;
-
-        $this->makeFixersTest(
-            array_merge($this->fixersMap[FixerInterface::PSR1_LEVEL], $this->fixersMap[FixerInterface::PSR2_LEVEL]),
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithLevelConfigAndFixersConfigAndLevelOption()
-    {
-        $this->config
-            ->level(FixerInterface::SYMFONY_LEVEL)
-            ->fixers(array('strict'))
-        ;
-        $this->resolver
-            ->setOption('level', 'psr2')
-            ->resolve()
-        ;
-
-        $this->makeFixersTest(
-            array_merge($this->fixersMap[FixerInterface::PSR1_LEVEL], $this->fixersMap[FixerInterface::PSR2_LEVEL]),
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithLevelConfigAndFixersConfigAndPositiveFixersOption()
-    {
-        $this->config
-            ->level(FixerInterface::PSR2_LEVEL)
-            ->fixers(array('strict'))
-        ;
-        $this->resolver
-            ->setOption('fixers', 'short_tag')
-            ->resolve()
-        ;
-
-        $this->makeFixersTest(
-            array($this->fixersMap[FixerInterface::PSR1_LEVEL]['short_tag']),
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithLevelConfigAndFixersConfigAndNegativeFixersOption()
-    {
-        $this->config
-            ->level(FixerInterface::SYMFONY_LEVEL)
-            ->fixers(array('strict'))
-        ;
-        $this->resolver
-            ->setOption('fixers', 'strict, -include,strict_param ')
-            ->resolve()
-        ;
-
-        $expectedFixers = array(
-            $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'],
-            $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'],
-        );
-
-        $this->makeFixersTest(
-            $expectedFixers,
-            $this->resolver->getFixers()
-        );
-    }
-
-    public function testResolveFixersWithLevelConfigAndFixersConfigAndLevelOptionsAndFixersOption()
-    {
-        $this->config
-            ->level(FixerInterface::PSR2_LEVEL)
-            ->fixers(array('concat_with_spaces'))
-        ;
-        $this->resolver
-            ->setOption('level', 'symfony')
-            ->setOption('fixers', 'strict, -include,strict_param ')
-            ->resolve()
-        ;
-
-        $expectedFixers = array_merge(
-            $this->fixersMap[FixerInterface::PSR1_LEVEL],
-            $this->fixersMap[FixerInterface::PSR2_LEVEL],
-            $this->fixersMap[FixerInterface::SYMFONY_LEVEL],
-            array($this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'], $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'])
-        );
-
-        foreach ($expectedFixers as $key => $fixer) {
-            if ($fixer->getName() === 'include') {
-                unset($expectedFixers[$key]);
-                break;
-            }
-        }
-
-        $this->makeFixersTest(
-            $expectedFixers,
-            $this->resolver->getFixers()
-        );
     }
 
     public function testResolveProgressWithPositiveConfigAndPositiveOption()
@@ -598,5 +409,63 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->resolver->resolve();
 
         $this->assertSame($optionCacheFile, $this->config->getCacheFile());
+    }
+
+    public function testResolveRulesWithConfig()
+    {
+        $this->config->setRules(array(
+            'braces' => true,
+            'strict' => false,
+        ));
+
+        $this->resolver->resolve();
+
+        $this->assertSameRules(
+            array(
+                'braces' => true,
+            ),
+            $this->resolver->getRules()
+        );
+    }
+
+    public function testResolveRulesWithOption()
+    {
+        $this->resolver->setOption('rules', 'braces,-strict');
+
+        $this->resolver->resolve();
+
+        $this->assertSameRules(
+            array(
+                'braces' => true,
+            ),
+            $this->resolver->getRules()
+        );
+    }
+
+    public function testResolveRulesWithConfigAndOption()
+    {
+        $this->config->setRules(array(
+            'braces' => true,
+            'strict' => false,
+        ));
+
+        $this->resolver->setOption('rules', 'return');
+
+        $this->resolver->resolve();
+
+        $this->assertSameRules(
+            array(
+                'return' => true,
+            ),
+            $this->resolver->getRules()
+        );
+    }
+
+    private function assertSameRules(array $expected, array $actual, $message = '')
+    {
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertSame($expected, $actual, $message);
     }
 }

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -31,12 +31,18 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $fixer = new Fixer();
-        $fixer->registerBuiltInFixers();
         $fixer->registerBuiltInConfigs();
+
+        $this->config = new Config();
+        $this->resolver = new ConfigurationResolver();
+        $this->resolver
+            ->setDefaultConfig($this->config)
+            ->setFixer($fixer)
+        ;
 
         $fixersMap = array();
 
-        foreach ($fixer->getFixers() as $singleFixer) {
+        foreach ($this->resolver->getFixerFactory()->getFixers() as $singleFixer) {
             $level = $singleFixer->getLevel();
 
             if (!isset($fixersMap[$level])) {
@@ -47,13 +53,6 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->fixersMap = $fixersMap;
-
-        $this->config = new Config();
-        $this->resolver = new ConfigurationResolver();
-        $this->resolver
-            ->setDefaultConfig($this->config)
-            ->setFixer($fixer)
-        ;
     }
 
     protected function tearDown()

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -25,7 +25,15 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
     {
         $name = 'Symfony\CS\Fixer'.substr(get_called_class(), strlen(__NAMESPACE__), -strlen('Test'));
 
-        return new $name();
+        $fixer = new $name();
+        $fixer->configure($this->getFixerConfiguration());
+
+        return $fixer;
+    }
+
+    protected function getFixerConfiguration()
+    {
+        return;
     }
 
     protected function getTestFile($filename = __FILE__)

--- a/Symfony/CS/Tests/Fixer/Contrib/HeaderCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/HeaderCommentFixerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\CS\Tests\Fixer\Contrib;
 
-use Symfony\CS\Fixer\Contrib\HeaderCommentFixer;
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
@@ -19,7 +18,6 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
  */
 final class HeaderCommentFixerTest extends AbstractFixerTestBase
 {
-    protected static $savedHeader;
     protected static $testHeader = <<<EOH
 This file is part of the PHP CS utility.
 
@@ -29,17 +27,9 @@ This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 EOH;
 
-    protected function setUp()
+    protected function getFixerConfiguration()
     {
-        parent::setUp();
-        self::$savedHeader = HeaderCommentFixer::getHeader();
-        HeaderCommentFixer::setHeader(self::$testHeader);
-    }
-
-    protected function tearDown()
-    {
-        HeaderCommentFixer::setHeader(self::$savedHeader);
-        parent::tearDown();
+        return array('header' => self::$testHeader);
     }
 
     public function testFixWithPreviousHeader()
@@ -137,7 +127,6 @@ EOH;
 
     public function testFixRemovePreviousHeader()
     {
-        HeaderCommentFixer::setHeader('');
         $expected = <<<'EOH'
 <?php
 
@@ -159,7 +148,10 @@ EOH;
 phpinfo();
 EOH;
 
-        $this->makeTest($expected, $input);
+        $fixer = $this->getFixer();
+        $fixer->configure(array('header' => ''));
+
+        $this->makeTest($expected, $input, null, $fixer);
     }
 
     public function testFixDoNotTouchFilesWithSeveralOpenTags()

--- a/Symfony/CS/Tests/FixerFactoryTest.php
+++ b/Symfony/CS/Tests/FixerFactoryTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+use Symfony\CS\Fixer\Contrib\Psr0Fixer;
+use Symfony\CS\FixerFactory;
+use Symfony\CS\FixerInterface;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInterfaceIsFluent()
+    {
+        $factory = new FixerFactory();
+
+        $testInstance = $factory->registerBuiltInFixers();
+        $this->assertSame($factory, $testInstance);
+
+        $mocks = array($this->getMock('Symfony\CS\FixerInterface'), $this->getMock('Symfony\CS\FixerInterface'));
+        $testInstance = $factory->registerCustomFixers($mocks);
+        $this->assertSame($factory, $testInstance);
+
+        $mock = $this->getMock('Symfony\CS\FixerInterface');
+        $testInstance = $factory->registerFixer($mock);
+        $this->assertSame($factory, $testInstance);
+
+        $mock = $this->getMock('Symfony\CS\ConfigInterface');
+        $testInstance = $factory->attachConfig($mock);
+        $this->assertSame($factory, $testInstance);
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::create
+     */
+    public function testCreate()
+    {
+        $factory = FixerFactory::create();
+
+        $this->assertInstanceOf('Symfony\CS\FixerFactory', $factory);
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::registerBuiltInFixers
+     */
+    public function testRegisterBuiltInFixers()
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+
+        $this->assertGreaterThan(0, count($factory->getFixers()));
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::attachConfig
+     */
+    public function testMethodAttachConfig()
+    {
+        $factory = new FixerFactory();
+
+        $fixer = new Psr0Fixer();
+        $factory->registerFixer($fixer);
+
+        $mock = $this->getMock('Symfony\CS\ConfigInterface');
+        $testInstance = $factory->attachConfig($mock);
+
+        $classReflection = new \ReflectionClass($fixer);
+        $propertyReflection = $classReflection->getProperty('config');
+        $propertyReflection->setAccessible(true);
+        $property = $propertyReflection->getValue($fixer);
+
+        $this->assertSame($mock, $property);
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::getFixers
+     * @covers Symfony\CS\FixerFactory::sortFixers
+     */
+    public function testThatFixersAreSorted()
+    {
+        $factory = new FixerFactory();
+
+        $fxPrototypes = array(
+            array('getPriority' => 0),
+            array('getPriority' => -10),
+            array('getPriority' => 10),
+            array('getPriority' => -10),
+        );
+
+        $fxs = array();
+
+        foreach ($fxPrototypes as $fxPrototype) {
+            $fx = $this->getMock('Symfony\CS\FixerInterface');
+            $fx->expects($this->any())->method('getPriority')->willReturn($fxPrototype['getPriority']);
+
+            $factory->registerFixer($fx);
+            $fxs[] = $fx;
+        }
+
+        // There are no rules that forces $fxs[1] to be prioritized before $fxs[3]. We should not test against that
+        $this->assertSame(array($fxs[2], $fxs[0]), array_slice($factory->getFixers(), 0, 2));
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::getFixers
+     * @covers Symfony\CS\FixerFactory::registerCustomFixers
+     * @covers Symfony\CS\FixerFactory::registerFixer
+     */
+    public function testThatCanRegisterAndGetFixers()
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+
+        $f1 = $this->getMock('Symfony\CS\FixerInterface');
+        $f2 = $this->getMock('Symfony\CS\FixerInterface');
+        $f3 = $this->getMock('Symfony\CS\FixerInterface');
+        $factory->registerFixer($f1);
+        $factory->registerCustomFixers(array($f2, $f3));
+
+        $this->assertTrue(in_array($f1, $factory->getFixers(), true));
+        $this->assertTrue(in_array($f2, $factory->getFixers(), true));
+        $this->assertTrue(in_array($f3, $factory->getFixers(), true));
+    }
+
+    public function testFixersPriorityEdgeFixers()
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+        $fixers = $factory->getFixers();
+
+        $this->assertSame('encoding', $fixers[0]->getName());
+        $this->assertSame('eof_ending', $fixers[count($fixers) - 1]->getName());
+    }
+
+    /**
+     * @dataProvider getFixersPriorityCases
+     */
+    public function testFixersPriority(FixerInterface $first, FixerInterface $second)
+    {
+        $this->assertLessThan($first->getPriority(), $second->getPriority());
+    }
+
+    public function getFixersPriorityCases()
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+
+        $fixers = array();
+
+        foreach ($factory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        $cases = array(
+            array($fixers['php_closing_tag'], $fixers['short_tag']),
+            array($fixers['unused_use'], $fixers['extra_empty_lines']),
+            array($fixers['multiple_use'], $fixers['unused_use']),
+            array($fixers['multiple_use'], $fixers['ordered_use']),
+            array($fixers['remove_lines_between_uses'], $fixers['ordered_use']),
+            array($fixers['unused_use'], $fixers['remove_leading_slash_use']),
+            array($fixers['multiple_use'], $fixers['remove_leading_slash_use']),
+            array($fixers['concat_without_spaces'], $fixers['concat_with_spaces']),
+            array($fixers['elseif'], $fixers['braces']),
+            array($fixers['duplicate_semicolon'], $fixers['braces']),
+            array($fixers['duplicate_semicolon'], $fixers['spaces_before_semicolon']),
+            array($fixers['duplicate_semicolon'], $fixers['multiline_spaces_before_semicolon']),
+            array($fixers['standardize_not_equal'], $fixers['strict']),
+            array($fixers['double_arrow_multiline_whitespaces'], $fixers['multiline_array_trailing_comma']),
+            array($fixers['double_arrow_multiline_whitespaces'], $fixers['align_double_arrow']),
+            array($fixers['indentation'], $fixers['phpdoc_indent']),
+            array($fixers['phpdoc_order'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_access'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_access'], $fixers['phpdoc_order']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_order']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_separation']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_order']),
+            array($fixers['phpdoc_no_access'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_no_package'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_separation'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_short_description'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
+            array($fixers['unused_use'], $fixers['line_after_namespace']),
+            array($fixers['linefeed'], $fixers['eof_ending']),
+            array($fixers['php_unit_strict'], $fixers['php_unit_construct']),
+            array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_spaces']),
+            array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_successor_space']),
+            array($fixers['method_separation'], $fixers['braces']),
+            array($fixers['method_separation'], $fixers['indentation']),
+        );
+
+        // prepare bulk tests for phpdoc fixers to test that:
+        // * `phpdoc_to_comment` is first
+        // * `phpdoc_indent` is second
+        // * `phpdoc_types` is third
+        // * `phpdoc_scalar` is fourth
+        // * `phpdoc_align` is last
+        $cases[] = array($fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']);
+        $cases[] = array($fixers['phpdoc_indent'], $fixers['phpdoc_types']);
+        $cases[] = array($fixers['phpdoc_types'], $fixers['phpdoc_scalar']);
+
+        $docFixerNames = array_filter(
+            array_keys($fixers),
+            function ($name) {
+                return false !== strpos($name, 'phpdoc');
+            }
+        );
+
+        foreach ($docFixerNames as $docFixerName) {
+            if (!in_array($docFixerName, array('phpdoc_to_comment', 'phpdoc_indent', 'phpdoc_types', 'phpdoc_scalar'), true)) {
+                $cases[] = array($fixers['phpdoc_to_comment'], $fixers[$docFixerName]);
+                $cases[] = array($fixers['phpdoc_indent'], $fixers[$docFixerName]);
+                $cases[] = array($fixers['phpdoc_types'], $fixers[$docFixerName]);
+                $cases[] = array($fixers['phpdoc_scalar'], $fixers[$docFixerName]);
+            }
+
+            if ('phpdoc_align' !== $docFixerName) {
+                $cases[] = array($fixers[$docFixerName], $fixers['phpdoc_align']);
+            }
+        }
+
+        return $cases;
+    }
+}

--- a/Symfony/CS/Tests/FixerFactoryTest.php
+++ b/Symfony/CS/Tests/FixerFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\CS\Tests;
 use Symfony\CS\Fixer\Contrib\Psr0Fixer;
 use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
+use Symfony\CS\RuleSet;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -35,6 +36,11 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
 
         $mock = $this->getMock('Symfony\CS\FixerInterface');
         $testInstance = $factory->registerFixer($mock);
+        $this->assertSame($factory, $testInstance);
+
+        $mock = $this->getMock('Symfony\CS\RuleSetInterface');
+        $mock->expects($this->any())->method('getRules')->willReturn(array());
+        $testInstance = $factory->useRuleSet($mock);
         $this->assertSame($factory, $testInstance);
 
         $mock = $this->getMock('Symfony\CS\ConfigInterface');
@@ -132,6 +138,26 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(in_array($f1, $factory->getFixers(), true));
         $this->assertTrue(in_array($f2, $factory->getFixers(), true));
         $this->assertTrue(in_array($f3, $factory->getFixers(), true));
+    }
+
+    /**
+     * @covers Symfony\CS\FixerFactory::useRuleSet
+     */
+    public function testUseRuleSet()
+    {
+        $factory = FixerFactory::create()
+            ->registerBuiltInFixers()
+            ->useRuleSet(new RuleSet(array()))
+        ;
+        $this->assertCount(0, $factory->getFixers());
+
+        $factory = FixerFactory::create()
+            ->registerBuiltInFixers()
+            ->useRuleSet(new RuleSet(array('strict' => true, 'return' => false)))
+        ;
+        $fixers = $factory->getFixers();
+        $this->assertCount(1, $fixers);
+        $this->assertSame('strict', $fixers[0]->getName());
     }
 
     public function testFixersPriorityEdgeFixers()

--- a/Symfony/CS/Tests/FixerFactoryTest.php
+++ b/Symfony/CS/Tests/FixerFactoryTest.php
@@ -160,6 +160,22 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('strict', $fixers[0]->getName());
     }
 
+    /**
+     * @covers Symfony\CS\FixerFactory::useRuleSet
+     * @expectedException        \UnexpectedValueException
+     * @expectedExceptionMessage Rule "non_existing_rule" does not exist.
+     */
+    public function testUseRuleSetWithNonExistingRule()
+    {
+        $factory = FixerFactory::create()
+            ->registerBuiltInFixers()
+            ->useRuleSet(new RuleSet(array('non_existing_rule' => true)))
+        ;
+        $fixers = $factory->getFixers();
+        $this->assertCount(1, $fixers);
+        $this->assertSame('strict', $fixers[0]->getName());
+    }
+
     public function testFixersPriorityEdgeFixers()
     {
         $factory = new FixerFactory();

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -140,6 +140,12 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
 
         $config
             ->expects($this->any())
+            ->method('getRules')
+            ->willReturn(array())
+        ;
+
+        $config
+            ->expects($this->any())
             ->method('getFinder')
             ->willReturn(array())
         ;

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\CS\Tests;
 use Symfony\CS\Config\Config;
 use Symfony\CS\Error\Error;
 use Symfony\CS\Fixer;
+use Symfony\CS\FixerFactory;
 use Symfony\CS\FixerInterface;
 use Symfony\CS\Linter\Linter;
 
@@ -23,72 +24,15 @@ use Symfony\CS\Linter\Linter;
 final class FixerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Symfony\CS\Fixer::sortFixers
-     */
-    public function testThatFixersAreSorted()
-    {
-        $fixer = new Fixer();
-
-        $fxPrototypes = array(
-            array('getPriority' => 0),
-            array('getPriority' => -10),
-            array('getPriority' => 10),
-            array('getPriority' => -10),
-        );
-
-        $fxs = array();
-
-        foreach ($fxPrototypes as $fxPrototype) {
-            $fx = $this->getMock('Symfony\CS\FixerInterface');
-            $fx->expects($this->any())->method('getPriority')->willReturn($fxPrototype['getPriority']);
-
-            $fixer->addFixer($fx);
-            $fxs[] = $fx;
-        }
-
-        // There are no rules that forces $fxs[1] to be prioritized before $fxs[3]. We should not test against that
-        $this->assertSame(array($fxs[2], $fxs[0]), array_slice($fixer->getFixers(), 0, 2));
-    }
-
-    /**
-     * @covers Symfony\CS\Fixer::registerBuiltInFixers
-     */
-    public function testThatRegisterBuiltInFixers()
-    {
-        $fixer = new Fixer();
-
-        $this->assertCount(0, $fixer->getFixers());
-        $fixer->registerBuiltInFixers();
-        $this->assertGreaterThan(0, count($fixer->getFixers()));
-    }
-
-    /**
      * @covers Symfony\CS\Fixer::registerBuiltInConfigs
      */
-    public function testThatRegisterBuiltInConfigs()
+    public function testRegisterBuiltInConfigs()
     {
         $fixer = new Fixer();
 
         $this->assertCount(0, $fixer->getConfigs());
         $fixer->registerBuiltInConfigs();
         $this->assertGreaterThan(0, count($fixer->getConfigs()));
-    }
-
-    /**
-     * @covers Symfony\CS\Fixer::addFixer
-     * @covers Symfony\CS\Fixer::getFixers
-     */
-    public function testThatCanAddAndGetFixers()
-    {
-        $fixer = new Fixer();
-
-        $f1 = $this->getMock('Symfony\CS\FixerInterface');
-        $f2 = $this->getMock('Symfony\CS\FixerInterface');
-        $fixer->addFixer($f1);
-        $fixer->addFixer($f2);
-
-        $this->assertTrue(in_array($f1, $fixer->getFixers(), true));
-        $this->assertTrue(in_array($f2, $fixer->getFixers(), true));
     }
 
     /**
@@ -110,17 +54,18 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\CS\Fixer::fix
      * @covers Symfony\CS\Fixer::fixFile
-     * @covers Symfony\CS\Fixer::prepareFixers
      */
     public function testThatFixSuccessfully()
     {
         $fixer = new Fixer();
-        $fixer->addFixer(new \Symfony\CS\Fixer\PSR2\VisibilityFixer());
-        $fixer->addFixer(new \Symfony\CS\Fixer\Symfony\UnusedUseFixer()); //will be ignored cause of test keyword in namespace
-
-        $config = Config::create()->finder(new \DirectoryIterator(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix'));
-        $config->fixers($fixer->getFixers());
-        $config->setUsingCache(false);
+        $config = Config::create()
+            ->finder(new \DirectoryIterator(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix'))
+            ->fixers(array(
+                new \Symfony\CS\Fixer\PSR2\VisibilityFixer(),
+                new \Symfony\CS\Fixer\Symfony\UnusedUseFixer(), // will be ignored cause of test keyword in namespace
+            ))
+            ->setUsingCache(false)
+        ;
 
         $changed = $fixer->fix($config, true, true);
         $pathToInvalidFile = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix'.DIRECTORY_SEPARATOR.'somefile.php';
@@ -134,18 +79,20 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\CS\Fixer::fix
      * @covers Symfony\CS\Fixer::fixFile
-     * @covers Symfony\CS\Fixer::prepareFixers
      */
     public function testThatFixInvalidFileReportsToErrorManager()
     {
         $fixer = new Fixer();
-        $fixer->addFixer(new \Symfony\CS\Fixer\PSR2\VisibilityFixer());
-        $fixer->addFixer(new \Symfony\CS\Fixer\Symfony\UnusedUseFixer()); //will be ignored cause of test keyword in namespace
         $fixer->setLinter(new Linter());
 
-        $config = Config::create()->finder(new \DirectoryIterator(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid'));
-        $config->fixers($fixer->getFixers());
-        $config->setUsingCache(false);
+        $config = Config::create()
+            ->finder(new \DirectoryIterator(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid'))
+            ->fixers(array(
+                new \Symfony\CS\Fixer\PSR2\VisibilityFixer(),
+                new \Symfony\CS\Fixer\Symfony\UnusedUseFixer(), // will be ignored cause of test keyword in namespace
+            ))
+            ->setUsingCache(false)
+        ;
 
         $changed = $fixer->fix($config, true, true);
         $pathToInvalidFile = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid'.DIRECTORY_SEPARATOR.'somefile.php';
@@ -165,133 +112,6 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\CS\Fixer::getLevelAsString
-     * @dataProvider getFixerLevels
-     */
-    public function testThatCanGetFixerLevelString($level, $expectedLevelString)
-    {
-        $fixer = new Fixer();
-
-        $fixerInstance = $this->getMock('Symfony\CS\FixerInterface');
-        $fixerInstance->expects($this->any())->method('getLevel')->will($this->returnValue($level));
-
-        $this->assertSame($expectedLevelString, $fixer->getLevelAsString($fixerInstance));
-    }
-
-    public function testFixersPriorityEdgeFixers()
-    {
-        $fixer = new Fixer();
-        $fixer->registerBuiltInFixers();
-        $fixers = $fixer->getFixers();
-
-        $this->assertSame('encoding', $fixers[0]->getName());
-        $this->assertSame('eof_ending', $fixers[count($fixers) - 1]->getName());
-    }
-
-    /**
-     * @dataProvider getFixersPriorityCases
-     */
-    public function testFixersPriority(FixerInterface $first, FixerInterface $second)
-    {
-        $this->assertLessThan($first->getPriority(), $second->getPriority());
-    }
-
-    public function getFixersPriorityCases()
-    {
-        $fixer = new Fixer();
-        $fixer->registerBuiltInFixers();
-
-        $fixers = array();
-
-        foreach ($fixer->getFixers() as $fixer) {
-            $fixers[$fixer->getName()] = $fixer;
-        }
-
-        $cases = array(
-            array($fixers['php_closing_tag'], $fixers['short_tag']),
-            array($fixers['unused_use'], $fixers['extra_empty_lines']),
-            array($fixers['multiple_use'], $fixers['unused_use']),
-            array($fixers['multiple_use'], $fixers['ordered_use']),
-            array($fixers['remove_lines_between_uses'], $fixers['ordered_use']),
-            array($fixers['unused_use'], $fixers['remove_leading_slash_use']),
-            array($fixers['multiple_use'], $fixers['remove_leading_slash_use']),
-            array($fixers['concat_without_spaces'], $fixers['concat_with_spaces']),
-            array($fixers['elseif'], $fixers['braces']),
-            array($fixers['duplicate_semicolon'], $fixers['braces']),
-            array($fixers['duplicate_semicolon'], $fixers['spaces_before_semicolon']),
-            array($fixers['duplicate_semicolon'], $fixers['multiline_spaces_before_semicolon']),
-            array($fixers['standardize_not_equal'], $fixers['strict']),
-            array($fixers['double_arrow_multiline_whitespaces'], $fixers['multiline_array_trailing_comma']),
-            array($fixers['double_arrow_multiline_whitespaces'], $fixers['align_double_arrow']),
-            array($fixers['indentation'], $fixers['phpdoc_indent']),
-            array($fixers['phpdoc_order'], $fixers['phpdoc_separation']),
-            array($fixers['phpdoc_no_access'], $fixers['phpdoc_separation']),
-            array($fixers['phpdoc_no_access'], $fixers['phpdoc_order']),
-            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_separation']),
-            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_order']),
-            array($fixers['phpdoc_no_package'], $fixers['phpdoc_separation']),
-            array($fixers['phpdoc_no_package'], $fixers['phpdoc_order']),
-            array($fixers['phpdoc_no_access'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_no_package'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_separation'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_short_description'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
-            array($fixers['unused_use'], $fixers['line_after_namespace']),
-            array($fixers['linefeed'], $fixers['eof_ending']),
-            array($fixers['php_unit_strict'], $fixers['php_unit_construct']),
-            array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_spaces']),
-            array($fixers['unary_operators_spaces'], $fixers['logical_not_operators_with_successor_space']),
-            array($fixers['method_separation'], $fixers['braces']),
-            array($fixers['method_separation'], $fixers['indentation']),
-        );
-
-        $docFixerNames = array_filter(
-            array_keys($fixers),
-            function ($name) {
-                return false !== strpos($name, 'phpdoc');
-            }
-        );
-
-        // prepare bulk tests for phpdoc fixers to test that:
-        // * `phpdoc_to_comment` is first
-        // * `phpdoc_indent` is second
-        // * `phpdoc_types` is third
-        // * `phpdoc_scalar` is fourth
-        // * `phpdoc_align` is last
-        $cases[] = array($fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']);
-        $cases[] = array($fixers['phpdoc_indent'], $fixers['phpdoc_types']);
-        $cases[] = array($fixers['phpdoc_types'], $fixers['phpdoc_scalar']);
-
-        foreach ($docFixerNames as $docFixerName) {
-            if (!in_array($docFixerName, array('phpdoc_to_comment', 'phpdoc_indent', 'phpdoc_types', 'phpdoc_scalar'), true)) {
-                $cases[] = array($fixers['phpdoc_to_comment'], $fixers[$docFixerName]);
-                $cases[] = array($fixers['phpdoc_indent'], $fixers[$docFixerName]);
-                $cases[] = array($fixers['phpdoc_types'], $fixers[$docFixerName]);
-                $cases[] = array($fixers['phpdoc_scalar'], $fixers[$docFixerName]);
-            }
-
-            if ('phpdoc_align' !== $docFixerName) {
-                $cases[] = array($fixers[$docFixerName], $fixers['phpdoc_align']);
-            }
-        }
-
-        return $cases;
-    }
-
-    public static function getFixerLevels()
-    {
-        return array(
-            array(FixerInterface::NONE_LEVEL, 'none'),
-            array(FixerInterface::PSR1_LEVEL, 'PSR-1'),
-            array(FixerInterface::PSR2_LEVEL, 'PSR-2'),
-            array(FixerInterface::SYMFONY_LEVEL, 'symfony'),
-            array(FixerInterface::CONTRIB_LEVEL, 'contrib'),
-        );
-    }
-
-    /**
      * @dataProvider provideFixersDescriptionConsistencyCases
      */
     public function testFixersDescriptionConsistency(FixerInterface $fixer)
@@ -301,12 +121,7 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
 
     public function provideFixersDescriptionConsistencyCases()
     {
-        $fixer = new Fixer();
-        $fixer->registerBuiltInFixers();
-        $fixers = $fixer->getFixers();
-        $cases = array();
-
-        foreach ($fixers as $fixer) {
+        foreach ($this->getAllFixers() as $fixer) {
             $cases[] = array($fixer);
         }
 
@@ -344,15 +159,19 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
 
     public function provideFixersForFinalCheckCases()
     {
-        $fixer = new Fixer();
-        $fixer->registerBuiltInFixers();
-        $fixers = $fixer->getFixers();
         $cases = array();
 
-        foreach ($fixers as $fixer) {
+        foreach ($this->getAllFixers() as $fixer) {
             $cases[] = array(new \ReflectionClass($fixer));
         }
 
         return $cases;
+    }
+
+    private function getAllFixers()
+    {
+        $factory = new FixerFactory();
+
+        return $factory->registerBuiltInFixers()->getFixers();
     }
 }

--- a/Symfony/CS/Tests/Fixtures/FixCommand/.phpcs
+++ b/Symfony/CS/Tests/Fixtures/FixCommand/.phpcs
@@ -5,10 +5,9 @@ $config = Symfony\CS\Config\Config::create();
 $finder = $config->getFinder()->in(__DIR__);
 
 return $config
-    ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
     ->setUsingCache(false)
     ->setUsingLinter(true)
-    ->fixers(array(
-        'short_tag',
+    ->setRules(array(
+        'short_tag' => true,
     ))
 ;

--- a/Symfony/CS/Tests/Fixtures/Integration/psr2.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/psr2.test
@@ -1,7 +1,7 @@
 --TEST--
 PSR2 integration
 --CONFIG--
-level=psr2
+{"@PSR2": true}
 --INPUT--
 <?php
 namespace Vendor\Package;

--- a/Symfony/CS/Tests/Fixtures/Integration/symfony.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/symfony.test
@@ -1,7 +1,7 @@
 --TEST--
 Symfony test
 --CONFIG--
-level=symfony
+{"@Symfony": true}
 --INPUT--
 <?php
 

--- a/Symfony/CS/Tests/RuleSetTest.php
+++ b/Symfony/CS/Tests/RuleSetTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+use Symfony\CS\FixerFactory;
+use Symfony\CS\RuleSet;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class RuleSetTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $ruleSet = RuleSet::create();
+
+        $this->assertInstanceOf('Symfony\CS\RuleSet', $ruleSet);
+    }
+
+    /**
+     * @dataProvider provideAllRulesFromSets
+     */
+    public function testIfAllRulesInSetsExists($rule)
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+
+        $fixers = array();
+
+        foreach ($factory->getFixers() as $fixer) {
+            $fixers[$fixer->getName()] = $fixer;
+        }
+
+        $this->assertArrayHasKey($rule, $fixers);
+    }
+
+    public function provideAllRulesFromSets()
+    {
+        $cases = array();
+        foreach (RuleSet::create()->getSetDefinitionNames() as $setName) {
+            $cases = array_merge($cases, RuleSet::create(array($setName => true))->getRules());
+        }
+
+        return array_map(
+            function ($item) {
+                return array($item);
+            },
+            array_keys($cases)
+        );
+    }
+
+    /**
+     * @expectedException        \UnexpectedValueException
+     * @expectedExceptionMessage Set "@foo" does not exist.
+     */
+    public function testResolveRulesWithInvalidSet()
+    {
+        RuleSet::create(array(
+            '@foo' => true,
+        ));
+    }
+
+    public function testResolveRulesWithSet()
+    {
+        $ruleSet = RuleSet::create(array(
+            'strict' => true,
+            '@PSR1' => true,
+            'braces' => true,
+            'encoding' => false,
+            'linefeed' => true,
+        ));
+
+        $this->assertSameRules(
+            array(
+                'strict' => true,
+                'short_tag' => true,
+                'braces' => true,
+                'linefeed' => true,
+            ),
+            $ruleSet->getRules()
+        );
+    }
+
+    public function testResolveRulesWithNestedSet()
+    {
+        $ruleSet = RuleSet::create(array(
+            '@PSR2' => true,
+            'strict' => true,
+        ));
+
+        $this->assertSameRules(
+            array(
+                'encoding' => true,
+                'short_tag' => true,
+                'linefeed' => true,
+                'indentation' => true,
+                'trailing_spaces' => true,
+                'php_closing_tag' => true,
+                'elseif' => true,
+                'visibility' => true,
+                'lowercase_keywords' => true,
+                'single_line_after_imports' => true,
+                'parenthesis' => true,
+                'multiple_use' => true,
+                'function_call_space' => true,
+                'method_argument_space' => true,
+                'function_declaration' => true,
+                'lowercase_constants' => true,
+                'line_after_namespace' => true,
+                'braces' => true,
+                'eof_ending' => true,
+                'strict' => true,
+            ),
+            $ruleSet->getRules()
+        );
+    }
+
+    public function testResolveRulesWithDisabledSet()
+    {
+        $ruleSet = RuleSet::create(array(
+            '@PSR2' => true,
+            '@PSR1' => false,
+            'encoding' => true,
+        ));
+
+        $this->assertSameRules(
+            array(
+                'encoding' => true,
+                'linefeed' => true,
+                'indentation' => true,
+                'trailing_spaces' => true,
+                'php_closing_tag' => true,
+                'elseif' => true,
+                'visibility' => true,
+                'lowercase_keywords' => true,
+                'single_line_after_imports' => true,
+                'parenthesis' => true,
+                'multiple_use' => true,
+                'function_call_space' => true,
+                'method_argument_space' => true,
+                'function_declaration' => true,
+                'lowercase_constants' => true,
+                'line_after_namespace' => true,
+                'braces' => true,
+                'eof_ending' => true,
+            ),
+            $ruleSet->getRules()
+        );
+    }
+
+    private function assertSameRules(array $expected, array $actual, $message = '')
+    {
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertSame($expected, $actual, $message);
+    }
+}


### PR DESCRIPTION
Hi everyone!
Few changes that I have been working on lately...

I have tried to keep commits very clean to show what has changed step by step.
Below some description... Each point should match commit.
Please ignore merge commits, I will get rid of them later.

This PR may be big, so it may be worth to read changes commit by commit instead of all at once.
Please split discussion into two parts - first do we like changes described below and implemented, and then, if we agreed about changes, I will fill the docs and review of the code itself may begin.

1. **Introduce FixerFactory**
It's a class that will register build in fixers, allow to register custom fixers, sort them and attach config to them (see ConfigAwareInterface).
In future (see next changes in this PR) it will also allow to configure fixers.

2. **Replace level and fixers from configuration in favor of rules, remove getLevel from FixerInterface**
Closes #866 (ping @Seldaek).
Instead of setting level and fixers start setting rules. Many rules can be grouped in sets.
Eg to take all psr2 fixers, remove braces fixer and add strict fixer we can use:
CLI args:
`--rules=@PSR2,-braces,strict`
config file:
    ```php
    ->setRules([
        '@PSR2' => true,
        'braces' => false,
        'strict' => true,
    ])
    ```
One set can include other set (like `@Symfony` is `@PSR2` + extra fixers, `@PSR2` is `@PSR1` + other fixers).
When setting the rules set expand to it's definition and adding/removing fixers is doing step by step (so one may exclude set and then add one fixer from it).
For example, consider the following:
    ```
    @PSR1 = encoding,short_tag
    @PSR2 = @PSR1,braces,elseif
    @Symfony = @PSR2,return

    // then, one uses:
    --rules=strict,@Symfony,-@PSR2,@PSR1,-encoding
    // which expanded step by step into:
    --rules=strict,@PSR2,return,-@PSR2,@PSR1,-encoding
    --rules=strict,return,@PSR1,-encoding
    --rules=strict,return,encoding,short_tag,-encoding
    --rules=strict,return,short_tag
    ```
Also, remove getLevel method from FixerInterface.

3. **Add FixerInterface::configure method**
For now we have only way to turn fixer on or off, without possibility to configure how it should fix the code. This problem manifested first time with HeaderCommentFixer, when we have no way to configure the header itself!
Now, the fixers may have configuration (eg PhpUnitStrictFixer) and we have a way to change default configuration.
Setting the configuration for Fixers when using CLI tool is only possible in .php_cs file, not via CLI args.
In .php_cs file configuration is passed as part of rules definition:
    ```php
    ->setRules([
        '@PSR2' => true,
        'braces' => false,
        'strict' => true,
        'php_unit_strict' => [ 'assertEquals', 'assertNotEquals' ],
    ])
    ```
When a rule is false then fixer is off, when rule is truly then rule is on - especially when true it is on with default configuration and when it's array it is on and array is passed to configure method.
Also, remove Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader method

4. **Cache now detects configuration change not only by tool version and names of fixers, but also their configuration**
Closes #1305. (ping @GrahamCampbell)

5. **Disallow to set non-existing rules**
