### PR TITLE
Add report to XML report as the root node

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -422,8 +422,12 @@ EOF
                 break;
             case 'xml':
                 $dom = new \DOMDocument('1.0', 'UTF-8');
+                // new nodes should be added to this or existing children
+                $root = $dom->createElement('report');
+                $dom->appendChild($root);
+
                 $filesXML = $dom->createElement('files');
-                $dom->appendChild($filesXML);
+                $root->appendChild($filesXML);
 
                 foreach ($changed as $file => $fixResult) {
                     $fileXML = $dom->createElement('file');
@@ -453,8 +457,8 @@ EOF
 
                 $timeXML = $dom->createElement('time');
                 $memoryXML = $dom->createElement('memory');
-                $filesXML->appendChild($timeXML);
-                $filesXML->appendChild($memoryXML);
+                $root->appendChild($timeXML);
+                $root->appendChild($memoryXML);
 
                 $memoryXML->setAttribute('value', round($fixEvent->getMemory() / 1024 / 1024, 3));
                 $memoryXML->setAttribute('unit', 'MB');


### PR DESCRIPTION
Continuation of #1376 

Add `report` as the root node. Then, use it instead of `files`.

#### Command
`php-cs-fixer fix --no-ansi --verbose --dry-run --diff --format=xml --no-interaction /home/junichi11/Some.php`

#### PHP File
Some.php
```php
<?php
namespace Foo\Bar;
/**
 * Description of Some
 *
 * @author junichi11
 */
class Some2 {
}

```

#### Before
```xml
<files>
  <file id="1" name="/home/junichi11/Some.php">
    <applied_fixers>
      <applied_fixer name="line_after_namespace"/>
      <applied_fixer name="braces"/>
    </applied_fixers>
    <diff><![CDATA[      --- Original
      +++ New
      @@ @@
       <?php
       namespace Foo\Bar;
      +
       /**
        * Description of Some
        *
        * @author junichi11
        */
      -class Some2 {
      +class Some2
      +{
       }
       
      ]]></diff>
  </file>
  <time unit="s">
    <total value="0.062"/>
  </time>
  <memory value="5.5" unit="MB"/>
</files>
```

#### After
```xml
<report>
  <files>
    <file id="1" name="/home/junichi11/Some.php">
      <applied_fixers>
        <applied_fixer name="line_after_namespace"/>
        <applied_fixer name="braces"/>
      </applied_fixers>
      <diff><![CDATA[      --- Original
      +++ New
      @@ @@
       <?php
       namespace Foo\Bar;
      +
       /**
        * Description of Some
        *
        * @author junichi11
        */
      -class Some2 {
      +class Some2
      +{
       }
       
      ]]></diff>
    </file>
  </files>
  <time unit="s">
    <total value="0.047"/>
  </time>
  <memory value="5.5" unit="MB"/>
</report>
```
