### PR TITLE
Fix token equals for when both line numbers are <null>.

### DIFF
--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -1232,6 +1232,48 @@ PHP;
     }
 
     /**
+     * @dataProvider provideTokenEquals
+     */
+    public function testTokenEquals(Token $token, $compare, $expected, $caseSensitive = true, $lineNumberSensitive = true)
+    {
+        $this->assertSame($expected, $token->equals($compare, $caseSensitive, $lineNumberSensitive));
+    }
+
+    public function provideTokenEquals()
+    {
+        return array(
+            array(
+                new Token(array(T_STATIC, 'static')),
+                new Token(array(T_STATIC, 'static')),
+                true,
+            ),
+            array(
+                new Token(array(T_STATIC, 'static')),
+                new Token(array(T_STATIC, 'STATIC')),
+                false,
+            ),
+            array(
+                new Token(array(T_STATIC, 'static')),
+                new Token(array(T_STATIC, 'STATIC')),
+                true,
+                false,
+            ),
+            array(
+                new Token(array(T_STATIC, 'static', 1)),
+                new Token(array(T_STATIC, 'static', 2)),
+                false,
+            ),
+            array(
+                new Token(array(T_STATIC, 'static', 1)),
+                new Token(array(T_STATIC, 'static', 2)),
+                true,
+                true,
+                false,
+            ),
+        );
+    }
+
+    /**
      * @param string  $source
      * @param int[]   $indexes
      * @param Token[] $expected

--- a/Symfony/CS/Tests/Tokenizer/TokensTest.php
+++ b/Symfony/CS/Tests/Tokenizer/TokensTest.php
@@ -1270,6 +1270,11 @@ PHP;
                 true,
                 false,
             ),
+            array(
+                new Token(array(T_STATIC, 'static', 17)),
+                array(T_STATIC, 'static'),
+                true,
+            ),
         );
     }
 

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -101,12 +101,13 @@ class Token
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param Token|array|string $other         token or it's prototype
-     * @param bool               $caseSensitive perform a case sensitive comparison
+     * @param Token|array|string $other               token or it's prototype
+     * @param bool               $caseSensitive       perform a case sensitive comparison
+     * @param bool               $lineNumberSensitive when comparing tokens take line numbers into account
      *
      * @return bool
      */
-    public function equals($other, $caseSensitive = true)
+    public function equals($other, $caseSensitive = true, $lineNumberSensitive = true)
     {
         $otherPrototype = $other instanceof self ? $other->getPrototype() : $other;
 
@@ -122,7 +123,7 @@ class Token
 
         foreach ($otherPrototype as $key => $val) {
             // make sure the token has such key
-            if (!isset($selfPrototype[$key])) {
+            if (!array_key_exists($key, $selfPrototype)) {
                 return false;
             }
 
@@ -131,7 +132,7 @@ class Token
                 if (0 !== strcasecmp($val, $selfPrototype[1])) {
                     return false;
                 }
-            } else {
+            } elseif (2 !== $key || $lineNumberSensitive) {
                 // regular comparison
                 if ($selfPrototype[$key] !== $val) {
                     return false;


### PR DESCRIPTION
This PR fixes the `Token::equals` method wrongly returning `false` when calling it with two `Token`-objects which both have no value (i.e. `<null>` / `0` / `''`) for line number.
Secondly it adds an option to the `equals` method to ignore the `line number` completely as the value of it may be arbitrary in some cases.