### PR TITLE
Fix: EofEndingFixer adds another newline after a single line comment.

### DIFF
--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -48,7 +48,7 @@ class EofEndingFixer extends AbstractFixer
             if ($this->tokenEndsWithNewline($token)) {
                 return $content;
             }
-            $token->setContent($token->getContent() . "\n");
+            $token->setContent($token->getContent()."\n");
         } else {
             $tokens->insertAt($count, new Token(array(T_WHITESPACE, "\n")));
         }
@@ -78,6 +78,7 @@ class EofEndingFixer extends AbstractFixer
      * This can occur e.g. at single line comments.
      *
      * @param Token $token
+     *
      * @return bool
      */
     private function tokenEndsWithNewline(Token $token)

--- a/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
+++ b/Symfony/CS/Fixer/PSR2/EofEndingFixer.php
@@ -38,8 +38,17 @@ class EofEndingFixer extends AbstractFixer
         }
 
         if ($token->isWhitespace()) {
-            $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
-            $token->setContent($lineBreak);
+            if ($count > 1 && $this->tokenEndsWithNewline($tokens[$count - 2])) {
+                $token->clear();
+            } else {
+                $lineBreak = false === strrpos($token->getContent(), "\r") ? "\n" : "\r\n";
+                $token->setContent($lineBreak);
+            }
+        } elseif ($token->isComment()) {
+            if ($this->tokenEndsWithNewline($token)) {
+                return $content;
+            }
+            $token->setContent($token->getContent() . "\n");
         } else {
             $tokens->insertAt($count, new Token(array(T_WHITESPACE, "\n")));
         }
@@ -62,5 +71,17 @@ class EofEndingFixer extends AbstractFixer
     {
         // must run last to be sure the file is properly formatted before it runs
         return -50;
+    }
+
+    /**
+     * Checks if a Token already ends with an newline.
+     * This can occur e.g. at single line comments.
+     *
+     * @param Token $token
+     * @return bool
+     */
+    private function tokenEndsWithNewline(Token $token)
+    {
+        return substr($token->getContent(), -1) === "\n";
     }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/EofEndingFixerTest.php
@@ -65,6 +65,22 @@ $a = 3;
                 "<?php\r\n\$a = 5;\r\n    \r\n",
             ),
             array(
+                // test for not adding a line after a single line comment
+                "<?php\n\$a = 4; // a comment\n",
+                null,
+            ),
+            array(
+                // test for removing lines after a single line comment
+                "<?php\n\$a = 4; // a comment\n",
+                "<?php\n\$a = 4; // a comment\n\n",
+            ),
+            array(
+                // for not adding a line after a single line comment which do
+                // not end with a linebreak
+                "<?php\n\$a = 4; // a comment\n",
+                "<?php\n\$a = 4; // a comment",
+            ),
+            array(
                 '<?php
 $a = 6;
 


### PR DESCRIPTION
EofEndingFixer did add a second line after a single line comment at the end of a file, because the newline is enclosed in the T_COMMENT token.