### PR TITLE
FixCommand - fix output

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -422,8 +422,9 @@ EOF
                 }
 
                 foreach ($changed as $file => $fixResult) {
+                    $output->write(sprintf('%4d) %s', $i++, $file));
+
                     if ($fixerDetailLine) {
-                        $output->write(sprintf('%4d) %s', $i++, $file));
                         $output->write(sprintf($fixerDetailLine, implode(', ', $fixResult['appliedFixers'])));
                     }
 


### PR DESCRIPTION
Bug introduced by #1586 (in 1.12-dev line!), which isn't released yet so I'm not treating it as a bug.

Before #1586 without `-v` there were list of fixed file, after there is _empty line per fixed file_.

```bash
λ php php-cs-fixer fix 1
   1) FixCommand.php
   2) ReadmeCommand.php
   3) SelfUpdateCommand.php
Fixed all files in 4.126 seconds, 6.250 MB memory used
```

```bash
λ php php-cs-fixer fix 1



Fixed all files in 4.097 seconds, 6.250 MB memory used
```