### PR TITLE
SpacesBeforeSemicolonFixer - do not remove space before semicolon if that space is after a semicolon

### DIFF
--- a/Symfony/CS/Fixer/Symfony/SpacesBeforeSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SpacesBeforeSemicolonFixer.php
@@ -27,14 +27,17 @@ class SpacesBeforeSemicolonFixer extends AbstractFixer
         $tokens = Tokens::fromCode($content);
 
         foreach ($tokens as $index => $token) {
-            if (!$token->equals(';')) {
+            if (!$token->equals(';') || !$tokens[$index - 1]->isWhitespace(array('whitespaces' => " \t"))) {
                 continue;
             }
 
-            $previous = $tokens[$index - 1];
-
-            if ($previous->isWhitespace(array('whitespaces' => " \t")) && !$tokens[$index - 2]->isComment()) {
-                $previous->clear();
+            if ($tokens[$index - 2]->equals(';')) {
+                // do not remove all whitespace before the semicolon because it is also whitespace after another semicolon
+                if (!$tokens[$index - 1]->equals(' ')) {
+                    $tokens[$index - 1]->setContent(' ');
+                }
+            } elseif (!$tokens[$index - 2]->isComment()) {
+                $tokens[$index - 1]->clear();
             }
         }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/SpacesBeforeSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SpacesBeforeSemicolonFixerTest.php
@@ -32,6 +32,10 @@ class SpacesBeforeSemicolonFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php for ($uu = 0; ; ++$uu) {}',
+                '<?php for ($uu = 0    ;    ; ++$uu) {}',
+            ),
+            array(
                 '<?php
 $this
     ->setName(\'readme1\')


### PR DESCRIPTION
In order to create a fixer to add whitespace after a semicolon if needed, first this fixer should stop removing such space in order for the fixers not to become conflicting. 