### PR TITLE
[Feature, 1.11] Add 'for' semicolon fixer.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,10 @@ Choose from the list of available fixers:
                         A file must always end with a
                         single empty line feed.
 
+* **for_loop_semicolon** [PSR-2]
+                        Spacing around semicolons in
+                        `for` control structures.
+
 * **function_call_space** [PSR-2]
                         When making a method or
                         function call, there MUST NOT

--- a/Symfony/CS/Fixer/PSR2/ForLoopSemicolonFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ForLoopSemicolonFixer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\PSR2;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Fix spacing around semicolons in `for` control structures as defined in PSR2 ¶5.4.
+ *
+ * @author SpacePossum <possumfromspace@gmail.com>
+ */
+final class ForLoopSemicolonFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        for ($i = count($tokens) - 1; 0 <= $i; --$i) {
+            if ($tokens[$i]->isGivenKind(T_FOR)) {
+                $this->fixLoopSemicolonSpacing($tokens, $i);
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Spacing around semicolons in `for` control structures.';
+    }
+
+    private function fixLoopSemicolonSpacing(Tokens $tokens, $index)
+    {
+        $expressionStart = $tokens->getNextTokenOfKind($index, array('('));
+        $expressionEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $expressionStart);
+        $this->fixSemicolonSpacing($tokens, $expressionStart, $expressionEnd);
+    }
+
+    private function fixSemicolonSpacing(Tokens $tokens, $expressionStart, $expressionEnd)
+    {
+        for ($index = $expressionEnd - 1; $index > $expressionStart; --$index) {
+            if (!$tokens[$index]->equals(';') || $index === $expressionEnd - 1) {
+                continue;
+            }
+
+            if ($tokens[$index + 1]->isWhitespace()) {
+                if (!$tokens[$index + 1]->equals(' ')) {
+                    $tokens[$index + 1]->setContent(' ');
+                }
+            } else {
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
+            }
+
+            if ($tokens[$index - 1]->isWhitespace() && !$tokens[$index - 2]->equals(';')) {
+                $tokens[$index - 1]->clear();
+                --$index;
+            }
+        }
+    }
+}

--- a/Symfony/CS/Tests/Fixer/PSR2/ForLoopSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/ForLoopSemicolonFixerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\PSR2;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum <possumfromspace@gmail.com>
+ *
+ * @internal
+ */
+class ForLoopSemicolonFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFixes($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php
+for(; ; --$p){
+    //
+}',
+                '<?php
+for(;       ;     --$p){
+    //
+}',
+            ),
+            array(
+                '<?php
+for(; ; --$p1){
+    //
+}',
+                '<?php
+for(;;--$p1){
+    //
+}',
+            ),
+            array(
+                '<?php
+for($z=0/**/; $z<4; --$z){
+    //
+}',
+                '<?php
+for($z=0/**/   ;       $z<4;     --$z){
+    //
+}',
+            ),
+            array(
+                '<?php
+for($k=0; $k<4; --$k){
+    //
+}',
+                '<?php
+for($k=0;$k<4;--$k){
+    //
+}',
+            ),
+            array(
+                '<?php
+for($t=0; $t<4; --$t){
+    //
+}',
+                '<?php
+for($t=0;       $t<4;     --$t){
+    //
+}',
+            ),
+            array(
+                '<?php
+for(; ; --$n){
+    //
+}',
+                '<?php
+for(    ;;--$n){
+    //
+}',
+            ),
+            array(
+                '<?php
+for(; /*;*/$m<4; --$m){
+    //
+}',
+                '<?php
+for(;/*;*/$m<4;     --$m){
+    //
+}',
+            ),
+            array(
+                '<?php
+for ($c=";", $uu = 0; $uu < 4;) {
+}',
+                '<?php
+for ($c=";", $uu = 0;$uu < 4;) {
+}',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Add fixer for spacing around semicolons in a `for` loop

 @ see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1564

