### PR TITLE
EmptyReturnFixer - move fixer outside of Symfony level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -337,11 +337,6 @@ Choose from the list of available fixers:
 * **duplicate_semicolon** [symfony]
                         Remove duplicated semicolons.
 
-* **empty_return** [symfony]
-                        A return statement wishing to
-                        return nothing should be
-                        simply "return".
-
 * **extra_empty_lines** [symfony]
                         Removes extra empty lines.
 
@@ -635,6 +630,11 @@ Choose from the list of available fixers:
                         Converts echo language
                         construct to print if
                         possible.
+
+* **empty_return** [contrib]
+                        A return statement wishing to
+                        return nothing should be
+                        simply "return".
 
 * **ereg_to_preg** [contrib]
                         Replace deprecated ereg

--- a/Symfony/CS/Fixer/Contrib/EmptyReturnFixer.php
+++ b/Symfony/CS/Fixer/Contrib/EmptyReturnFixer.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Fixer\Symfony;
+namespace Symfony\CS\Fixer\Contrib;
 
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;

--- a/Symfony/CS/Tests/Fixer/Contrib/EmptyReturnFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/EmptyReturnFixerTest.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Symfony\CS\Tests\Fixer\Symfony;
+namespace Symfony\CS\Tests\Fixer\Contrib;
 
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 


### PR DESCRIPTION
ref #1638

cc @stof 