### PR TITLE
Add SwitchCaseCurlyBraceFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -735,6 +735,11 @@ Choose from the list of available fixers:
                          Functions should be used with
                          $strict param. (Risky fixer!)
 
+* **switch_case_curly_brace**
+                         Removes unneeded curly braces
+                         after case- and default
+                         statements.
+
 * **switch_case_semicolon_to_colon** [@PSR2, @Symfony]
                          A case should be followed by
                          a colon and not a semicolon.

--- a/src/Fixer/ControlStructure/SwitchCaseCurlyBraceFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseCurlyBraceFixer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ControlStructure;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class SwitchCaseCurlyBraceFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound(array(T_CASE, T_DEFAULT));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(array(T_CASE, T_DEFAULT))) {
+                continue;
+            }
+
+            $next = $tokens->getNextTokenOfKind($index, array(':', ';'));
+            while (true) {
+                $next = $tokens->getNextMeaningfulToken($next);
+                if (!$tokens[$next]->equals('{')) {
+                    break;
+                }
+
+                $tokens->clearTokenAndMergeSurroundingWhitespace($tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $next));
+                $tokens->clearTokenAndMergeSurroundingWhitespace($next);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Removes unneeded curly braces after case- and default statements.';
+    }
+}

--- a/tests/Fixer/ControlStructure/SwitchCaseCurlyBraceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseCurlyBraceFixerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ControlStructure;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author SapcePossum
+ *
+ * @internal
+ */
+final class SwitchCaseCurlyBraceFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            array(
+                '<?php
+                    switch($a) {
+                        case 0; '.'
+                        '.'
+                        case 1 : /**/
+                        '.'
+                        case 2 :  // a
+                        '.'
+                        default : '.'
+                            $a = function() {};
+                        '.'
+                    }
+                ',
+                '<?php
+                    switch($a) {
+                        case 0; {
+                        }
+                        case 1 : /**/{
+                        }
+                        case 2 : {{{ // a
+                        }}}
+                        default : {
+                            $a = function() {};
+                        }
+                    }
+                ',
+            ),
+            array(
+'<?php switch ($foo): ?>
+<?php case 1:  ?>
+        ...
+<?php  endswitch ?>
+                ',
+'<?php switch ($foo): ?>
+<?php case 1: { ?>
+        ...
+<?php } endswitch ?>
+                ',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1540

ping @gharlan 

Expected
```php
<?php
    switch($a) {
        case 0; 
        
        case 1 : /**/
                
        case 2 :  // a
                
        default : 
            $a = function() {};
        
    }
```

Input
```php
<?php
     switch($a) {
          case 0; {
          }
          case 1 : /**/{
          }
          case 2 : {{{ // a
          }}}
          default : {
              $a = function() {};
          }
    }
```