### PR TITLE
ExtraEmptyLinesFixer - Remove extra lines after comment lines too

### DIFF
--- a/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
@@ -12,6 +12,7 @@
 namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
@@ -25,10 +26,15 @@ class ExtraEmptyLinesFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
-
-        foreach ($tokens->findGivenKind(T_WHITESPACE) as $token) {
+        /** @var Token $token */
+        foreach ($tokens->findGivenKind(T_WHITESPACE) as $index => $token) {
             $content = '';
             $count = 0;
+            if ($index > 0 && $tokens[$index - 1]->isComment()) {
+                $prevContent = $tokens[$index - 1]->getContent();
+                $count = strrpos($prevContent, "\n") === strlen($prevContent) - 1 ? 1 : 0;
+            }
+
             $parts = explode("\n", $token->getContent());
 
             for ($i = 0, $last = count($parts) - 1; $i <= $last; ++$i) {
@@ -36,7 +42,6 @@ class ExtraEmptyLinesFixer extends AbstractFixer
                     // if part is empty then we between two \n
                     ++$count;
                 } else {
-                    $count = 0;
                     $content .= $parts[$i];
                 }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/ExtraEmptyLinesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/ExtraEmptyLinesFixerTest.php
@@ -222,4 +222,27 @@ EOF;
 ";
         $this->makeTest($expected);
     }
+
+    public function testFixWithComments()
+    {
+        $expected = <<<'EOF'
+<?php
+//class Test
+$a; //
+
+$b;
+EOF;
+
+        $input = <<<'EOF'
+<?php
+//class Test
+$a; //
+
+
+
+
+$b;
+EOF;
+        $this->makeTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Bug fix for ExtraEmptyLinesFixer.
Case:

Input
```php

<?php
//class Test
$a; //




$b;

```

Expected
```php

<?php
//class Test
$a; //

$b;

```
