### PR TITLE
Add docblock to AbstractFixerTestBase::makeTest

### DIFF
--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -38,8 +38,9 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests if a fixer fixes a given input string to match the expected result. It is used both if you want to test
-     * if something is fixed or if it is not touched by the fixer.
+     * Tests if a fixer fixes a given input string to match the expected result.
+     *
+     * It is used both if you want to test if something is fixed or if it is not touched by the fixer.
      * It also makes sure that the expected output does not change when run through the fixer. That means that you do not
      * need two test cases like [$expected] and [$expected, $input] (where $expected is the same in both cases)
      * as the latter covers both of them.

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -38,10 +38,18 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if a fixer fixes a given input string to match the expected result. It is used both if you want to test
+     * if something is fixed or if it is not touched by the fixer.
+     * It also makes sure that the expected output does not change when run through the fixer. That means that you do not
+     * need two test cases like [$expected] and [$expected, $input] (where $expected is the same in both cases)
+     * as the latter covers both of them.
+     *
      * @param string              $expected The expected fixer output.
      * @param string|null         $input    The fixer input, or null if it should intentionally be equal to the output.
      * @param \SplFileInfo|null   $file     The file to fix, or null if unneeded.
      * @param FixerInterface|null $fixer    A fixer that should be used, or null if it should be inferred from the test name.
+     *
+     * @throws \InvalidArgumentException If $expected and $input are equal. Leave $input blank if that is intended.
      */
     protected function makeTest($expected, $input = null, \SplFileInfo $file = null, FixerInterface $fixer = null)
     {

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -37,6 +37,12 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
         return $files[$filename];
     }
 
+    /**
+     * @param string              $expected The expected fixer output.
+     * @param string|null         $input    The fixer input, or null if it should intentionally be equal to the output.
+     * @param \SplFileInfo|null   $file     The file to fix, or null if unneeded.
+     * @param FixerInterface|null $fixer    A fixer that should be used, or null if it should be inferred from the test name.
+     */
     protected function makeTest($expected, $input = null, \SplFileInfo $file = null, FixerInterface $fixer = null)
     {
         if ($expected === $input) {

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -40,26 +40,17 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
     /**
      * Tests if a fixer fixes a given string to match the expected result.
      *
-     * It is used both if you want to test if something is fixed or if it
-     * is not touched by the fixer. It also makes sure that the expected
-     * output does not change when run through the fixer. That means that
-     * you do not need two test cases like
-     * [$expected] and
-     * [$expected, $input] (where $expected is the same in both cases)
+     * It is used both if you want to test if something is fixed or if it is not touched by the fixer.
+     * It also makes sure that the expected output does not change when run through the fixer. That means that you
+     * do not need two test cases like [$expected] and [$expected, $input] (where $expected is the same in both cases)
      * as the latter covers both of them.
+     * This method throws an exception if $expected and $input are equal to prevent test cases that accidentally do
+     * not test anything.
      *
      * @param string              $expected The expected fixer output.
-     * @param string|null         $input    The fixer input, or null
-     *                                      if it should intentionally
-     *                                      be equal to the output.
-     * @param \SplFileInfo|null   $file     The file to fix, or null
-     *                                      if unneeded.
-     * @param FixerInterface|null $fixer    The fixer to be used, or null
-     *                                      if it should be inferred
-     *                                      from the test name.
-     *
-     * @throws \InvalidArgumentException If $expected and $input are equal.
-     *                                   Omit $input if that is intended.
+     * @param string|null         $input    The fixer input, or null if it should intentionally be equal to the output.
+     * @param \SplFileInfo|null   $file     The file to fix, or null if unneeded.
+     * @param FixerInterface|null $fixer    The fixer to be used, or null if it should be inferred from the test name.
      */
     protected function makeTest($expected, $input = null, \SplFileInfo $file = null, FixerInterface $fixer = null)
     {

--- a/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
+++ b/Symfony/CS/Tests/Fixer/AbstractFixerTestBase.php
@@ -38,19 +38,28 @@ abstract class AbstractFixerTestBase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests if a fixer fixes a given input string to match the expected result.
+     * Tests if a fixer fixes a given string to match the expected result.
      *
-     * It is used both if you want to test if something is fixed or if it is not touched by the fixer.
-     * It also makes sure that the expected output does not change when run through the fixer. That means that you do not
-     * need two test cases like [$expected] and [$expected, $input] (where $expected is the same in both cases)
+     * It is used both if you want to test if something is fixed or if it
+     * is not touched by the fixer. It also makes sure that the expected
+     * output does not change when run through the fixer. That means that
+     * you do not need two test cases like
+     * [$expected] and
+     * [$expected, $input] (where $expected is the same in both cases)
      * as the latter covers both of them.
      *
      * @param string              $expected The expected fixer output.
-     * @param string|null         $input    The fixer input, or null if it should intentionally be equal to the output.
-     * @param \SplFileInfo|null   $file     The file to fix, or null if unneeded.
-     * @param FixerInterface|null $fixer    A fixer that should be used, or null if it should be inferred from the test name.
+     * @param string|null         $input    The fixer input, or null
+     *                                      if it should intentionally
+     *                                      be equal to the output.
+     * @param \SplFileInfo|null   $file     The file to fix, or null
+     *                                      if unneeded.
+     * @param FixerInterface|null $fixer    The fixer to be used, or null
+     *                                      if it should be inferred
+     *                                      from the test name.
      *
-     * @throws \InvalidArgumentException If $expected and $input are equal. Leave $input blank if that is intended.
+     * @throws \InvalidArgumentException If $expected and $input are equal.
+     *                                   Omit $input if that is intended.
      */
     protected function makeTest($expected, $input = null, \SplFileInfo $file = null, FixerInterface $fixer = null)
     {


### PR DESCRIPTION
Just a quick addition of a docblock for the makeTest function, explaining a bit more what to pass in.

Intended to avoid confusion in the future, feel free to make additions to it!

Best regards,

Lucas