### PR TITLE
Add fixer suite support

### DIFF
--- a/Symfony/CS/Config/Config.php
+++ b/Symfony/CS/Config/Config.php
@@ -15,6 +15,7 @@ use Symfony\CS\ConfigInterface;
 use Symfony\CS\Finder\DefaultFinder;
 use Symfony\CS\FinderInterface;
 use Symfony\CS\FixerInterface;
+use Symfony\CS\FixerSuiteInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -137,6 +138,15 @@ class Config implements ConfigInterface
     public function getCustomFixers()
     {
         return $this->customFixers;
+    }
+
+    public function addCustomFixerSuite(FixerSuiteInterface $suite)
+    {
+        foreach ($suite->getFixers() as $fixer) {
+            $this->addCustomFixer($fixer);
+        }
+
+        return $this;
     }
 
     public function hideProgress($hideProgress)

--- a/Symfony/CS/ConfigInterface.php
+++ b/Symfony/CS/ConfigInterface.php
@@ -82,4 +82,9 @@ interface ConfigInterface
      * @return FixerInterface[]
      */
     public function getCustomFixers();
+
+    /**
+     * Adds all fixers contained inside the given FixerSuiteInterface.
+     */
+    public function addCustomFixerSuite(FixerSuiteInterface $suite);
 }

--- a/Symfony/CS/Fixer/Symfony/MethodArgumentDefaultValueFixer.php
+++ b/Symfony/CS/Fixer/Symfony/MethodArgumentDefaultValueFixer.php
@@ -125,7 +125,7 @@ final class MethodArgumentDefaultValueFixer extends AbstractFixer
      */
     private function removeDefaultArgument(Tokens $tokens, $startIndex, $endIndex)
     {
-        for ($i = $startIndex; $i <= $endIndex; ) {
+        for ($i = $startIndex; $i <= $endIndex;) {
             $tokens[$i]->clear();
             $this->clearWhitespacesBeforeIndex($tokens, $i);
             $i = $tokens->getNextMeaningfulToken($i);

--- a/Symfony/CS/FixerSuiteInterface.php
+++ b/Symfony/CS/FixerSuiteInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+/**
+ * @author Pierre Plazanet
+ */
+interface FixerSuiteInterface
+{
+    /**
+     * Returns all fixers contained in this suite.
+     *
+     * @return FixerInterface[]
+     */
+    public function getFixers();
+}

--- a/Symfony/CS/Tests/Config/ConfigTest.php
+++ b/Symfony/CS/Tests/Config/ConfigTest.php
@@ -14,6 +14,8 @@ namespace Symfony\CS\Tests\Config;
 use Symfony\Component\Finder\Finder;
 use Symfony\CS\Config\Config;
 use Symfony\CS\Finder\DefaultFinder;
+use Symfony\CS\Fixer\Symfony\ArrayElementNoSpaceBeforeCommaFixer;
+use Symfony\CS\Fixer\Symfony\HeredocToNowdocFixer;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,5 +56,28 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1, count($iterator));
         $iterator->rewind();
         $this->assertSame('somefile.php', $iterator->current()->getFilename());
+    }
+
+    public function testThatFixerSuiteAreLoaded()
+    {
+        $suite = $this->getMockBuilder('Symfony\CS\FixerSuiteInterface')
+            ->getMock()
+        ;
+
+        $fixers = array(
+            new ArrayElementNoSpaceBeforeCommaFixer(),
+            new HeredocToNowdocFixer(),
+        );
+
+        $suite
+            ->method('getFixers')
+            ->willReturn($fixers)
+        ;
+
+        $config = Config::create();
+
+        $config->addCustomFixerSuite($suite);
+
+        $this->assertSame($config->getCustomFixers(), $fixers);
     }
 }


### PR DESCRIPTION
Good morning.

So, here is the use case.
Imagine I have a HUGE set of custom fixers, and I wan't to provide this set as a plugin to PHP-CS-FIXER, then the customer have to add all my fixers one by one by calling the `addCustomFixer`.

Now, I can provider one (or more) fixers suite

ex:
```php
class MyCustomSuite implements FixerSuiteInterface
{
    public function getFixers()
    {
        return array(
            new MyCustumFixer1(),
            new MyCustumFixer2(),
            new MyCustumFixer3(),
            new MyCustumFixer4(),
            new MyCustumFixer5(),
            new MyCustumFixer6(),
        );
    }
}
```

```php
<?php

$finder = Symfony\CS\Finder\DefaultFinder::create()
    ->in('src/')
;

return Symfony\CS\Config\Config::create()
    ->setUsingCache(true)
    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
    ->fixers([
        '..',
        'custum-1',
        'custum-2',
        'custum-3',
        'custum-4',
        'custum-5',
        'custum-6',
    ])
    ->addCustomFixer(new Project\CS\MyCustomSuite())
    ->finder($finder)
;
```