### PR TITLE
PhpUnitConstructFixer - Fix more use cases

### DIFF
--- a/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
@@ -94,27 +94,13 @@ final class PhpUnitConstructFixer extends AbstractFixer
 
     private function fixAssertNegative(Tokens $tokens, $index, $method)
     {
-        $sequence = $tokens->findSequence(
-            array(
-                array(T_VARIABLE, '$this'),
-                array(T_OBJECT_OPERATOR, '->'),
-                array(T_STRING, $method),
-                '(',
-                array(T_STRING, 'null'),
-                ',',
-            ),
-            $index
+        static $map = array(
+            'false' => 'assertNotFalse',
+            'null' => 'assertNotNull',
+            'true' => 'assertNotTrue',
         );
 
-        if (null === $sequence) {
-            return;
-        }
-
-        $sequenceIndexes = array_keys($sequence);
-        $tokens[$sequenceIndexes[2]]->setContent('assertNotNull');
-        $tokens->clearRange($sequenceIndexes[4], $tokens->getNextNonWhitespace($sequenceIndexes[5]) - 1);
-
-        return $sequenceIndexes[5];
+        return $this->fixAssert($map, $tokens, $index, $method);
     }
 
     private function fixAssertPositive(Tokens $tokens, $index, $method)
@@ -125,6 +111,11 @@ final class PhpUnitConstructFixer extends AbstractFixer
             'true' => 'assertTrue',
         );
 
+        return $this->fixAssert($map, $tokens, $index, $method);
+    }
+
+    private function fixAssert(array $map, Tokens $tokens, $index, $method)
+    {
         $sequence = $tokens->findSequence(
             array(
                 array(T_VARIABLE, '$this'),

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
@@ -62,36 +62,8 @@ class PhpUnitConstructFixerTest extends AbstractFixerTestBase
 
     public function provideTestFixCases()
     {
-        return array(
+        $cases = array(
             array('<?php $sth->assertSame(true, $foo);'),
-            array(
-                '<?php $this->assertTrue($a);',
-                '<?php $this->assertSame(true, $a);',
-            ),
-            array(
-                '<?php $this->assertTrue($a  , "true" . $bar);',
-                '<?php $this->assertSame(true  , $a  , "true" . $bar);',
-            ),
-            array(
-                '<?php $this->assertFalse(  $a, "false" . $bar);',
-                '<?php $this->assertSame(  false, $a, "false" . $bar);',
-            ),
-            array(
-                '<?php $this->assertNull(  $a  , "null" . $bar);',
-                '<?php $this->assertSame(  null, $a  , "null" . $bar);',
-            ),
-            array(
-                '<?php $this->assertNotNull(  $a  , "notNull" . $bar);',
-                '<?php $this->assertNotSame(  null, $a  , "notNull" . $bar);',
-            ),
-            array(
-                '<?php $this->assertFalse(  $a, "false" . $bar);',
-                '<?php $this->assertEquals(  false, $a, "false" . $bar);',
-            ),
-            array(
-                '<?php $this->assertNotNull(  $a  , "notNull" . $bar);',
-                '<?php $this->assertNotEquals(  null, $a  , "notNull" . $bar);',
-            ),
             array(
                 '<?php
     $this->assertTrue(
@@ -106,5 +78,27 @@ class PhpUnitConstructFixerTest extends AbstractFixerTestBase
     );',
             ),
         );
+
+        return array_merge(
+            $cases,
+            $this->generateCases('<?php $this->assert%s(%s, $a); //%s %s', '<?php $this->assert%s%s($a); //%s %s'),
+            $this->generateCases('<?php $this->assert%s(%s, $a, "%s", "%s");', '<?php $this->assert%s%s($a, "%s", "%s");')
+        );
+    }
+
+    private function generateCases($expectedTemplate, $inputTemplate)
+    {
+        $cases = array();
+        $functionTypes = array('Same' => true, 'NotSame' => false, 'Equals' => true, 'NotEquals' => false);
+        foreach (array('true', 'false', 'null') as $type) {
+            foreach ($functionTypes as $method => $positive) {
+                $cases[] = array(
+                    sprintf($expectedTemplate, $positive ? '' : 'Not', ucfirst($type), $method, $type),
+                    sprintf($inputTemplate, $method, $type, $method, $type),
+                );
+            }
+        }
+
+        return $cases;
     }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
@@ -81,8 +81,8 @@ class PhpUnitConstructFixerTest extends AbstractFixerTestBase
 
         return array_merge(
             $cases,
-            $this->generateCases('<?php $this->assert%s(%s, $a); //%s %s', '<?php $this->assert%s%s($a); //%s %s'),
-            $this->generateCases('<?php $this->assert%s(%s, $a, "%s", "%s");', '<?php $this->assert%s%s($a, "%s", "%s");')
+            $this->generateCases('<?php $this->assert%s%s($a); //%s %s', '<?php $this->assert%s(%s, $a); //%s %s'),
+            $this->generateCases('<?php $this->assert%s%s($a, "%s", "%s");', '<?php $this->assert%s(%s, $a, "%s", "%s");')
         );
     }
 


### PR DESCRIPTION
Fix the following (Not) cases as well.

```php
<?php $this->assertNotSame(false, $a);
<?php $this->assertNotFalse($a);
```

```php
<?php $this->assertNotSame(true, $a);
<?php $this->assertNotTrue($a);
```

```php
<?php $this->assertNotSame(false, $a);
<?php $this->assertNotFalse($a);
```

```php
<?php $this->assertNotSame(true, $a);
<?php $this->assertNotTrue($a);
```
Replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1380 (which was targeted at master and more of a mess).