### PR TITLE
Refactor the way types work on annotations

### DIFF
--- a/Symfony/CS/DocBlock/Annotation.php
+++ b/Symfony/CS/DocBlock/Annotation.php
@@ -19,13 +19,42 @@ namespace Symfony\CS\DocBlock;
 class Annotation
 {
     /**
-     * The lines that make up the annotation.
+     * All the annotation tag names with types.
      *
-     * Note that the array indexes represent the position in the docblock.
+     * @var string[]
+     */
+    private static $tags = array(
+        'method',
+        'param',
+        'property',
+        'property-read',
+        'property-write',
+        'return',
+        'throws',
+        'type',
+        'var',
+    );
+
+    /**
+     * The lines that make up the annotation.
      *
      * @var Line[]
      */
     private $lines;
+
+    /**
+     * The position of the first line of the annotation in the docblock.
+     *
+     * @var int
+     */
+    private $start;
+
+    /**
+     * The position of the last line of the annotation in the docblock.
+     *
+     * @var int
+     */
+    private $end;
 
     /**
      * The associated tag.
@@ -35,13 +64,35 @@ class Annotation
     private $tag;
 
     /**
+     * The cached types content.
+     *
+     * @var string|null
+     */
+    private $typesContent;
+
+    /**
      * Create a new line instance.
      *
      * @param Line[] $lines
      */
     public function __construct(array $lines)
     {
-        $this->lines = $lines;
+        $this->lines = array_values($lines);
+
+        $keys = array_keys($lines);
+
+        $this->start = $keys[0];
+        $this->end = end($keys);
+    }
+
+    /**
+     * Get all the annotation tag names with types.
+     *
+     * @var string[]
+     */
+    public static function getTagsWithTypes()
+    {
+        return self::$tags;
     }
 
     /**
@@ -51,9 +102,7 @@ class Annotation
      */
     public function getStart()
     {
-        $keys = array_keys($this->lines);
-
-        return $keys[0];
+        return $this->start;
     }
 
     /**
@@ -63,9 +112,7 @@ class Annotation
      */
     public function getEnd()
     {
-        $keys = array_keys($this->lines);
-
-        return end($keys);
+        return $this->end;
     }
 
     /**
@@ -81,6 +128,55 @@ class Annotation
         }
 
         return $this->tag;
+    }
+
+    /**
+     * Get the current types content.
+     *
+     * Be careful modifying the underlying line as that won't flush the cache.
+     *
+     * @return string
+     */
+    private function getTypesContent()
+    {
+        if (null === $this->typesContent) {
+            $name = $this->getTag()->getName();
+
+            if (!in_array($name, self::$tags, true)) {
+                throw new \RuntimeException('This tag does not support types');
+            }
+
+            $tagSplit = preg_split('/\s*\@'.$name.'\s*/', $this->lines[0]->getContent(), 2);
+            $spaceSplit = preg_split('/\s/', $tagSplit[1], 2);
+
+            $this->typesContent = $spaceSplit[0];
+        }
+
+        return $this->typesContent;
+    }
+
+    /**
+     * Get the types associated with this annotation.
+     *
+     * @return string[]
+     */
+    public function getTypes()
+    {
+        return explode('|', $this->getTypesContent());
+    }
+
+    /**
+     * Set the types associated with this annotation.
+     *
+     * @param string[] $types
+     */
+    public function setTypes(array $types)
+    {
+        $pattern = '/'.preg_quote($this->getTypesContent()).'/';
+
+        $this->lines[0]->setContent(preg_replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
+
+        $this->typesContent = null;
     }
 
     /**

--- a/Symfony/CS/Tests/DocBlock/AnnotationTest.php
+++ b/Symfony/CS/Tests/DocBlock/AnnotationTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\CS\Tests\DocBlock;
 
+use Symfony\CS\DocBlock\Annotation;
 use Symfony\CS\DocBlock\DocBlock;
+use Symfony\CS\DocBlock\Line;
 
 /**
  * @author Graham Campbell <graham@mineuk.com>
@@ -186,5 +188,54 @@ class AnnotationTest extends \PHPUnit_Framework_TestCase
         }
 
         return $cases;
+    }
+
+    /**
+     * @dataProvider provideTypesCases
+     */
+    public function testTypes($expected, $new, $input, $output)
+    {
+        $line = new Line($input);
+        $tag = new Annotation(array($line));
+
+        $this->assertSame($expected, $tag->getTypes());
+
+        $tag->setTypes($new);
+
+        $this->assertSame($new, $tag->getTypes());
+
+        $this->assertSame($output, $line->getContent());
+    }
+
+    public function provideTypesCases()
+    {
+        return array(
+            array(array('Foo', 'null'), array('Bar[]'), '     * @param Foo|null $foo', '     * @param Bar[] $foo'),
+            array(array('false'), array('bool'), '*   @return            false', '*   @return            bool'),
+            array(array('RUNTIMEEEEeXCEPTION'), array('Throwable'), "\t@throws\t  \t RUNTIMEEEEeXCEPTION\t\t\t\t\t\t\t\n\n\n", "\t@throws\t  \t Throwable\t\t\t\t\t\t\t\n\n\n"),
+            array(array('string'), array('string', 'null'), ' * @method string getString()', ' * @method string|null getString()'),
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage This tag does not support types
+     */
+    public function testGetTypesOnBadTag()
+    {
+        $tag = new Annotation(array(new Line(' * @deprecated since 1.2')));
+
+        $tag->getTypes();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage This tag does not support types
+     */
+    public function testSetTypesOnBadTag()
+    {
+        $tag = new Annotation(array(new Line(' * @author Chuck Norris')));
+
+        $tag->setTypes(array('string'));
     }
 }


### PR DESCRIPTION
This will allow me to build more advanced fixers on 1.x without duplicating code, and later refactor on 2.x to deal with nested types.

We also have even more test coverage of things that were only implicitly tested by functional tests before.