### PR TITLE
UniqueFileIterator - performance improvement

### DIFF
--- a/Symfony/CS/UniqueFileIterator.php
+++ b/Symfony/CS/UniqueFileIterator.php
@@ -27,18 +27,14 @@ final class UniqueFileIterator extends \FilterIterator
         /** @var SplFileInfo $file */
         $file = $this->current();
 
-        if ($file->isDir() || $file->isLink()) {
-            return false;
-        }
-
         $path = $file->getRealPath();
 
-        if (array_key_exists($path, $this->visitedElements)) {
+        if (isset($this->visitedElements[$path])) {
             return false;
         }
 
-        $this->visitedElements[$path] = null;
+        $this->visitedElements[$path] = true;
 
-        return true;
+        return !$file->isDir() && !$file->isLink();
     }
 }


### PR DESCRIPTION
We should mark the file as processed before we bother checking if it's valid so we don't double check files we no are invalid.

---

Replaces #1753 and #1758.