### PR TITLE
Fix running the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
 script:
-    - phpunit --verbose --coverage-clover build/logs/clover.xml
+    - composer test-ci
     - phpenv config-rm xdebug.ini || return 0
     - php php-cs-fixer --diff --dry-run -v fix
 

--- a/Symfony/CS/Tests/Linter/LinterTest.php
+++ b/Symfony/CS/Tests/Linter/LinterTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests;
+namespace Symfony\CS\Tests\Linter;
 
 use Symfony\Component\Process\ProcessUtils;
 use Symfony\CS\Linter\Linter;

--- a/Symfony/CS/Tests/Standalone/ProjectCodeTest.php
+++ b/Symfony/CS/Tests/Standalone/ProjectCodeTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests;
+namespace Symfony\CS\Tests\Standalone;
 
 use Symfony\Component\Finder\Finder;
 use Symfony\CS\DocBlock\DocBlock;
@@ -83,7 +83,7 @@ final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
         $finder = Finder::create()
             ->files()
             ->name('*.php')
-            ->in(__DIR__.'/..')
+            ->in(__DIR__.'/../..')
             ->exclude(array(
                 'Resources',
                 'Tests/Fixtures',

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,19 @@
         "psr-4": { "Symfony\\CS\\": "Symfony/CS/" }
     },
     "bin": ["php-cs-fixer"],
+    "scripts": {
+        "test": [
+            "phpunit",
+            "phpunit Symfony/CS/Tests/Standalone/ProjectCodeTest.php"
+        ],
+        "test-ci": [
+            "phpunit --verbose --coverage-clover build/logs/clover.xml",
+            "phpunit Symfony/CS/Tests/Standalone/ProjectCodeTest.php"
+        ]
+    },
+    "config": {
+		"process-timeout": 0
+	},
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,26 +12,9 @@
          bootstrap="./vendor/autoload.php"
 >
     <testsuites>
-        <testsuite name="general">
+        <testsuite>
             <directory>./Symfony/CS/Tests/</directory>
-            <exclude>
-                <directory>./Symfony/CS/Tests/Console/</directory>
-                <directory>./Symfony/CS/Tests/Fixer/</directory>
-                <directory>./Symfony/CS/Tests/Fixtures/</directory>
-                <directory>./Symfony/CS/Tests/Tokenizer/</directory>
-            </exclude>
-        </testsuite>
-        <testsuite name="console">
-            <directory>./Symfony/CS/Tests/Console/</directory>
-        </testsuite>
-        <testsuite name="fixer">
-            <directory>./Symfony/CS/Tests/Fixer/</directory>
-        </testsuite>
-        <testsuite name="tokenizer">
-            <directory>./Symfony/CS/Tests/Tokenizer/</directory>
-        </testsuite>
-        <testsuite name="docblock">
-            <directory>./Symfony/CS/Tests/DocBlock/</directory>
+            <exclude>./Symfony/CS/Tests/Standalone</exclude>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Hi!

During working on one of my latests PR I noticed some strange behaviour that I know the tests should fail, but they pass. After a lot of digging I found out that not all tests are run!
It turned out that PHPUnit load all `*Test` classes and execute them, but if you load some of them on your own - PHPUnit won't know about them. And we are loading some `*Test` classes by ourselves in our tests...

```bash
λ phpunit
(...)
Tests: 2532, Assertions: 41425, Skipped: 5.

λ rm Symfony/CS/Tests/ProjectCodeTest.php

λ phpunit
(...)
Tests: 2698, Assertions: 41991, Skipped: 7.
```

I encapsulate the tricky test to run on it's own, separately from all other tests.

after my changes:
```bash
λ composer test                                        
> phpunit
(...)
Tests: 2698, Assertions: 41991, Skipped: 7.
> phpunit Symfony/CS/Tests/Standalone/ProjectCodeTest.php
(...)
OK (252 tests, 252 assertions)
```

-----------------------

I do not like the solution showed by this PR, but I can't figure out any better :(