### PR TITLE
Added Symfony 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,27 @@
 language: php
 
-php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - hhvm
-
 matrix:
     fast_finish: true
     include:
         - php: 5.3
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-    allow_failures:
+        - php: 5.4
+        - php: 5.5
+        - php: 5.6
+          env: SYMFONY_VERSION="~2.7"
+        - php: 5.6
+          env: SYMFONY_VERSION="~3.0@dev" COMPOSER_FLAGS="--prefer-stable"
         - php: 7.0
+        - php: hhvm
 
 sudo: false
 
 cache:
     directories:
         - $HOME/.composer/cache
+
+before_install:
+    - 'if [ "$SYMFONY_VERSION" != "" ]; then sed -i "s/\"symfony\/\([^\"]*\)\": \"[^\"]*\"/\"symfony\/\1\": \"$SYMFONY_VERSION\"/g" composer.json; fi'
 
 install:
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": ">=5.3.6",
         "ext-tokenizer": "*",
-        "symfony/console": "~2.3",
-        "symfony/event-dispatcher" : "~2.1",
-        "symfony/filesystem": "~2.1",
-        "symfony/finder": "~2.1",
-        "symfony/process": "~2.3",
-        "symfony/stopwatch": "~2.5",
+        "symfony/console": "~2.3|~3.0",
+        "symfony/event-dispatcher": "~2.1|~3.0",
+        "symfony/filesystem": "~2.1|~3.0",
+        "symfony/finder": "~2.1|~3.0",
+        "symfony/process": "~2.3|~3.0",
+        "symfony/stopwatch": "~2.5|~3.0",
         "sebastian/diff": "~1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds symfony 3.0 support. Several packages can't support symfony 3.0 because of this package ...

This was already discussed in #1281 but it was possible to have dev dependencies during the travis build.
This PR only allows ``symfony/symfony`` to be in a dev version and ``prefer-stable`` is used so when symfony 3.0 will be released, the travis build will use directly the stable version.
