### PR TITLE
Support more annotations when fixing types in phpdoc

### DIFF
--- a/Symfony/CS/AbstractPhpdocTypesFixer.php
+++ b/Symfony/CS/AbstractPhpdocTypesFixer.php
@@ -27,7 +27,17 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
      *
      * @var string[]
      */
-    protected static $tags = array('param', 'property', 'property-read', 'property-write', 'return', 'type', 'var');
+    protected static $tags = array(
+        'method',
+        'param',
+        'property',
+        'property-read',
+        'property-write',
+        'return',
+        'throws',
+        'type',
+        'var',
+    );
 
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocScalarFixerTest.php
@@ -44,6 +44,7 @@ EOF;
         $expected = <<<'EOF'
 <?php
 /**
+ * @method int foo()
  * @property int $foo
  * @property-read bool $bar
  * @property-write float $baz
@@ -54,6 +55,7 @@ EOF;
         $input = <<<'EOF'
 <?php
 /**
+ * @method integer foo()
  * @property integer $foo
  * @property-read boolean $bar
  * @property-write double $baz

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypesFixerTest.php
@@ -90,11 +90,12 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
-    public function testPropertyFix()
+    public function testMethodAndPropertyFix()
     {
         $expected = <<<'EOF'
 <?php
 /**
+ * @method self foo()
  * @property int $foo
  * @property-read boolean $bar
  * @property-write mixed $baz
@@ -105,9 +106,31 @@ EOF;
         $input = <<<'EOF'
 <?php
 /**
+ * @method Self foo()
  * @property Int $foo
  * @property-read Boolean $bar
  * @property-write MIXED $baz
+ */
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
+    public function testThrows()
+    {
+        $expected = <<<'EOF'
+<?php
+/**
+ * @throws static
+ */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+/**
+ * @throws STATIC
  */
 
 EOF;


### PR DESCRIPTION
Adds support for `throws` and `method` annotations.