### PR TITLE
BracesFixer - added support for declare

### DIFF
--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -22,6 +22,8 @@ use Symfony\CS\Tokenizer\Tokens;
  */
 class BracesFixer extends AbstractFixer
 {
+    private $singleLineWhitespaceOptions = array('whitespaces' => " \t");
+
     /**
      * {@inheritdoc}
      */
@@ -369,7 +371,7 @@ class BracesFixer extends AbstractFixer
 
             // Declare tokens don't follow the same rules are other control statements
             if ($token->isGivenKind(T_DECLARE)) {
-                $tokens->removeTrailingWhitespace($index);
+                $this->fixDeclareStatement($tokens, $index);
             } elseif ($token->isGivenKind($controlTokens) || $token->isGivenKind(T_USE)) {
                 $nextNonWhitespaceIndex = $tokens->getNextNonWhitespace($index);
 
@@ -607,5 +609,56 @@ class BracesFixer extends AbstractFixer
         }
 
         return array();
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int $index
+     */
+    private function fixDeclareStatement(Tokens $tokens, $index)
+    {
+        $tokens->removeTrailingWhitespace($index);
+
+        $startParenthesisIndex = $tokens->getNextTokenOfKind($index, array('('));
+        $endParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startParenthesisIndex);
+        $startBraceIndex = $tokens->getNextTokenOfKind($endParenthesisIndex, array(';', '{'));
+        $startBraceToken = $tokens[$startBraceIndex];
+
+        if ($startBraceToken->equals('{')) {
+            $this->fixSingleLineWhitespaceForDeclare($tokens, $startBraceIndex);
+        }
+
+        $this->removeWhitespaceInParenthesis($tokens, $startParenthesisIndex, $endParenthesisIndex);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int $startBraceIndex
+     */
+    private function fixSingleLineWhitespaceForDeclare(Tokens $tokens, $startBraceIndex)
+    {
+        // fix single-line whitespace before {
+        // eg: `declare(ticks=1){` => `declare(ticks=1) {`
+        // eg: `declare(ticks=1)   {` => `declare(ticks=1) {`
+        if (
+            !$tokens[$startBraceIndex - 1]->isWhitespace() ||
+            $tokens[$startBraceIndex - 1]->isWhitespace($this->singleLineWhitespaceOptions)
+        ) {
+            $tokens->ensureWhitespaceAtIndex($startBraceIndex - 1, 1, ' ');
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int $startParenthesisIndex
+     * @param int $endParenthesisIndex
+     */
+    private function removeWhitespaceInParenthesis(Tokens $tokens, $startParenthesisIndex, $endParenthesisIndex)
+    {
+        for ($i = $startParenthesisIndex; $i < $endParenthesisIndex; $i++) {
+            if ($tokens[$i]->isWhitespace()) {
+                $tokens[$i]->clear();
+            }
+        }
     }
 }

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -613,7 +613,7 @@ class BracesFixer extends AbstractFixer
 
     /**
      * @param Tokens $tokens
-     * @param int $index
+     * @param int    $index
      */
     private function fixDeclareStatement(Tokens $tokens, $index)
     {
@@ -633,7 +633,7 @@ class BracesFixer extends AbstractFixer
 
     /**
      * @param Tokens $tokens
-     * @param int $startBraceIndex
+     * @param int    $startBraceIndex
      */
     private function fixSingleLineWhitespaceForDeclare(Tokens $tokens, $startBraceIndex)
     {
@@ -650,12 +650,12 @@ class BracesFixer extends AbstractFixer
 
     /**
      * @param Tokens $tokens
-     * @param int $startParenthesisIndex
-     * @param int $endParenthesisIndex
+     * @param int    $startParenthesisIndex
+     * @param int    $endParenthesisIndex
      */
     private function removeWhitespaceInParenthesis(Tokens $tokens, $startParenthesisIndex, $endParenthesisIndex)
     {
-        for ($i = $startParenthesisIndex; $i < $endParenthesisIndex; $i++) {
+        for ($i = $startParenthesisIndex; $i < $endParenthesisIndex; ++$i) {
             if ($tokens[$i]->isWhitespace()) {
                 $tokens[$i]->clear();
             }

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -36,6 +36,7 @@ class BracesFixer extends AbstractFixer
         $this->fixSpaceAroundToken($tokens);
         $this->fixDoWhile($tokens);
         $this->fixLambdas($tokens);
+        $this->fixDeclareStrictTypes($tokens);
 
         // Set code to itself to redo tokenizer work, that will guard as against token collection corruption.
         // TODO: This MUST be removed on 2.0-dev version, where we add more transformers (and lack of them causes corruption on 1.x line).
@@ -604,5 +605,28 @@ class BracesFixer extends AbstractFixer
         }
 
         return array();
+    }
+
+    private function fixDeclareStrictTypes(Tokens $tokens)
+    {
+        $declares = $tokens->findGivenKind(T_DECLARE);
+
+        foreach ($declares as $index => $declare) {
+            if ($this->isStrictTypeDeclare($index, $tokens)) {
+                $tokens->removeTrailingWhitespace($index);
+            }
+        }
+    }
+
+    private function isStrictTypeDeclare($index, Tokens $tokens)
+    {
+        $openParenthesisIndex = $tokens->getNextMeaningfulToken($index);
+        $nextTokenIndex = $tokens->getNextNonWhitespace($openParenthesisIndex);
+
+        if ($tokens[$nextTokenIndex]->getContent() === 'strict_types') {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -127,30 +127,6 @@ class BracesFixerTest extends AbstractFixerTestBase
     }
                 ',
             ),
-            array(
-                '<?php
-    declare(strict_types=1);
-
-    class Test
-    {
-    }',
-                '<?php
-    declare (strict_types=1);
-
-    class Test
-    {
-    }',
-            ),
-            array(
-                '<?php
-    declare (ticks=1) {
-        //
-    }',
-                '<?php
-    declare(ticks=1) {
-        //
-    }',
-            ),
         );
     }
 
@@ -410,11 +386,11 @@ if (1) {
             ),
             array(
                 '<?php
-    declare (ticks=1) {
+    declare(ticks=1) {
         $ticks = 1;
     }',
                 '<?php
-    declare (ticks=1) {
+    declare(ticks=1) {
   $ticks = 1;
     }',
             ),
@@ -1250,10 +1226,18 @@ class Foo
                 '<?php
 
 // comment
-declare (ticks = 1);
+declare(strict_types=1);
 
 // comment
 while (true) {
+}',
+            ),
+            array(
+                '<?php
+declare(ticks=1) {
+}',
+                '<?php
+declare (ticks=1) {
 }',
             ),
         );

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1237,7 +1237,7 @@ while (true) {
 declare(ticks=1) {
 }',
                 '<?php
-declare (ticks=1) {
+declare   (   ticks   =   1   )   {
 }',
             ),
         );

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -134,14 +134,6 @@ class BracesFixerTest extends AbstractFixerTestBase
     class Test
     {
     }',
-            ),
-            array(
-                '<?php
-    declare(strict_types=1);
-
-    class Test
-    {
-    }',
                 '<?php
     declare (strict_types=1);
 
@@ -156,12 +148,6 @@ class BracesFixerTest extends AbstractFixerTestBase
     }',
                 '<?php
     declare(ticks=1) {
-        //
-    }',
-            ),
-            array(
-                '<?php
-    declare (ticks=1) {
         //
     }',
             ),

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -127,6 +127,44 @@ class BracesFixerTest extends AbstractFixerTestBase
     }
                 ',
             ),
+            array(
+                '<?php
+    declare(strict_types=1);
+
+    class Test
+    {
+    }',
+            ),
+            array(
+                '<?php
+    declare(strict_types=1);
+
+    class Test
+    {
+    }',
+                '<?php
+    declare (strict_types=1);
+
+    class Test
+    {
+    }',
+            ),
+            array(
+                '<?php
+    declare (ticks=1) {
+        //
+    }',
+                '<?php
+    declare(ticks=1) {
+        //
+    }',
+            ),
+            array(
+                '<?php
+    declare (ticks=1) {
+        //
+    }',
+            ),
         );
     }
 


### PR DESCRIPTION
This is a RP for #1494  Not sure this is the best/correct way to do something like this.

Basically, `declare(strict_types=1);` shouldn't have a space between the `declare` and opening `(` but other `declare`s should be formatted like `if`s, `where`s, etc..

The strict types declare should only be on the second line too, is this something that needs to be checked as well?