### PR TITLE
NoUselessReturnFixer - Do not remove return if last statement in short if statement

### DIFF
--- a/Symfony/CS/Fixer/Contrib/NoUselessReturnFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NoUselessReturnFixer.php
@@ -79,6 +79,11 @@ final class NoUselessReturnFixer extends AbstractFixer
                 continue;
             }
 
+            $previous = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$previous]->equalsAny(array(array(T_ELSE), ')'))) {
+                continue;
+            }
+
             $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             $tokens->clearTokenAndMergeSurroundingWhitespace($nextAt);
         }

--- a/Symfony/CS/Tests/Fixer/Contrib/NoUselessReturnFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NoUselessReturnFixerTest.php
@@ -34,6 +34,44 @@ final class NoUselessReturnFixerTest extends AbstractFixerTestBase
         return array(
             array(
                 '<?php
+                    function bar($baz)
+                    {
+                        if ($baz)
+                            return $this->baz();
+                        else
+                            return;
+                    }',
+            ),
+            array(
+                '<?php
+                    function bar($baz)
+                    {
+                        if ($baz)
+                            return $this->baz();
+                        elseif($a)
+                            return;
+                    }',
+            ),
+            array(
+                '<?php
+                    function bar($baz)
+                    {
+                        if ($baz)
+                            return $this->baz();
+                        else if($a)
+                            return;
+                    }',
+            ),
+            array(
+                '<?php
+                    function bar($baz)
+                    {
+                        if ($baz)
+                            return;
+                    }',
+            ),
+            array(
+                '<?php
     function b($b) {
         if ($b) {
             return;


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1830

bug @ 1.12