### PR TITLE
[helper PR@1.12] Tokens - handle semi-reserved PHP 7 keywords

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1357,15 +1357,15 @@ declare   (   ticks   =   1   )   {
     }
 
     /**
-     * @dataProvider provideAnonymousClassesCases
+     * @dataProvider provide70Cases
      * @requires PHP 7.0
      */
-    public function testAnonymousClasses($expected, $input = null)
+    public function test70($expected, $input = null)
     {
         $this->makeTest($expected, $input);
     }
 
-    public function provideAnonymousClassesCases()
+    public function provide70Cases()
     {
         return array(
             array(
@@ -1396,6 +1396,15 @@ declare   (   ticks   =   1   )   {
     }, 3);',
                 '<?php
     foo(1, new class implements Logger { public function log($message) { log($message); } }, 3);',
+            ),
+            array(
+                '<?php
+    class Foo
+    {
+        public function use()
+        {
+        }
+    }',
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/Symfony/UnaryOperatorsSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnaryOperatorsSpacesFixerTest.php
@@ -95,13 +95,28 @@ class UnaryOperatorsSpacesFixerTest extends AbstractFixerTestBase
                 '<?php function foo(&$a, array &$b, Bar &$c) {}',
                 '<?php function foo(& $a, array & $b, Bar & $c) {}',
             ),
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideCasesLT70
+     * @requires PHP <7.0
+     */
+    public function testFixLT70($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCasesLT70()
+    {
+        return array(
             array(
                 '<?php foo(+$a, -2,-$b, &$c);',
                 '<?php foo(+ $a, - 2,- $b, & $c);',
             ),
         );
-
-        return $cases;
     }
 
     /**

--- a/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
@@ -43,6 +43,10 @@ class ClassConstantTest extends AbstractTransformerTestBase
                 ),
             ),
             array(
+                '<?php echo X::bar;',
+                array(),
+            ),
+            array(
                 '<?php class X{}',
                 array(),
             ),

--- a/Symfony/CS/Tokenizer/Tokens.php
+++ b/Symfony/CS/Tokenizer/Tokens.php
@@ -139,18 +139,10 @@ class Tokens extends \SplFixedArray
             }
         }
 
-        $tokens = token_get_all($code);
+        $tokens = new self();
+        $tokens->setCode($code);
 
-        foreach ($tokens as $index => $tokenPrototype) {
-            $tokens[$index] = new Token($tokenPrototype);
-        }
-
-        $collection = self::fromArray($tokens);
-        $transformers = Transformers::create();
-        $transformers->transform($collection);
-        $collection->changeCodeHash($codeHash);
-
-        return $collection;
+        return $tokens;
     }
 
     /**
@@ -1322,7 +1314,10 @@ class Tokens extends \SplFixedArray
         // clear memory
         $this->setSize(0);
 
-        $tokens = token_get_all($code);
+        $tokens = defined('TOKEN_PARSE')
+            ? token_get_all($code, TOKEN_PARSE)
+            : token_get_all($code);
+
         $this->setSize(count($tokens));
 
         foreach ($tokens as $index => $token) {

--- a/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
+++ b/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
@@ -27,7 +27,14 @@ class ClassConstant extends AbstractTransformer
      */
     public function process(Tokens $tokens)
     {
-        foreach ($tokens->findGivenKind(T_CLASS) as $index => $token) {
+        foreach ($tokens as $index => $token) {
+            if (!$token->equalsAny(array(
+                array(T_CLASS, 'class'),
+                array(T_STRING, 'class'),
+            ))) {
+                continue;
+            }
+
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevIndex];
 


### PR DESCRIPTION
This PR should not be merged.
It's only helper for #1970. It's purpose is to check build matrix and be used during merging #1970 to newer version line.