### PR TITLE
UnneededControlParenthesesFixer - fix test samples

### DIFF
--- a/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
@@ -110,7 +110,7 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
-                clone new Class();
+                clone new Foo();
                 ',
             ),
             array(
@@ -123,10 +123,10 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
-                clone new Class();
+                clone new Foo();
                 ',
                 '<?php
-                clone (new Class());
+                clone (new Foo());
                 ',
             ),
             array(


### PR DESCRIPTION
without this the tests will fail on 2.x line