### PR TITLE
tests - stop using deprecated method

### DIFF
--- a/tests/Fixer/Basic/Psr0FixerTest.php
+++ b/tests/Fixer/Basic/Psr0FixerTest.php
@@ -24,7 +24,11 @@ final class Psr0FixerTest extends AbstractFixerTestCase
         $fixer = $this->getFixer();
         $fixer->configure(array('dir' => __DIR__));
 
-        $file = $this->getMock('SplFileInfo', array('getRealPath'), array(__DIR__.'/Psr0/Foo/Bar.php'));
+        $file = $this->getMockBuilder('SplFileInfo')
+                     ->setMethods(array('getRealPath'))
+                     ->setConstructorArgs(array(__DIR__.'/Psr0/Foo/Bar.php'))
+                     ->getMock();
+
         $file->expects($this->any())->method('getRealPath')->willReturn(__DIR__.'/Psr0/Foo/Bar.php');
 
         $expected = <<<'EOF'

--- a/tests/Fixer/Basic/Psr4FixerTest.php
+++ b/tests/Fixer/Basic/Psr4FixerTest.php
@@ -25,7 +25,11 @@ final class Psr4FixerTest extends AbstractFixerTestCase
     {
         $fixer = $this->getFixer();
 
-        $file = $this->getMock('SplFileInfo', array('getRealPath'), array(__DIR__.'/Psr4/Foo/Bar.php'));
+        $file = $this->getMockBuilder('SplFileInfo')
+                     ->setMethods(array('getRealPath'))
+                     ->setConstructorArgs(array(__DIR__.'/Psr4/Foo/Bar.php'))
+                     ->getMock();
+
         $file->expects($this->any())->method('getRealPath')->willReturn(__DIR__.'/Psr4/Foo/Bar.php');
 
         $expected = <<<'EOF'

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -38,7 +38,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
         $testInstance = $factory->registerFixer($mock);
         $this->assertSame($factory, $testInstance);
 
-        $mock = $this->getMock('PhpCsFixer\RuleSetInterface');
+        $mock = $this->getMockBuilder('PhpCsFixer\RuleSetInterface')->getMock();
         $mock->expects($this->any())->method('getRules')->willReturn(array());
         $testInstance = $factory->useRuleSet($mock);
         $this->assertSame($factory, $testInstance);
@@ -382,7 +382,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
 
     private function createFixerMock($name, $priority = 0)
     {
-        $fixer = $this->getMock('PhpCsFixer\FixerInterface');
+        $fixer = $this->getMockBuilder('PhpCsFixer\FixerInterface')->getMock();
         $fixer->expects($this->any())->method('getName')->willReturn($name);
         $fixer->expects($this->any())->method('getPriority')->willReturn($priority);
 

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -36,7 +36,7 @@ final class ReporterFactoryTest extends \PHPUnit_Framework_TestCase
 
     private function createReporterMock($format)
     {
-        $report = $this->getMock('PhpCsFixer\Report\ReporterInterface');
+        $report = $this->getMockBuilder('PhpCsFixer\Report\ReporterInterface')->getMock();
         $report->expects($this->any())->method('getFormat')->willReturn($format);
 
         return $report;


### PR DESCRIPTION
Replaced usage of `getMock()` with `getMockBuilder()` which works fine with PHPUnit < 5.4 and >= 5.4.