### PR TITLE
Add PhpUnitDedicateAssertFixer.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -689,6 +689,14 @@ Choose from the list of available fixers:
                         This could change code
                         behavior.
 
+* **php_unit_dedicate_assert** [contrib]
+                        PHPUnit assertions like
+                        "assertInternalType",
+                        "assertFileExists", should be
+                        used over "assertTrue".
+                        Warning! This could change
+                        code behavior.
+
 * **php_unit_strict** [contrib]
                         PHPUnit methods like
                         "assertSame" should be used

--- a/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitConstructFixer.php
@@ -35,6 +35,9 @@ final class PhpUnitConstructFixer extends AbstractFixer
         'assertNotSame' => 'fixAssertNegative',
     );
 
+    /**
+     * @param array<string, bool> $usingMethods
+     */
     public function configure(array $usingMethods)
     {
         foreach ($usingMethods as $method => $fix) {
@@ -90,10 +93,17 @@ final class PhpUnitConstructFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        // should be run after the PhpUnitStrictFixer
+        // should be run after the PhpUnitStrictFixer and before PhpUnitDedicateAssertFixer.
         return -10;
     }
 
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param string $method
+     *
+     * @return int|null
+     */
     private function fixAssertNegative(Tokens $tokens, $index, $method)
     {
         static $map = array(
@@ -105,6 +115,13 @@ final class PhpUnitConstructFixer extends AbstractFixer
         return $this->fixAssert($map, $tokens, $index, $method);
     }
 
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param string $method
+     *
+     * @return int|null
+     */
     private function fixAssertPositive(Tokens $tokens, $index, $method)
     {
         static $map = array(
@@ -116,6 +133,14 @@ final class PhpUnitConstructFixer extends AbstractFixer
         return $this->fixAssert($map, $tokens, $index, $method);
     }
 
+    /**
+     * @param array<string, string> $map
+     * @param Tokens                $tokens
+     * @param int                   $index
+     * @param string                $method
+     *
+     * @return int|null
+     */
     private function fixAssert(array $map, Tokens $tokens, $index, $method)
     {
         $sequence = $tokens->findSequence(

--- a/Symfony/CS/Fixer/Contrib/PhpUnitDedicateAssertFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitDedicateAssertFixer.php
@@ -71,12 +71,16 @@ final class PhpUnitDedicateAssertFixer extends AbstractFixer
     );
 
     /**
-     * @param string[] $usingMethods
+     * @param array|null $configuration
      */
-    public function configure(array $usingMethods)
+    public function configure(array $configuration = null)
     {
+        if (null === $configuration) {
+            throw new InvalidFixerConfigurationException($this->getName(), 'Configuration is required.');
+        }
+
         $this->configuration = array();
-        foreach ($usingMethods as $method) {
+        foreach ($configuration as $method) {
             if (!array_key_exists($method, $this->fixMap)) {
                 throw new InvalidFixerConfigurationException($this->getName(), sprintf('Unknown configuration method "%s".', $method));
             }

--- a/Symfony/CS/Fixer/Contrib/PhpUnitDedicateAssertFixer.php
+++ b/Symfony/CS/Fixer/Contrib/PhpUnitDedicateAssertFixer.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\ConfigurationException\InvalidFixerConfigurationException;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class PhpUnitDedicateAssertFixer extends AbstractFixer
+{
+    private $fixMap = array(
+        'array_key_exists' => array('assertArrayNotHasKey', 'assertArrayHasKey'),
+        'empty' => array('assertNotEmpty', 'assertEmpty'),
+        'file_exists' => array('assertFileNotExists', 'assertFileExists'),
+        'is_infinite' => array('assertFinite', 'assertInfinite'),
+        'is_nan' => array(false, 'assertNan'),
+        'is_null' => array('assertNotNull', 'assertNull'),
+        'is_array' => true,
+        'is_bool' => true,
+        'is_boolean' => true,
+        'is_callable' => true,
+        'is_double' => true,
+        'is_float' => true,
+        'is_int' => true,
+        'is_integer' => true,
+        'is_long' => true,
+        'is_​numeric' => true,
+        'is_object' => true,
+        'is_real' => true,
+        'is_​resource' => true,
+        'is_scalar' => true,
+        'is_string' => true,
+    );
+
+    private $configuration = array(
+        'array_key_exists',
+        'empty',
+        'file_exists',
+        'is_infinite',
+        'is_nan',
+        'is_null',
+        'is_array',
+        'is_bool',
+        'is_boolean',
+        'is_callable',
+        'is_double',
+        'is_float',
+        'is_int',
+        'is_integer',
+        'is_long',
+        'is_​numeric',
+        'is_object',
+        'is_real',
+        'is_​resource',
+        'is_scalar',
+        'is_string',
+    );
+
+    /**
+     * @param string[] $usingMethods
+     */
+    public function configure(array $usingMethods)
+    {
+        $this->configuration = array();
+        foreach ($usingMethods as $method) {
+            if (!array_key_exists($method, $this->fixMap)) {
+                throw new InvalidFixerConfigurationException($this->getName(), sprintf('Unknown configuration method "%s".', $method));
+            }
+
+            $this->configuration[] = $method;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        static $searchSequence = array(
+            array(T_VARIABLE, '$this'),
+            array(T_OBJECT_OPERATOR, '->'),
+            array(T_STRING),
+        );
+
+        $index = 1;
+        $candidate = $tokens->findSequence($searchSequence, $index);
+        while (null !== $candidate) {
+            end($candidate);
+            $index = $this->getAssertCandidate($tokens, key($candidate));
+            if (is_array($index)) {
+                $index = $this->fixAssert($tokens, $index);
+            }
+
+            ++$index;
+            $candidate = $tokens->findSequence($searchSequence, $index);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'PHPUnit assertions like "assertInternalType", "assertFileExists", should be used over "assertTrue". Warning! This could change code behavior.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run after the PhpUnitConstructFixer.
+        return -15;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $assertCallIndex Token index of assert method call.
+     *
+     * @return int|int[] indexes of assert call, test call and positive flag, or last index checked.
+     */
+    private function getAssertCandidate(Tokens $tokens, $assertCallIndex)
+    {
+        $content = strtolower($tokens[$assertCallIndex]->getContent());
+        if ('asserttrue' === $content) {
+            $isPositive = 1;
+        } elseif ('assertfalse' === $content) {
+            $isPositive = 0;
+        } else {
+            return $assertCallIndex;
+        }
+
+        // test candidate for simple calls like: ([\]+'some fixable call'(...))
+        $assertCallOpenIndex = $tokens->getNextMeaningfulToken($assertCallIndex);
+        if (!$tokens[$assertCallOpenIndex]->equals('(')) {
+            return $assertCallIndex;
+        }
+
+        $testDefaultNamespaceTokenIndex = false;
+        $testIndex = $tokens->getNextMeaningfulToken($assertCallOpenIndex);
+
+        if (!$tokens[$testIndex]->isGivenKind(array(T_EMPTY, T_STRING))) {
+            if (!$tokens[$testIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                return $testIndex;
+            }
+
+            $testDefaultNamespaceTokenIndex = $testIndex;
+            $testIndex = $tokens->getNextMeaningfulToken($testIndex);
+        }
+
+        $testOpenIndex = $tokens->getNextMeaningfulToken($testIndex);
+        if (!$tokens[$testOpenIndex]->equals('(')) {
+            return $testOpenIndex;
+        }
+
+        $testCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $testOpenIndex);
+
+        $assertCallCloseIndex = $tokens->getNextMeaningfulToken($testCloseIndex);
+        if (!$tokens[$assertCallCloseIndex]->equalsAny(array(')', ','))) {
+            return $assertCallCloseIndex;
+        }
+
+        return array(
+            $isPositive,
+            $assertCallIndex,
+            $assertCallOpenIndex,
+            $testDefaultNamespaceTokenIndex,
+            $testIndex,
+            $testOpenIndex,
+            $testCloseIndex,
+            $assertCallCloseIndex,
+        );
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param array  $assertIndexes
+     *
+     * @return int index up till processed, number of tokens added
+     */
+    private function fixAssert(Tokens $tokens, array $assertIndexes)
+    {
+        list(
+            $isPositive,
+            $assertCallIndex,
+            $assertCallOpenIndex,
+            $testDefaultNamespaceTokenIndex,
+            $testIndex,
+            $testOpenIndex,
+            $testCloseIndex,
+            $assertCallCloseIndex
+        ) = $assertIndexes;
+
+        $content = strtolower($tokens[$testIndex]->getContent());
+        if (!in_array($content, $this->configuration, true)) {
+            return $assertCallCloseIndex;
+        }
+
+        if (is_array($this->fixMap[$content])) {
+            if (false !== $this->fixMap[$content][$isPositive]) {
+                $tokens[$assertCallIndex]->setContent($this->fixMap[$content][$isPositive]);
+                $this->removeFunctionCall($tokens, $testDefaultNamespaceTokenIndex, $testIndex, $testOpenIndex, $testCloseIndex);
+            }
+
+            return $assertCallCloseIndex;
+        }
+
+        $type = substr($content, 3);
+        $tokens[$assertCallIndex]->setContent($isPositive ? 'assertInternalType' : 'assertNotInternalType');
+        $tokens->overrideAt($testIndex, array(T_CONSTANT_ENCAPSED_STRING, "'".$type."'", $tokens[$testIndex]->getLine()));
+        $tokens->overrideAt($testOpenIndex, ',');
+        $tokens->clearTokenAndMergeSurroundingWhitespace($testCloseIndex);
+
+        if (!$tokens[$testOpenIndex + 1]->isWhitespace()) {
+            $tokens->insertAt($testOpenIndex + 1, new Token(array(T_WHITESPACE, ' ')));
+        }
+
+        if (false !== $testDefaultNamespaceTokenIndex) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($testDefaultNamespaceTokenIndex);
+        }
+
+        return $assertCallCloseIndex;
+    }
+
+    /**
+     * @param Tokens    $tokens
+     * @param int|false $callNSIndex
+     * @param int       $callIndex
+     * @param int       $openIndex
+     * @param int       $closeIndex
+     */
+    private function removeFunctionCall(Tokens $tokens, $callNSIndex, $callIndex, $openIndex, $closeIndex)
+    {
+        $tokens->clearTokenAndMergeSurroundingWhitespace($callIndex);
+        if (false !== $callNSIndex) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($callNSIndex);
+        }
+
+        $tokens->clearTokenAndMergeSurroundingWhitespace($openIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($closeIndex);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpUnitDedicateAssertFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpUnitDedicateAssertFixerTest.php
@@ -197,10 +197,19 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestBase
 
     /**
      * @expectedException \Symfony\CS\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [php_unit_dedicate_assert] Unknown configuration method "_unknown_".
+     * @expectedExceptionMessageRegExp /^\[php_unit_dedicate_assert\] Unknown configuration method "_unknown_".$/
      */
     public function testInvalidConfig()
     {
         $this->getFixer()->configure(array('_unknown_'));
+    }
+
+    /**
+     * @expectedException \Symfony\CS\ConfigurationException\InvalidFixerConfigurationException
+     * @expectedExceptionMessageRegExp /^\[php_unit_dedicate_assert\] Configuration is required.$/
+     */
+    public function testNullConfig()
+    {
+        $this->getFixer()->configure(null);
     }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/PhpUnitDedicateAssertFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/PhpUnitDedicateAssertFixerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideInternalTypeMethods
+     */
+    public function testInternalTypeMethods($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideInternalTypeMethods()
+    {
+        $cases = array();
+        foreach (array('array', 'bool', 'boolean', 'callable', 'double', 'float', 'int', 'integer', 'long', '​numeric', 'object', '​resource', 'real', 'scalar', 'string') as $type) {
+            $cases[] = array(
+                sprintf('<?php $this->assertInternalType(\'%s\', $a);', $type),
+                sprintf('<?php $this->assertTrue(is_%s($a));', $type),
+            );
+
+            $cases[] = array(
+                sprintf('<?php $this->assertNotInternalType(\'%s\', $a);', $type),
+                sprintf('<?php $this->assertFalse(is_%s($a));', $type),
+            );
+        }
+
+        $cases[] = array(
+            '<?php $this->assertInternalType(\'float\', $a, "my message");',
+            '<?php $this->assertTrue(is_float( $a), "my message");',
+        );
+
+        $cases[] = array(
+            '<?php $this->assertInternalType(\'float\', $a);',
+            '<?php $this->assertTrue(\IS_FLOAT($a));',
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideDedicatedAssertsCases
+     */
+    public function testDedicatedAsserts($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideDedicatedAssertsCases()
+    {
+        return array(
+            array(
+                '<?php
+                    $this->assertNan($a);
+                    $this->assertNan($a);
+                    $this->assertTrue(test\is_nan($a));
+                    $this->assertTrue(test\a\is_nan($a));
+                ',
+                '<?php
+                    $this->assertTrue(is_nan($a));
+                    $this->assertTrue(\is_nan($a));
+                    $this->assertTrue(test\is_nan($a));
+                    $this->assertTrue(test\a\is_nan($a));
+                ',
+            ),
+            array(
+                '<?php
+                    $this->assertFileExists($a);
+                    $this->assertFileNotExists($a);
+                    $this->assertFileExists($a);
+                    $this->assertFileNotExists($a);
+                ',
+                '<?php
+                    $this->assertTrue(file_exists($a));
+                    $this->assertFalse(file_exists($a));
+                    $this->assertTrue(\file_exists($a));
+                    $this->assertFalse(\file_exists($a));
+                ',
+            ),
+            array(
+                '<?php
+                    $this->assertNull($a);
+                    $this->assertNotNull($a);
+                    $this->assertNull($a);
+                    $this->assertNotNull($a, "my message");
+                ',
+                '<?php
+                    $this->assertTrue(is_null($a));
+                    $this->assertFalse(is_null($a));
+                    $this->assertTrue(\is_null($a));
+                    $this->assertFalse(\is_null($a), "my message");
+                ',
+            ),
+            array(
+                '<?php
+                    $this->assertEmpty($a);
+                    $this->assertNotEmpty($a);
+                ',
+                '<?php
+                    $this->assertTrue(empty($a));
+                    $this->ASSERTFALSE(empty($a));
+                ',
+            ),
+            array(
+                '<?php
+                    $this->assertInfinite($a);
+                    $this->assertFinite($a, "my message");
+                    $this->assertInfinite($a);
+                    $this->assertFinite($a, "my message");
+                ',
+                '<?php
+                    $this->assertTrue(is_infinite($a));
+                    $this->assertFalse(is_infinite($a), "my message");
+                    $this->assertTrue(\is_infinite($a));
+                    $this->assertFalse(\is_infinite($a), "my message");
+                ',
+            ),
+            array(
+                '<?php
+                    $this->assertArrayHasKey("test", $a);
+                    $this->assertArrayNotHasKey($b, $a, $c);
+                ',
+                '<?php
+                    $this->assertTrue(\array_key_exists("test", $a));
+                    $this->ASSERTFALSE(array_key_exists($b, $a), $c);
+                ',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideNotFixCases
+     */
+    public function testNotFix($expected)
+    {
+        $this->makeTest($expected);
+    }
+
+    public function provideNotFixCases()
+    {
+        return array(
+            array(
+                '<?php echo $this->assertTrue;',
+            ),
+            array(
+                '<?php echo $this->assertTrue?>',
+            ),
+            array(
+                '<?php
+                    const is_null = 1;
+                    $this->assertTrue(is_null);
+                    $this->assertTrue(is_int($a) && $b);
+                    $this->assertFalse(is_nan($a));
+                    $this->assertTrue(is_int($a) || \is_bool($b));
+                    $this->assertTrue($a&&is_int($a));
+                ',
+            ),
+        );
+    }
+
+    public function testConfig()
+    {
+        $fixer = $this->getFixer();
+        $fixer->configure(array('file_exists'));
+        $this->makeTest(
+            '<?php
+                    $this->assertFileExists($a);
+                    $this->assertTrue(is_infinite($a));
+            ',
+            '<?php
+                    $this->assertTrue(file_exists($a));
+                    $this->assertTrue(is_infinite($a));
+            ',
+            null,
+            $fixer
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\CS\ConfigurationException\InvalidFixerConfigurationException
+     * @expectedExceptionMessage [php_unit_dedicate_assert] Unknown configuration method "_unknown_".
+     */
+    public function testInvalidConfig()
+    {
+        $this->getFixer()->configure(array('_unknown_'));
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -227,6 +227,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['combine_consecutive_unsets'], $fixers['extra_empty_lines']), // tested also in: combine_consecutive_unsets,extra_empty_lines.test
             array($fixers['duplicate_semicolon'], $fixers['combine_consecutive_unsets']), // tested also in: duplicate_semicolon,combine_consecutive_unsets.test
             array($fixers['phpdoc_type_to_var'], $fixers['phpdoc_single_line_var_spacing']), // tested also in: phpdoc_type_to_var,phpdoc_single_line_var_spacing.test
+            array($fixers['php_unit_construct'], $fixers['php_unit_dedicate_assert']), // tested also in: php_unit_construct,php_unit_dedicate_assert.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/php_unit_construct,php_unit_dedicate_assert.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/php_unit_construct,php_unit_dedicate_assert.test
@@ -1,0 +1,14 @@
+--TEST--
+Integration of fixers: php_unit_construct,php_unit_dedicate_assert.
+--CONFIG--
+level=none
+fixers=php_unit_construct,php_unit_dedicate_assert
+--EXPECT--
+<?php
+
+$this->assertInternalType('array', $a);
+
+--INPUT--
+<?php
+
+$this->assertSame(true, is_array($a));

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -1049,7 +1049,7 @@ PHP;
         $tokens = Tokens::fromCode($source);
         /** @var Token[] $found */
         $found = $tokens->findGivenKind(T_CLASS);
-        $this->assertTrue(is_array($found));
+        $this->assertInternalType('array', $found);
         $this->assertCount(1, $found);
         $this->assertArrayHasKey(1, $found);
         $this->assertSame(T_CLASS, $found[1]->getId());
@@ -1058,13 +1058,13 @@ PHP;
         $found = $tokens->findGivenKind(array(T_CLASS, T_FUNCTION));
         $this->assertCount(2, $found);
         $this->assertArrayHasKey(T_CLASS, $found);
-        $this->assertTrue(is_array($found[T_CLASS]));
+        $this->assertInternalType('array', $found[T_CLASS]);
         $this->assertCount(1, $found[T_CLASS]);
         $this->assertArrayHasKey(1, $found[T_CLASS]);
         $this->assertSame(T_CLASS, $found[T_CLASS][1]->getId());
 
         $this->assertArrayHasKey(T_FUNCTION, $found);
-        $this->assertTrue(is_array($found[T_FUNCTION]));
+        $this->assertInternalType('array', $found[T_FUNCTION]);
         $this->assertCount(2, $found[T_FUNCTION]);
         $this->assertArrayHasKey(9, $found[T_FUNCTION]);
         $this->assertSame(T_FUNCTION, $found[T_FUNCTION][9]->getId());


### PR DESCRIPTION
Expected
```
<?php
$this->assertEmpty($a);
$this->assertNotEmpty($a);
$this->assertFileExists($a);
$this->assertFileNotExists($a);
$this->assertNotNull($a);
$this->assertNull($a);
$this->assertNan($a);
$this->assertInternalType('float', $a);
```

Input
```php
<?php
$this->assertTrue(empty($a));
$this->ASSERTFALSE(empty($a));
$this->assertTrue(file_exists($a));
$this->assertFalse(file_exists($a));
$this->assertTrue(is_null($a));
$this->assertFalse(is_null($a));
$this->assertTrue(is_nan($a));
$this->assertTrue(is_real( $a));
```