### PR TITLE
Ensure that PhpUnitDedicateAssertFixer runs after NoAliasFunctionsFixer, clean up NoEmptyCommentFixer

### DIFF
--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -68,7 +68,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
         // single line comment starting with '#'
         if ('#' === $content[0]) {
             if (preg_match('|^#\s*$|', $content)) {
-                $this->clearCommentToken($tokens, $index);
+                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             }
 
             return;
@@ -77,7 +77,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
         // single line comment starting with '//'
         if ('/' === $content[1]) {
             if (preg_match('|^//\s*$|', $content)) {
-                $this->clearCommentToken($tokens, $index);
+                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             }
 
             return;
@@ -87,46 +87,5 @@ final class NoEmptyCommentFixer extends AbstractFixer
         if (preg_match('|^/\*\s*\*/$|', $content)) {
             $tokens->clearTokenAndMergeSurroundingWhitespace($index);
         }
-    }
-
-    /**
-     * Clear comment token, but preserve trailing linebreak if there is any.
-     *
-     * @param Tokens $tokens
-     * @param int    $index  T_COMMENT index
-     *
-     * @deprecated Will be removed in the 2.0.
-     */
-    private function clearCommentToken(Tokens $tokens, $index)
-    {
-        if ("\n" !== substr($tokens[$index]->getContent(), -1, 1)) {
-            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-
-            return;
-        }
-
-        // if previous not-cleared token is whitespace;
-        // append line break to content
-        $previous = $tokens->getNonEmptySibling($index, -1);
-        if ($tokens[$previous]->isWhitespace()) {
-            $tokens[$previous]->setContent($tokens[$previous]->getContent()."\n");
-            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-
-            return;
-        }
-
-        // elseif the next not-cleared token is whitespace;
-        // prepend with line break
-        $next = $tokens->getNonEmptySibling($index, 1);
-        if (null !== $next && $tokens[$next]->isWhitespace()) {
-            $tokens[$next]->setContent("\n".$tokens[$next]->getContent());
-            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-
-            return;
-        }
-
-        // else
-        // override with whitespace token linebreak
-        $tokens->overrideAt($index, array(T_WHITESPACE, "\n"));
     }
 }

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -66,10 +66,12 @@ final class NoEmptyCommentFixerTest extends AbstractFixerTestCase
             ),
             array(
                 '<?php
+                echo 2;
                     '.'
 echo 1;
                 ',
                 '<?php
+                echo 2;
                     //
 echo 1;
                 ',

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -254,6 +254,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
             array($fixers['no_empty_comment'], $fixers['no_extra_consecutive_blank_lines']), // tested also in: no_empty_comment,no_extra_consecutive_blank_lines.test
             array($fixers['no_empty_comment'], $fixers['no_trailing_whitespace']), // tested also in: no_empty_comment,no_trailing_whitespace.test
             array($fixers['no_empty_comment'], $fixers['no_whitespace_in_blank_lines']), // tested also in: no_empty_comment,no_whitespace_in_blank_lines.test
+            array($fixers['no_alias_functions'], $fixers['php_unit_dedicate_assert']), // tested also in: no_alias_functions,php_unit_dedicate_assert.test
         );
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixtures/Integration/priority/no_alias_functions,php_unit_dedicate_assert.test
+++ b/tests/Fixtures/Integration/priority/no_alias_functions,php_unit_dedicate_assert.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: no_alias_functions,php_unit_dedicate_assert.
+--CONFIG--
+{"no_alias_functions": true, "php_unit_dedicate_assert": ["is_int"]}
+--EXPECT--
+<?php
+$this->assertInternalType('int', $a);
+
+--INPUT--
+<?php
+$this->assertTrue(is_integer($a));


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1820
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1817