### PR TITLE
Fixed the runner iterators

### DIFF
--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -40,7 +40,7 @@ final class FileFilterIterator extends \FilterIterator
     private $visitedElements = array();
 
     public function __construct(
-        \Traversable $iterator,
+        \Iterator $iterator,
         EventDispatcher $eventDispatcher = null,
         FileCacheManager $cacheManager
     ) {

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -100,13 +100,13 @@ final class Runner
         $finder = $config->getFinder();
         $finderIterator = $finder instanceof \IteratorAggregate ? $finder->getIterator() : $finder;
 
-        $collection = new FileLintingIterator(
-            new FileFilterIterator(
+        $collection = new FileFilterIterator(
+            new FileLintingIterator(
                 $finderIterator,
-                $this->eventDispatcher,
-                $this->cacheManager
+                $this->linter
             ),
-            $this->linter
+            $this->eventDispatcher,
+            $this->cacheManager
         );
 
         foreach ($collection as $file) {


### PR DESCRIPTION
1. The native `CachingIterator` and `FilterIterator` both require an `Iterator` as the first param, not just `Traversable`
2. We need to run the filter iterator first, not the linting one, otherwise we're linting files we know we can already skip. This leads to very poor performance.