### PR TITLE
Backport Finder and Config classes from 2.x line

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,7 +11,7 @@ EOF;
 
 Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
 
-return Symfony\CS\Config\Config::create()
+return Symfony\CS\Config::create()
     // use default SYMFONY_LEVEL and extra fixers:
     ->fixers(array(
         'header_comment',
@@ -23,7 +23,7 @@ return Symfony\CS\Config\Config::create()
         'strict_param',
     ))
     ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
+        Symfony\CS\Finder::create()
             ->exclude('Symfony/CS/Tests/Fixtures')
             ->in(__DIR__)
     )

--- a/README.rst
+++ b/README.rst
@@ -722,12 +722,12 @@ to the default list of symfony-level fixers:
 
     <?php
 
-    $finder = Symfony\CS\Finder\DefaultFinder::create()
+    $finder = Symfony\CS\Finder::create()
         ->exclude('somedir')
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->fixers(array('strict_param', 'short_array_syntax'))
         ->finder($finder)
     ;
@@ -739,11 +739,11 @@ then specify all fixers to be used:
 
     <?php
 
-    $finder = Symfony\CS\Finder\DefaultFinder::create()
+    $finder = Symfony\CS\Finder::create()
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
         ->fixers(array('trailing_spaces', 'encoding'))
         ->finder($finder)
@@ -757,12 +757,12 @@ Note the additional ``-`` in front of the Fixer name.
 
     <?php
 
-    $finder = Symfony\CS\Finder\DefaultFinder::create()
+    $finder = Symfony\CS\Finder::create()
         ->exclude('somedir')
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->fixers(array('-psr0'))
         ->finder($finder)
     ;
@@ -773,7 +773,7 @@ The ``symfony`` level is set by default, you can also change the default level:
 
     <?php
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ;
 
@@ -798,7 +798,7 @@ speed up further runs.
 
     <?php
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->setUsingCache(true)
     ;
 

--- a/Symfony/CS/Config.php
+++ b/Symfony/CS/Config.php
@@ -131,6 +131,22 @@ class Config implements ConfigInterface
         return $this;
     }
 
+    public function addCustomFixers($fixers)
+    {
+        if (false === is_array($fixers) && false === $fixers instanceof \Traversable) {
+            throw new \InvalidArgumentException(sprintf(
+                'Argument must be an array or a Traversable, got "%s".',
+                is_object($fixers) ? get_class($fixers) : gettype($fixers)
+            ));
+        }
+
+        foreach ($fixers as $fixer) {
+            $this->addCustomFixer($fixer);
+        }
+
+        return $this;
+    }
+
     public function getCustomFixers()
     {
         return $this->customFixers;

--- a/Symfony/CS/Config.php
+++ b/Symfony/CS/Config.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+use Symfony\CS\Finder\DefaultFinder;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
+ */
+class Config implements ConfigInterface
+{
+    protected $name;
+    protected $description;
+    protected $finder;
+    protected $level;
+    protected $fixers;
+    protected $dir;
+    protected $customFixers;
+    protected $usingCache = false;
+    protected $usingLinter = true;
+    protected $hideProgress = false;
+
+    public function __construct($name = 'default', $description = 'A default configuration')
+    {
+        $this->name = $name;
+        $this->description = $description;
+        $this->level = FixerInterface::SYMFONY_LEVEL;
+        $this->fixers = array();
+        $this->finder = new DefaultFinder();
+        $this->customFixers = array();
+    }
+
+    public static function create()
+    {
+        return new static();
+    }
+
+    public function setDir($dir)
+    {
+        $this->dir = $dir;
+    }
+
+    public function setUsingCache($usingCache)
+    {
+        $this->usingCache = $usingCache;
+
+        return $this;
+    }
+
+    public function setUsingLinter($usingLinter)
+    {
+        $this->usingLinter = $usingLinter;
+
+        return $this;
+    }
+
+    public function getDir()
+    {
+        return $this->dir;
+    }
+
+    public function finder(\Traversable $finder)
+    {
+        $this->finder = $finder;
+
+        return $this;
+    }
+
+    public function getFinder()
+    {
+        if ($this->finder instanceof FinderInterface && $this->dir !== null) {
+            $this->finder->setDir($this->dir);
+        }
+
+        return $this->finder;
+    }
+
+    public function level($level)
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    public function fixers($fixers)
+    {
+        $this->fixers = $fixers;
+
+        return $this;
+    }
+
+    public function getFixers()
+    {
+        return $this->fixers;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getHideProgress()
+    {
+        return $this->hideProgress;
+    }
+
+    public function addCustomFixer(FixerInterface $fixer)
+    {
+        $this->customFixers[] = $fixer;
+
+        return $this;
+    }
+
+    public function getCustomFixers()
+    {
+        return $this->customFixers;
+    }
+
+    public function hideProgress($hideProgress)
+    {
+        $this->hideProgress = $hideProgress;
+
+        return $this;
+    }
+
+    public function usingCache()
+    {
+        return $this->usingCache;
+    }
+
+    public function usingLinter()
+    {
+        return $this->usingLinter;
+    }
+}

--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -11,148 +11,27 @@
 
 namespace Symfony\CS\Config;
 
-use Symfony\CS\ConfigInterface;
-use Symfony\CS\Finder\DefaultFinder;
-use Symfony\CS\FinderInterface;
-use Symfony\CS\FixerInterface;
+use Symfony\CS\Config as BaseConfig;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
+ *
+ * @deprecated
  */
-class Config implements ConfigInterface
+class Config extends BaseConfig
 {
-    protected $name;
-    protected $description;
-    protected $finder;
-    protected $level;
-    protected $fixers;
-    protected $dir;
-    protected $customFixers;
-    protected $usingCache = false;
-    protected $usingLinter = true;
-    protected $hideProgress = false;
-
-    public function __construct($name = 'default', $description = 'A default configuration')
+    public function __construct()
     {
-        $this->name = $name;
-        $this->description = $description;
-        $this->level = FixerInterface::SYMFONY_LEVEL;
-        $this->fixers = array();
-        $this->finder = new DefaultFinder();
-        $this->customFixers = array();
-    }
+        @trigger_error(
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Config'
+            ),
+            E_USER_DEPRECATED
+        );
 
-    public static function create()
-    {
-        return new static();
-    }
-
-    public function setDir($dir)
-    {
-        $this->dir = $dir;
-    }
-
-    public function setUsingCache($usingCache)
-    {
-        $this->usingCache = $usingCache;
-
-        return $this;
-    }
-
-    public function setUsingLinter($usingLinter)
-    {
-        $this->usingLinter = $usingLinter;
-
-        return $this;
-    }
-
-    public function getDir()
-    {
-        return $this->dir;
-    }
-
-    public function finder(\Traversable $finder)
-    {
-        $this->finder = $finder;
-
-        return $this;
-    }
-
-    public function getFinder()
-    {
-        if ($this->finder instanceof FinderInterface && $this->dir !== null) {
-            $this->finder->setDir($this->dir);
-        }
-
-        return $this->finder;
-    }
-
-    public function level($level)
-    {
-        $this->level = $level;
-
-        return $this;
-    }
-
-    public function getLevel()
-    {
-        return $this->level;
-    }
-
-    public function fixers($fixers)
-    {
-        $this->fixers = $fixers;
-
-        return $this;
-    }
-
-    public function getFixers()
-    {
-        return $this->fixers;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function getDescription()
-    {
-        return $this->description;
-    }
-
-    public function getHideProgress()
-    {
-        return $this->hideProgress;
-    }
-
-    public function addCustomFixer(FixerInterface $fixer)
-    {
-        $this->customFixers[] = $fixer;
-
-        return $this;
-    }
-
-    public function getCustomFixers()
-    {
-        return $this->customFixers;
-    }
-
-    public function hideProgress($hideProgress)
-    {
-        $this->hideProgress = $hideProgress;
-
-        return $this;
-    }
-
-    public function usingCache()
-    {
-        return $this->usingCache;
-    }
-
-    public function usingLinter()
-    {
-        return $this->usingLinter;
+        parent::__construct();
     }
 }

--- a/Symfony/CS/Config/MagentoConfig.php
+++ b/Symfony/CS/Config/MagentoConfig.php
@@ -15,13 +15,19 @@ use Symfony\CS\Finder\MagentoFinder;
 
 /**
  * @author Myke Hines <myke@webhines.com>
+ *
+ * @deprecated
  */
 class MagentoConfig extends Config
 {
     public function __construct()
     {
         @trigger_error(
-            sprintf('The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version.', __CLASS__),
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Config'
+            ),
             E_USER_DEPRECATED
         );
 

--- a/Symfony/CS/Config/Symfony23Config.php
+++ b/Symfony/CS/Config/Symfony23Config.php
@@ -15,13 +15,19 @@ use Symfony\CS\Finder\Symfony23Finder;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated
  */
 class Symfony23Config extends Config
 {
     public function __construct()
     {
         @trigger_error(
-            sprintf('The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version.', __CLASS__),
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Config'
+            ),
             E_USER_DEPRECATED
         );
 

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -187,12 +187,12 @@ to the default list of symfony-level fixers:
 
     <?php
 
-    \$finder = Symfony\CS\Finder\DefaultFinder::create()
+    \$finder = Symfony\CS\Finder::create()
         ->exclude('somedir')
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->fixers(array('strict_param', 'short_array_syntax'))
         ->finder(\$finder)
     ;
@@ -204,11 +204,11 @@ then specify all fixers to be used:
 
     <?php
 
-    \$finder = Symfony\CS\Finder\DefaultFinder::create()
+    \$finder = Symfony\CS\Finder::create()
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->level(Symfony\CS\FixerInterface::NONE_LEVEL)
         ->fixers(array('trailing_spaces', 'encoding'))
         ->finder(\$finder)
@@ -222,12 +222,12 @@ Note the additional <comment>-</comment> in front of the Fixer name.
 
     <?php
 
-    \$finder = Symfony\CS\Finder\DefaultFinder::create()
+    \$finder = Symfony\CS\Finder::create()
         ->exclude('somedir')
         ->in(__DIR__)
     ;
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->fixers(array('-psr0'))
         ->finder(\$finder)
     ;
@@ -238,7 +238,7 @@ The ``symfony`` level is set by default, you can also change the default level:
 
     <?php
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ;
 
@@ -263,7 +263,7 @@ speed up further runs.
 
     <?php
 
-    return Symfony\CS\Config\Config::create()
+    return Symfony\CS\Config::create()
         ->setUsingCache(true)
     ;
 
@@ -340,8 +340,8 @@ EOF
         } elseif (file_exists($configFile)) {
             $config = include $configFile;
             // verify that the config has an instance of Config
-            if (!$config instanceof Config) {
-                throw new InvalidConfigurationException(sprintf('The config file "%s" does not return a "Symfony\CS\Config\Config" instance. Got: "%s".', $configFile, is_object($config) ? get_class($config) : gettype($config)));
+            if (!$config instanceof ConfigInterface) {
+                throw new InvalidConfigurationException(sprintf('The config file "%s" does not return a "Symfony\CS\ConfigInterface" instance. Got: "%s".', $configFile, is_object($config) ? get_class($config) : gettype($config)));
             }
 
             if ('txt' === $input->getOption('format')) {

--- a/Symfony/CS/Finder.php
+++ b/Symfony/CS/Finder.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+use Symfony\Component\Finder\Finder as BaseFinder;
+
+/**
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Finder extends BaseFinder implements FinderInterface
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $files = $this->getFilesToExclude();
+
+        $this
+            ->files()
+            ->name('*.php')
+            ->name('*.twig')
+            ->name('*.xml')
+            ->name('*.yml')
+            ->ignoreDotFiles(true)
+            ->ignoreVCS(true)
+            ->exclude('vendor')
+            ->filter(
+                function (\SplFileInfo $file) use ($files) {
+                    return !in_array($file->getRelativePathname(), $files, true);
+                }
+            )
+        ;
+    }
+
+    public function setDir($dir)
+    {
+        $this->in($this->getDirs($dir));
+    }
+
+    /**
+     * Gets the directories that needs to be scanned for files to validate.
+     *
+     * @param string $dir
+     *
+     * @return string[]
+     */
+    protected function getDirs($dir)
+    {
+        return array($dir);
+    }
+
+    /**
+     * Excludes files because modifying them would break.
+     *
+     * This is mainly useful for fixtures in unit tests.
+     *
+     * @return string[]
+     */
+    protected function getFilesToExclude()
+    {
+        return array();
+    }
+}

--- a/Symfony/CS/Finder.php
+++ b/Symfony/CS/Finder.php
@@ -28,8 +28,6 @@ class Finder extends BaseFinder implements FinderInterface
             ->files()
             ->name('*.php')
             ->name('*.twig')
-            ->name('*.xml')
-            ->name('*.yml')
             ->ignoreDotFiles(true)
             ->ignoreVCS(true)
             ->exclude('vendor')

--- a/Symfony/CS/Finder/DefaultFinder.php
+++ b/Symfony/CS/Finder/DefaultFinder.php
@@ -11,63 +11,26 @@
 
 namespace Symfony\CS\Finder;
 
-use Symfony\Component\Finder\Finder;
-use Symfony\CS\FinderInterface;
+use Symfony\CS\Finder as BaseFinder;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated
  */
-class DefaultFinder extends Finder implements FinderInterface
+class DefaultFinder extends BaseFinder
 {
     public function __construct()
     {
+        @trigger_error(
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Finder'
+            ),
+            E_USER_DEPRECATED
+        );
+
         parent::__construct();
-
-        $files = $this->getFilesToExclude();
-
-        $this
-            ->files()
-            ->name('*.php')
-            ->name('*.twig')
-            ->name('*.xml')
-            ->name('*.yml')
-            ->ignoreDotFiles(true)
-            ->ignoreVCS(true)
-            ->exclude('vendor')
-            ->filter(
-                function (\SplFileInfo $file) use ($files) {
-                    return !in_array($file->getRelativePathname(), $files, true);
-                }
-            )
-        ;
-    }
-
-    public function setDir($dir)
-    {
-        $this->in($this->getDirs($dir));
-    }
-
-    /**
-     * Gets the directories that needs to be scanned for files to validate.
-     *
-     * @param string $dir
-     *
-     * @return string[]
-     */
-    protected function getDirs($dir)
-    {
-        return array($dir);
-    }
-
-    /**
-     * Excludes files because modifying them would break.
-     *
-     * This is mainly useful for fixtures in unit tests.
-     *
-     * @return string[]
-     */
-    protected function getFilesToExclude()
-    {
-        return array();
     }
 }

--- a/Symfony/CS/Finder/DefaultFinder.php
+++ b/Symfony/CS/Finder/DefaultFinder.php
@@ -32,5 +32,10 @@ class DefaultFinder extends BaseFinder
         );
 
         parent::__construct();
+
+        $this
+            ->name('*.xml')
+            ->name('*.yml')
+        ;
     }
 }

--- a/Symfony/CS/Finder/MagentoFinder.php
+++ b/Symfony/CS/Finder/MagentoFinder.php
@@ -13,13 +13,19 @@ namespace Symfony\CS\Finder;
 
 /**
  * @author Myke Hines <myke@webhines.com>
+ *
+ * @deprecated
  */
 class MagentoFinder extends DefaultFinder
 {
     public function __construct()
     {
         @trigger_error(
-            sprintf('The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version.', __CLASS__),
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Finder'
+            ),
             E_USER_DEPRECATED
         );
 

--- a/Symfony/CS/Finder/Symfony23Finder.php
+++ b/Symfony/CS/Finder/Symfony23Finder.php
@@ -13,13 +13,19 @@ namespace Symfony\CS\Finder;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated
  */
 class Symfony23Finder extends DefaultFinder
 {
     public function __construct()
     {
         @trigger_error(
-            sprintf('The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version.', __CLASS__),
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will soon be removed in 2.0 version. Use "%s" instead.',
+                __CLASS__,
+                'Symfony\CS\Finder'
+            ),
             E_USER_DEPRECATED
         );
 

--- a/Symfony/CS/Fixer/Contrib/ShortEchoTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortEchoTagFixer.php
@@ -36,7 +36,7 @@ class ShortEchoTagFixer extends AbstractFixer
                 continue;
             }
 
-            $token->override(array(T_OPEN_TAG, '<?php ', $token->getLine()));
+            $tokens->overrideAt($i, array(T_OPEN_TAG, '<?php ', $token->getLine()));
 
             if (!$tokens[$nextIndex]->isWhitespace()) {
                 $tokens->insertAt($nextIndex, new Token(array(T_WHITESPACE, ' ')));

--- a/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
@@ -191,7 +191,8 @@ class UnusedUseFixer extends AbstractFixer
             return;
         }
 
-        $nextToken = $tokens[$useDeclaration['end'] + 1];
+        $nextIndex = $useDeclaration['end'] + 1;
+        $nextToken = $tokens[$nextIndex];
 
         if ($nextToken->isWhitespace()) {
             $content = ltrim($nextToken->getContent(), " \t");
@@ -204,7 +205,7 @@ class UnusedUseFixer extends AbstractFixer
         }
 
         if ($prevToken->isWhitespace() && $nextToken->isWhitespace()) {
-            $nextToken->override(array(T_WHITESPACE, $prevToken->getContent().$nextToken->getContent(), $prevToken->getLine()));
+            $tokens->overrideAt($nextIndex, array(T_WHITESPACE, $prevToken->getContent().$nextToken->getContent(), $prevToken->getLine()));
             $prevToken->clear();
         }
     }


### PR DESCRIPTION
As on 2.x line we want to remove `Symfony\CS\Config\Config` and use only `Symfony\CS\Config` it would be great to allow to switch to it already on 1.x line, same for Finder.

// requested by @GrahamCampbell 

ref #1646