### PR TITLE
Enhancement: Implement and use cache handlers

### DIFF
--- a/src/CacheHandler.php
+++ b/src/CacheHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ */
+interface CacheHandler
+{
+    /**
+     * @return bool
+     */
+    public function willCache();
+
+    /**
+     * @return string
+     */
+    public function read();
+
+    /**
+     * @param string $content
+     */
+    public function write($content);
+}

--- a/src/FileCacheHandler.php
+++ b/src/FileCacheHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+use Symfony\Component\Filesystem\Exception\IOException;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ */
+final class FileCacheHandler implements CacheHandler
+{
+    /**
+     * @var string
+     */
+    private $cacheFile;
+
+    public function __construct($cacheFile)
+    {
+        $this->cacheFile = $cacheFile;
+    }
+
+    public function willCache()
+    {
+        return true;
+    }
+
+    public function read()
+    {
+        if (!file_exists($this->cacheFile)) {
+            return;
+        }
+
+        return file_get_contents($this->cacheFile);
+    }
+
+    public function write($content)
+    {
+        $bytesWritten = @file_put_contents($this->cacheFile, $content, LOCK_EX);
+
+        if (false === $bytesWritten) {
+            throw new IOException(sprintf('Failed to write file "%s".', $this->cacheFile), 0, null, $this->cacheFile);
+        }
+    }
+}

--- a/src/NullCacheHandler.php
+++ b/src/NullCacheHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ */
+final class NullCacheHandler implements CacheHandler
+{
+    public function willCache()
+    {
+        return false;
+    }
+
+    public function read()
+    {
+    }
+
+    public function write($content)
+    {
+    }
+}

--- a/tests/FileCacheHandlerTest.php
+++ b/tests/FileCacheHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Test;
+
+use PhpCsFixer\FileCacheHandler;
+
+class FileCacheHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function tearDown()
+    {
+        $cacheFile = $this->cacheFile();
+
+        if (file_exists($cacheFile)) {
+            unlink($cacheFile);
+        }
+    }
+
+    public function testImplementsCacheHandlerInterface()
+    {
+        $cacheFile = $this->cacheFile();
+
+        $handler = new FileCacheHandler($cacheFile);
+
+        $this->assertInstanceOf('PhpCsFixer\CacheHandler', $handler);
+    }
+
+    public function testWillCache()
+    {
+        $cacheFile = $this->cacheFile();
+
+        $handler = new FileCacheHandler($cacheFile);
+
+        $this->assertTrue($handler->willCache());
+    }
+
+    public function testReadReturnsNullIfFileDoesNotExist()
+    {
+        $cacheFile = $this->cacheFile();
+
+        $handler = new FileCacheHandler($cacheFile);
+
+        $this->assertNull($handler->read());
+    }
+
+    public function testReadReturnsFileContent()
+    {
+        $cacheFile = $this->cacheFile();
+
+        $content = 'foo';
+
+        file_put_contents($cacheFile, $content);
+
+        $handler = new FileCacheHandler($cacheFile);
+
+        $this->assertSame($content, $handler->read());
+    }
+
+    public function testWriteWritesFileContent()
+    {
+        $cacheFile = $this->cacheFile();
+
+        $content = 'foo';
+
+        $handler = new FileCacheHandler($cacheFile);
+
+        $handler->write($content);
+
+        $this->assertFileExists($cacheFile);
+        $this->assertSame($content, file_get_contents($cacheFile));
+    }
+
+    /**
+     * @return string
+     */
+    private function cacheFile()
+    {
+        return __DIR__.'/.php_cs.cache';
+    }
+}

--- a/tests/FileCacheManagerTest.php
+++ b/tests/FileCacheManagerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Test;
+
+use PhpCsFixer\CacheHandler;
+use PhpCsFixer\FileCacheManager;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ */
+class FileCacheManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoesNotReadFromOrWriteToCache()
+    {
+        $cacheHandler = $this->cacheHandlerMock();
+
+        $cacheHandler
+            ->expects($this->any())
+            ->method('willCache')
+            ->willReturn(false)
+        ;
+
+        $cacheHandler
+            ->expects($this->never())
+            ->method('read')
+        ;
+
+        $cacheHandler
+            ->expects($this->never())
+            ->method('write')
+        ;
+
+        $fileCacheManager = new FileCacheManager(
+            $cacheHandler,
+            '.php_cs.cache',
+            true,
+            array()
+        );
+
+        $fileCacheManager->setFile('example.php', 'hello');
+
+        unset($fileCacheManager);
+    }
+
+    public function testReadsFromAndWritesToCache()
+    {
+        $cacheHandler = $this->cacheHandlerMock();
+
+        $cacheHandler
+            ->expects($this->any())
+            ->method('willCache')
+            ->willReturn(true)
+        ;
+
+        $cacheHandler
+            ->expects($this->once())
+            ->method('read')
+            ->willReturn(null)
+        ;
+
+        $cacheHandler
+            ->expects($this->once())
+            ->method('write')
+        ;
+
+        $fileCacheManager = new FileCacheManager(
+            $cacheHandler,
+            '.php_cs.cache',
+            true,
+            array()
+        );
+
+        $fileCacheManager->setFile('example.php', 'hello');
+
+        unset($fileCacheManager);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|CacheHandler
+     */
+    private function cacheHandlerMock()
+    {
+        return $this->getMockBuilder('PhpCsFixer\CacheHandler')->getMock();
+    }
+}

--- a/tests/NullCacheHandlerTest.php
+++ b/tests/NullCacheHandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Test;
+
+use PhpCsFixer\NullCacheHandler;
+
+class NullCacheHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsCacheHandlerInterface()
+    {
+        $handler = new NullCacheHandler();
+
+        $this->assertInstanceOf('PhpCsFixer\CacheHandler', $handler);
+    }
+
+    public function testWillNotCache()
+    {
+        $handler = new NullCacheHandler();
+
+        $this->assertFalse($handler->willCache());
+    }
+
+    public function testReadReturnsNull()
+    {
+        $handler = new NullCacheHandler();
+
+        $this->assertNull($handler->read());
+    }
+}


### PR DESCRIPTION
This PR

* [x] extracts a `CacheHandler` interface, implemented by `FileCacheHandler` and `NullCacheHandler`, and injects either implementation into `FileCacheManager`, depending on whether caching is enabled and the environment allows it

Related to #1888.

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1888#issuecomment-215381346.