### PR TITLE
Psr0Fixer - Ignore filenames that are a reserved keyword or predefined constant

### DIFF
--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -161,6 +161,11 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
             return false;
         }
 
+        $tokens = Tokens::fromCode(sprintf('<?php %s {}', $filenameParts[0]));
+        if ($tokens[1]->isKeyword() || $tokens[1]->isMagicConstant()) {
+            return false;
+        }
+
         // ignore stubs/fixtures, since they are typically containing invalid files for various reasons
         return !preg_match('{[/\\\\](stub|fixture)s?[/\\\\]}i', $file->getRealPath());
     }

--- a/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR0/Psr0FixerTest.php
@@ -193,11 +193,33 @@ EOF;
 
     public function provideIgnoredCases()
     {
-        return array(
+        $ignoreCases = array(
             array('.php'),
             array('Foo.class.php'),
             array('4Foo.php'),
             array('$#.php'),
         );
+
+        foreach (array('__halt_compiler', 'abstract', 'and', 'array', 'as', 'break', 'case', 'catch', 'class', 'clone', 'const', 'continue', 'declare', 'default', 'die', 'do', 'echo', 'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif', 'endswitch', 'endwhile', 'eval', 'exit', 'extends', 'final', 'for', 'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include', 'include_once', 'instanceof', 'interface', 'isset', 'list', 'namespace', 'new', 'or', 'print', 'private', 'protected', 'public', 'require', 'require_once', 'return', 'static', 'switch', 'throw', 'try', 'unset', 'use', 'var', 'while', 'xor') as $keyword) {
+            $ignoreCases[] = array($keyword.'.php');
+        }
+
+        foreach (array('__CLASS__', '__DIR__', '__FILE__', '__FUNCTION__', '__LINE__', '__METHOD__', '__NAMESPACE__') as $magicConstant) {
+            $ignoreCases[] = array($magicConstant.'.php');
+            $ignoreCases[] = array(strtolower($magicConstant).'.php');
+        }
+
+        if (PHP_VERSION_ID >= 50400) {
+            $ignoreCases[] = array('callable.php');
+            $ignoreCases[] = array('trait.php');
+            $ignoreCases[] = array('__TRAIT__.php');
+            $ignoreCases[] = array('insteadof.php');
+        }
+
+        if (PHP_VERSION_ID >= 50500) {
+            $ignoreCases[] = array('finally.php');
+        }
+
+        return $ignoreCases;
     }
 }

--- a/Symfony/CS/Tests/Tokenizer/TokenTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokenTest.php
@@ -174,11 +174,45 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->getBraceToken()->isKeyword());
     }
 
-    public function testIsMagicConstant()
+    /**
+     * @param int    $tokenId
+     * @param string $content
+     * @param bool   $isConstant
+     *
+     * @dataProvider provideMagicConstantCases
+     */
+    public function testIsMagicConstant($tokenId, $content, $isConstant = true)
     {
-        $this->assertFalse($this->getBraceToken()->isMagicConstant());
-        $token = new Token(array(T_CLASS_C, '__CLASS__'));
-        $this->assertTrue($token->isMagicConstant());
+        $token = new Token(array($tokenId, $content));
+        $this->assertSame($isConstant, $token->isMagicConstant());
+    }
+
+    public function provideMagicConstantCases()
+    {
+        $cases = array(
+            array(T_CLASS_C, '__CLASS__'),
+            array(T_DIR, '__DIR__'),
+            array(T_FILE, '__FILE__'),
+            array(T_FUNC_C, '__FUNCTION__'),
+            array(T_LINE, '__LINE__'),
+            array(T_METHOD_C, '__METHOD__'),
+            array(T_NS_C, '__NAMESPACE__'),
+        );
+
+        if (defined('T_TRAIT_C')) {
+            $cases[] = array(T_TRAIT_C, '__TRAIT__');
+        }
+
+        foreach ($cases as $case) {
+            $cases[] = array($case[0], strtolower($case[1]));
+        }
+
+        foreach (array($this->getForeachToken(), $this->getBraceToken()) as $token) {
+            $cases[] = array($token->getId(), $token->getContent(), false);
+            $cases[] = array($token->getId(), strtolower($token->getContent()), false);
+        }
+
+        return $cases;
     }
 
     /**

--- a/Symfony/CS/Tests/Tokenizer/TokenTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokenTest.php
@@ -174,6 +174,13 @@ class TokenTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->getBraceToken()->isKeyword());
     }
 
+    public function testIsMagicConstant()
+    {
+        $this->assertFalse($this->getBraceToken()->isMagicConstant());
+        $token = new Token(array(T_CLASS_C, '__CLASS__'));
+        $this->assertTrue($token->isMagicConstant());
+    }
+
     /**
      * @dataProvider provideIsNativeConstantCases
      */

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -234,17 +234,16 @@ class Token
     }
 
     /**
-     * Generate keywords array contains all keywords that exists in used PHP version.
+     * Generate array containing all keywords that exists in PHP version in use.
      *
-     * @return array
+     * @return array<int, int>
      */
     public static function getKeywords()
     {
         static $keywords = null;
 
         if (null === $keywords) {
-            $keywords = array();
-            $keywordsStrings = array('T_ABSTRACT', 'T_ARRAY', 'T_AS', 'T_BREAK', 'T_CALLABLE', 'T_CASE',
+            $keywords = self::getTokenKindsForNames(array('T_ABSTRACT', 'T_ARRAY', 'T_AS', 'T_BREAK', 'T_CALLABLE', 'T_CASE',
                 'T_CATCH', 'T_CLASS', 'T_CLONE', 'T_CONST', 'T_CONTINUE', 'T_DECLARE', 'T_DEFAULT', 'T_DO',
                 'T_ECHO', 'T_ELSE', 'T_ELSEIF', 'T_EMPTY', 'T_ENDDECLARE', 'T_ENDFOR', 'T_ENDFOREACH',
                 'T_ENDIF', 'T_ENDSWITCH', 'T_ENDWHILE', 'T_EVAL', 'T_EXIT', 'T_EXTENDS', 'T_FINAL',
@@ -253,14 +252,43 @@ class Token
                 'T_INTERFACE', 'T_ISSET', 'T_LIST', 'T_LOGICAL_AND', 'T_LOGICAL_OR', 'T_LOGICAL_XOR',
                 'T_NAMESPACE', 'T_NEW', 'T_PRINT', 'T_PRIVATE', 'T_PROTECTED', 'T_PUBLIC', 'T_REQUIRE',
                 'T_REQUIRE_ONCE', 'T_RETURN', 'T_STATIC', 'T_SWITCH', 'T_THROW', 'T_TRAIT', 'T_TRY',
-                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD',
-            );
+                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD', 'CT_ARRAY_TYPEHINT',
+            ));
+        }
 
-            foreach ($keywordsStrings as $keywordName) {
-                if (defined($keywordName)) {
-                    $keyword = constant($keywordName);
-                    $keywords[$keyword] = $keyword;
-                }
+        return $keywords;
+    }
+
+    /**
+     * Generate array containing all predefined constants that exists in PHP version in use.
+     *
+     * @see http://php.net/manual/en/language.constants.predefined.php
+     *
+     * @return array<int, int>
+     */
+    public static function getMagicConstants()
+    {
+        static $magicConstants = null;
+
+        if (null === $magicConstants) {
+            $magicConstants = self::getTokenKindsForNames(array('T_CLASS_C', 'T_DIR', 'T_FILE', 'T_FUNC_C', 'T_LINE', 'T_METHOD_C', 'T_NS_C', 'T_TRAIT_C'));
+        }
+
+        return $magicConstants;
+    }
+
+    /**
+     * @param string[] $tokenNames
+     *
+     * @return array<int, int>
+     */
+    private static function getTokenKindsForNames(array $tokenNames)
+    {
+        $keywords = array();
+        foreach ($tokenNames as $keywordName) {
+            if (defined($keywordName)) {
+                $keyword = constant($keywordName);
+                $keywords[$keyword] = $keyword;
             }
         }
 
@@ -365,6 +393,20 @@ class Token
         static $nativeConstantStrings = array('true', 'false', 'null');
 
         return $this->isArray && in_array(strtolower($this->content), $nativeConstantStrings, true);
+    }
+
+    /**
+     * Returns if the token is of a Magic constants type.
+     *
+     * @see http://php.net/manual/en/language.constants.predefined.php
+     *
+     * @return bool
+     */
+    public function isMagicConstant()
+    {
+        $magicConstants = static::getMagicConstants();
+
+        return $this->isArray && isset($magicConstants[$this->id]);
     }
 
     /**

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -68,6 +68,24 @@ class Token
     }
 
     /**
+     * @param string[] $tokenNames
+     *
+     * @return array<int, int>
+     */
+    private static function getTokenKindsForNames(array $tokenNames)
+    {
+        $keywords = array();
+        foreach ($tokenNames as $keywordName) {
+            if (defined($keywordName)) {
+                $keyword = constant($keywordName);
+                $keywords[$keyword] = $keyword;
+            }
+        }
+
+        return $keywords;
+    }
+
+    /**
      * Clear token at given index.
      *
      * Clearing means override token by empty string.
@@ -275,24 +293,6 @@ class Token
         }
 
         return $magicConstants;
-    }
-
-    /**
-     * @param string[] $tokenNames
-     *
-     * @return array<int, int>
-     */
-    private static function getTokenKindsForNames(array $tokenNames)
-    {
-        $keywords = array();
-        foreach ($tokenNames as $keywordName) {
-            if (defined($keywordName)) {
-                $keyword = constant($keywordName);
-                $keywords[$keyword] = $keyword;
-            }
-        }
-
-        return $keywords;
     }
 
     /**


### PR DESCRIPTION
The PSR0 fixer should not try to fix files that are named a predefined constant or keyword,
like `interface.php`