### PR TITLE
Fixer::getLevelAsString is no longer static

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -320,7 +320,7 @@ class Fixer
         return $file->getPathname();
     }
 
-    public static function getLevelAsString(FixerInterface $fixer)
+    public function getLevelAsString(FixerInterface $fixer)
     {
         $level = $fixer->getLevel();
 

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -167,10 +167,12 @@ final class FixerTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatCanGetFixerLevelString($level, $expectedLevelString)
     {
-        $fixer = $this->getMock('Symfony\CS\FixerInterface');
-        $fixer->expects($this->any())->method('getLevel')->will($this->returnValue($level));
+        $fixer = new Fixer();
 
-        $this->assertSame($expectedLevelString, Fixer::getLevelAsString($fixer));
+        $fixerInstance = $this->getMock('Symfony\CS\FixerInterface');
+        $fixerInstance->expects($this->any())->method('getLevel')->will($this->returnValue($level));
+
+        $this->assertSame($expectedLevelString, $fixer->getLevelAsString($fixerInstance));
     }
 
     public function testFixersPriorityEdgeFixers()


### PR DESCRIPTION
In non-tests code method is currently run in instance context and there is no way to mock static method.

Extracted from #1383, this little change looks quite ready and #1383 may have long review process.