### PR TITLE
FinerInterface - interface must extends Traversable

### DIFF
--- a/Symfony/CS/FinderInterface.php
+++ b/Symfony/CS/FinderInterface.php
@@ -15,7 +15,7 @@ namespace Symfony\CS;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface FinderInterface
+interface FinderInterface extends \Traversable
 {
     public function setDir($dir);
 }


### PR DESCRIPTION
Anything that extends `FinderInterface` cannot be used if it won't implement `Traversable` as well.