### PR TITLE
[WIP] Add ReturnAssignmentFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -675,6 +675,11 @@ Choose from the list of available fixers:
                          with their mt_* analogs.
                          (Risky fixer!)
 
+* **return_assignment**
+                         Variables should not be
+                         assigned and directly
+                         returned.
+
 * **self_accessor** [@Symfony]
                          Inside a classy element
                          "self" should be preferred to

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -34,13 +34,15 @@ final class ReturnAssignmentFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        // stop at 4, smallest number of tokens that could be a candidate: "<?php $a=1;return $a;"
-        for ($index = count($tokens) - 1; null !== $index && $index > 4; --$index) {
-            if (!$tokens[$index]->isGivenKind(T_RETURN)) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_FUNCTION)) {
                 continue;
             }
 
-            $index = $this->fixAssignmentBeforeReturn($tokens, $index);
+            $index = $tokens->getNextTokenOfKind($index, array(';', '{'));
+            if ($tokens[$index]->equals('{')) {
+                $this->fixFunction($tokens, $index, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index));
+            }
         }
     }
 
@@ -49,7 +51,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Variables should not be assigned and directly returned.';
+        return 'Non global, static or reference variables should not be assigned and directly returned.';
     }
 
     /**
@@ -67,66 +69,69 @@ final class ReturnAssignmentFixer extends AbstractFixer
 
     /**
      * @param Tokens $tokens
-     * @param int    $index  index of T_RETURN token to fix
-     *
-     * @return int
+     * @param int    $start  Token index of the opening brace token of the function.
+     * @param int    $end    Token index of the closing brace token of the function.
      */
-    private function fixAssignmentBeforeReturn(Tokens $tokens, $index)
+    private function fixFunction(Tokens $tokens, $start, $end)
     {
-        // Check if returning only a variable (i.e. not the result of an expression, function call etc.)
-        $returnVarIndex = $tokens->getNextMeaningfulToken($index);
-        if (!$tokens[$returnVarIndex]->isGivenKind(T_VARIABLE)) {
-            return $index;
+        for ($index = $end; $index > $start; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_RETURN)) {
+                continue;
+            }
+
+            // Check if returning only a variable (i.e. not the result of an expression, function call etc.)
+            $returnVarIndex = $tokens->getNextMeaningfulToken($index);
+            if (!$tokens[$returnVarIndex]->isGivenKind(T_VARIABLE)) {
+                continue;
+            }
+
+            $endReturnVarIndex = $tokens->getNextMeaningfulToken($returnVarIndex);
+            if (!$tokens[$endReturnVarIndex]->equalsAny(array(';', array(T_CLOSE_TAG)))) {
+                continue;
+            }
+
+            // Check that the variable is assigned just before it is returned
+            $endAssignVarIndex = $tokens->getPrevMeaningfulToken($index);
+            if (!$tokens[$endAssignVarIndex]->equals(';')) {
+                continue;
+            }
+
+            $assignVarOperatorIndex = $tokens->getPrevTokenOfKind(
+                $endAssignVarIndex,
+                array('=', ';', '{', array(T_OPEN_TAG), array(T_OPEN_TAG_WITH_ECHO))
+            );
+
+            if (null === $assignVarOperatorIndex || !$tokens[$assignVarOperatorIndex]->equals('=')) {
+                continue;
+            }
+
+            $assignVarIndex = $tokens->getPrevMeaningfulToken($assignVarOperatorIndex);
+            if (!$tokens[$assignVarIndex]->equals($tokens[$returnVarIndex], false)) {
+                continue;
+            }
+
+            $beforeAssignVarIndex = $tokens->getPrevMeaningfulToken($assignVarIndex);
+            if (!$tokens[$beforeAssignVarIndex]->equalsAny(array(';', '{', '}'))) {
+                continue;
+            }
+
+            // remove the return statement itself
+            if ($tokens[$endReturnVarIndex]->equals(';')) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($endReturnVarIndex);
+            }
+
+            $tokens->clearTokenAndMergeSurroundingWhitespace($returnVarIndex);
+            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+            // remove the variable and the assignment
+            $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarOperatorIndex);
+            $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarIndex);
+
+            // insert new return statement
+            $tokens->insertAt($assignVarIndex, new Token(array(T_RETURN, 'return')));
+            if (!$tokens[$assignVarIndex + 1]->isWhitespace() || $tokens[$assignVarIndex + 1]->isEmpty()) {
+                $tokens->insertAt($assignVarIndex + 1, new Token(array(T_WHITESPACE, ' ')));
+            }
         }
-
-        $endReturnVarIndex = $tokens->getNextMeaningfulToken($returnVarIndex);
-        if (!$tokens[$endReturnVarIndex]->equalsAny(array(';', array(T_CLOSE_TAG)))) {
-            return $index;
-        }
-
-        // Check that the variable is assigned just before it is returned
-        $endAssignVarIndex = $tokens->getPrevMeaningfulToken($index);
-        if (!$tokens[$endAssignVarIndex]->equals(';')) {
-            return $endAssignVarIndex;
-        }
-
-        $assignVarOperatorIndex = $tokens->getPrevTokenOfKind(
-            $endAssignVarIndex,
-            array('=', ';', array(T_OPEN_TAG), array(T_OPEN_TAG_WITH_ECHO))
-        );
-
-        if (null === $assignVarOperatorIndex || !$tokens[$assignVarOperatorIndex]->equals('=')) {
-            return $assignVarOperatorIndex;
-        }
-
-        $assignVarIndex = $tokens->getPrevMeaningfulToken($assignVarOperatorIndex);
-        if (!$tokens[$assignVarIndex]->equals($tokens[$returnVarIndex], false)) {
-            return $assignVarIndex;
-        }
-
-        $beforeAssignVarIndex = $tokens->getPrevMeaningfulToken($assignVarIndex);
-        if (!$tokens[$beforeAssignVarIndex]->equalsAny(array(';', '{', '}', array(T_OPEN_TAG), array(T_OPEN_TAG_WITH_ECHO)))) {
-            return $assignVarIndex;
-        }
-
-        // remove the return statement itself
-        if ($tokens[$endReturnVarIndex]->equals(';')) {
-            $tokens->clearTokenAndMergeSurroundingWhitespace($endReturnVarIndex);
-        }
-
-        $tokens->clearTokenAndMergeSurroundingWhitespace($returnVarIndex);
-        $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-
-        // remove the variable and the assignment
-        $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarOperatorIndex);
-        $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarIndex);
-
-        // insert new return statement
-        $tokens->insertAt($assignVarIndex, new Token(array(T_RETURN, 'return')));
-        if (!$tokens[$assignVarIndex + 1]->isWhitespace() || $tokens[$assignVarIndex + 1]->isEmpty()) {
-            $tokens->insertAt($assignVarIndex + 1, new Token(array(T_WHITESPACE, ' ')));
-        }
-
-        return $assignVarIndex - 1;
     }
 }

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ReturnNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class ReturnAssignmentFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound(array(T_VARIABLE, T_RETURN));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        // stop at 4, smallest number of tokens that could be a candidate: "<?php $a=1;return $a;"
+        for ($index = count($tokens) - 1; null !== $index && $index > 4; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_RETURN)) {
+                continue;
+            }
+
+            $index = $this->fixAssignmentBeforeReturn($tokens, $index);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Variables should not be assigned and directly returned.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+
+        // FIXME
+        // should be run before white space lines, extra empty lines,
+        // should be run after the EmptyStatementFixer and DuplicateSemicolonFixer (NoEmptyStatementFixer).
+
+        return -15;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index  index of T_RETURN token to fix
+     *
+     * @return int
+     */
+    private function fixAssignmentBeforeReturn(Tokens $tokens, $index)
+    {
+        // Check if returning only a variable (i.e. not the result of an expression, function call etc.)
+        $returnVarIndex = $tokens->getNextMeaningfulToken($index);
+        if (!$tokens[$returnVarIndex]->isGivenKind(T_VARIABLE)) {
+            return $index;
+        }
+
+        $endReturnVarIndex = $tokens->getNextMeaningfulToken($returnVarIndex);
+        if (!$tokens[$endReturnVarIndex]->equalsAny(array(';', array(T_CLOSE_TAG)))) {
+            return $index;
+        }
+
+        // Check that the variable is assigned just before it is returned
+        $endAssignVarIndex = $tokens->getPrevMeaningfulToken($index);
+        if (!$tokens[$endAssignVarIndex]->equals(';')) {
+            return $endAssignVarIndex;
+        }
+
+        $assignVarOperatorIndex = $tokens->getPrevTokenOfKind(
+            $endAssignVarIndex,
+            array('=', ';', array(T_OPEN_TAG), array(T_OPEN_TAG_WITH_ECHO))
+        );
+
+        if (null === $assignVarOperatorIndex || !$tokens[$assignVarOperatorIndex]->equals('=')) {
+            return $assignVarOperatorIndex;
+        }
+
+        $assignVarIndex = $tokens->getPrevMeaningfulToken($assignVarOperatorIndex);
+        if (!$tokens[$assignVarIndex]->equals($tokens[$returnVarIndex], false)) {
+            return $assignVarIndex;
+        }
+
+        $beforeAssignVarIndex = $tokens->getPrevMeaningfulToken($assignVarIndex);
+        if (!$tokens[$beforeAssignVarIndex]->equalsAny(array(';', '{', '}', array(T_OPEN_TAG), array(T_OPEN_TAG_WITH_ECHO)))) {
+            return $assignVarIndex;
+        }
+
+        // remove the return statement itself
+        if ($tokens[$endReturnVarIndex]->equals(';')) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($endReturnVarIndex);
+        }
+
+        $tokens->clearTokenAndMergeSurroundingWhitespace($returnVarIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+        // remove the variable and the assignment
+        $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarOperatorIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($assignVarIndex);
+
+        // insert new return statement
+        $tokens->insertAt($assignVarIndex, new Token(array(T_RETURN, 'return')));
+        if (!$tokens[$assignVarIndex + 1]->isWhitespace() || $tokens[$assignVarIndex + 1]->isEmpty()) {
+            $tokens->insertAt($assignVarIndex + 1, new Token(array(T_WHITESPACE, ' ')));
+        }
+
+        return $assignVarIndex - 1;
+    }
+}

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ReturnNotation;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class ReturnAssignmentFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            array(
+                '<?php
+                    function a {
+                          return 123;
+                         '.'
+                    }
+                ',
+                '<?php
+                    function a {
+                        $a = 123;
+                        return $a;
+                    }
+                ',
+            ),
+            array(
+                '<?php return (1 + 2 + $b); ',
+                '<?php $a= (1 + 2 + $b);return $a;',
+            ),
+            array(
+                '<?php return 1;  ?>',
+                '<?php $b=1;return $b ?>',
+            ),
+            array(
+                '<?php return 2;   ?>',
+                '<?php $c=2; return $c ?>',
+            ),
+            array(
+                '<?php return  3;   ?>',
+                '<?php $c = 3; return $c ?>',
+            ),
+            array(
+                '<?php if ($c > 4){}   return 3;   ?>',
+                '<?php if ($c > 4){} $c = 3; return $c ?>',
+            ),
+            array(
+                '<?php
+                    if ($c) {
+                          return 0;
+                         '.'
+                    }
+                      return testFunction(123+1);
+                     '.'
+                ',
+                '<?php
+                    if ($c) {
+                        $b = 0;
+                        return $b;
+                    }
+                    $a = testFunction(123+1);
+                    return $a;
+                ',
+            ),
+            // do not fix the cases below
+            array(
+                '<?php $a1=1;return $a;',
+            ),
+            array(
+                '<?php $a=1;return $a + 1;',
+            ),
+            array(
+                '<?php
+                    $_SERVER["abc"] = 3;
+                    return $_SERVER;
+                ',
+            ),
+            array('
+                <?php
+                    static $b, $a = 1;
+                    return $a
+                ?>
+                ',
+            ),
+            array('
+                <?php
+                    $d = $c && $a = 1;
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    static $a = 1;
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    $a = 1;
+                    $a += 1;
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    if ($a = 1)
+                        return $a;
+                ',
+            ),
+            array('
+                <?php
+                    echo $a;
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    $a = 1;
+                ?>
+                <?php
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    $a = 1
+                ?>
+                <?php
+                    ;
+                    return $a;
+                ',
+            ),
+            array('
+                <?php
+                    $a = 1;
+                ?>
+                <?php
+                    ;
+                    return $a;
+                ',
+            ),
+        );
+    }
+}

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -131,6 +131,16 @@ final class ReturnAssignmentFixerTest extends AbstractFixerTestCase
             ),
             array('
                 <?php
+                    function foo ($bar)
+                    {
+                        $a = 123;
+                        if ($bar)
+                            $a = 12345;
+                        return $a;
+                    }',
+            ),
+            array('
+                <?php
                     echo $a;
                     return $a;
                 ',


### PR DESCRIPTION
Taking this fixer for a run by Travis.
It is still WIP, however please state if you do or do not want this fixer to be added to the fixer project (after it would be finished of course).
Target is master because I need the fixed `Token:equals`.
There are hits on SF in 16 files (2.3 current).

Fixes var assignments that are return directly, for example:

Expected:
```php
<?php
return 1;
```

Input:
```php
<?php
$a = 1;
return $a;
```

TODO;
- [ ] integration tests and priority fixing
- [ ] only fix within functions/methods and do not touch `static` or `global` variables

