### PR TITLE
NoEmptyCommentFixer - Only remove complete empty comment blocks

### DIFF
--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -20,22 +20,31 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class NoEmptyCommentFixer extends AbstractFixer
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isCandidate(Tokens $tokens)
-    {
-        return $tokens->isTokenKindFound(T_COMMENT);
-    }
+    const TYPE_HASH = 1;
+    const TYPE_DOUBLE_SLASH = 2;
+    const TYPE_SLASH_ASTERISK = 3;
 
     /**
      * {@inheritdoc}
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
-            if ($token->isGivenKind(T_COMMENT)) {
-                $this->fixComment($tokens, $index);
+        for ($index = 0, $count = count($tokens); $index < $count; ++$index) {
+            if (!$tokens[$index]->isGivenKind(T_COMMENT)) {
+                continue;
+            }
+
+            list($blockStart, $index, $isEmpty) = $this->getCommentBlock($tokens, $index);
+            if (false === $isEmpty) {
+                continue;
+            }
+
+            if ($tokens[$index]->isWhitespace() && false !== strpos($tokens[$index]->getContent(), "\n")) {
+                --$index;
+            }
+
+            for ($i = $blockStart; $i <= $index; ++$i) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($i);
             }
         }
     }
@@ -58,34 +67,105 @@ final class NoEmptyCommentFixer extends AbstractFixer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_COMMENT);
+    }
+
+    /**
+     * Return the start index, end index and a flag stating if the comment block is empty.
+     *
      * @param Tokens $tokens
      * @param int    $index  T_COMMENT index
+     *
+     * @return array
      */
-    private function fixComment(Tokens $tokens, $index)
+    private function getCommentBlock(Tokens $tokens, $index)
     {
-        $content = $tokens[$index]->getContent();
+        $commentType = $this->getCommentType($tokens[$index]->getContent());
+        $empty = $this->isEmptyComment($tokens[$index]->getContent());
+        $start = $index;
+        $count = count($tokens);
+        ++$index;
 
-        // single line comment starting with '#'
+        for (; $index < $count; ++$index) {
+            if ($tokens[$index]->isComment()) {
+                if ($commentType !== $this->getCommentType($tokens[$index]->getContent())) {
+                    break;
+                }
+
+                if ($empty) { // don't retest if already known the block not being empty
+                    $empty = $this->isEmptyComment($tokens[$index]->getContent());
+                }
+
+                continue;
+            }
+
+            if (!$tokens[$index]->isWhitespace() || $this->getLineBreakCount($tokens, $index, $index + 1) > 1) {
+                break;
+            }
+        }
+
+        return array($start, $index - 1, $empty);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return int
+     */
+    private function getCommentType($content)
+    {
         if ('#' === $content[0]) {
-            if (preg_match('|^#\s*$|', $content)) {
-                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-            }
-
-            return;
+            return self::TYPE_HASH;
         }
 
-        // single line comment starting with '//'
-        if ('/' === $content[1]) {
-            if (preg_match('|^//\s*$|', $content)) {
-                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-            }
-
-            return;
+        if ('*' === $content[1]) {
+            return self::TYPE_SLASH_ASTERISK;
         }
 
-        // comment starting with '/*' and ending with '*/' (but not a PHPDoc)
-        if (preg_match('|^/\*\s*\*/$|', $content)) {
-            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+        return self::TYPE_DOUBLE_SLASH;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $whiteStart
+     * @param int    $whiteEnd
+     *
+     * @return int
+     */
+    private function getLineBreakCount(Tokens $tokens, $whiteStart, $whiteEnd)
+    {
+        $lineCount = 0;
+        for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
+            $lineCount += substr_count($tokens[$i]->getContent(), "\n");
+        }
+
+        return $lineCount;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return bool
+     */
+    private function isEmptyComment($content)
+    {
+        $type = $this->getCommentType($content);
+        switch ($type) {
+            case self::TYPE_HASH:
+                // single line comment starting with '#'
+                return 1 === preg_match('|^#\s*$|', $content);
+            case self::TYPE_SLASH_ASTERISK:
+                // comment starting with '/*' and ending with '*/' (but not a PHPDoc)
+                return 1 === preg_match('|^/\*\s*\*/$|', $content);
+            case self::TYPE_DOUBLE_SLASH:
+                // single line comment starting with '//'
+                return 1 === preg_match('|^//\s*$|', $content);
+            default:
+                throw new \UnexpectedValueException('Comment type detected failed.');
         }
     }
 }

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -39,10 +39,6 @@ final class NoEmptyCommentFixer extends AbstractFixer
                 continue;
             }
 
-            if ($tokens[$index]->isWhitespace() && false !== strpos($tokens[$index]->getContent(), "\n")) {
-                --$index;
-            }
-
             for ($i = $blockStart; $i <= $index; ++$i) {
                 $tokens->clearTokenAndMergeSurroundingWhitespace($i);
             }
@@ -164,8 +160,6 @@ final class NoEmptyCommentFixer extends AbstractFixer
             case self::TYPE_DOUBLE_SLASH:
                 // single line comment starting with '//'
                 return 1 === preg_match('|^//\s*$|', $content);
-            default:
-                throw new \UnexpectedValueException('Comment type detected failed.');
         }
     }
 }

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Tests\Fixer\Comment;
 
 use PhpCsFixer\Test\AbstractFixerTestCase;
+use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @author SpacePossum
@@ -32,6 +33,55 @@ final class NoEmptyCommentFixerTest extends AbstractFixerTestCase
     public function provideFixCases()
     {
         return array(
+            // fix cases
+            array(
+                '<?php
+                    echo 0;
+echo 1;
+                ',
+                '<?php
+                    echo 0;//
+echo 1;
+                ',
+            ),
+            array(
+                '<?php
+                    echo 0;
+    echo 1;
+                ',
+                '<?php
+                    echo 0;//
+    echo 1;
+                ',
+            ),
+            array(
+                '<?php
+                    echo 1;
+                ',
+                '<?php
+                    echo 1;//
+                ',
+            ),
+            array(
+                '<?php
+                echo 2;
+                    '.'
+echo 1;
+                ',
+                '<?php
+                echo 2;
+                    //
+echo 1;
+                ',
+            ),
+            array(
+                '<?php
+
+                ?>',
+                '<?php
+
+                //?>',
+            ),
             array(
                 '<?php
                     '.'
@@ -58,32 +108,10 @@ final class NoEmptyCommentFixerTest extends AbstractFixerTestCase
             ),
             array(
                 '<?php
-                    echo 1;'.'
+                    echo 0;echo 1;
                 ',
                 '<?php
-                    echo 1;//
-                ',
-            ),
-            array(
-                '<?php
-                echo 2;
-                    '.'
-echo 1;
-                ',
-                '<?php
-                echo 2;
-                    //
-echo 1;
-                ',
-            ),
-            array(
-                '<?php
-                    echo 0;'.'
-echo 1;
-                ',
-                '<?php
-                    echo 0;//
-echo 1;
+                    echo 0;/**/echo 1;
                 ',
             ),
             array(
@@ -91,7 +119,7 @@ echo 1;
                     echo 0;echo 1;
                 ',
                 '<?php
-                    echo 0;/**/echo 1;
+                    echo 0;/**//**//**/echo 1/**/;
                 ',
             ),
             array(
@@ -111,14 +139,6 @@ echo 1;
             ),
             array(
                 '<?php
-
-                ?>',
-                '<?php
-
-                //?>',
-            ),
-            array(
-                '<?php
                     '.'
                     '.'
                     '.'
@@ -131,6 +151,7 @@ echo 1;
                     /**///
                 ',
             ),
+            // do not fix cases
             array(
                 '<?php
                 // a
@@ -141,9 +162,169 @@ echo 1;
             ),
             array(
                 '<?php
-                '.'
+                    // This comment could be nicely formatted.
+                    //
+                    //
+                    // For that, it could have some empty comment lines inside.
+                    //
+
+                    ## A 1
+                    ##
+                    ##
+                    ## A 2
+                    ##
+
+                    // B 1
+                    //
+                    // B 2
+
+                    ## C 1
+                    ##
+                    ## C 2
+
+                    $foo = 1;
+
+                    //
+                    // a
+                    //
+
+                    $bar = 2;
                 ',
             ),
         );
+    }
+
+    /**
+     * @param string $source     valid PHP source code
+     * @param int    $startIndex start index of the comment block
+     * @param int    $endIndex   expected index of the last token of the block
+     * @param bool   $isEmpty    expected value of empty flag returned
+     *
+     * @dataProvider provideCommentBlockCases
+     */
+    public function testGetCommentBlock($source, $startIndex, $endIndex, $isEmpty)
+    {
+        Tokens::clearCache();
+        $tokens = Tokens::fromCode($source);
+        $this->assertTrue($tokens[$startIndex]->isComment(), sprintf('Misconfiguration of test, expected comment token at index "%d".', $startIndex));
+
+        $fixer = $this->getFixer();
+        $method = new \ReflectionMethod($fixer, 'getCommentBlock');
+        $method->setAccessible(true);
+
+        list($foundStart, $foundEnd, $foundIsEmpty) = $method->invoke($fixer, $tokens, $startIndex);
+
+        $this->assertSame($startIndex, $foundStart, 'Find start index of block failed.');
+        $this->assertSame($endIndex, $foundEnd, 'Find end index of block failed.');
+        $this->assertSame($isEmpty, $foundIsEmpty, 'Is empty comment block detection failed.');
+    }
+
+    public function provideCommentBlockCases()
+    {
+        $cases = array(
+            array(
+                '<?php // a',
+                1,
+                1,
+                false,
+            ),
+            array(
+                '<?php
+                    // This comment could be nicely formatted.
+                    //
+                    //
+                    // For that, it could have some empty comment lines inside.
+                    //           ',
+                2,
+                11,
+                false,
+            ),
+            array(
+                '<?php
+/**///',
+                1,
+                1,
+                true,
+            ),
+            array(
+                '<?php
+//
+//
+
+#
+#
+',
+                5,
+                8,
+                true,
+            ),
+            array(
+                '<?php
+//
+//
+
+//
+//
+',
+                5,
+                8,
+                true,
+            ),
+            array(
+                '<?php
+//
+//
+
+//
+//
+',
+                1,
+                3,
+                true,
+            ),
+            array(
+                '<?php
+//
+
+//
+',
+                1,
+                1,
+                true,
+            ),
+            array(
+                '<?php
+//
+//
+              $a;  ',
+                1,
+                4,
+                true,
+            ),
+            array(
+                '<?php
+//',
+                1,
+                1,
+                true,
+            ),
+        );
+
+        $src = '<?php
+                // a2
+            // /*4*/
+              // #6
+/* b8 */ // s10
+          #                        c12';
+
+        foreach (array(2, 4, 6) as $i) {
+            $cases[] = array($src, $i, 7, false);
+        }
+
+        $cases[] = array($src, 8, 9, false);
+        $cases[] = array($src, 10, 11, false);
+        $cases[] = array($src, 12, 12, false);
+
+        return $cases;
     }
 }


### PR DESCRIPTION
master version of;
@see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1941

I've changed the spec a bit to only complete empty comment blocks.
Started on master because of the comment with line break transformers are helping a lot...