### PR TITLE
[feature] Method argument multi line (wip)

### DIFF
--- a/Symfony/CS/Fixer/PSR2/MethodArgumentSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/MethodArgumentSpaceFixer.php
@@ -53,31 +53,6 @@ final class MethodArgumentSpaceFixer extends AbstractFixer
     }
 
     /**
-     * Check if last item of current line is a comment.
-     *
-     * @param Tokens $tokens tokens to handle
-     * @param int    $index  index of token
-     *
-     * @return bool
-     */
-    private function isCommentLastLineToken(Tokens $tokens, $index)
-    {
-        if (!$tokens[$index]->isComment()) {
-            return false;
-        }
-
-        $nextToken = $tokens[$index + 1];
-
-        if (!$nextToken->isWhitespace()) {
-            return false;
-        }
-
-        $content = $nextToken->getContent();
-
-        return $content !== ltrim($content, "\r\n");
-    }
-
-    /**
      * Fix arguments spacing for given function.
      *
      * @param Tokens $tokens             Tokens to handle
@@ -112,7 +87,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer
      * @param Tokens $tokens
      * @param int    $index
      */
-    public function fixSpace(Tokens $tokens, $index)
+    private function fixSpace(Tokens $tokens, $index)
     {
         // remove space before comma if exist
         if ($tokens[$index - 1]->isWhitespace()) {
@@ -147,5 +122,30 @@ final class MethodArgumentSpaceFixer extends AbstractFixer
         if (!$this->isCommentLastLineToken($tokens, $index + 1)) {
             $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
         }
+    }
+
+    /**
+     * Check if last item of current line is a comment.
+     *
+     * @param Tokens $tokens tokens to handle
+     * @param int    $index  index of token
+     *
+     * @return bool
+     */
+    private function isCommentLastLineToken(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index]->isComment()) {
+            return false;
+        }
+
+        $nextToken = $tokens[$index + 1];
+
+        if (!$nextToken->isWhitespace()) {
+            return false;
+        }
+
+        $content = $nextToken->getContent();
+
+        return $content !== ltrim($content, "\r\n");
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -51,13 +51,13 @@ $c ,"d");',
 
             ),
             array(
-                '<?php function(
+                '<?php function a(
 "e",
 "f", // comment 1
                 "g",
 "h"
 ) /* comment 2 */;',
-                '<?php function("e","f", // comment 1
+                '<?php function a("e","f", // comment 1
                 "g","h"  ) /* comment 2 */;',
 
             ),

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -228,16 +228,16 @@ $b2=2000,
             array(
                 "<?php
     \$this->foo(
-<<<EOTXTa
+        <<<EOTXTa
     heredoc
 EOTXTa
         ,
-<<<'EOTXTb'
+        <<<'EOTXTb'
     nowdoc
 EOTXTb
         ,
-'foo'
-);
+        'foo'
+    );
 ",
             ),
         );

--- a/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/MethodArgumentSpaceFixerTest.php
@@ -33,7 +33,33 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
         return array(
             array(
                 '<?php xyz("", "", "", "");',
+                '<?php xyz(   "", "" ,"" ,""  );',
+            ),
+            array(
+                '<?php xyz("", "", "", "");',
                 '<?php xyz("","","","");',
+            ),
+            array(
+                '<?php xyz(
+$a,
+"b",
+$c,
+"d"
+);',
+                '<?php xyz($a , "b"  ,
+$c ,"d");',
+
+            ),
+            array(
+                '<?php function(
+"e",
+"f", // comment 1
+                "g",
+"h"
+) /* comment 2 */;',
+                '<?php function("e","f", // comment 1
+                "g","h"  ) /* comment 2 */;',
+
             ),
             // test method arguments
             array(
@@ -60,14 +86,6 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                 '<?php xyz($a=10, $b=20, $c=30);',
                 "<?php xyz(\$a=10 , \$b=20 ,\t \$c=30);",
             ),
-            // test method call with \n not affected
-            array(
-                "<?php xyz(\$a=10, \$b=20,\n                    \$c=30);",
-            ),
-            // test method call with \r\n not affected
-            array(
-                "<?php xyz(\$a=10, \$b=20,\r\n                    \$c=30);",
-            ),
             // test method call
             array(
                 '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
@@ -77,6 +95,10 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
             array(
                 '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
                 '<?php xyz($a=10,$b=20 ,         $this->foo() ,$c=30);',
+            ),
+            array(
+                '<?php function xyz($a=10, $b=20, $c=30) {',
+                '<?php function xyz($a=10,$b=20,$c=30 ) {',
             ),
             // test receiving data in list context with omitted values
             array(
@@ -97,6 +119,10 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                 '<?php list($path, $mode, ) = foo();',
                 '<?php list($path, $mode,) = foo();',
             ),
+            array(
+                '<?php list($path, $mode, ) = foo();',
+                '<?php list($path, $mode,     ) = foo();',
+            ),
             //inline comments with spaces
             array(
                 '<?php xyz($a=10, /*comment1*/ $b=2000, /*comment2*/ $c=30);',
@@ -108,14 +134,18 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                 '<?php function xyz(
                     $a=10,      //comment1
                     $b=20,      //comment2
-                    $c=30) {
+                    $c=30
+) {
                 }',
             ),
             array(
+
                 '<?php function xyz(
                     $a=10,  //comment1
                     $b=2000,//comment2
-                    $c=30) {
+                    $c=30
+) {
+
                 }',
             ),
             //multiline comments also must be ignored
@@ -127,43 +157,33 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
                     $b=2000,/* comment2a
                         comment 2b
                         comment 2c */
-                    $c=30) {
+                    $c=30
+) {
                 }',
             ),
             // multiline comments also must be ignored
             array(
                 '<?php
                     function xyz(
-                        $a=10, /* multiline comment
+                        $a=10,
+/* multiline comment
                                  not at the end of line
                                 */ $b=2000,
                         $a2=10 /* multiline comment
                                  not at the end of line
-                                */, $b2=2000,
-                        $c=30) {
-                    }',
-                '<?php
-                    function xyz(
-                        $a=10, /* multiline comment
-                                 not at the end of line
-                                */ $b=2000,
-                        $a2=10 /* multiline comment
-                                 not at the end of line
-                                */ ,$b2=2000,
-                        $c=30) {
+                                */,
+$b2=2000,
+                        $c=30
+) {
                     }',
             ),
             // multi line testing method arguments
             array(
                 '<?php function xyz(
-                    $a=10,
-                    $b=20,
-                    $c=30) {
-                }',
-                '<?php function xyz(
-                    $a=10 ,
-                    $b=20,
-                    $c=30) {
+                                $a=10,      //comment1
+                                $b=20,      //comment2
+                                $c=30
+            ) {
                 }',
             ),
             // multi line testing method call
@@ -208,16 +228,16 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestBase
             array(
                 "<?php
     \$this->foo(
-        <<<EOTXTa
+<<<EOTXTa
     heredoc
 EOTXTa
         ,
-        <<<'EOTXTb'
+<<<'EOTXTb'
     nowdoc
 EOTXTb
         ,
-        'foo'
-    );
+'foo'
+);
 ",
             ),
         );


### PR DESCRIPTION
This PR fixes a few issues with the `MethodArgumentSpaceFixer`.

It removes white space between the method opening bracket and the first argument,
and between the last argument and the method closing round bracket.
For example:

```php
<?php xyz(   "", "" ,"" ,""  );
```
will now be fixed to:
```php
<?php xyz("", "", "", "");
```

It will add line breaks after the arguments if there is one line break found between the arguments.
It does not fix the indenting of these new lines (which reminds me to add a fixer order test).

For example:
```php
<?php function("e","f", // comment 1
                "g","h"  ) /* comment 2 */;
```
To:
```php
<?php function(
"e",
"f", // comment 1
                "g",
"h"
) /* comment 2 */;
```

I also made a method of the fixer private, which I don't consider a BC break since the Fixer is already final and internal.

see also:
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#44-method-arguments

https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#46-method-and-function-calls

and https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1397
There a few cases where the current codebase is not following the PSR, so I expect the tests to fail.

I'll work on this a bit, like the missing order test, a 1.x version and the CS fixes of the project itself, if this seems a good idea ^-^