### PR TITLE
PhpUnitConstructFixer - fix case when first argument is an expression

### DIFF
--- a/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
@@ -121,7 +121,12 @@ final class PhpUnitConstructFixer extends AbstractFixer
             return;
         }
 
-        $sequenceIndexes[5] = $tokens->getNextNonWhitespace($sequenceIndexes[4]);
+        $sequenceIndexes[5] = $tokens->getNextMeaningfulToken($sequenceIndexes[4]);
+
+        // return if first method argument is an expression, not value
+        if (!$tokens[$sequenceIndexes[5]]->equals(',')) {
+            return;
+        }
 
         $tokens[$sequenceIndexes[2]]->setContent($map[$firstParameterToken->getContent()]);
         $tokens->clearRange($sequenceIndexes[4], $tokens->getNextNonWhitespace($sequenceIndexes[5]) - 1);

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
@@ -63,6 +63,16 @@ class PhpUnitConstructFixerTest extends AbstractFixerTestBase
         "foo" . $bar
     );',
             ),
+            array(
+                '<?php $this->assertNull(/*bar*/ $a);',
+                '<?php $this->assertSame(null /*foo*/, /*bar*/ $a);',
+            ),
+            array(
+                '<?php $this->assertSame(null === $eventException ? $exception : $eventException, $event->getException());',
+            ),
+            array(
+                '<?php $this->assertSame(null /*comment*/ === $eventException ? $exception : $eventException, $event->getException());',
+            ),
         );
     }
 }


### PR DESCRIPTION
Fixes #1457.