### PR TITLE
NoMultilineWhitespaceBeforeSemicolonsFixer - Semicolon should not be moved into comment

### DIFF
--- a/src/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixer.php
@@ -39,8 +39,13 @@ final class NoMultilineWhitespaceBeforeSemicolonsFixer extends AbstractFixer
             }
 
             $previous = $tokens[$index - 1];
+            if (!$previous->isWhitespace() || false === strpos($previous->getContent(), "\n")) {
+                continue;
+            }
 
-            if ($previous->isWhitespace() && false !== strpos($previous->getContent(), "\n")) {
+            if (("\n" === $previous->getContent()[0] || "\r" === $previous->getContent()[0]) && $tokens[$index - 2]->isComment()) {
+                $previous->setContent("\r" === $previous->getContent()[0] ? "\r\n" : "\n");
+            } else {
                 $previous->clear();
             }
         }

--- a/src/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixer.php
@@ -43,8 +43,9 @@ final class NoMultilineWhitespaceBeforeSemicolonsFixer extends AbstractFixer
                 continue;
             }
 
-            if (("\n" === $previous->getContent()[0] || "\r" === $previous->getContent()[0]) && $tokens[$index - 2]->isComment()) {
-                $previous->setContent("\r" === $previous->getContent()[0] ? "\r\n" : "\n");
+            $content = $previous->getContent();
+            if (("\n" === $content[0] || "\r" === $content[0]) && $tokens[$index - 2]->isComment()) {
+                $previous->setContent("\r" === $content[0] ? "\r\n" : "\n");
             } else {
                 $previous->clear();
             }

--- a/tests/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -36,6 +36,30 @@ final class NoMultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixer
         return array(
             array(
                 '<?php
+                    $foo->bar() // test
+;',
+                '<?php
+                    $foo->bar() // test
+                    ;',
+            ),
+            array(
+                "<?php echo(1) // test\r\n;",
+            ),
+            array(
+                '<?php
+                    $foo->bar() # test
+;',
+                '<?php
+                    $foo->bar() # test
+
+
+                ;',
+            ),
+            array(
+                "<?php\n;",
+            ),
+            array(
+                '<?php
 $this
     ->setName(\'readme1\')
     ->setDescription(\'Generates the README\');


### PR DESCRIPTION
Bug on master only. 
The fixer is broken because of the transformer that splits up a comment with a trailing line break.

Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1808