### PR TITLE
DuplicateSemicolonFixer - Remove duplicate semicolons even if there are comments between those

### DIFF
--- a/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
@@ -41,7 +41,7 @@ class DuplicateSemicolonFixer extends AbstractFixer
                 continue;
             }
 
-            $prevIndex = $tokens->getPrevNonWhitespace($index);
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
 
             if (!$tokens[$prevIndex]->equals(';')) {
                 continue;

--- a/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
+++ b/Symfony/CS/Fixer/Symfony/DuplicateSemicolonFixer.php
@@ -25,25 +25,17 @@ class DuplicateSemicolonFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
-        $limit = $tokens->count();
 
-        for ($index = 0; $index < $limit; ++$index) {
+        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
             $token = $tokens[$index];
 
             // skip T_FOR parenthesis to ignore duplicated `;` like `for ($i = 1; ; ++$i) {...}`
             if ($token->isGivenKind(T_FOR)) {
-                $index = $tokens->getNextMeaningfulToken($index);
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextMeaningfulToken($index)) + 1;
                 continue;
             }
 
-            if (!$token->equals(';')) {
-                continue;
-            }
-
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
-
-            if (!$tokens[$prevIndex]->equals(';')) {
+            if (!$token->equals(';') || !$tokens[$tokens->getPrevMeaningfulToken($index)]->equals(';')) {
                 continue;
             }
 

--- a/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
@@ -30,25 +30,51 @@ class DuplicateSemicolonFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php $foo = 2 ; //
+
+                ',
+                '<?php $foo = 2 ; //
+                    ;
+                ',
+            ),
+            array(
+                '<?php $foo = 3; /**/',
+                '<?php $foo = 3; /**/; ;',
+            ),
+            array(
                 '<?php $foo = 1;',
                 '<?php $foo = 1;;;',
             ),
             array(
-                '<?php $foo = 1;',
-                '<?php $foo = 1;; ;;',
+                '<?php $foo = 4;',
+                '<?php $foo = 4;; ;;',
             ),
             array(
-                '<?php $foo = 1;',
-                '<?php $foo = 1;;
+                '<?php $foo = 5;',
+                '<?php $foo = 5;;
 ;
     ;',
             ),
             array(
-                '<?php $foo = 1; ',
-                '<?php $foo = 1;; ',
+                '<?php $foo = 6; ',
+                '<?php $foo = 6;; ',
             ),
             array(
-                '<?php for ($i = 0; ; ++$i) {}',
+                '<?php for ($i = 7; ; ++$i) {}',
+            ),
+            array(
+                '<?php
+                    switch($a){
+                        case 8;
+                            echo 2;
+                    }
+                ',
+                '<?php
+                    switch($a){
+                        case 8;;
+                            echo 2;
+                    }
+                ',
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/DuplicateSemicolonFixerTest.php
@@ -32,9 +32,11 @@ class DuplicateSemicolonFixerTest extends AbstractFixerTestBase
             array(
                 '<?php $foo = 2 ; //
 
+
                 ',
                 '<?php $foo = 2 ; //
                     ;
+
                 ',
             ),
             array(

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -179,6 +179,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['duplicate_semicolon'], $fixers['braces']),
             array($fixers['duplicate_semicolon'], $fixers['spaces_before_semicolon']),
             array($fixers['duplicate_semicolon'], $fixers['multiline_spaces_before_semicolon']),
+            array($fixers['duplicate_semicolon'], $fixers['extra_empty_lines']), // tested also in: duplicate_semicolon,extra_empty_lines.test
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['multiline_array_trailing_comma']),
             array($fixers['double_arrow_multiline_whitespaces'], $fixers['align_double_arrow']), // tested also in: double_arrow_multiline_whitespaces,align_double_arrow.test
             array($fixers['operators_spaces'], $fixers['align_double_arrow']), // tested also in: align_double_arrow,operators_spaces.test

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/duplicate_semicolon,extra_empty_lines.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/duplicate_semicolon,extra_empty_lines.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: duplicate_semicolon,extra_empty_lines.
+--CONFIG--
+level=none
+fixers=duplicate_semicolon,extra_empty_lines
+--EXPECT--
+<?php $foo = 2 ; //
+
+//
+
+--INPUT--
+<?php $foo = 2 ; //
+                    ;
+
+//


### PR DESCRIPTION
With this PR duplicate semicolons will be removed even if there are comment between the semicolons. 

~~WIP because it seems there might be a priority issue with the multiple empty/blank and trailing whitespace on empty line fixers.~~ added