### PR TITLE
DocBlock - Remove some old unused phpdoc tags

### DIFF
--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -28,8 +28,7 @@ class Tag
         'api', 'author', 'category', 'copyright', 'deprecated', 'example',
         'global', 'internal', 'license', 'link', 'method', 'package', 'param',
         'property', 'property-read', 'property-write', 'return', 'see',
-        'since', 'struct', 'subpackage', 'throws', 'todo', 'typedef', 'uses',
-        'var', 'version',
+        'since', 'subpackage', 'throws', 'todo', 'uses', 'var', 'version',
     );
 
     /**


### PR DESCRIPTION
These aren't in the PSR Spec anymore (for a good while), and nobody uses them as far as I know.