### PR TITLE
[1.10] Support "@property-read" and "@property-write"

### DIFF
--- a/Symfony/CS/DocBlock/Tag.php
+++ b/Symfony/CS/DocBlock/Tag.php
@@ -26,8 +26,9 @@ class Tag
     private static $tags = array(
         'api', 'author', 'category', 'copyright', 'deprecated', 'example',
         'global', 'internal', 'license', 'link', 'method', 'package', 'param',
-        'property', 'return', 'see', 'since', 'struct', 'subpackage', 'throws',
-        'todo', 'typedef', 'uses', 'var', 'version',
+        'property', 'property-read', 'property-write', 'return', 'see',
+        'since', 'struct', 'subpackage', 'throws', 'todo', 'typedef', 'uses',
+        'var', 'version',
     );
 
     /**
@@ -45,7 +46,7 @@ class Tag
     public function __construct($content)
     {
         $this->name = 'other';
-        preg_match_all('/@[a-zA-Z0-9_]+(?=\s|$)/', $content, $matches);
+        preg_match_all('/@[a-zA-Z0-9_-]+(?=\s|$)/', $content, $matches);
 
         if (isset($matches[0][0])) {
             $this->name = ltrim($matches[0][0], '@');

--- a/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocScalarFixer.php
@@ -26,7 +26,7 @@ class PhpdocScalarFixer extends AbstractFixer
      *
      * @var array
      */
-    private static $tags = array('param', 'return', 'type', 'var', 'property');
+    private static $tags = array('param', 'property', 'property-read', 'property-write', 'return', 'type', 'var');
 
     /**
      * The types to fix.

--- a/Symfony/CS/Tests/DocBlock/TagTest.php
+++ b/Symfony/CS/Tests/DocBlock/TagTest.php
@@ -61,6 +61,7 @@ class TagTest extends \PHPUnit_Framework_TestCase
             array(true, '*@throws \Exception'),
             array(true, ' * @method'),
             array(true, ' * @method string getString()'),
+            array(true, ' * @property-read integer $daysInMonth number of days in the given month'),
             array(false, ' * @method("GET")'),
             array(false, '*@thRoWs \InvalidArgumentException'),
             array(false, "\t@THROWSSS\t  \t RUNTIMEEEEeXCEPTION\t\t\t\t\t\t\t\n\n\n"),

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
@@ -45,6 +45,8 @@ EOF;
 <?php
 /**
  * @property int $foo
+ * @property-read bool $bar
+ * @property-write float $baz
  */
 
 EOF;
@@ -53,6 +55,8 @@ EOF;
 <?php
 /**
  * @property integer $foo
+ * @property-read boolean $bar
+ * @property-write double $baz
  */
 
 EOF;


### PR DESCRIPTION
Noticed this when I ran php-cs-fixer on Carbon. We now have this committed:

![image](https://cloud.githubusercontent.com/assets/2829600/10945710/912d3c70-8316-11e5-88c4-ec63103d08b2.png)

We need to get the other stuff fixed too basically. :)