### PR TITLE
AlignDoubleArrowFixer - fix handling of nested arrays

### DIFF
--- a/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
+++ b/Symfony/CS/Fixer/Contrib/AlignDoubleArrowFixer.php
@@ -141,9 +141,25 @@ class AlignDoubleArrowFixer extends AbstractAlignFixer
 
             if ($token->equals(',')) {
                 for ($i = $index; $i < $endAt - 1; ++$i) {
-                    if ($tokens->isArray($i + 1) || false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
+                    if (false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
                         break;
                     }
+
+                    if ($tokens->isArray($i + 1)) {
+                        $arrayStartIndex = $tokens[$i + 1]->isGivenKind(T_ARRAY)
+                            ? $tokens->getNextMeaningfulToken($i + 1)
+                            : $i + 1
+                        ;
+                        $blockType = Tokens::detectBlockType($tokens[$arrayStartIndex]);
+                        $arrayEndIndex = $tokens->findBlockEnd($blockType['type'], $arrayStartIndex);
+
+                        $arrayContent = $tokens->generatePartialCode($arrayStartIndex, $arrayEndIndex);
+
+                        if (false !== strpos($arrayContent, "\n")) {
+                            break;
+                        }
+                    }
+
                     ++$index;
                 }
             }

--- a/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/AlignDoubleArrowFixerTest.php
@@ -432,6 +432,22 @@ class AlignDoubleArrowFixerTest extends AbstractFixerTestBase
         "utė\b" => "us",
     );',
             ),
+            array(
+                '<?php
+                $formMapper
+                    ->add(\'foo\', null, [\'required\' => false])
+                    ->add(\'dummy_field\', null, [\'required\' => false])
+                ;
+                ',
+            ),
+            array(
+                '<?php
+                $formMapper
+                    ->add(\'foo\', null, array(\'required\' => false))
+                    ->add(\'dummy_field\', null, array(\'required\' => false))
+                ;
+                ',
+            ),
         );
     }
 }


### PR DESCRIPTION
Fixes #1450.
Replaces #1455.