### PR TITLE
EofEndingFixer - new line on end line comment is allowed

### DIFF
--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -40,13 +40,25 @@ class EofEndingFixer extends AbstractFixer
             return $content;
         }
 
-        if ($token->isWhitespace()) {
-            $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
-            $token->setContent($lineBreak);
-        } elseif ($token->isComment() and '//' === substr($token->getContent(), 0, 2)) {
+        $isSingleLineComment = function (Token $token) {
+            return $token->isComment() and '//' === substr($token->getContent(), 0, 2);
+        };
+        $clearSingleLineComment = function (Token $token) {
             $content = $token->getContent();
             $content = rtrim($content, "\n")."\n";
             $token->setContent($content);
+        };
+
+        if ($token->isWhitespace()) {
+            if ($count > 1 and $isSingleLineComment($tokens[$count - 2])) {
+                $clearSingleLineComment($tokens[$count - 2]);
+                $token->clear();
+            } else {
+                $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
+                $token->setContent($lineBreak);
+            }
+        } elseif ($isSingleLineComment($token)) {
+            $clearSingleLineComment($token);
         } else {
             $tokens->insertAt($count, new Token(array(T_WHITESPACE, "\n")));
         }

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -43,6 +43,10 @@ class EofEndingFixer extends AbstractFixer
         if ($token->isWhitespace()) {
             $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
             $token->setContent($lineBreak);
+        } elseif ($token->isComment() and '//' === substr($token->getContent(), 0, 2)) {
+            $content = $token->getContent();
+            $content = rtrim($content, "\n")."\n";
+            $token->setContent($content);
         } else {
             $tokens->insertAt($count, new Token(array(T_WHITESPACE, "\n")));
         }

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -41,7 +41,7 @@ class EofEndingFixer extends AbstractFixer
         }
 
         $isSingleLineComment = function (Token $token) {
-            return $token->isComment() and '/*' !== substr($token->getContent(), 0, 2);
+            return $token->isComment() && '/*' !== substr($token->getContent(), 0, 2);
         };
         $clearSingleLineComment = function (Token $token) {
             $content = $token->getContent();
@@ -50,7 +50,7 @@ class EofEndingFixer extends AbstractFixer
         };
 
         if ($token->isWhitespace()) {
-            if ($count > 1 and $isSingleLineComment($tokens[$count - 2])) {
+            if ($count > 1 && $isSingleLineComment($tokens[$count - 2])) {
                 $clearSingleLineComment($tokens[$count - 2]);
                 $token->clear();
             } else {

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -41,7 +41,7 @@ class EofEndingFixer extends AbstractFixer
         }
 
         $isSingleLineComment = function (Token $token) {
-            return $token->isComment() and '//' === substr($token->getContent(), 0, 2);
+            return $token->isComment() and '/*' !== substr($token->getContent(), 0, 2);
         };
         $clearSingleLineComment = function (Token $token) {
             $content = $token->getContent();

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -110,11 +110,19 @@ inline 1
                 "<?php return true;\n// A comment",
             ),
             array(
+                "<?php return true;\n// A comment\n",
+                "<?php return true;\n// A comment\n\n",
+            ),
+            array(
                 "<?php return true;\n/*\nA comment\n*/\n",
             ),
             array(
                 "<?php return true;\n/*\nA comment\n*/\n",
                 "<?php return true;\n/*\nA comment\n*/",
+            ),
+            array(
+                "<?php return true;\n/*\nA comment\n*/\n",
+                "<?php return true;\n/*\nA comment\n*/\n\n",
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -114,6 +114,17 @@ inline 1
                 "<?php return true;\n// A comment\n\n",
             ),
             array(
+                "<?php return true;\n# A comment\n",
+            ),
+            array(
+                "<?php return true;\n# A comment\n",
+                "<?php return true;\n# A comment",
+            ),
+            array(
+                "<?php return true;\n# A comment\n",
+                "<?php return true;\n# A comment\n\n",
+            ),
+            array(
                 "<?php return true;\n/*\nA comment\n*/\n",
             ),
             array(

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -102,6 +102,20 @@ inline 1
 <?php
 
 ?>Inline2\r\n", ),
+            array(
+                "<?php return true;\n// A comment\n",
+            ),
+            array(
+                "<?php return true;\n// A comment\n",
+                "<?php return true;\n// A comment",
+            ),
+            array(
+                "<?php return true;\n/*\nA comment\n*/\n",
+            ),
+            array(
+                "<?php return true;\n/*\nA comment\n*/\n",
+                "<?php return true;\n/*\nA comment\n*/",
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -104,9 +104,6 @@ inline 1
 ?>Inline2\r\n", ),
             array(
                 "<?php return true;\n// A comment\n",
-            ),
-            array(
-                "<?php return true;\n// A comment\n",
                 "<?php return true;\n// A comment",
             ),
             array(
@@ -115,17 +112,11 @@ inline 1
             ),
             array(
                 "<?php return true;\n# A comment\n",
-            ),
-            array(
-                "<?php return true;\n# A comment\n",
                 "<?php return true;\n# A comment",
             ),
             array(
                 "<?php return true;\n# A comment\n",
                 "<?php return true;\n# A comment\n\n",
-            ),
-            array(
-                "<?php return true;\n/*\nA comment\n*/\n",
             ),
             array(
                 "<?php return true;\n/*\nA comment\n*/\n",


### PR DESCRIPTION
The new line of a comment in the last line is indeed a new line and no other new lines should be attached.

As of yet, this code (I will expand line-feeds):
```php
<?php[\n]
return true;[\n]
// Comment[\n]
```
is fixed like
```php
<?php[\n]
return true;[\n]
// Comment[\n]
[\n]
```
Which breaks the statement of the fixer:
`A file must always end with a single empty line feed.`
and also the Unix file management.