### PR TITLE
Removed phpstorm plugin link in favor of gist link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -787,7 +787,7 @@ projects for instance).
 .. _php-cs-fixer.phar: http://get.sensiolabs.org/php-cs-fixer.phar
 .. _Atom:              https://github.com/Glavin001/atom-beautify
 .. _NetBeans:          http://plugins.netbeans.org/plugin/49042/php-cs-fixer
-.. _PhpStorm:          http://tzfrs.de/2015/01/automatically-format-code-to-match-psr-standards-with-phpstorm
+.. _PhpStorm:          https://gist.github.com/mpalourdio/46f792347cf9d46b121c
 .. _Sublime Text:      https://github.com/benmatselby/sublime-phpcs
 .. _Vim:               https://github.com/stephpy/vim-php-cs-fixer
 .. _contribute:        https://github.com/FriendsOfPhp/php-cs-fixer/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Link to _PhpStorm plugin is broken. 
I can't find any plugins online, is it gone?

You could go for this gist? It helped me :)