### PR TITLE
BlanklineAfterOpenTagFixer, NoBlankLinesBeforeNamespaceFixer - fix priority

### DIFF
--- a/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
+++ b/Symfony/CS/Fixer/Symfony/BlanklineAfterOpenTagFixer.php
@@ -71,4 +71,13 @@ class BlanklineAfterOpenTagFixer extends AbstractFixer
     {
         return 'Ensure there is no code on the same line as the PHP open tag and it is followed by a blankline.';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run before the NoBlankLinesBeforeNamespaceFixer 
+        return 1;
+    }
 }

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -208,6 +208,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['short_echo_tag'], $fixers['echo_to_print']), // tested also in: echo_to_print,short_echo_tag.test
             array($fixers['short_bool_cast'], $fixers['spaces_cast']),
             array($fixers['unneeded_control_parentheses'], $fixers['trailing_spaces']), // tested also in: trailing_spaces,unneeded_control_parentheses.test
+            array($fixers['blankline_after_open_tag'], $fixers['no_blank_lines_before_namespace']), // tested also in: blankline_after_open_tag,no_blank_lines_before_namespace.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/blankline_after_open_tag,no_blank_lines_before_namespace.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/blankline_after_open_tag,no_blank_lines_before_namespace.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: blankline_after_open_tag,no_blank_lines_before_namespace.
+--CONFIG--
+level=none
+fixers=blankline_after_open_tag,no_blank_lines_before_namespace
+--INPUT--
+<?php
+
+namespace A;
+
+class A
+{
+}
+
+--EXPECT--
+<?php
+namespace A;
+
+class A
+{
+}


### PR DESCRIPTION
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1804

The fixers are conflicting in some files, but not in others, so it makes sense to have both fixers in use.
Besides it could be considered a BC break as the app behavior changed between minor versions.

Kindly note that the expected and input part of the `.test` file must be swapped on 1.12 and up.