### PR TITLE
FixerInterface::configure - method should always override configuration, not patch it

### DIFF
--- a/src/Fixer/Contrib/PhpUnitConstructFixer.php
+++ b/src/Fixer/Contrib/PhpUnitConstructFixer.php
@@ -22,10 +22,10 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class PhpUnitConstructFixer extends AbstractFixer
 {
     private $configuration = array(
-        'assertSame' => true,
-        'assertEquals' => true,
-        'assertNotEquals' => true,
-        'assertNotSame' => true,
+        'assertSame',
+        'assertEquals',
+        'assertNotEquals',
+        'assertNotSame',
     );
 
     private $assertionFixers = array(
@@ -44,13 +44,13 @@ final class PhpUnitConstructFixer extends AbstractFixer
             return;
         }
 
-        foreach ($usingMethods as $method => $fix) {
-            if (!array_key_exists($method, $this->configuration)) {
+        foreach ($usingMethods as $method) {
+            if (!array_key_exists($method, $this->assertionFixers)) {
                 throw new InvalidFixerConfigurationException($this->getName(), sprintf('Configured method "%s" cannot be fixed by this fixer.', $method));
             }
-
-            $this->configuration[$method] = $fix;
         }
+
+        $this->configuration = $usingMethods;
     }
 
     /**
@@ -75,15 +75,11 @@ final class PhpUnitConstructFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
         // no assertions to be fixed - fast return
-        if (!in_array(true, $this->configuration, true)) {
+        if (empty($this->configuration)) {
             return;
         }
 
-        foreach ($this->configuration as $assertionMethod => $assertionShouldBeFixed) {
-            if (true !== $assertionShouldBeFixed) {
-                continue;
-            }
-
+        foreach ($this->configuration as $assertionMethod) {
             $assertionFixer = $this->assertionFixers[$assertionMethod];
 
             for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {

--- a/src/FixerInterface.php
+++ b/src/FixerInterface.php
@@ -22,6 +22,8 @@ interface FixerInterface
     /**
      * Set configuration.
      *
+     * New configuration must override current one, not patch it.
+     *
      * Some fixers may have no configuration, then - simply pass null.
      * Other ones may have configuration that will change behavior of fixer,
      * eg `php_unit_strict` fixer allows to configure which methods should be fixed.

--- a/tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/Contrib/PhpUnitConstructFixerTest.php
@@ -30,7 +30,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
     {
         /** @var $fixer PhpUnitConstructFixer */
         $fixer = $this->getFixer();
-        $fixer->configure(array('MyTest' => 'test'));
+        $fixer->configure(array('MyTest'));
     }
 
     /**
@@ -41,31 +41,18 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         $fixer = $this->getFixer();
 
         $fixer->configure(array(
-            'assertEquals' => true,
-            'assertSame' => true,
-            'assertNotEquals' => true,
-            'assertNotSame' => true,
+            'assertEquals',
+            'assertSame',
+            'assertNotEquals',
+            'assertNotSame',
         ));
         $this->doTest($expected, $input, null, $fixer);
 
-        $fixer->configure(array(
-            'assertEquals' => false,
-            'assertSame' => false,
-            'assertNotEquals' => false,
-            'assertNotSame' => false,
-        ));
+        $fixer->configure(array());
         $this->doTest($input ?: $expected, null, null, $fixer);
 
         foreach (array('assertSame', 'assertEquals', 'assertNotEquals', 'assertNotSame') as $method) {
-            $config = array(
-                'assertEquals' => false,
-                'assertSame' => false,
-                'assertNotEquals' => false,
-                'assertNotSame' => false,
-            );
-            $config[$method] = true;
-
-            $fixer->configure($config);
+            $fixer->configure(array($method));
             $this->doTest(
                 $expected,
                 $input && false !== strpos($input, $method) ? $input : null,
@@ -120,7 +107,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
     {
         /** @var PhpUnitConstructFixer $fixer */
         $fixer = $this->getFixer();
-        $fixer->configure(array('__TEST__' => 'abc'));
+        $fixer->configure(array('__TEST__'));
     }
 
     private function generateCases($expectedTemplate, $inputTemplate)

--- a/tests/Fixer/Contrib/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/Contrib/PhpUnitStrictFixerTest.php
@@ -32,7 +32,7 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
 
     public function provideTestFixCases()
     {
-        $methodsMap = AccessibleObject::create($this->getFixer())->configuration;
+        $methodsMap = AccessibleObject::create($this->getFixer())->assertionMap;
 
         $cases = array(
             array('<?php $self->foo();'),


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1617#discussion_r49540026