### PR TITLE
Fix not wanted unneeded_control_parentheses fixer for clone

### DIFF
--- a/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
@@ -37,7 +37,7 @@ final class UnneededControlParenthesesFixer extends AbstractFixer
         'switch_case' => array('lookupTokens' => T_CASE, 'neededSuccessors' => array(';', ':')),
         'echo_print' => array('lookupTokens' => array(T_ECHO, T_PRINT), 'neededSuccessors' => array(';', array(T_CLOSE_TAG))),
         'return' => array('lookupTokens' => T_RETURN, 'neededSuccessors' => array(';')),
-        'clone' => array('lookupTokens' => T_CLONE, 'neededSuccessors' => array(';', ':', ',', ')')),
+        'clone' => array('lookupTokens' => T_CLONE, 'neededSuccessors' => array(';', ':', ',', ')'), 'forbiddenContents' => array('?', ':')),
     );
 
     /**
@@ -88,6 +88,14 @@ final class UnneededControlParenthesesFixer extends AbstractFixer
 
                 if (!$tokens[$blockEndNextIndex]->equalsAny($loop['neededSuccessors'])) {
                     continue;
+                }
+
+                if (array_key_exists('forbiddenContents', $loop)) {
+                    $forbiddenTokenIndex = $tokens->getNextTokenOfKind($blockStartIndex, $loop['forbiddenContents']);
+                    // A forbidden token is found and is inside the parenthesis.
+                    if (null !== $forbiddenTokenIndex && $forbiddenTokenIndex < $blockEndIndex) {
+                        continue;
+                    }
                 }
 
                 if ($tokens[$blockStartIndex - 1]->isWhitespace() || $tokens[$blockStartIndex - 1]->isComment()) {

--- a/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
@@ -115,6 +115,16 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
+                $var = clone ($obj1 ?: $obj2);
+                ',
+            ),
+            array(
+                '<?php
+                $var = clone ($obj1 ? $obj1->getSubject() : $obj2);
+                ',
+            ),
+            array(
+                '<?php
                 clone $object;
                 ',
                 '<?php


### PR DESCRIPTION
If the clone argument contains a ternary, parenthesis should not be removed.

Closes #1942.

I started this PR by just adding test proofs. I'll try to fix it ASAP.

If anybody have a suggestion to add tests or for the fix, feel free to comment. :+1: 

cc @jsor