### PR TITLE
FixCommand - Fix escaping of diff output

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -312,29 +312,17 @@ class Fixer
         return 'symfony';
     }
 
+    /**
+     * @deprecated Will be removed in the 2.0.
+     *
+     * @param string $old
+     * @param string $new
+     *
+     * @return string
+     */
     protected function stringDiff($old, $new)
     {
-        $diff = $this->diff->diff($old, $new);
-
-        $diff = implode(
-            PHP_EOL,
-            array_map(
-                function ($string) {
-                    $string = preg_replace('/^(\+){3}/', '<info>+++</info>', $string);
-                    $string = preg_replace('/^(\+){1}/', '<info>+</info>', $string);
-
-                    $string = preg_replace('/^(\-){3}/', '<error>---</error>', $string);
-                    $string = preg_replace('/^(\-){1}/', '<error>-</error>', $string);
-
-                    $string = str_repeat(' ', 6).$string;
-
-                    return $string;
-                },
-                explode(PHP_EOL, $diff)
-            )
-        );
-
-        return $diff;
+        return $this->diff->diff($old, $new);
     }
 
     /**

--- a/Symfony/CS/Tests/Console/TextDiffTest.php
+++ b/Symfony/CS/Tests/Console/TextDiffTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Console;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\CS\Console\Command\FixCommand;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class TextDiffTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $expected
+     * @param string $format
+     * @param bool   $isDecorated
+     *
+     * @dataProvider provideDiffReporting
+     */
+    public function testDiffReportingDecorated($expected, $format, $isDecorated)
+    {
+        $command = new FixCommand();
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array(
+                'path' => __DIR__.'/TextDiffTestInput.test',
+                '--fixers' => 'concat_without_spaces',
+                '--dry-run' => true,
+                '--diff' => true,
+                '--format' => $format,
+            ),
+            array(
+                'decorated' => $isDecorated,
+                'verbosity' => OutputInterface::VERBOSITY_NORMAL,
+            )
+        );
+
+        if ($isDecorated !== $commandTester->getOutput()->isDecorated()) {
+            $this->markTestSkipped(sprintf('Output should %sbe decorated.', $isDecorated ? '' : 'not '));
+        }
+
+        if ($isDecorated !== $commandTester->getOutput()->getFormatter()->isDecorated()) {
+            $this->markTestSkipped(sprintf('Formatter should %sbe decorated.', $isDecorated ? '' : 'not '));
+        }
+
+        $this->assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
+    }
+
+    public function provideDiffReporting()
+    {
+        $expected = <<<'TEST'
+%A$output->writeln('<error>' . 'a' . '</error>');%A
+%A$output->writeln('<error>'.'a'.'</error>');%A
+TEST;
+        $cases = array();
+        foreach (array('txt', 'xml') as $format) {
+            $cases[] = array($expected, $format, true);
+            $cases[] = array($expected, $format, false);
+        }
+
+        $expected = substr(json_encode($expected), 1, -1);
+        $cases[] = array($expected, 'json', true);
+        $cases[] = array($expected, 'json', false);
+
+        return $cases;
+    }
+}

--- a/Symfony/CS/Tests/Console/TextDiffTestInput.test
+++ b/Symfony/CS/Tests/Console/TextDiffTestInput.test
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Input for @see \Symfony\CS\Tests\Console\TextDiffTest.
+ *
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class TextDiffTestInput
+{
+    private function foo($output)
+    {
+        $output->writeln('<error>' . 'a' . '</error>');
+    }
+}


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1895#issuecomment-220003344

after
![after](https://cloud.githubusercontent.com/assets/10462973/15357642/4774b476-1d00-11e6-8fc1-7939a0a49b97.png)

before
![before](https://cloud.githubusercontent.com/assets/10462973/15357643/4777ce18-1d00-11e6-8073-6e52569b0631.png)
