### PR TITLE
BlanklineAfterOpenTagFixer - Do not add a line break if there is one already.

### DIFF
--- a/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
+++ b/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
@@ -38,6 +38,7 @@ class BlanklineAfterOpenTagFixer extends AbstractFixer
         }
 
         $newlineFound = false;
+        /** @var Token $token */
         foreach ($tokens as $token) {
             if ($token->isWhitespace(array('whitespaces' => "\n"))) {
                 $newlineFound = true;
@@ -56,7 +57,7 @@ class BlanklineAfterOpenTagFixer extends AbstractFixer
             $token->setContent(rtrim($token->getContent())."\n");
         }
 
-        if (!$tokens[1]->isWhitespace(array('whitespaces' => "\n"))) {
+        if (!$tokens[1]->isWhitespace() && false === strpos($tokens[1]->getContent(), "\n")) {
             $tokens->insertAt(1, new Token(array(T_WHITESPACE, "\n")));
         }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/BlanklineAfterOpenTagFixerTest.php
@@ -40,6 +40,16 @@ class BlanklineAfterOpenTagFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php
+
+ class SomeClass
+ {
+     const VERSION = "1.1.1";
+     const FOO = "bar";
+ }
+',
+            ),
+            array(
                 '<?php $foo = true; ?>',
             ),
             array(


### PR DESCRIPTION
The `BlanklineAfterOpenTagFixer` adds a line even is there is one already.

Fix for:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1331