### PR TITLE
composer.json - fix dependencies for PHP 5.3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-tokenizer": "*",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/event-dispatcher": "^2.1 || ^3.0",
-        "symfony/filesystem": "^2.7 || ^3.0",
+        "symfony/filesystem": "^2.4 || ^3.0",
         "symfony/finder": "^2.2 || ^3.0",
         "symfony/polyfill-php54": "^1.0",
         "symfony/process": "^2.3 || ^3.0",


### PR DESCRIPTION
Detected during playing with https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1969 (without this fix given PR will fail on 2.x)

Introduced by https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1888#discussion_r63902254