### PR TITLE
Tokens - simplify isLambda()

### DIFF
--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -952,20 +952,7 @@ class Tokens extends \SplFixedArray
             $nextToken = $this[$nextIndex];
         }
 
-        if (!$nextToken->equals('(')) {
-            return false;
-        }
-
-        $endParenthesisIndex = $this->findBlockEnd(self::BLOCK_TYPE_PARENTHESIS_BRACE, $nextIndex);
-
-        $nextIndex = $this->getNextMeaningfulToken($endParenthesisIndex);
-        $nextToken = $this[$nextIndex];
-
-        if (!$nextToken->equalsAny(array('{', array(T_USE)))) {
-            return false;
-        }
-
-        return true;
+        return $nextToken->equals('(');
     }
 
     /**


### PR DESCRIPTION
why do we need the additional check for `{` / `use`?