### PR TITLE
Strict types declaration fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -736,6 +736,10 @@ Choose from the list of available fixers:
                          Functions should be used with
                          $strict param. (Risky fixer!)
 
+* **strict_types**
+                         Force strict types
+                         declaration in all files.
+
 * **switch_case_semicolon_to_colon** [@PSR2, @Symfony]
                          A case should be followed by
                          a colon and not a semicolon.

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -70,7 +70,7 @@ final class HeaderCommentFixer extends AbstractFixer
             return;
         }
 
-        $this->replaceHeaderComment($tokens, $oldHeaderIndex);
+        $this->replaceHeaderComment($tokens, $oldHeaderIndex, $newHeaderIndex);
     }
 
     /**
@@ -101,7 +101,7 @@ final class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Find the header comment index.
+     * Find the closest whitespace block before the header comment index.
      *
      * @param Tokens $tokens
      *
@@ -110,14 +110,17 @@ final class HeaderCommentFixer extends AbstractFixer
     private function findHeaderCommentIndex(Tokens $tokens)
     {
         $index = $tokens->getNextNonWhitespace(0);
+        if (null !== $index && $tokens[$index]->isGivenKind(T_DECLARE)) {
+            $index = $this->skipDeclare($tokens, $index);
+        }
 
         if (null !== $index && $tokens[$index]->isGivenKind(T_COMMENT)) {
-            return $index;
+            return $index === 2 && $tokens[1]->isWhitespace() ? 1 : $index;
         }
     }
 
     /**
-     * Find the index where the header comment must be inserted.
+     * Find the closest whitespace block where the header comment must be inserted.
      *
      * @param Tokens $tokens
      *
@@ -126,13 +129,46 @@ final class HeaderCommentFixer extends AbstractFixer
     private function findHeaderCommentInsertionIndex(Tokens $tokens)
     {
         $index = $tokens->getNextNonWhitespace(0);
+        if (null !== $index && $tokens[$index]->isGivenKind(T_DECLARE)) {
+            $index = $this->skipDeclare($tokens, $index);
+        }
 
         if (null === $index) {
             // empty file, insert at the end
             $index = $tokens->getSize();
         }
 
-        return $index;
+        return $index === 2 && $tokens[1]->isWhitespace() ? 1 : $index;
+    }
+
+    /**
+     * Skips a declare(strict_type=1); statement as it is allowed to be before the header
+     *
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return int
+     */
+    private function skipDeclare(Tokens $tokens, $index)
+    {
+        $isOpen = false;
+        $isStrictTypes = false;
+        $originalIndex = $index;
+
+        while ($index = $tokens->getNextNonWhitespace($index)) {
+            if ($tokens[$index]->getContent() === '(') {
+                $isOpen = true;
+            }
+            if ($isOpen && $tokens[$index]->getContent() === 'strict_types') {
+                $isStrictTypes = true;
+            }
+            if ($tokens[$index]->getContent() === ';') {
+                $index++;
+                break;
+            }
+        }
+
+        return $isStrictTypes ? $index : $originalIndex;
     }
 
     /**
@@ -140,29 +176,34 @@ final class HeaderCommentFixer extends AbstractFixer
      *
      * @param Tokens $tokens
      * @param int    $oldHeaderIndex
+     * @param int    $headerInsertionIndex
      */
-    private function replaceHeaderComment(Tokens $tokens, $oldHeaderIndex)
+    private function replaceHeaderComment(Tokens $tokens, $oldHeaderIndex, $headerInsertionIndex)
     {
+        $headerEnd = null !== $oldHeaderIndex
+            ? $tokens->getNextNonWhitespace($oldHeaderIndex)
+            : $headerInsertionIndex - 1
+        ;
+
+        while (isset($tokens[$headerEnd + 1]) && ($tokens[$headerEnd + 1]->isWhitespace() || $tokens[$headerEnd + 1]->isGivenKind(T_COMMENT))) {
+            $headerEnd++;
+        }
+
         if ('' === $this->headerComment) {
             if ($oldHeaderIndex) {
-                $tokens->clearRange($oldHeaderIndex, $oldHeaderIndex + 1);
+                $tokens->clearRange($tokens->getNextNonWhitespace($oldHeaderIndex), $headerEnd);
             }
 
             return;
         }
 
         $headCommentTokens = array(
-            new Token(array(T_WHITESPACE, "\n")),
+            new Token(array(T_WHITESPACE, $headerInsertionIndex === 1 ? "\n" : "\n\n")),
             new Token(array(T_COMMENT, $this->headerComment)),
             new Token(array(T_WHITESPACE, "\n\n")),
         );
 
-        $newHeaderIndex = null !== $oldHeaderIndex
-            ? $oldHeaderIndex + 1
-            : $this->findHeaderCommentInsertionIndex($tokens) - 1
-        ;
-
-        $tokens->overrideRange(1, $newHeaderIndex, $headCommentTokens);
+        $tokens->overrideRange($headerInsertionIndex, $headerEnd, $headCommentTokens);
     }
 
     /**

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -142,7 +142,7 @@ final class HeaderCommentFixer extends AbstractFixer
     }
 
     /**
-     * Skips a declare(strict_type=1); statement as it is allowed to be before the header
+     * Skips a declare(strict_type=1); statement as it is allowed to be before the header.
      *
      * @param Tokens $tokens
      * @param int    $index
@@ -163,7 +163,7 @@ final class HeaderCommentFixer extends AbstractFixer
                 $isStrictTypes = true;
             }
             if ($tokens[$index]->getContent() === ';') {
-                $index++;
+                ++$index;
                 break;
             }
         }
@@ -186,7 +186,7 @@ final class HeaderCommentFixer extends AbstractFixer
         ;
 
         while (isset($tokens[$headerEnd + 1]) && ($tokens[$headerEnd + 1]->isWhitespace() || $tokens[$headerEnd + 1]->isGivenKind(T_COMMENT))) {
-            $headerEnd++;
+            ++$headerEnd;
         }
 
         if ('' === $this->headerComment) {

--- a/src/Fixer/Strict/StrictTypesFixer.php
+++ b/src/Fixer/Strict/StrictTypesFixer.php
@@ -51,7 +51,7 @@ final class StrictTypesFixer extends AbstractFixer
         );
 
         // check for valid construct, break on mismatch
-        for ($i = 0;; ++$i) {
+        for ($i = 0; ; ++$i) {
             if (!$tokens[$i]->equals($declareTokens[$i], true)) {
                 break;
             }
@@ -106,6 +106,6 @@ final class StrictTypesFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Force strict types declaration in all files';
+        return 'Force strict types declaration in all files.';
     }
 }

--- a/src/Fixer/Strict/StrictTypesFixer.php
+++ b/src/Fixer/Strict/StrictTypesFixer.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Strict;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+final class StrictTypesFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        if (!$tokens->isMonolithicPhp()) {
+            return;
+        }
+
+        $declareTokens = array(
+            new Token(array(T_OPEN_TAG, "<?php ")),
+            new Token(array(T_DECLARE, 'declare')),
+            new Token("("),
+            new Token(array(T_STRING, "strict_types")),
+            new Token("="),
+            new Token(array(T_LNUMBER, 1)),
+            new Token(")"),
+            new Token(";"),
+            new Token(array(T_WHITESPACE, "\n\n")),
+        );
+
+        // check for valid construct, break on mismatch
+        for ($i = 0;; $i++) {
+            if (!$tokens[$i]->equals($declareTokens[$i], true)) {
+                break;
+            }
+            if ($i === count($declareTokens) - 1) {
+                return;
+            }
+        }
+
+        $index = $tokens->getNextNonWhitespace(0);
+
+        // empty file, just add the tokens
+        if (null === $index) {
+            $tokens->overrideRange(0, 0, $declareTokens);
+
+            return;
+        }
+
+        // find the end of the declare if there is one already so we can replace it
+        if ($tokens[$index]->isGivenKind(T_DECLARE)) {
+            $isOpen = false;
+            $isStrictTypes = false;
+            $originalIndex = $index;
+
+            while ($index = $tokens->getNextNonWhitespace($index)) {
+                if ($tokens[$index]->getContent() === '(') {
+                    $isOpen = true;
+                }
+                if ($isOpen && $tokens[$index]->getContent() === 'strict_types') {
+                    $isStrictTypes = true;
+                }
+                if ($tokens[$index]->getContent() === ';') {
+                    $index = $tokens->getNextNonWhitespace($index);
+                    break;
+                }
+            }
+
+            if (!$isStrictTypes) {
+                $index = $originalIndex;
+            }
+        }
+
+        $tokens->overrideRange(0, $index - 1, $declareTokens);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Force strict types declaration in all files';
+    }
+}

--- a/src/Fixer/Strict/StrictTypesFixer.php
+++ b/src/Fixer/Strict/StrictTypesFixer.php
@@ -39,19 +39,19 @@ final class StrictTypesFixer extends AbstractFixer
         }
 
         $declareTokens = array(
-            new Token(array(T_OPEN_TAG, "<?php ")),
+            new Token(array(T_OPEN_TAG, '<?php ')),
             new Token(array(T_DECLARE, 'declare')),
-            new Token("("),
-            new Token(array(T_STRING, "strict_types")),
-            new Token("="),
+            new Token('('),
+            new Token(array(T_STRING, 'strict_types')),
+            new Token('='),
             new Token(array(T_LNUMBER, 1)),
-            new Token(")"),
-            new Token(";"),
+            new Token(')'),
+            new Token(';'),
             new Token(array(T_WHITESPACE, "\n\n")),
         );
 
         // check for valid construct, break on mismatch
-        for ($i = 0;; $i++) {
+        for ($i = 0;; ++$i) {
             if (!$tokens[$i]->equals($declareTokens[$i], true)) {
                 break;
             }

--- a/src/Fixer/Strict/StrictTypesFixer.php
+++ b/src/Fixer/Strict/StrictTypesFixer.php
@@ -44,7 +44,7 @@ final class StrictTypesFixer extends AbstractFixer
             new Token('('),
             new Token(array(T_STRING, 'strict_types')),
             new Token('='),
-            new Token(array(T_LNUMBER, 1)),
+            new Token(array(T_LNUMBER, '1')),
             new Token(')'),
             new Token(';'),
             new Token(array(T_WHITESPACE, "\n\n")),

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -194,6 +194,62 @@ EOH;
         $this->doTest($expected, $input);
     }
 
+    public function testFixSkipStrictDeclare()
+    {
+        $expected = <<<'EOH'
+<?php declare ( strict_types = 1) ;
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php declare ( strict_types = 1) ;
+
+phpinfo();
+EOH;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixSkipStrictDeclareWithExistingComment()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php declare(strict_types=1);
+
+/*
+ * Existing comment
+ */
+
+phpinfo();
+EOH;
+
+        $this->doTest($expected, $input);
+    }
+
     /**
      * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
      * @expectedExceptionMessage [header_comment] Header configuration is invalid. Expected "string", got "stdClass".

--- a/tests/Fixer/Strict/StrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/StrictTypesFixerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Strict;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ */
+final class StrictTypesFixerTest extends AbstractFixerTestCase
+{
+    public function testFixAlreadyThere()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+declare(strict_types = 1);
+
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testSkipValidDeclare()
+    {
+        $input = <<<'EOH'
+<?php declare(strict_types=1);
+
+phpinfo();
+EOH;
+
+        $this->doTest($input);
+    }
+
+    public function testFixAddsCorrectly()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsCorrectly2()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsToEmptyFile()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+
+EOH;
+
+        $input = "<?php\n";
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixDoNotTouchFilesWithSeveralOpenTags()
+    {
+        $input = "<?php\nphpinfo();\n?>\n<?";
+        $this->doTest($input);
+    }
+
+    public function testFixDoNotTouchFilesNotStartingWithOpenTag()
+    {
+        $input = " <?php\nphpinfo();\n";
+        $this->doTest($input);
+    }
+}

--- a/tests/Fixer/Strict/StrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/StrictTypesFixerTest.php
@@ -57,8 +57,7 @@ phpinfo();
 EOH;
 
         $input = <<<'EOH'
-<?php
-phpinfo();
+<?php phpinfo();
 EOH;
         $this->doTest($expected, $input);
     }
@@ -89,6 +88,95 @@ EOH;
 
         $input = "<?php\n";
         $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsAboveSingleLineComment()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+// foo
+EOH;
+
+        $input = <<<'EOH'
+<?php
+// foo
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsAbovePHPDoc()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+/**
+ * Foo
+ */
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+/**
+ * Foo
+ */
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsAboveComment()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+/*
+ * Foo
+ */
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+/*
+ * Foo
+ */
+
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixAddsAboveInlineComment()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+/* Foo */
+// Bla
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php /* Foo */
+// Bla
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixDoNotTouchShortOpenTag()
+    {
+        $input = <<<'EOH'
+<?
+
+phpinfo();
+EOH;
+        $this->doTest($input);
     }
 
     public function testFixDoNotTouchFilesWithSeveralOpenTags()

--- a/tests/Fixer/Strict/StrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/StrictTypesFixerTest.php
@@ -37,6 +37,27 @@ EOH;
         $this->doTest($expected, $input);
     }
 
+    public function testFixAlreadyThere2()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+phpinfo();
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+declare(
+    strict_types
+    = 1)
+;
+
+phpinfo();
+EOH;
+        $this->doTest($expected, $input);
+    }
+
     public function testSkipValidDeclare()
     {
         $input = <<<'EOH'
@@ -101,6 +122,22 @@ EOH;
         $input = <<<'EOH'
 <?php
 // foo
+EOH;
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixHandlesCommentsBeforeDeclare()
+    {
+        $expected = <<<'EOH'
+<?php declare(strict_types=1);
+
+/*test*/echo 123;
+EOH;
+
+        $input = <<<'EOH'
+<?php
+
+            /*test*/declare(strict_types=1)/**/;echo 123;
 EOH;
         $this->doTest($expected, $input);
     }
@@ -175,6 +212,23 @@ EOH;
 <?
 
 phpinfo();
+EOH;
+        $this->doTest($input);
+    }
+
+    public function testFixDoNotTouchShortOpenTag2()
+    {
+        $input = <<<'EOH'
+<? //test
+  declare      (
+strict_types  =1
+)
+
+
+
+
+?>
+test
 EOH;
         $this->doTest($input);
     }


### PR DESCRIPTION
This adds a fixer that ensures all files start with

```
<?php declare(strict_types=1);

// ...
```

I also had to adjust the header_comment fixer because it shouldn't insert a header above the declare IMO.

The only problem I have is that the tests fail with:

```
4) PhpCsFixer\Tests\Fixer\Strict\StrictTypesFixerTest::testFixAddsToEmptyFile
The token at index 5 must be {
    "id": 317,
    "name": "T_LNUMBER",
    "content": 1,
    "isArray": true,
    "changed": false
}, got {
    "id": 317,
    "name": "T_LNUMBER",
    "content": 1,
    "isArray": true,
    "changed": true
}
Failed asserting that false is true.
```

I can't make sense of it though, as the code works and does the right thing but only this changed flag is true when it shouldn't or something. I don't know enough about internals to know how to fix this. Advice would be nice.

Another improvement I wanted to make is to allow a blacklist and/or whitelist to be configured on the fixer, like an array of files/regex to ignore or include, because this isn't strictly speaking coding style, it has runtime impact and you don't necessarily want to enforce this on ALL files. However isCandidate doesn't receive the file path, only the tokens, so it's hard to make a decision about the file at that point. I could do it in fix() I guess but wanted to ask first.