### PR TITLE
Config - add addCustomFixers method

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -131,6 +131,19 @@ class Config implements ConfigInterface
         return $this;
     }
 
+    public function addCustomFixers($fixers)
+    {
+        if (false === is_array($fixers) && false === $fixers instanceof \Traversable) {
+            throw new \InvalidArgumentException('Argument must be an array or a Traversable');
+        }
+
+        foreach ($fixers as $fixer) {
+            $this->addCustomFixer($fixer);
+        }
+
+        return $this;
+    }
+
     public function getCustomFixers()
     {
         return $this->customFixers;

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -79,6 +79,13 @@ interface ConfigInterface
     public function addCustomFixer(FixerInterface $fixer);
 
     /**
+     * Adds a suite of custom fixers.
+     *
+     * @param FixerInterface[]|\Traversable $fixers
+     */
+    public function addCustomFixers($fixers);
+
+    /**
      * Returns the custom fixers to use.
      *
      * @return FixerInterface[]

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -79,4 +79,17 @@ final class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($config, $config->setCacheFile('some-directory/some.file'));
     }
+
+    public function testThatFixerSuiteAreLoaded()
+    {
+        $fixers = array(
+            new \Symfony\CS\Fixer\Symfony\ArrayElementNoSpaceBeforeCommaFixer(),
+            new \Symfony\CS\Fixer\Symfony\IncludeFixer(),
+        );
+
+        $config = Config::create();
+        $config->addCustomFixers(new \ArrayIterator($fixers));
+
+        $this->assertSame($config->getCustomFixers(), $fixers);
+    }
 }


### PR DESCRIPTION
Good morning.

So, here is the use case.
Imagine I have a HUGE set of custom fixers, and I wan't to provide this set as a plugin to PHP-CS-FIXER, then the customer have to add all my fixers one by one by calling the `addCustomFixer`.

Now, I can provider one (or more) fixers suite

ex:
```php
class MyCustomSuite extends AbstractFixerSuite
{
    public function getFixers()
    {
        return array(
            new MyCustumFixer1(),
            new MyCustumFixer2(),
            new MyCustumFixer3(),
            new MyCustumFixer4(),
            new MyCustumFixer5(),
            new MyCustumFixer6(),
        );
    }
}
```

```php
<?php

$finder = Symfony\CS\Finder\DefaultFinder::create()
    ->in('src/')
;

return Symfony\CS\Config\Config::create()
    ->setUsingCache(true)
    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
    ->fixers([
        '..',
        'custum-1',
        'custum-2',
        'custum-3',
        'custum-4',
        'custum-5',
        'custum-6',
    ])
    ->addCustomFixers(new Project\CS\MyCustomSuite())
    ->finder($finder)
;
```