### PR TITLE
[2.0] Revert broken change to the psr0 fixer

### DIFF
--- a/Symfony/CS/Fixer/Contrib/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/Contrib/Psr0Fixer.php
@@ -116,7 +116,6 @@ final class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 $newNamespace[0]->clear();
                 $newNamespace[1]->clear();
                 $newNamespace[2]->clear();
-                $newNamespace->clearEmptyTokens();
 
                 $tokens->insertAt($namespaceIndex, $newNamespace);
             }


### PR DESCRIPTION
The tests added in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1503 fail without reverting this change. It seems to only be present on the master branch. Not sure why it was added? Ping @keradus.