### PR TITLE
Fix: Ofsset should be Offset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -450,7 +450,7 @@ Choose from the list of available fixers:
                          or function name and the
                          opening parenthesis.
 
-* **no_spaces_inside_ofsset** [@Symfony]
+* **no_spaces_inside_offset** [@Symfony]
                          There MUST NOT be spaces
                          between the offset square
                          braces and its contained

--- a/src/Fixer/Whitespace/NoSpacesInsideOffsetFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideOffsetFixer.php
@@ -19,7 +19,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-final class NoSpacesInsideOfssetFixer extends AbstractFixer
+final class NoSpacesInsideOffsetFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -78,7 +78,7 @@ final class RuleSet implements RuleSetInterface
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
-            'no_spaces_inside_ofsset' => true,
+            'no_spaces_inside_offset' => true,
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,

--- a/tests/Fixer/Whitespace/NoSpacesInsideOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesInsideOffsetFixerTest.php
@@ -19,7 +19,7 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  *
  * @internal
  */
-final class NoSpacesInsideOfssetFixerTest extends AbstractFixerTestCase
+final class NoSpacesInsideOffsetFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideCases


### PR DESCRIPTION
This PR

* [x] fixes a typo in the name of a fixer

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1811.