### PR TITLE
renamed Composer package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global require fabpot/php-cs-fixer
+    $ ./composer.phar global require friendsofphp/php-cs-fixer
 
 Then make sure you have ``~/.composer/vendor/bin`` in your ``PATH`` and
 you're good to go:
@@ -106,7 +106,7 @@ You can update ``php-cs-fixer`` through this command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global update fabpot/php-cs-fixer
+    $ ./composer.phar global update friendsofphp/php-cs-fixer
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~
@@ -879,11 +879,11 @@ Cache file can be specified via ``--cache-file`` option or config file:
 Using PHP CS Fixer on Travis
 ----------------------------
 
-Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
+Require ``friendsofphp/php-cs-fixer`` as a `dev`` dependency:
 
 .. code-block:: bash
 
-    $ ./composer.phar require --dev fabpot/php-cs-fixer
+    $ ./composer.phar require --dev friendsofphp/php-cs-fixer
 
 Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
 for PHP CS Fixer cache files and have Travis cache it between builds.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fabpot/php-cs-fixer",
+    "name": "friendsofphp/php-cs-fixer",
     "type": "application",
     "description": "A tool to automatically fix PHP code style",
     "license": "MIT",

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -249,9 +249,9 @@ Cache file can be specified via ``--cache-file`` option or config file:
 Using PHP CS Fixer on Travis
 ----------------------------
 
-Require ``fabpot/php-cs-fixer`` as a `dev`` dependency:
+Require ``friendsofphp/php-cs-fixer`` as a `dev`` dependency:
 
-    $ ./composer.phar require --dev fabpot/php-cs-fixer
+    $ ./composer.phar require --dev friendsofphp/php-cs-fixer
 
 Create a build file to run ``php-cs-fixer`` on Travis. It's advisable to create a dedicated directory
 for PHP CS Fixer cache files and have Travis cache it between builds.

--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -100,7 +100,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global require fabpot/php-cs-fixer
+    $ ./composer.phar global require friendsofphp/php-cs-fixer
 
 Then make sure you have ``~/.composer/vendor/bin`` in your ``PATH`` and
 you're good to go:
@@ -148,7 +148,7 @@ You can update ``php-cs-fixer`` through this command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global update fabpot/php-cs-fixer
+    $ ./composer.phar global update friendsofphp/php-cs-fixer
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -24,7 +24,7 @@ use PhpCsFixer\Console\Application;
 final class ToolInfo
 {
     const COMPOSER_INSTALLED_FILE = '/../../composer/installed.json';
-    const COMPOSER_PACKAGE_NAME = 'fabpot/php-cs-fixer';
+    const COMPOSER_PACKAGE_NAME = 'friendsofphp/php-cs-fixer';
 
     public static function getComposerVersion()
     {


### PR DESCRIPTION
For 2.x, the package should be renamed to `friendsofphp/php-cs-fixer`. When this PR is merged, I will mark the current package as abandoned on Packagist and submit the new one.

For 1.x, everything will still work as before and anyone relying on the 1.x branch won't have to change anything.

For people relying on 2.x@dev, they will need to update their composer.json dependency. That seems fair as the code is in development.
