### PR TITLE
AlignDoubleArrowFixer - fix handling of nested array

### DIFF
--- a/Symfony/CS/AbstractAlignFixer.php
+++ b/Symfony/CS/AbstractAlignFixer.php
@@ -57,14 +57,12 @@ abstract class AbstractAlignFixer extends AbstractFixer
                 }
             }
 
-            $i = 0;
             foreach ($linesWithPlaceholder as $group) {
-                if (1 === count($group)) {
+                if (count($group) < 1) {
                     continue;
                 }
-                ++$i;
-                $rightmostSymbol = 0;
 
+                $rightmostSymbol = 0;
                 foreach ($group as $index) {
                     $rightmostSymbol = max($rightmostSymbol, strpos(utf8_decode($lines[$index]), $placeholder));
                 }

--- a/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
@@ -90,7 +90,7 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
                 continue;
             }
 
-            if ($token->isGivenKind(T_ARRAY)) {
+            if ($token->isGivenKind(T_ARRAY)) { // don't use "$tokens->isArray()" here, short arrays are handled in the next case
                 $from = $tokens->getNextMeaningfulToken($index);
                 $until = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $from);
                 $index = $until;
@@ -102,7 +102,7 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
                 continue;
             }
 
-            if ($token->equals('[')) {
+            if ($tokens->isShortArray($index)) {
                 $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
                 if ($prevToken->isGivenKind(array(T_STRING, T_VARIABLE))) {
                     continue;
@@ -141,7 +141,7 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
 
             if ($token->equals(',')) {
                 for ($i = $index; $i < $endAt - 1; ++$i) {
-                    if ($tokens[$i + 1]->equals('[') || $tokens[$i + 1]->isGivenKind(T_ARRAY) || false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
+                    if ($tokens->isArray($i + 1) || false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
                         break;
                     }
                     ++$index;

--- a/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
@@ -48,7 +48,7 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
         $this->deepestLevel = 0;
         $tokens = Tokens::fromCode($content);
 
-        $this->injectAlignmentPlaceholders($tokens);
+        $this->injectAlignmentPlaceholders($tokens, 0, count($tokens));
 
         return $this->replacePlaceholder($tokens, $this->deepestLevel);
     }
@@ -79,16 +79,8 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
      *
      * @return array($code, $context_counter)
      */
-    private function injectAlignmentPlaceholders(Tokens $tokens, $startAt = null, $endAt = null)
+    private function injectAlignmentPlaceholders(Tokens $tokens, $startAt, $endAt)
     {
-        if (empty($startAt)) {
-            $startAt = 0;
-        }
-
-        if (empty($endAt)) {
-            $endAt = count($tokens);
-        }
-
         for ($index = $startAt; $index < $endAt; ++$index) {
             $token = $tokens[$index];
 
@@ -148,10 +140,12 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
             }
 
             if ($token->equals(',')) {
-                do {
+                for ($i = $index; $i < $endAt - 1; ++$i) {
+                    if ($tokens[$i + 1]->equals('[') || $tokens[$i + 1]->isGivenKind(T_ARRAY) || false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
+                        break;
+                    }
                     ++$index;
-                    $token = $tokens[$index];
-                } while (false === strpos($token->getContent(), "\n"));
+                }
             }
         }
     }

--- a/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
@@ -31,6 +31,14 @@ class AlignDoubleArrowFixerTest extends AbstractFixerTestBase
         return array(
             array(
                 '<?php
+                switch ($a) {
+                    case "prod":
+                        break;
+                }
+                ',
+            ),
+            array(
+                '<?php
     $array = array(
         "closure" => function ($param1, $param2) {
             return;
@@ -98,14 +106,6 @@ class AlignDoubleArrowFixerTest extends AbstractFixerTestBase
         ]),
         "baz" => "OK",
     ]);',
-            ),
-            array(
-                '<?php
-    switch ($a) {
-        case "prod":
-            break;
-    }
-    ',
             ),
             array(
                 '<?php

--- a/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
@@ -31,11 +31,81 @@ class AlignDoubleArrowFixerTest extends AbstractFixerTestBase
         return array(
             array(
                 '<?php
-                switch ($a) {
-                    case "prod":
-                        break;
-                }
-                ',
+    $array = array(
+        "closure" => function ($param1, $param2) {
+            return;
+        }
+    );',
+            ),
+            array(
+                '<?php
+    return new JsonResponse(array(
+        "result" => "OK",
+        "html"   => 1, array(
+            "foo"    => "bar",
+            "foofoo" => array(
+                "a"  => 1,
+                "b"  => 2
+            )
+        ),)
+    );',
+                '<?php
+    return new JsonResponse(array(
+        "result" => "OK",
+        "html" => 1, array(
+            "foo" => "bar",
+            "foofoo" => array(
+                "a" => 1,
+                "b"  =>  2
+            )
+        ),)
+    );',
+            ),
+            array(
+                '<?php
+    return new JsonResponse([
+        "result" => "OK",
+        "html"   => renderView("views/my_view.html.twig", array(
+            "foo"    => "bar",
+            "foofoo" => 43,
+        )),
+    ]);',
+                '<?php
+    return new JsonResponse([
+        "result" => "OK",
+        "html" =>    renderView("views/my_view.html.twig", array(
+            "foo" => "bar",
+            "foofoo" => 43,
+        )),
+    ]);',
+            ),
+            array(
+                '<?php
+    return new JsonResponse([
+        "result" => "OK",
+        "html"   => renderView("views/my_view.html.twig", [
+            "foo"    => "bar",
+            "foofoo" => 42,
+        ]),
+        "baz" => "OK",
+    ]);',
+                '<?php
+    return new JsonResponse([
+        "result" => "OK",
+        "html" =>    renderView("views/my_view.html.twig", [
+            "foo" =>   "bar",
+            "foofoo" =>    42,
+        ]),
+        "baz" => "OK",
+    ]);',
+            ),
+            array(
+                '<?php
+    switch ($a) {
+        case "prod":
+            break;
+    }
+    ',
             ),
             array(
                 '<?php


### PR DESCRIPTION
Fixes: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1377

Replaces
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1417

on 1.10