### PR TITLE
NewWithBracesFixer - End tags 

### DIFF
--- a/Symfony/CS/Fixer/Symfony/NewWithBracesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NewWithBracesFixer.php
@@ -26,15 +26,14 @@ class NewWithBracesFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
-
-        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+        for ($index = $tokens->count() - 3; $index > 0; --$index) {
             $token = $tokens[$index];
 
             if (!$token->isGivenKind(T_NEW)) {
                 continue;
             }
 
-            $nextIndex = $tokens->getNextTokenOfKind($index, array(';', ',', '(', ')', '[', ']', ':'));
+            $nextIndex = $tokens->getNextTokenOfKind($index, array(';', ',', '(', ')', '[', ']', ':', array(T_CLOSE_TAG)));
             $nextToken = $tokens[$nextIndex];
 
             // entrance into array index syntax - need to look for exit
@@ -54,7 +53,7 @@ class NewWithBracesFixer extends AbstractFixer
                 continue;
             }
 
-            $meaningBeforeNextIndex = $tokens->getPrevNonWhitespace($nextIndex);
+            $meaningBeforeNextIndex = $tokens->getPrevMeaningfulToken($nextIndex);
 
             $tokens->insertAt($meaningBeforeNextIndex + 1, array(new Token('('), new Token(')')));
         }

--- a/Symfony/CS/Fixer/Symfony/NewWithBracesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NewWithBracesFixer.php
@@ -26,6 +26,7 @@ class NewWithBracesFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
+
         for ($index = $tokens->count() - 3; $index > 0; --$index) {
             $token = $tokens[$index];
 

--- a/Symfony/CS/Tests/Fixer/Symfony/NewWithBracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NewWithBracesFixerTest.php
@@ -47,6 +47,10 @@ class NewWithBracesFixerTest extends AbstractFixerTestBase
                 '<?php $y = new Y ;',
             ),
             array(
+                '<?php $x = new Z() /**/;//',
+                '<?php $x = new Z /**/;//',
+            ),
+            array(
                 '<?php $foo = new $foo();',
                 '<?php $foo = new $foo;',
             ),
@@ -106,6 +110,14 @@ class NewWithBracesFixerTest extends AbstractFixerTestBase
             array(
                 '<?php new self::$adapters[$name]["adapter"]();',
                 '<?php new self::$adapters[$name]["adapter"];',
+            ),
+            array(
+                '<?php $a = new \Exception()?> <?php echo 1;',
+                '<?php $a = new \Exception?> <?php echo 1;',
+            ),
+            array(
+                '<?php $b = new \StdClass() /**/?>',
+                '<?php $b = new \StdClass /**/?>',
             ),
         );
     }


### PR DESCRIPTION
Little bug fix for the `NewWithBracesFixer`;
Input
```php
<?php $a = new \Exception?> <?php echo 1;
```
gets fixed to;
```php
<?php $a = new \Exception?> <?php echo 1();
```
which breaks valid code.

Additional fix in this PR is for;
input:
```php
<?php $x = new Z /**/;//
```

get fixed to:
```php
<?php $x = new Z() /**/;//
```
