### PR TITLE
rename PhpdocShortDescriptionFixer into PhpdocSummaryFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -458,11 +458,11 @@ Choose from the list of available fixers:
                         type are separated by a single
                         blank line.
 
-* **phpdoc_short_description** [@Symfony]
-                        Phpdocs short descriptions
-                        should end in either a full
-                        stop, exclamation mark, or
-                        question mark.
+* **phpdoc_summary** [@Symfony]
+                        Phpdocs summary should end in
+                        either a full stop,
+                        exclamation mark, or question
+                        mark.
 
 * **phpdoc_to_comment** [@Symfony]
                         Docblocks should only be used

--- a/Symfony/CS/Fixer/Symfony/PhpdocSummaryFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocSummaryFixer.php
@@ -19,7 +19,7 @@ use Symfony\CS\Tokenizer\Tokens;
 /**
  * @author Graham Campbell <graham@mineuk.com>
  */
-final class PhpdocShortDescriptionFixer extends AbstractFixer
+final class PhpdocSummaryFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}
@@ -59,7 +59,7 @@ final class PhpdocShortDescriptionFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Phpdocs short descriptions should end in either a full stop, exclamation mark, or question mark.';
+        return 'Phpdocs summary should end in either a full stop, exclamation mark, or question mark.';
     }
 
     /**

--- a/Symfony/CS/RuleSet.php
+++ b/Symfony/CS/RuleSet.php
@@ -72,7 +72,7 @@ final class RuleSet implements RuleSetInterface
             'phpdoc_no_package' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,
-            'phpdoc_short_description' => true,
+            'phpdoc_summary' => true,
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_type_to_var' => true,

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSummaryFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSummaryFixerTest.php
@@ -18,7 +18,7 @@ use Symfony\CS\Test\AbstractFixerTestCase;
  *
  * @internal
  */
-final class PhpdocShortDescriptionFixerTest extends AbstractFixerTestCase
+final class PhpdocSummaryFixerTest extends AbstractFixerTestCase
 {
     public function testFix()
     {

--- a/Symfony/CS/Tests/FixerFactoryTest.php
+++ b/Symfony/CS/Tests/FixerFactoryTest.php
@@ -241,7 +241,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_no_package'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_separation'], $fixers['phpdoc_trim']),
-            array($fixers['phpdoc_short_description'], $fixers['phpdoc_trim']),
+            array($fixers['phpdoc_summary'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_var_without_name'], $fixers['phpdoc_trim']),
             array($fixers['phpdoc_order'], $fixers['phpdoc_trim']),
             array($fixers['unused_use'], $fixers['line_after_namespace']),


### PR DESCRIPTION
Just to follow PSR5 proposal:
https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#51-summary