### PR TITLE
LintManager - meaningful tempnam

### DIFF
--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -66,7 +66,7 @@ class LintManager
     public function createProcessForSource($source)
     {
         if (null === $this->temporaryFile) {
-            $this->temporaryFile = tempnam('.', 'tmp');
+            $this->temporaryFile = tempnam('.', 'phpcsfixer_tmp_');
         }
 
         file_put_contents($this->temporaryFile, $source);

--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -66,7 +66,7 @@ class LintManager
     public function createProcessForSource($source)
     {
         if (null === $this->temporaryFile) {
-            $this->temporaryFile = tempnam('.', 'phpcsfixer_tmp_');
+            $this->temporaryFile = tempnam('.', 'cs_fix_tmp_');
         }
 
         file_put_contents($this->temporaryFile, $source);

--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -66,7 +66,7 @@ class LintManager
     public function createProcessForSource($source)
     {
         if (null === $this->temporaryFile) {
-            $this->temporaryFile = tempnam('.', 'cs_fix_tmp_');
+            $this->temporaryFile = tempnam('.', 'cs_fixer_tmp_');
         }
 
         file_put_contents($this->temporaryFile, $source);


### PR DESCRIPTION
Killing the process manually leave the temporary file on the filesystem, as [`__destruct`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.11/Symfony/CS/LintManager.php#L31-L36) is not called.

In doubt, a meaningful name for the temporary file helps identifying them and manually getting rid of them if needed.