### PR TITLE
Tokens - handle semi-reserved PHP 7 keywords

### DIFF
--- a/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
+++ b/Symfony/CS/Fixer/PSR0/Psr0Fixer.php
@@ -157,12 +157,21 @@ class Psr0Fixer extends AbstractFixer implements ConfigAwareInterface
             (!isset($filenameParts[1]) || 'php' !== $filenameParts[1])
             // ignore file with name that cannot be a class name
             || 0 === preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $filenameParts[0])
+            // ignore filename that will halt compiler (and cannot be properly tokenized under PHP 5.3)
+            || '__halt_compiler' === $filenameParts[0]
         ) {
             return false;
         }
 
-        $tokens = Tokens::fromCode(sprintf('<?php class %s {}', $filenameParts[0]));
-        if ($tokens[3]->isKeyword() || $tokens[3]->isMagicConstant()) {
+        try {
+            $tokens = Tokens::fromCode(sprintf('<?php class %s {}', $filenameParts[0]));
+
+            if ($tokens[3]->isKeyword() || $tokens[3]->isMagicConstant()) {
+                // name can not be a class name - detected by PHP 5.x
+                return false;
+            }
+        } catch (\ParseError $e) {
+            // name can not be a class name - detected by PHP 7.x
             return false;
         }
 

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1301,6 +1301,31 @@ while (true) {
     }
 
     /**
+     * @dataProvider provide70Cases
+     * @requires PHP 7.0
+     */
+    public function test70($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provide70Cases()
+    {
+        return array(
+            array(
+                '<?php
+    class Foo
+    {
+        public function use()
+        {
+        }
+    }
+                ',
+            ),
+        );
+    }
+
+    /**
      * @dataProvider providePreserveLineAfterControlBrace
      */
     public function testPreserveLineAfterControlBrace($expected, $input = null)

--- a/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
@@ -42,6 +42,10 @@ class ClassConstantTest extends AbstractTransformerTestBase
                 ),
             ),
             array(
+                '<?php echo X::bar;',
+                array(),
+            ),
+            array(
                 '<?php class X{}',
                 array(),
             ),

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -137,18 +137,10 @@ class Tokens extends \SplFixedArray
             }
         }
 
-        $tokens = token_get_all($code);
+        $tokens = new self();
+        $tokens->setCode($code);
 
-        foreach ($tokens as $index => $tokenPrototype) {
-            $tokens[$index] = new Token($tokenPrototype);
-        }
-
-        $collection = self::fromArray($tokens);
-        $transformers = Transformers::create();
-        $transformers->transform($collection);
-        $collection->changeCodeHash($codeHash);
-
-        return $collection;
+        return $tokens;
     }
 
     /**
@@ -1279,7 +1271,10 @@ class Tokens extends \SplFixedArray
         // clear memory
         $this->setSize(0);
 
-        $tokens = token_get_all($code);
+        $tokens = defined('TOKEN_PARSE')
+            ? token_get_all($code, TOKEN_PARSE)
+            : token_get_all($code);
+
         $this->setSize(count($tokens));
 
         foreach ($tokens as $index => $token) {

--- a/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
+++ b/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
@@ -26,7 +26,14 @@ class ClassConstant extends AbstractTransformer
      */
     public function process(Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_CLASS) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->equalsAny(array(
+                array(T_CLASS, 'class'),
+                array(T_STRING, 'class'),
+            ))) {
+                continue;
+            }
+
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevIndex];
 


### PR DESCRIPTION
Fixing bug part of #1959 

Should be reviewed together with #1971 and #1972