### PR TITLE
[WIP] UnneededControlParenthesesFixer - Inline case is not fixed

### DIFF
--- a/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
@@ -81,8 +81,7 @@ final class UnneededControlParenthesesFixer extends AbstractFixer
             }
 
             $blockStartIndex = $index;
-            $index = $tokens->getPrevMeaningfulToken($index);
-            $token = $tokens[$index];
+            $token = $tokens[$tokens->getPrevMeaningfulToken($index)];
 
             foreach ($loops as $loop) {
                 if (!$token->isGivenKind($loop['lookupTokens'])) {

--- a/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
@@ -345,6 +345,22 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
+                switch($a){case $x : echo 1;}
+                ',
+                '<?php
+                switch($a){case ($x) : echo 1;}
+                ',
+            ),
+            array(
+                '<?php
+                switch($a){case 2 : echo 1;}
+                ',
+                '<?php
+                switch($a){case(2) : echo 1;}
+                ',
+            ),
+            array(
+                '<?php
                 $a = 5.1;
                 $b = 1.0;
                 switch($a) {

--- a/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
@@ -77,6 +77,30 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php
+                switch ($a) {
+                    case 2 :
+                        echo 1;
+                        break;
+                    case 3 : {
+                        echo "fix 2";
+                        break;
+                    }
+                }
+                ',
+                '<?php
+                switch ($a) {
+                    case (2) :
+                        echo 1;
+                        break;
+                    case (3) : {
+                        echo "fix 2";
+                        break;
+                    }
+                }
+                ',
+            ),
+            array(
                 '<?php while ($x) { break; }',
             ),
             array(
@@ -341,22 +365,6 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
                 switch ($a) {
                     case(2);
                 }
-                ',
-            ),
-            array(
-                '<?php
-                switch($a){case $x : echo 1;}
-                ',
-                '<?php
-                switch($a){case ($x) : echo 1;}
-                ',
-            ),
-            array(
-                '<?php
-                switch($a){case 2 : echo 1;}
-                ',
-                '<?php
-                switch($a){case(2) : echo 1;}
                 ',
             ),
             array(


### PR DESCRIPTION
When trying to fix invalid test code I came across this test case for the `UnneededControlParenthesesFixer`;

```php
<?php
case ($x);
```

when 'fixed' to:
```php
<?php
switch($a){case ($x) : echo 1;}
```

it failed, expected:
```php
<?php
switch($a){case $x : echo 1;}
```

(no fix (yet), just reporting the test case)