### PR TITLE
add fixer for namespace immediately following opening tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -584,6 +584,11 @@ Choose from the list of available fixers:
                         closing semicolon are
                         prohibited.
 
+* **namespace_follows_opening_tag** [contrib]
+                        There should be one space and
+                        no newline between the opening
+                        tag and namespace declaration.
+
 * **newline_after_open_tag** [contrib]
                         Ensure there is no code on the
                         same line as the PHP open tag.

--- a/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
@@ -42,8 +42,7 @@ class NamespaceFollowsOpeningTagFixer extends AbstractFixer
                 $openTag = $tokens[0]->getContent();
                 if (!strpos($openTag, 'php')) {
                     $tokens[0]->setContent('<? ');
-                }
-                else {
+                } else {
                     $tokens[0]->setContent('<?php ');
                 }
                 for ($x = 1; $x <= ($index - 1); ++$x) {

--- a/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
@@ -31,16 +31,23 @@ class NamespaceFollowsOpeningTagFixer extends AbstractFixer
             return $content;
         }
 
-        // ignore files with short open tag
+        // ignore files that begin with an echo
         if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
             return $content;
         }
 
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_NAMESPACE)) {
-                $tokens[0]->setContent('<?php ');
+                // respect short open tags
+                $openTag = $tokens[0]->getContent();
+                if (!strpos($openTag, 'php')) {
+                    $tokens[0]->setContent('<? ');
+                }
+                else {
+                    $tokens[0]->setContent('<?php ');
+                }
                 for ($x = 1; $x <= ($index - 1); ++$x) {
-                    $tokens[$x]->setContent('');
+                    $tokens[$x]->clear();
                 }
             }
         }

--- a/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NamespaceFollowsOpeningTagFixer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Ben Harold <benharold@mac.com>
+ */
+class NamespaceFollowsOpeningTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        // ignore non-monolithic files
+        if (!$tokens->isMonolithicPhp()) {
+            return $content;
+        }
+
+        // ignore files with short open tag
+        if (!$tokens[0]->isGivenKind(T_OPEN_TAG)) {
+            return $content;
+        }
+
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_NAMESPACE)) {
+                $tokens[0]->setContent('<?php ');
+                for ($x = 1; $x <= ($index - 1); ++$x) {
+                    $tokens[$x]->setContent('');
+                }
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'There should be one space and no newline between the opening tag and namespace declaration.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/NamespaceFollowsOpeningTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NamespaceFollowsOpeningTagFixerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Ben Harold <benharold@mac.com>
+ */
+class NamespaceFollowsOpeningTagFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideExamples()
+    {
+        return array(
+            array('<?php namespace X;'),
+            array('<?php\n\nclass {}'),
+            array('<?php namespace X;', "<?php\n\n\n\nnamespace X;"),
+            array('<?php namespace X;', "<?php\r\n\r\n\r\n\r\nnamespace X;"),
+        );
+    }
+
+    public function testFixExampleWithComment()
+    {
+        $expected = <<<'EOF'
+<?php namespace Symfony\CS\Fixer\Contrib;
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/NamespaceFollowsOpeningTagFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NamespaceFollowsOpeningTagFixerTest.php
@@ -36,7 +36,10 @@ class NamespaceFollowsOpeningTagFixerTest extends AbstractFixerTestBase
     {
         return array(
             array('<?php namespace X;'),
-            array('<?php\n\nclass {}'),
+            array("<?php\n\nclass Foo {}"),
+            array('<? namespace X;'),
+            array('<? namespace X;', "<?\n\nnamespace X;"),
+            array('<?= "output"; ?>'),
             array('<?php namespace X;', "<?php\n\n\n\nnamespace X;"),
             array('<?php namespace X;', "<?php\r\n\r\n\r\n\r\nnamespace X;"),
         );


### PR DESCRIPTION
This fixer will remove any content between the opening tag and namespace declaration except for a single space character.