### PR TITLE
Stop mixing level from config file and fixers from CLI arg when one of fixers has dash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,13 +153,13 @@ using ``-name_of_fixer``:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=-short_tag,-indentation
+    php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=-short_tag,-indentation
 
 When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag
+    php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=return,-short_tag
 
 A combination of ``--dry-run`` and ``--diff`` will
 display a summary of proposed fixes, leaving your files unchanged.
@@ -723,10 +723,7 @@ The ``psr2`` level is set by default, you can also change the default level:
 In combination with these config and command line options, you can choose various usage.
 
 For example, the default level is ``psr2``, but if you don't want to use
-the ``short_tag`` fixer, you can specify the ``--fixers="-short_tag"`` option.
-
-But if you use the ``--fixers`` option with only exact fixers,
-only those exact fixers are enabled whether or not level is set.
+the ``short_tag`` fixer, you can specify the ``--level=psr2 --fixers=-short_tag`` options.
 
 By using ``--using-cache`` option with yes or no you can set if the caching
 mechanism should be used.

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -146,11 +146,11 @@ apply (the fixer names must be separated by a comma):
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using <comment>-name_of_fixer</comment>:
 
-    <info>php %command.full_name% /path/to/dir --fixers=-short_tag,-indentation</info>
+    <info>php %command.full_name% /path/to/dir --level=psr2 --fixers=-short_tag,-indentation</info>
 
 When using combinations of exact and blacklist fixers, applying exact fixers along with above blacklisted results:
 
-    <info>php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag</info>
+    <info>php php-cs-fixer.phar fix /path/to/dir --level=psr2 --fixers=return,-short_tag</info>
 
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
 display a summary of proposed fixes, leaving your files unchanged.
@@ -252,10 +252,7 @@ The ``psr2`` level is set by default, you can also change the default level:
 In combination with these config and command line options, you can choose various usage.
 
 For example, the default level is ``psr2``, but if you don't want to use
-the ``short_tag`` fixer, you can specify the ``--fixers="-short_tag"`` option.
-
-But if you use the ``--fixers`` option with only exact fixers,
-only those exact fixers are enabled whether or not level is set.
+the ``short_tag`` fixer, you can specify the ``--level=psr2 --fixers=-short_tag`` options.
 
 By using ``--using-cache`` option with yes or no you can set if the caching
 mechanism should be used.

--- a/Symfony/CS/Console/ConfigurationResolver.php
+++ b/Symfony/CS/Console/ConfigurationResolver.php
@@ -264,11 +264,11 @@ final class ConfigurationResolver
             return array_map('trim', explode(',', $this->options['fixers']));
         }
 
-        if (null === $this->options['level']) {
-            return $this->config->getFixers();
+        if (null !== $this->options['level']) {
+            return;
         }
 
-        return;
+        return $this->config->getFixers();
     }
 
     /**
@@ -295,17 +295,11 @@ final class ConfigurationResolver
             return $levelMap[$levelOption];
         }
 
-        if (null === $this->options['fixers']) {
-            return $this->config->getLevel();
+        if (null !== $this->options['fixers']) {
+            return;
         }
 
-        foreach ($this->parseFixers() as $fixer) {
-            if (0 === strpos($fixer, '-')) {
-                return $this->config->getLevel();
-            }
-        }
-
-        return;
+        return $this->config->getLevel();
     }
 
     /**

--- a/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
+++ b/Symfony/CS/Tests/Console/ConfigurationResolverTest.php
@@ -257,19 +257,10 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ->resolve()
         ;
 
-        $expectedFixers = array_merge(
-            $this->fixersMap[FixerInterface::PSR1_LEVEL],
-            $this->fixersMap[FixerInterface::PSR2_LEVEL],
-            $this->fixersMap[FixerInterface::SYMFONY_LEVEL],
-            array($this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'], $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'])
+        $expectedFixers = array(
+            $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict'],
+            $this->fixersMap[FixerInterface::CONTRIB_LEVEL]['strict_param'],
         );
-
-        foreach ($expectedFixers as $key => $fixer) {
-            if ($fixer->getName() === 'include') {
-                unset($expectedFixers[$key]);
-                break;
-            }
-        }
 
         $this->makeFixersTest(
             $expectedFixers,


### PR DESCRIPTION
**Stop mixing level from config file and fixers from CLI arg when one of fixers has dash**
Current behavior is very confusing and has so few user scenarios. The whole behavior changed when one add dash to fixers list.
So let us stop mixing the fixers configuration from CLI args and from config file.
One can still use `--level=psr2 --fixers=strict,-braces` to create target group of fixers from psr2 plus strict minus braces,
same with config file, but cannot mix fixers from CLI arg with level from some magic place.
Previous behavior description:
`--fixers=fixer1,fixer2,fixer3,fixer4,fixer5,fixer6,fixer7,fixer8`
which creates a group of 8 fixers (and ignore level set in config file)
and
`--fixers=fixer1,fixer2,fixer3,fixer4,-fixer5,fixer6,fixer7,fixer8`
which creates a group of fixers in the following steps:
  - get all fixers for level in config file (**unlike previously**!) or default one,
  - add 7 fixers from `--fixers` arg
  - remove fixer5 (from `--fixers` arg)