### PR TITLE
FileFilterIterator - Corrected an iterator typehint

### DIFF
--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -40,7 +40,7 @@ final class FileFilterIterator extends \FilterIterator
     private $visitedElements = array();
 
     public function __construct(
-        \Traversable $iterator,
+        \Iterator $iterator,
         EventDispatcher $eventDispatcher = null,
         FileCacheManager $cacheManager
     ) {


### PR DESCRIPTION
The native `CachingIterator` and `FilterIterator` both require an `Iterator`, not just `Traversable`.