### PR TITLE
PhpdocScalarFixer - Fix lowercase str to string too

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -29,6 +29,7 @@ final class PhpdocScalarFixer extends AbstractPhpdocTypesFixer
         'double' => 'float',
         'integer' => 'int',
         'real' => 'float',
+        'str' => 'string',
     );
 
     /**

--- a/tests/Fixer/Phpdoc/PhpdocScalarFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocScalarFixerTest.php
@@ -108,6 +108,7 @@ EOF;
      *
      * @param int|float $integer
      * @param int|int[] $foo
+     * @param string|null $bar
      *
      * @return string|bool
      */
@@ -121,6 +122,7 @@ EOF;
      *
      * @param integer|real $integer
      * @param int|integer[] $foo
+     * @param str|null $bar
      *
      * @return string|boolean
      */


### PR DESCRIPTION
Some languages, such as Python use `str` rather than `string`, and people that switch between a lot of languages can often lose track of details like this, so I think it would be a good idea for our fixers to help out for fixing `str` to `string`.

Sending to 2.0 since this is technically a breaking change.