### PR TITLE
Psr0Fixer - change way of configuring the fixer

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -115,3 +115,10 @@ unneeded_control_parentheses                   | no_unneeded_control_parentheses
 unused_use                                     | no_unused_imports
 visibility                                     | visibility_required
 whitespacy_lines                               | no_whitespace_in_blank_lines
+
+Changes to Fixers
+-----------------
+
+Fixer | Note
+----- | ----
+psr0  | Fixer no longer takes base dir from `ConfigInterface::getDir`, instead you may configure the fixer with `['dir' => 'my/path']`.

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -14,7 +14,6 @@ namespace PhpCsFixer\Console;
 
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
-use PhpCsFixer\Fixer;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\FixerInterface;
 use PhpCsFixer\RuleSet;

--- a/src/Fixer/Contrib/Psr0Fixer.php
+++ b/src/Fixer/Contrib/Psr0Fixer.php
@@ -13,8 +13,6 @@
 namespace PhpCsFixer\Fixer\Contrib;
 
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\ConfigAwareInterface;
-use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -24,9 +22,23 @@ use PhpCsFixer\Tokenizer\Tokens;
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Bram Gotink <bram@gotink.me>
  */
-final class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
+final class Psr0Fixer extends AbstractFixer
 {
-    protected $config;
+    private $configuration = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        if (null === $configuration) {
+            return;
+        }
+
+        if (isset($configuration['dir'])) {
+            $this->configuration['dir'] = $configuration['dir'];
+        }
+    }
 
     /**
      * {@inheritdoc}
@@ -85,8 +97,8 @@ final class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
             $path = str_replace('\\', '/', $file->getRealPath());
             $dir = dirname($path);
 
-            if ($this->config) {
-                $dir = substr($dir, strlen(realpath($this->config->getDir())) + 1);
+            if (isset($this->configuration['dir'])) {
+                $dir = substr($dir, strlen(realpath($this->configuration['dir'])) + 1);
                 if (strlen($normNamespace) > strlen($dir)) {
                     if ('' !== $dir) {
                         $normNamespace = substr($normNamespace, -strlen($dir));
@@ -130,14 +142,6 @@ final class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
                 $tokens[$classyIndex]->setContent(str_replace('/', '_', $filename));
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setConfig(ConfigInterface $config)
-    {
-        $this->config = $config;
     }
 
     /**

--- a/tests/Fixer/Contrib/Psr0FixerTest.php
+++ b/tests/Fixer/Contrib/Psr0FixerTest.php
@@ -12,7 +12,6 @@
 
 namespace PhpCsFixer\Tests\Fixer\Contrib;
 
-use PhpCsFixer\Config;
 use PhpCsFixer\Test\AbstractFixerTestCase;
 
 /**
@@ -23,9 +22,7 @@ final class Psr0FixerTest extends AbstractFixerTestCase
     public function testFixCase()
     {
         $fixer = $this->getFixer();
-        $config = new Config();
-        $config->setDir(__DIR__.'/../../Fixtures/FixerTest/');
-        $fixer->setConfig($config);
+        $fixer->configure(array('dir' => __DIR__.'/../../Fixtures/FixerTest/'));
 
         $file = $this->getMock('SplFileInfo', array('getRealPath'), array(__DIR__.'/Psr0/Foo/Bar.php'));
         $file->expects($this->any())->method('getRealPath')->willReturn(__DIR__.'/Psr0/Foo/Bar.php');
@@ -138,9 +135,7 @@ EOF;
     public function testHandlePartialNamespaces()
     {
         $fixer = $this->getFixer();
-        $config = new Config();
-        $config->setDir(__DIR__.'/../../../src/');
-        $fixer->setConfig($config);
+        $fixer->configure(array('dir' => __DIR__.'/../../../src/'));
 
         $file = $this->getTestFile(__DIR__.'/../../../src/Fixer/Contrib/Psr0Fixer.php');
 
@@ -168,7 +163,7 @@ class /* hi there */ Psr0Fixer {}
 EOF;
         $this->doTest($expected, $input, $file, $fixer);
 
-        $config->setDir(__DIR__.'/../../../src/Fixer/Contrib');
+        $fixer->configure(array('dir' => __DIR__.'/../../../src/Fixer/Contrib'));
         $expected = <<<'EOF'
 <?php
 namespace Foo\Bar\Baz;

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -12,11 +12,9 @@
 
 namespace PhpCsFixer\Tests;
 
-use PhpCsFixer\Fixer\Contrib\Psr0Fixer;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\FixerInterface;
 use PhpCsFixer\RuleSet;
-use PhpCsFixer\Test\AccessibleObject;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -69,23 +67,6 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->registerBuiltInFixers();
 
         $this->assertGreaterThan(0, count($factory->getFixers()));
-    }
-
-    /**
-     * @covers PhpCsFixer\FixerFactory::attachConfig
-     */
-    public function testMethodAttachConfig()
-    {
-        $factory = new FixerFactory();
-
-        $fixer = new Psr0Fixer();
-        $factory->registerFixer($fixer);
-
-        $mock = $this->getMock('PhpCsFixer\ConfigInterface');
-        $testInstance = $factory->attachConfig($mock);
-        $property = AccessibleObject::create($fixer)->config;
-
-        $this->assertSame($mock, $property);
     }
 
     /**


### PR DESCRIPTION
`ConfigInterface::getDir` is actually used only once. I want to get rid of it from `ConfigInterface`.
To do so let us replace the only usage with simply configuring the fixer.