### PR TITLE
Enforce unix style line endings using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
I also propose we export-ignore some stuff on 2.x, like, the massive tests folder.