### PR TITLE
[helper PR@2.x] Tokens - handle semi-reserved PHP 7 keywords

### DIFF
--- a/src/AbstractPsrAutoloadingFixer.php
+++ b/src/AbstractPsrAutoloadingFixer.php
@@ -71,8 +71,15 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
             return false;
         }
 
-        $tokens = Tokens::fromCode(sprintf('<?php class %s {}', $filenameParts[0]));
-        if ($tokens[3]->isKeyword() || $tokens[3]->isMagicConstant()) {
+        try {
+            $tokens = Tokens::fromCode(sprintf('<?php class %s {}', $filenameParts[0]));
+
+            if ($tokens[3]->isKeyword() || $tokens[3]->isMagicConstant()) {
+                // name can not be a class name - detected by PHP 5.x
+                return false;
+            }
+        } catch (\ParseError $e) {
+            // name can not be a class name - detected by PHP 7.x
             return false;
         }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -970,7 +970,10 @@ class Tokens extends \SplFixedArray
         // clear memory
         $this->setSize(0);
 
-        $tokens = token_get_all($code);
+        $tokens = defined('TOKEN_PARSE')
+            ? token_get_all($code, TOKEN_PARSE)
+            : token_get_all($code);
+
         $this->setSize(count($tokens));
 
         foreach ($tokens as $index => $token) {

--- a/src/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/src/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -38,7 +38,10 @@ final class ClassConstantTransformer extends AbstractTransformer
      */
     public function process(Tokens $tokens, Token $token, $index)
     {
-        if (!$token->isGivenKind(T_CLASS)) {
+        if (!$token->equalsAny(array(
+            array(T_CLASS, 'class'),
+            array(T_STRING, 'class'),
+        ))) {
             return;
         }
 

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -1416,15 +1416,15 @@ declare   (   ticks   =   1   )   {
     }
 
     /**
-     * @dataProvider provideAnonymousClassesCases
+     * @dataProvider provide70Cases
      * @requires PHP 7.0
      */
-    public function testAnonymousClasses($expected, $input = null)
+    public function test70($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideAnonymousClassesCases()
+    public function provide70Cases()
     {
         return array(
             array(
@@ -1455,6 +1455,15 @@ declare   (   ticks   =   1   )   {
     }, 3);',
                 '<?php
     foo(1, new class implements Logger { public function log($message) { log($message); } }, 3);',
+            ),
+            array(
+                '<?php
+    class Foo
+    {
+        public function use()
+        {
+        }
+    }',
             ),
         );
     }

--- a/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
@@ -108,7 +108,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      */
     public function testFixLT70($expected, $input = null)
     {
-        $this->makeTest($expected, $input);
+        $this->doTest($expected, $input);
     }
 
     public function provideCasesLT70()

--- a/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
@@ -97,13 +97,28 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
                 '<?php function foo(&$a, array &$b, Bar &$c) {}',
                 '<?php function foo(& $a, array & $b, Bar & $c) {}',
             ),
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider provideCasesLT70
+     * @requires PHP <7.0
+     */
+    public function testFixLT70($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCasesLT70()
+    {
+        return array(
             array(
                 '<?php foo(+$a, -2,-$b, &$c);',
                 '<?php foo(+ $a, - 2,- $b, & $c);',
             ),
         );
-
-        return $cases;
     }
 
     /**

--- a/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
@@ -30,14 +30,14 @@ final class FullOpeningTagFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideClosingTagExamples
+     * @dataProvider provideFixCases
      */
-    public function testOneLineFix($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideClosingTagExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php echo \'Foo\';', '<? echo \'Foo\';'),
@@ -61,10 +61,6 @@ echo \'Foo\';
                 "<? if ('<?php' === '<?') { }",
             ),
             array(
-                'foo <?php  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <?php echo "<? ";',
-                'foo <?  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <? echo "<? ";',
-            ),
-            array(
                 "<?php
 '<?
 ';",
@@ -82,6 +78,28 @@ echo \'Foo\';
             ),
             array(
                 "<?php \$this->data = preg_replace('/<\?(?!xml|php)/s', '<?php ',       \$this->data);",
+            ),
+            array(
+                'foo <?php  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <?php echo "<? ";',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideFixCasesLT70
+     * @requires PHP <7.0
+     */
+    public function testFixLT70($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCasesLT70()
+    {
+        return array(
+            array(
+                'foo <?php  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <?php echo "<? ";',
+                'foo <?  echo "-"; echo "aaa <?php bbb <? ccc"; echo \'<? \'; /* <? */ /** <? */ ?> bar <? echo "<? ";',
             ),
         );
     }

--- a/tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
@@ -39,6 +39,10 @@ final class ClassConstantTransformerTest extends AbstractTransformerTestCase
                 ),
             ),
             array(
+                '<?php echo X::bar;',
+                array(),
+            ),
+            array(
                 '<?php class X{}',
                 array(),
             ),

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -82,7 +82,7 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
                 '<?php
                     echo $arr{$index};
                     echo $arr[$index];
-                    if {}
+                    if (1) {}
                 ',
                 array(
                     5 => 'CT_ARRAY_INDEX_CURLY_BRACE_OPEN',


### PR DESCRIPTION
This PR should not be merged.
It's only helper for #1970. It's purpose is to check build matrix and be used during merging #1970 to newer version line.