### PR TITLE
PhpdocVarWithoutNameFixer - Fixed the var without name fixer for inline docs

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocVarWithoutNameFixer.php
@@ -36,15 +36,14 @@ class PhpdocVarWithoutNameFixer extends AbstractFixer
                 continue;
             }
 
-            $annotations = $doc->getAnnotationsOfType(array('var', 'type'));
+            $annotations = $doc->getAnnotationsOfType(array('param', 'return', 'type', 'var'));
 
-            if (empty($annotations)) {
+            // only process docblocks where the first meaningful annotation is @type or @var
+            if (!isset($annotations[0]) || !in_array($annotations[0]->getTag()->getName(), array('type', 'var'), true)) {
                 continue;
             }
 
-            foreach ($annotations as $annotation) {
-                $this->fixLine($doc->getLine($annotation->getStart()));
-            }
+            $this->fixLine($doc->getLine($annotations[0]->getStart()));
 
             $token->setContent($doc->getContent());
         }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
@@ -73,6 +73,58 @@ EOF;
         $this->makeTest($expected);
     }
 
+    public function testFixVarWithOtherAnnotation()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var string Hello!
+     *
+     * @deprecated
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var string $foo Hello!
+     *
+     * @deprecated
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testFixVarWithNestedKeys()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @var array {
+     *     @var bool   $required Whether this element is required
+     *     @var string $label    The display name for this element
+     * }
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @var array $options {
+     *     @var bool   $required Whether this element is required
+     *     @var string $label    The display name for this element
+     * }
+     */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
     public function testSingleLine()
     {
         $expected = <<<'EOF'

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocVarWithoutNameFixerTest.php
@@ -148,4 +148,39 @@ EOF;
 
         $this->makeTest($expected);
     }
+
+    public function testInlineDoc()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Initializes this class with the given options.
+     *
+     * @param array $options {
+     *     @var bool   $required Whether this element is required
+     *     @var string $label    The display name for this element
+     * }
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
+
+    public function testInlineDocAgain()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int[] $stuff {
+     *     @var int $foo
+     * }
+     *
+     * @return void
+     */
+
+EOF;
+
+        $this->makeTest($expected);
+    }
 }


### PR DESCRIPTION
Closes #1352. Replaces #1381.