### PR TITLE
Add PhpdocSingleLineVarSpacingFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -476,6 +476,10 @@ Choose from the list of available fixers:
                         stop, exclamation mark, or
                         question mark.
 
+* **phpdoc_single_line_var_spacing** [symfony]
+                        Single line @var PHPDoc should
+                        have proper spacing.
+
 * **phpdoc_to_comment** [symfony]
                         Docblocks should only be used
                         on structural elements.

--- a/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocParamsFixer.php
@@ -75,7 +75,7 @@ class PhpdocParamsFixer extends AbstractFixer
          * annotations are of the correct type, and are grouped correctly
          * before running this fixer.
          */
-        return -10;
+        return -11;
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/PhpdocSingleLineVarSpacingFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocSingleLineVarSpacingFixer.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * Fixer for part of rule defined in PSR5 ¶7.22.
+ *
+ * @author SpacePossum
+ */
+final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        /** @var Token $token */
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_DOC_COMMENT)) {
+                $token->setContent($this->fixTokenContent($token->getContent()));
+                continue;
+            }
+
+            if (!$token->isGivenKind(T_COMMENT)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+            $fixedContent = $this->fixTokenContent($content);
+            if ($content !== $fixedContent) {
+                $tokens->overrideAt($index, array(T_DOC_COMMENT, $fixedContent, $token->getLine()));
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    private function fixTokenContent($content)
+    {
+        return preg_replace_callback(
+            '#^/\*\*[ \t]*@var[ \t]+(\S+)[ \t]*(\$\S+)?[ \t]*([^\n]*)\*/$#',
+            function (array $matches) {
+                $content = '/** @var';
+                for ($i = 1, $m = count($matches); $i < $m; ++$i) {
+                    if ('' !== $matches[$i]) {
+                        $content .= ' '.$matches[$i];
+                    }
+                }
+
+                $content = rtrim($content);
+
+                return $content.' */';
+            },
+            $content
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Single line @var PHPDoc should have proper spacing.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be ran after the PhpdocTypeToVarFixer.
+        return -10;
+    }
+}

--- a/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTypeToVarFixer.php
@@ -28,7 +28,11 @@ class PhpdocTypeToVarFixer extends AbstractFixer
     {
         $tokens = Tokens::fromCode($content);
 
-        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
             $doc = new DocBlock($token->getContent());
             $annotations = $doc->getAnnotationsOfType('type');
 
@@ -53,5 +57,14 @@ class PhpdocTypeToVarFixer extends AbstractFixer
     public function getDescription()
     {
         return '@type should always be written as @var.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be ran before the PhpdocSingleLineVarSpacingFixer.
+        return -9;
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSingleLineVarSpacingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSingleLineVarSpacingFixerTest.php
@@ -64,16 +64,14 @@ final class PhpdocSingleLineVarSpacingFixerTest extends AbstractFixerTestBase
                     $test2 = 3;
 
                     class A {
+                        /** @var MyCass4 aa */
+                        public $test4 = 4;
 
-                    /** @var MyCass4 aa */
-                    public $test4 = 4;
+                        /** @var MyCass5 */
+                        public $test5 = 5;
 
-                    /** @var MyCass5 */
-                    public $test5 = 5;
-                    }
-
-                    /** @var MyCass6 */
-                    public $test6 = 6;
+                        /** @var MyCass6 */
+                        public $test6 = 6;
                     }
                 ',
                 '<?php
@@ -87,16 +85,14 @@ final class PhpdocSingleLineVarSpacingFixerTest extends AbstractFixerTestBase
                     $test2 = 3;
 
                     class A {
+                        /**  @var   MyCass4   aa       */
+                        public $test4 = 4;
 
-                    /**  @var   MyCass4   aa       */
-                    public $test4 = 4;
+                        /**     @var		MyCass5       */
+                        public $test5 = 5;
 
-                    /**     @var		MyCass5       */
-                    public $test5 = 5;
-                    }
-
-                    /**     @var		MyCass6*/
-                    public $test6 = 6;
+                        /**     @var		MyCass6*/
+                        public $test6 = 6;
                     }
                 ',
             ),

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocSingleLineVarSpacingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocSingleLineVarSpacingFixerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class PhpdocSingleLineVarSpacingFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php
+                    class A {
+                        /** @var MyCass6 $a */
+                        public $test6 = 6;
+
+                        /** @var MyCass6 */
+                        public $testB = 7;
+                    }
+                ',
+                '<?php
+                    class A {
+                        /**@var MyCass6 $a */
+                        public $test6 = 6;
+
+                        /**@var MyCass6*/
+                        public $testB = 7;
+                    }
+                ',
+            ),
+            array(
+                '<?php
+                    /** @var MyCass1 $test1 description   and more. */
+                    $test0 = 1;
+
+                    /** @var MyCass2 description and    such. */
+                    $test1 = 2;
+
+                    /** @var MyCass3 description. */
+                    $test2 = 3;
+
+                    class A {
+
+                    /** @var MyCass4 aa */
+                    public $test4 = 4;
+
+                    /** @var MyCass5 */
+                    public $test5 = 5;
+                    }
+
+                    /** @var MyCass6 */
+                    public $test6 = 6;
+                    }
+                ',
+                '<?php
+                    /**    @var   MyCass1 $test1      description   and more.*/
+                    $test0 = 1;
+
+                    /**    @var   MyCass2    description and    such. */
+                    $test1 = 2;
+
+                    /** @var	MyCass3    description.    */
+                    $test2 = 3;
+
+                    class A {
+
+                    /**  @var   MyCass4   aa       */
+                    public $test4 = 4;
+
+                    /**     @var		MyCass5       */
+                    public $test5 = 5;
+                    }
+
+                    /**     @var		MyCass6*/
+                    public $test6 = 6;
+                    }
+                ',
+            ),
+            array(
+                '<?php
+class A
+{
+    /**
+     * @param array $options {
+     *     @var bool   $required Whether this element is required
+     *     @var string $label    The display name for this element
+     * }
+     */
+    public function __construct(array $options = array())
+    {
+
+    }
+
+    /**
+     * @var bool   $required Whether this element is required
+     * @var string $label    The display name for this element
+     */
+    public function test($required, $label)
+    {
+
+    }
+
+    /** @var   MyCass3
+    */
+    private $test0 = 0;
+}',
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -221,6 +221,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_no_access'], $fixers['no_empty_phpdoc']), // tested also in: phpdoc_no_access,no_empty_phpdoc.test
             array($fixers['phpdoc_no_empty_return'], $fixers['no_empty_phpdoc']), // tested also in: phpdoc_no_empty_return,no_empty_phpdoc.test
             array($fixers['phpdoc_no_package'], $fixers['no_empty_phpdoc']), // tested also in: phpdoc_no_package,no_empty_phpdoc.test
+            array($fixers['phpdoc_type_to_var'], $fixers['phpdoc_single_line_var_spacing']), // tested also in: phpdoc_type_to_var,phpdoc_single_line_var_spacing.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/phpdoc_type_to_var,phpdoc_single_line_var_spacing.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/phpdoc_type_to_var,phpdoc_single_line_var_spacing.test
@@ -1,0 +1,12 @@
+--TEST--
+Integration of fixers: phpdoc_type_to_var,phpdoc_single_line_var_spacing.
+--CONFIG--
+level=none
+fixers=phpdoc_type_to_var,phpdoc_single_line_var_spacing
+--EXPECT--
+<?php
+/** @var Test $test */
+
+--INPUT--
+<?php
+/** @type   Test  $test    */


### PR DESCRIPTION
Fixes spacing around single line `@var` PHPDoc's.
For example:
Input
```php
                <?php
                    /**    @var   MyCass1 $test1      description   and more.*/
                    $test = 1;

                    /**    @var   MyCass2    description and    such. */
                    $test = 2;

                    /** @var   MyCass3    description.    */
                    $test = 3;
```
Output
```php
                <?php
                    /** @var MyCass1 $test1 description   and more. */
                    $test = 1;

                    /** @var MyCass2 description and    such. */
                    $test = 2;

                    /** @var MyCass3 description. */
                    $test = 3;
```
