### PR TITLE
Revert "Travis - set dist to trusty"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
 
 sudo: false
 
-dist: trusty
-
 cache:
     directories:
         - $HOME/.composer/cache


### PR DESCRIPTION
Withuout sudo it will still install precise: 
https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/98816507#L13