### PR TITLE
SwitchCaseSpaceFixer - Fix spacing between 'case' and semicolon

### DIFF
--- a/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
@@ -38,7 +38,7 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
                     ++$ternariesCount;
                 }
 
-                if ($tokens[$colonIndex]->equalsAny(array(':', ';'), false)) {
+                if ($tokens[$colonIndex]->equalsAny(array(':', ';'))) {
                     if (0 === $ternariesCount) {
                         break;
                     }

--- a/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
@@ -38,7 +38,7 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
                     ++$ternariesCount;
                 }
 
-                if ($tokens[$colonIndex]->equals(':') || $tokens[$colonIndex]->equals(';')) {
+                if ($tokens[$colonIndex]->equalsAny(array(':', ';'), false)) {
                     if (0 === $ternariesCount) {
                         break;
                     }

--- a/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SwitchCaseSpaceFixer.php
@@ -38,7 +38,7 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
                     ++$ternariesCount;
                 }
 
-                if ($tokens[$colonIndex]->equals(':')) {
+                if ($tokens[$colonIndex]->equals(':') || $tokens[$colonIndex]->equals(';')) {
                     if (0 === $ternariesCount) {
                         break;
                     }

--- a/Symfony/CS/Tests/Fixer/PSR2/SwitchCaseSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/SwitchCaseSpaceFixerTest.php
@@ -272,6 +272,32 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestBase
                 }
                 ',
             ),
+            array(
+                '<?php
+                    switch($foo) {
+                        case 4:  ; ;
+                        case 31 + test(";");  ; ; ;;
+                        case 1 + test(";"); // ;
+                        case (1+2/*;*/);
+                        case 1;
+                        case 2;
+                            return 1;
+                        default;
+                            return 2;
+                }',
+                '<?php
+                    switch($foo) {
+                        case 4  :  ; ;
+                        case 31 + test(";") ;  ; ; ;;
+                        case 1 + test(";") ; // ;
+                        case (1+2/*;*/) ;
+                        case 1  ;
+                        case 2 ;
+                            return 1;
+                        default;
+                            return 2;
+                }',
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/SwitchCaseSpaceFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/SwitchCaseSpaceFixerTest.php
@@ -294,7 +294,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestBase
                         case 1  ;
                         case 2 ;
                             return 1;
-                        default;
+                        default ;
                             return 2;
                 }',
             ),


### PR DESCRIPTION
@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1656