### PR TITLE
Integration tests - don't check priority for tests using short_tag fixer

### DIFF
--- a/Symfony/CS/Tests/Fixtures/Integration/misc/php_closing_tag,short_tag.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/misc/php_closing_tag,short_tag.test
@@ -3,6 +3,8 @@ Integration of fixers: php_closing_tag,short_tag.
 --CONFIG--
 level=none
 fixers=php_closing_tag,short_tag
+--SETTINGS--
+checkPriority=false
 --REQUIREMENTS--
 hhvm=false
 --EXPECT--

--- a/Symfony/CS/Tests/Fixtures/Integration/set/@PSR2.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/set/@PSR2.test
@@ -2,6 +2,8 @@
 PSR2 integration.
 --CONFIG--
 level=psr2
+--SETTINGS--
+checkPriority=false
 --EXPECT--
 <?php
 namespace Vendor\Package;

--- a/Symfony/CS/Tests/Fixtures/Integration/set/@Symfony.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/set/@Symfony.test
@@ -2,6 +2,8 @@
 Symfony test.
 --CONFIG--
 level=symfony
+--SETTINGS--
+checkPriority=false
 --EXPECT--
 <?php
 


### PR DESCRIPTION
Closes #1615