### PR TITLE
LowercaseConstantFixer - Fix comment cases.

### DIFF
--- a/Symfony/CS/Fixer/PSR2/LowercaseConstantsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/LowercaseConstantsFixer.php
@@ -34,9 +34,8 @@ class LowercaseConstantsFixer extends AbstractFixer
             }
 
             if (
-                $this->isNeighbourAccepted($tokens, $tokens->getPrevNonWhitespace($index))
-                &&
-                $this->isNeighbourAccepted($tokens, $tokens->getNextNonWhitespace($index))
+                $this->isNeighbourAccepted($tokens, $tokens->getPrevMeaningfulToken($index)) &&
+                $this->isNeighbourAccepted($tokens, $tokens->getNextMeaningfulToken($index))
             ) {
                 $token->setContent(strtolower($token->getContent()));
             }

--- a/Symfony/CS/Tests/Fixer/PSR2/LowercaseConstantsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LowercaseConstantsFixerTest.php
@@ -15,15 +15,109 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author SpacePossum
  */
 class LowercaseConstantsFixerTest extends AbstractFixerTestBase
 {
+    /**
+     * @dataProvider provideGeneratedCases
+     */
+    public function testFixGeneratedCases($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideGeneratedCases()
+    {
+        $cases = array();
+        foreach (array('true', 'false', 'null') as $case) {
+            $cases [] = array(
+                sprintf('<?php $x = %s;', $case),
+                sprintf('<?php $x = %s;', strtoupper($case)),
+            );
+
+            $cases [] = array(
+                sprintf('<?php $x = %s;', $case),
+                sprintf('<?php $x = %s;', ucfirst($case)),
+            );
+
+            $cases [] = array(sprintf('<?php $x = new %s;', ucfirst($case)));
+            $cases [] = array(sprintf('<?php $x = new %s;', strtoupper($case)));
+            $cases [] = array(sprintf('<?php $x = "%s story";', $case));
+            $cases [] = array(sprintf('<?php $x = "%s";', $case));
+        }
+
+        return $cases;
+    }
+
     /**
      * @dataProvider provideCases
      */
     public function testFix($expected, $input = null)
     {
         $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+                array(
+                    '<?php if (true) if (false) if (null) {}',
+                    '<?php if (TRUE) if (FALSE) if (NULL) {}',
+                ),
+                array(
+                    '<?php if (!true) if (!false) if (!null) {}',
+                    '<?php if (!TRUE) if (!FALSE) if (!NULL) {}',
+                ),
+                array(
+                    '<?php if ($a == true) if ($a == false) if ($a == null) {}',
+                    '<?php if ($a == TRUE) if ($a == FALSE) if ($a == NULL) {}',
+                ),
+                array(
+                    '<?php if ($a === true) if ($a === false) if ($a === null) {}',
+                    '<?php if ($a === TRUE) if ($a === FALSE) if ($a === NULL) {}',
+                ),
+                array(
+                    '<?php if ($a != true) if ($a != false) if ($a != null) {}',
+                    '<?php if ($a != TRUE) if ($a != FALSE) if ($a != NULL) {}',
+                ),
+                array(
+                    '<?php if ($a !== true) if ($a !== false) if ($a !== null) {}',
+                    '<?php if ($a !== TRUE) if ($a !== FALSE) if ($a !== NULL) {}',
+                ),
+                array(
+                    '<?php if (true && true and true AND true || false or false OR false xor null XOR null) {}',
+                    '<?php if (TRUE && TRUE and TRUE AND TRUE || FALSE or FALSE OR FALSE xor NULL XOR NULL) {}',
+                ),
+                array(
+                    '<?php /* foo */ true; /** bar */ false;',
+                    '<?php /* foo */ TRUE; /** bar */ FALSE;',
+                ),
+                array('<?php echo $null;'),
+                array('<?php $x = False::foo();'),
+                array('<?php namespace Foo\Null;'),
+                array('<?php use Foo\Null;'),
+                array('<?php use Foo\Null as Null;'),
+                array('<?php class True {} class False {} class Null {}'),
+                array('<?php class Foo extends True {}'),
+                array('<?php class Foo implements False {}'),
+                array('<?php Class Null { use True; }'),
+                array('<?php interface True {}'),
+                array('<?php $foo instanceof True; $foo instanceof False; $foo instanceof Null;'),
+                array(
+                    '<?php
+        class Foo
+        {
+            const TRUE = 1;
+            const FALSE = 2;
+            const NULL = null;
+        }',
+                ),
+                array('<?php $x = new /**/False?>'),
+                array('<?php Null/**/::test();'),
+                array('<?php True//
+                                    ::test();'),
+        );
     }
 
     /**
@@ -33,80 +127,6 @@ class LowercaseConstantsFixerTest extends AbstractFixerTestBase
     public function test54($expected, $input = null)
     {
         $this->makeTest($expected, $input);
-    }
-
-    public function provideCases()
-    {
-        return array(
-            array('<?php $x = true;'),
-            array('<?php $x = true;', '<?php $x = True;'),
-            array('<?php $x = true;', '<?php $x = TruE;'),
-            array('<?php $x = true;', '<?php $x = TRUE;'),
-            array('<?php $x = false;'),
-            array('<?php $x = false;', '<?php $x = False;'),
-            array('<?php $x = false;', '<?php $x = FalsE;'),
-            array('<?php $x = false;', '<?php $x = FALSE;'),
-            array('<?php $x = null;'),
-            array('<?php $x = null;', '<?php $x = Null;'),
-            array('<?php $x = null;', '<?php $x = NulL;'),
-            array('<?php $x = null;', '<?php $x = NULL;'),
-            array('<?php $x = "true story";'),
-            array('<?php $x = "false";'),
-            array('<?php $x = "that is null";'),
-            array('<?php $x = new True;'),
-            array('<?php $x = new True();'),
-            array('<?php $x = False::foo();'),
-            array('<?php namespace Foo\Null;'),
-            array('<?php use Foo\Null;'),
-            array('<?php use Foo\Null as Null;'),
-            array(
-                '<?php if (true) if (false) if (null) {}',
-                '<?php if (TRUE) if (FALSE) if (NULL) {}',
-            ),
-            array(
-                '<?php if (!true) if (!false) if (!null) {}',
-                '<?php if (!TRUE) if (!FALSE) if (!NULL) {}',
-            ),
-            array(
-                '<?php if ($a == true) if ($a == false) if ($a == null) {}',
-                '<?php if ($a == TRUE) if ($a == FALSE) if ($a == NULL) {}',
-            ),
-            array(
-                '<?php if ($a === true) if ($a === false) if ($a === null) {}',
-                '<?php if ($a === TRUE) if ($a === FALSE) if ($a === NULL) {}',
-            ),
-            array(
-                '<?php if ($a != true) if ($a != false) if ($a != null) {}',
-                '<?php if ($a != TRUE) if ($a != FALSE) if ($a != NULL) {}',
-            ),
-            array(
-                '<?php if ($a !== true) if ($a !== false) if ($a !== null) {}',
-                '<?php if ($a !== TRUE) if ($a !== FALSE) if ($a !== NULL) {}',
-            ),
-            array(
-                '<?php if (true && true and true AND true || false or false OR false xor null XOR null) {}',
-                '<?php if (TRUE && TRUE and TRUE AND TRUE || FALSE or FALSE OR FALSE xor NULL XOR NULL) {}',
-            ),
-            array(
-                '<?php /* foo */ true; /** bar */ false;',
-                '<?php /* foo */ TRUE; /** bar */ FALSE;',
-            ),
-            array('<?php class True {} class False {} class Null {}'),
-            array('<?php class Foo extends True {}'),
-            array('<?php class Foo implements False {}'),
-            array('<?php Class Null { use True; }'),
-            array('<?php interface True {}'),
-            array('<?php $foo instanceof True; $foo instanceof False; $foo instanceof Null;'),
-            array(
-                '<?php
-    class Foo
-    {
-        const TRUE = 1;
-        const FALSE = 2;
-        const NULL = null;
-    }',
-            ),
-        );
     }
 
     public function provide54Cases()


### PR DESCRIPTION
Little bug fix (so targetting 1.11).
The following cases are getting 'fixed' by the `LowercaseConstantFixer` while those should not be touched;
```php
<?php 
$x = new /**/False?>
<?php
Null/**/::test();
True//
  ::test();
```

The diff. looks more heavy because I've added a bunch of test cases using templating. 
(you gonna love PHP for allowing comments all over the place ;) )