### PR TITLE
Use PHP_BINARY constant for syntax checking

### DIFF
--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -49,7 +49,9 @@ class LintManager
             return $this->createProcessForSource(file_get_contents($path));
         }
 
-        $process = new Process('php -l '.ProcessUtils::escapeArgument($path));
+        $phpBin = PHP_VERSION_ID >= 50400 ? PHP_BINARY : 'php';
+
+        $process = new Process($phpBin.' -l '.ProcessUtils::escapeArgument($path));
         $process->setTimeout(null);
         $process->run();
 


### PR DESCRIPTION
Currently the `LintManager` class check syntax by running `php -l path/`, it can cause some errors if the php binary has another name.