### PR TITLE
Php Inspections (EA Extended): SCA for 1.12

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -533,11 +533,11 @@ EOF
         }
 
         if (!$this->errorsManager->isEmpty()) {
-            $output->writeLn('');
-            $output->writeLn('Files that were not fixed due to internal error:');
+            $output->writeln('');
+            $output->writeln('Files that were not fixed due to internal error:');
 
             foreach ($this->errorsManager->getErrors() as $i => $error) {
-                $output->writeLn(sprintf('%4d) %s', $i + 1, $error['filepath']));
+                $output->writeln(sprintf('%4d) %s', $i + 1, $error['filepath']));
             }
         }
 

--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -166,7 +166,7 @@ class Fixer
 
     public function fixFile(\SplFileInfo $file, array $fixers, $dryRun, $diff, FileCacheManager $fileCacheManager)
     {
-        $new = $old = file_get_contents($file->getRealpath());
+        $new = $old = file_get_contents($file->getRealPath());
 
         if (
             '' === $old
@@ -184,7 +184,7 @@ class Fixer
             return;
         }
 
-        if ($this->lintManager && !$this->lintManager->createProcessForFile($file->getRealpath())->isSuccessful()) {
+        if ($this->lintManager && !$this->lintManager->createProcessForFile($file->getRealPath())->isSuccessful()) {
             if ($this->eventDispatcher) {
                 $this->eventDispatcher->dispatch(
                     FixerFileProcessedEvent::NAME,
@@ -250,7 +250,7 @@ class Fixer
             }
 
             if (!$dryRun) {
-                file_put_contents($file->getRealpath(), $new);
+                file_put_contents($file->getRealPath(), $new);
             }
 
             $fixInfo = array('appliedFixers' => $appliedFixers);

--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -65,8 +65,8 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
         }
 
         if (false !== $namespace) {
-            $normNamespace = strtr($namespace, '\\', '/');
-            $path = strtr($file->getRealPath(), '\\', '/');
+            $normNamespace = str_replace('\\', '/', $namespace);
+            $path = str_replace('\\', '/', $file->getRealPath());
             $dir = dirname($path);
 
             if ($this->config) {
@@ -95,7 +95,7 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 for ($i = $namespaceIndex; $i <= $namespaceEndIndex; ++$i) {
                     $tokens[$i]->clear();
                 }
-                $namespace = substr($namespace, 0, -strlen($dir)).strtr($dir, '/', '\\');
+                $namespace = substr($namespace, 0, -strlen($dir)).str_replace('/', '\\', $dir);
 
                 $newNamespace = Tokens::fromCode('<?php namespace '.$namespace.';');
                 $newNamespace[0]->clear();
@@ -105,12 +105,12 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 $tokens->insertAt($namespaceIndex, $newNamespace);
             }
         } else {
-            $normClass = strtr($classyName, '_', '/');
-            $path = strtr($file->getRealPath(), '\\', '/');
+            $normClass = str_replace('_', '/', $classyName);
+            $path = str_replace('\\', '/', $file->getRealPath());
             $filename = substr($path, -strlen($normClass) - 4, -4);
 
             if ($normClass !== $filename && strtolower($normClass) === strtolower($filename)) {
-                $tokens[$classyIndex]->setContent(strtr($filename, '/', '_'));
+                $tokens[$classyIndex]->setContent(str_replace('/', '_', $filename));
             }
         }
 

--- a/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
@@ -38,11 +38,11 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
                     ++$ternariesCount;
                 }
 
-                if ($tokens[$colonIndex]->equals(':') && 0 === $ternariesCount) {
-                    break;
-                }
-
                 if ($tokens[$colonIndex]->equals(':')) {
+                    if (0 === $ternariesCount) {
+                        break;
+                    }
+
                     --$ternariesCount;
                 }
             }

--- a/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
@@ -133,7 +133,7 @@ class PhpdocParamsFixer extends AbstractFixer
                     $line =
                         $item['indent']
                         .' *  '
-                        .str_repeat(' ', ($tagMax + $hintMax + $varMax + ('param' === $currTag ? 3 : 2)))
+                        .str_repeat(' ', $tagMax + $hintMax + $varMax + ('param' === $currTag ? 3 : 2))
                         .$item['desc']
                         ."\n";
 

--- a/Symfony/CS/Fixer/Symfony/SingleQuoteFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SingleQuoteFixer.php
@@ -39,8 +39,7 @@ class SingleQuoteFixer extends AbstractFixer
                 !preg_match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["$\\\\])/', $content)
             ) {
                 $content = substr($content, 1, -1);
-                $content = str_replace('\\"', '"', $content);
-                $content = str_replace('\\$', '$', $content);
+                $content = str_replace(array('\\"', '\\$'), array('"', '$'), $content);
                 $token->setContent('\''.$content.'\'');
             }
         }

--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -70,8 +70,7 @@ class LintManager
         }
 
         file_put_contents($this->temporaryFile, $source);
-        $process = $this->createProcessForFile($this->temporaryFile);
 
-        return $process;
+        return $this->createProcessForFile($this->temporaryFile);
     }
 }

--- a/Symfony/CS/Tests/AbstractIntegrationTest.php
+++ b/Symfony/CS/Tests/AbstractIntegrationTest.php
@@ -347,7 +347,7 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
 
             switch ($label) {
                 case 'hhvm':
-                    $requirements['hhvm'] = 'false' === $value ? false : true;
+                    $requirements['hhvm'] = 'false' !== $value;
                     break;
                 case 'php':
                     $requirements['php'] = $value;


### PR DESCRIPTION
Php Inspections (EA Extended): fixed following inspections complains

- methods names case mismatches
- strtr -> str_replace usage semantics
- un-needed parenthesises
- cascading str_replace calls
- not optimal if conditions
- simplifying ternary-expressions
- one-time use variables