### PR TITLE
ExtraEmptyLinesFixer - allow to remove empty blank lines after configured tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,9 @@ Choose from the list of available fixers:
                         with preg. (Risky fixer!)
 
 * **extra_empty_lines** [@Symfony]
-                        Removes extra empty lines.
+                        Removes extra blank lines
+                        and/or blank lines following
+                        configuration.
 
 * **function_call_space** [@PSR2, @Symfony]
                         When making a method or

--- a/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ExtraEmptyLinesFixer.php
@@ -12,13 +12,71 @@
 namespace Symfony\CS\Fixer\Symfony;
 
 use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author SpacePossum <possumfromspace@gmail.com>
  */
 final class ExtraEmptyLinesFixer extends AbstractFixer
 {
+    /**
+     * @var array<int, string> key is token id, value is name of callback
+     */
+    private $tokenCallbackMap = array(T_WHITESPACE => 'removeMultipleBlankLines');
+
+    /**
+     * @var Tokens
+     */
+    private $tokens;
+
+    /**
+     * Set configuration.
+     *
+     * Valid configuration options are:
+     * - 'break' remove blank lines after a line with a 'break' statement
+     * - 'continue' remove blank lines after a line with a 'break' statement
+     * - 'extra' [default] remove extra blank lines
+     * - 'return' remove blank lines after a line with a 'break' statement
+     * - 'throw' remove blank lines after a line with a 'break' statement
+     * - 'use' remove blank lines between 'use' import statements
+     *
+     * @param string[]|null $configuration
+     */
+    public function configure(array $configuration = null)
+    {
+        if (null === $configuration) {
+            return;
+        }
+
+        $this->tokenCallbackMap = array();
+        foreach ($configuration as $item) {
+            switch ($item) {
+                case 'break':
+                    $this->tokenCallbackMap[T_BREAK] = 'removeEmptyLinesAfterLineWithTokenAt';
+                    break;
+                case 'continue':
+                    $this->tokenCallbackMap[T_CONTINUE] = 'removeEmptyLinesAfterLineWithTokenAt';
+                    break;
+                case 'extra' :
+                    $this->tokenCallbackMap[T_WHITESPACE] = 'removeMultipleBlankLines';
+                    break;
+                case 'return':
+                    $this->tokenCallbackMap[T_RETURN] = 'removeEmptyLinesAfterLineWithTokenAt';
+                    break;
+                case 'throw':
+                    $this->tokenCallbackMap[T_THROW] = 'removeEmptyLinesAfterLineWithTokenAt';
+                    break;
+                case 'use':
+                    $this->tokenCallbackMap[T_USE] = 'removeBetweenUse';
+                    break;
+                default :
+                    throw new \UnexpectedValueException(sprintf('Unknown configuration item "%s" passed.', $item));
+            }
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -32,31 +90,9 @@ final class ExtraEmptyLinesFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
-            if (!$token->isWhitespace()) {
-                continue;
-            }
-
-            $content = '';
-            $count = 0;
-
-            $parts = explode("\n", $token->getContent());
-
-            for ($i = 0, $last = count($parts) - 1; $i <= $last; ++$i) {
-                if ('' === $parts[$i]) {
-                    // if part is empty then we between two \n
-                    ++$count;
-                } else {
-                    $count = 0;
-                    $content .= $parts[$i];
-                }
-
-                if ($i !== $last && $count < 3) {
-                    $content .= "\n";
-                }
-            }
-
-            $token->setContent($content);
+        $this->tokens = $tokens;
+        for ($index = $tokens->getSize() - 1; $index > 0; --$index) {
+            $this->fixByToken($tokens[$index], $index);
         }
     }
 
@@ -65,7 +101,7 @@ final class ExtraEmptyLinesFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Removes extra empty lines.';
+        return 'Removes extra blank lines and/or blank lines following configuration.';
     }
 
     /**
@@ -75,5 +111,93 @@ final class ExtraEmptyLinesFixer extends AbstractFixer
     {
         // should be run after the UnusedUseFixer
         return -20;
+    }
+
+    private function fixByToken(Token $token, $index)
+    {
+        foreach ($this->tokenCallbackMap as $kind => $callback) {
+            if (!$token->isGivenKind($kind)) {
+                continue;
+            }
+
+            $callback = $this->tokenCallbackMap[$kind];
+            $this->$callback($index);
+
+            return;
+        }
+    }
+
+    private function removeBetweenUse($index)
+    {
+        $tokenCount = count($this->tokens);
+        for ($i = $index; $i < $tokenCount; ++$i) {
+            if (!$this->tokens[$i]->equals(';')) {
+                continue;
+            }
+
+            $next = $this->tokens->getNextMeaningfulToken($i);
+            if (!$this->tokens[$next]->isGivenKind(T_USE)) {
+                continue;
+            }
+
+            for ($i = $next; $i > $index; --$i) {
+                if ($this->tokens[$i]->isWhitespace() && substr_count($this->tokens[$i]->getContent(), "\n") > 1) {
+                    $this->tokens[$i]->setContent("\n");
+                }
+            }
+            break;
+        }
+    }
+
+    private function removeMultipleBlankLines($index)
+    {
+        $token = $this->tokens[$index];
+        $content = '';
+        $count = 0;
+        $parts = explode("\n", $token->getContent());
+
+        for ($i = 0, $last = count($parts) - 1; $i <= $last; ++$i) {
+            if ('' === $parts[$i] || "\r" === $parts[$i]) {
+                // if part is empty then we between two \n
+                ++$count;
+            } else {
+                $content .= $parts[$i];
+            }
+
+            if ($i !== $last && $count < 3) {
+                $content .= "\n";
+            }
+        }
+
+        $token->setContent($content);
+    }
+
+    private function removeEmptyLinesAfterLineWithTokenAt($index)
+    {
+        // find the line break
+        $tokenCount = count($this->tokens);
+        for ($end = $index; $end < $tokenCount; ++$end) {
+            if (false !== strpos($this->tokens[$end]->getContent(), "\n")) {
+                break;
+            }
+        }
+
+        if ($end === $tokenCount) {
+            return; // not found, early return
+        }
+
+        for ($i = $end; $i < $tokenCount && $this->tokens[$i]->isWhitespace(); ++$i) {
+            $content = $this->tokens[$i]->getContent();
+            if (substr_count($content, "\n") < 1) {
+                continue;
+            }
+
+            $pos = strrpos($content, "\n");
+            if ($pos + 2 < strlen($content)) { // preserve indenting where possible
+                $this->tokens[$i]->setContent("\n".substr($content, $pos + 1));
+            } else {
+                $this->tokens[$i]->setContent("\n");
+            }
+        }
     }
 }


### PR DESCRIPTION
This will add the following configuration options to the `ExtraEmptyLinesFixer`:
* `use` - remove blank lines between `use` -import lines
* `extra` - current behaviour
* `return` - remove blank lines after a `return` statement
* `continue` - remove blank lines after a `continue` statement
* `break` - remove blank lines after a `break` statement
* `throw ` - remove blank lines after a `throw` statement

I think the configuration naming can be better, so if you have an idea please let me know :)

Notes:
Targeting master because it uses the configuration system.
Waiting for https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1486 since it needs merging after that one.
(suggested tags: feature, master/2.0)