### PR TITLE
Added SpacesAfterSemicolonFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -504,6 +504,10 @@ Choose from the list of available fixers:
                         single quotes for simple
                         strings.
 
+* **spaces_after_semicolon** [symfony]
+                        Fix whitespace after a
+                        semicolon.
+
 * **spaces_before_semicolon** [symfony]
                         Single-line whitespace before
                         closing semicolon are

--- a/Symfony/CS/Fixer/Symfony/SpacesAfterSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SpacesAfterSemicolonFixer.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class SpacesAfterSemicolonFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        for ($index = count($tokens) - 3; $index > 0; --$index) {
+            if (!$tokens[$index]->equals(';') || $tokens[$index + 2]->isComment()) {
+                continue;
+            }
+
+            if (!$tokens[$index + 1]->isWhitespace()) {
+                $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
+            } elseif (!$tokens[$index + 1]->equals(array(T_WHITESPACE, ' ')) && $tokens[$index + 1]->isWhitespace(array('whitespaces' => " \t"))) {
+                $tokens[$index + 1]->setContent(' ');
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Fix whitespace after a semicolon.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/SpacesAfterSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SpacesAfterSemicolonFixerTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class SpacesAfterSemicolonFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php
+                    test();
+                    $a; // test
+                ',
+            ),
+            array(
+                '<?php test();     ',
+            ),
+            array(
+                '<?php
+                    test();     // test
+                ',
+            ),
+            array(
+                '<?php test();       /* */ //',
+            ),
+            array(
+                '<?php
+                    test(); $a = 4;
+                ',
+                '<?php
+                    test();     $a = 4;
+                ',
+            ),
+            array(
+                '<?php
+                    test(); $b = 7;
+                ',
+                '<?php
+                    test();$b = 7;
+                ',
+            ),
+            array(
+                '<?php
+                    for (; ; ) {
+                    }
+                ',
+                '<?php
+                    for (;;) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; ; ++$u1) {
+                    }
+                ',
+                '<?php
+                    for (;;++$u1) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; $u2 < 0; ) {
+                    }
+                ',
+                '<?php
+                    for (;$u2 < 0;) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; $u3 < 3; ++$u3) {
+                    }
+                ',
+                '<?php
+                    for (;$u3 < 3;++$u3) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u4 = 0; ; ) {
+                    }
+                ',
+                '<?php
+                    for ($u4 = 0;;) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u5 = 0; ; ++$u5) {
+                    }
+                ',
+                '<?php
+                    for ($u5 = 0;;++$u5) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u6 = 0; $u6 < 6; ) {
+                    }
+                ',
+                '<?php
+                    for ($u6 = 0;$u6 < 6;) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u7 = 0; $u7 < 7; ++$u7) {
+                    }
+                ',
+                '<?php
+                    for ($u7 = 0;$u7 < 7;++$u7) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; ; ) {
+                    }
+                ',
+                '<?php
+                    for (;    ;    ) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; ; ++$u1) {
+                    }
+                ',
+                '<?php
+                    for (;    ;    ++$u1) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; $u2 < 0; ) {
+                    }
+                ',
+                '<?php
+                    for (;    $u2 < 0;    ) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for (; $u3 < 3; ++$u3) {
+                    }
+                ',
+                '<?php
+                    for (;    $u3 < 3;    ++$u3) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u4 = 0; ; ) {
+                    }
+                ',
+                '<?php
+                    for ($u4 = 0;    ;    ) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u5 = 0; ; ++$u5) {
+                    }
+                ',
+                '<?php
+                    for ($u5 = 0;    ;    ++$u5) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u6 = 0; $u6 < 6; ) {
+                    }
+                ',
+                '<?php
+                    for ($u6 = 0;    $u6 < 6;    ) {
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    for ($u7 = 0; $u7 < 7; ++$u7) {
+                    }
+                ',
+                '<?php
+                    for ($u7 = 0;    $u7 < 7;    ++$u7) {
+                    }
+                ',
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -402,7 +402,7 @@ class Tokens extends \SplFixedArray
             $elements[$kind] = array();
         }
 
-        for ($i = $start;  $i < $end; ++$i) {
+        for ($i = $start; $i < $end; ++$i) {
             $token = $this[$i];
             if ($token->isGivenKind($possibleKinds)) {
                 $elements[$token->getId()][$i] = $token;


### PR DESCRIPTION
Add fixer for whitespace after semicolon fixing.

~~The changes in `Tokens` shows the problem if the fixer does not know if the semicolon is inside a `for` expression ;)~~

~~(ps. fixer is in conflict until https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1576 is resolved)~~