### PR TITLE
FixCommand - fix passing NullLinter to Runner

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -323,13 +323,11 @@ EOF
             $output->writeln(sprintf('Loaded config from "%s"', $configFile));
         }
 
-        $linter = null;
+        $linter = new NullLinter();
         if ($config->usingLinter()) {
             try {
                 $linter = new Linter($config->getPhpExecutable());
             } catch (UnavailableLinterException $e) {
-                $linter = new NullLinter();
-
                 if ($configFile && 'txt' === $input->getOption('format')) {
                     $output->writeln('Unable to use linter, can not find PHP executable');
                 }


### PR DESCRIPTION
Fixes error when one does not use linter:

> PHP Fatal error:  Uncaught TypeError: Argument 5 passed to PhpCsFixer\Runner\Runner::__construct() must be an instance of PhpCsFixer\Linter\LinterInterface, null given, called in /xxx/vendor/fabpot/php-cs-fixer/src/Console/Command/FixCommand.php on line 346 and defined in /xxx/vendor/fabpot/php-cs-fixer/src/Runner/Runner.php:70