### PR TITLE
HashToSlashCommentFixer - Add

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,11 @@ Choose from the list of available fixers:
                         function's argument and its
                         typehint.
 
+* **hash_to_slash_comment** [symfony]
+                        Single line comments should
+                        use double slashes (//) and
+                        not hash (#).
+
 * **include** [symfony]
                         Include/Require and file path
                         should be divided with a

--- a/Symfony/CS/Fixer/PSR2/ElseifFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ElseifFixer.php
@@ -50,8 +50,8 @@ class ElseifFixer extends AbstractFixer
             $nextToken->clear();
         }
 
-        # handle `T_ELSE T_WHITESPACE T_IF` treated as single `T_ELSEIF` by HHVM
-        # see https://github.com/facebook/hhvm/issues/4796
+        // handle `T_ELSE T_WHITESPACE T_IF` treated as single `T_ELSEIF` by HHVM
+        // see https://github.com/facebook/hhvm/issues/4796
         if (defined('HHVM_VERSION')) {
             foreach ($tokens->findGivenKind(T_ELSEIF) as $token) {
                 $token->setContent('elseif');

--- a/Symfony/CS/Fixer/Symfony/HashToSlashCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/HashToSlashCommentFixer.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Changes single comments prefixes '#' with '//'.
+ *
+ * @author SpacePossum
+ */
+final class HashToSlashCommentFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        for ($i = 0, $count = count($tokens); $i < $count - 1; ++$i) {
+            if ($tokens[$i]->isGivenKind(T_COMMENT) && '#' === substr($tokens[$i]->getContent(), 0, 1)) {
+                $tokens[$i]->setContent('//'.substr($tokens[$i]->getContent(), 1));
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Single line comments should use double slashes (//) and not hash (#).';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/HashToSlashCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/HashToSlashCommentFixerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class HashToSlashCommentFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            array(
+                '<h1>This is an <?php //echo 123;?> example</h1>',
+                '<h1>This is an <?php #echo 123;?> example</h1>',
+            ),
+            array(
+                '<?php
+                    //#test
+                ',
+            ),
+            array(
+                '<?php
+                    /*
+                        #test
+                    */
+                ',
+            ),
+            array(
+                '<?php
+                    // test
+                ',
+                '<?php
+                    # test
+                ',
+            ),
+            array(
+                '<?php
+                    // test1
+                    //test2
+                    // test3
+                    // test 4
+                ',
+                '<?php
+                    # test1
+                    #test2
+                    # test3
+                    # test 4
+                ',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Just a little fixer from my collection I think others might want to use once in a while (so on contrib level).
It changes single line comments starting with `#` to starting with `\\`.
PHP handles those the same so changing those should not be a problem.
For example

```php
<h1>This is an <?php #echo 123;?> example</h1>
```
to
```php
<h1>This is an <?php //echo 123;?> example</h1>
```

```php
<?php
    # test
```
to
```php
<?php
    // test
```