### PR TITLE
PhpdocIndentFixer - Fix for open tag

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocIndentFixer.php
@@ -40,7 +40,8 @@ class PhpdocIndentFixer extends AbstractFixer
 
             // ignore inline docblocks
             if (
-                ($prevToken->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isGivenKind(T_OPEN_TAG))
+                $prevToken->isGivenKind(T_OPEN_TAG)
+                || ($prevToken->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isGivenKind(T_OPEN_TAG))
                 || $prevToken->equalsAny(array(';', '{'))
             ) {
                 continue;

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocIndentFixerTest.php
@@ -30,6 +30,8 @@ class PhpdocIndentFixerTest extends AbstractFixerTestBase
     {
         $cases = array();
 
+        $cases[] = array('<?php /** @var Foo $foo */ ?>');
+
         $cases[] = array('<?php /** foo */');
 
         $cases[] = array(


### PR DESCRIPTION
This PR addresses this issue:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1407