### PR TITLE
Cache should use absolute pathname

### DIFF
--- a/Symfony/CS/Fixer.php
+++ b/Symfony/CS/Fixer.php
@@ -174,7 +174,7 @@ class Fixer
 
         if (
             '' === $old
-            || !$fileCacheManager->needFixing($this->getFileRelativePathname($file), $old)
+            || !$fileCacheManager->needFixing($file->getRealpath(), $old)
             // PHP 5.3 has a broken implementation of token_get_all when the file uses __halt_compiler() starting in 5.3.6
             || (PHP_VERSION_ID >= 50306 && PHP_VERSION_ID < 50400 && false !== stripos($old, '__halt_compiler()'))
         ) {
@@ -290,7 +290,7 @@ class Fixer
             }
         }
 
-        $fileCacheManager->setFile($this->getFileRelativePathname($file), $new);
+        $fileCacheManager->setFile($file->getRealpath(), $new);
 
         if ($this->eventDispatcher) {
             $this->eventDispatcher->dispatch(

--- a/Symfony/CS/Tests/FileCacheManagerIntegrationTest.php
+++ b/Symfony/CS/Tests/FileCacheManagerIntegrationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\SplFileInfo as FinderSplFileInfo;
+use Symfony\CS\FileCacheManager;
+use Symfony\CS\Fixer;
+
+class FileCacheManagerIntegrationTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->fs = new Filesystem();
+        $this->rootDir = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FileCacheManagerIntegrationTest';
+
+        $this->fs->mkdir($this->rootDir);
+        $this->isCacheAvailable = $this->isCacheAvailable();
+
+        // Never ever rely on last test results
+        $this->clearFileCacheManagerIntegrationTestFiles();
+
+        $this->customConfigDir = $this->rootDir.DIRECTORY_SEPARATOR.'custom_config_dir';
+
+        $this->files = array(
+            'one' => $this->rootDir.DIRECTORY_SEPARATOR.'path_one'.DIRECTORY_SEPARATOR.'CommonFilename.php',
+            'two' => $this->rootDir.DIRECTORY_SEPARATOR.'path_two'.DIRECTORY_SEPARATOR.'CommonFilename.php',
+        );
+
+        $this->fs->mkdir($this->rootDir);
+        $this->fs->mkdir($this->customConfigDir);
+
+        $fs = $this->fs;
+        array_walk($this->files, function ($filename) use ($fs) {
+            $fs->mkdir(dirname($filename));
+            file_put_contents($filename, "<?\n// {$filename}\n");
+        });
+    }
+
+    protected function tearDown()
+    {
+        $this->clearFileCacheManagerIntegrationTestFiles();
+    }
+
+    private function clearFileCacheManagerIntegrationTestFiles()
+    {
+        $this->fs->remove($this->rootDir);
+    }
+
+    private function isCacheAvailable()
+    {
+        $fileCacheManager = new FileCacheManager(true, $this->rootDir, array());
+        $reflectionIsCacheAvailable = new \ReflectionMethod($fileCacheManager, 'isCacheAvailable');
+        $reflectionIsCacheAvailable->setAccessible(true);
+        $isCacheAvailable = $reflectionIsCacheAvailable->invoke($fileCacheManager);
+        $reflectionIsCacheAvailable->setAccessible(false);
+
+        // We don't want FileCacheManager::__destruct() interferences
+        unset($reflectionIsCacheAvailable, $fileCacheManager);
+
+        return $isCacheAvailable;
+    }
+
+    /**
+     * @dataProvider provideScenarios
+     */
+    public function testCacheScenarios($insideCacheFileDir)
+    {
+        if (!$this->isCacheAvailable) {
+            $this->markTestSkipped('Cache functionality not supported');
+        }
+
+        $configDir = $this->rootDir;
+        if (!$insideCacheFileDir) {
+            $configDir = $this->customConfigDir;
+        }
+
+        $fixer = new Fixer();
+        $fixer->addFixer(new Fixer\PSR1\ShortTagFixer());
+        $fixers = $fixer->getFixers();
+
+        $files = array_map(function ($filename) {
+            return new FinderSplFileInfo(
+                $filename,
+                dirname($filename),
+                basename($filename)
+            );
+        }, $this->files);
+
+        $fileCacheManager = new FileCacheManager(true, $configDir, $fixers);
+        $this->assertNotNull($fixer->fixFile($files['one'], $fixers, false, false, $fileCacheManager));
+        $this->assertNotNull($fixer->fixFile($files['two'], $fixers, false, false, $fileCacheManager));
+
+        // This unset() calls FileCacheManager::saveToFile() and is needed for the test
+        unset($fileCacheManager);
+
+        $fileCacheManager = new FileCacheManager(true, $configDir, $fixers);
+        $this->assertFalse($fileCacheManager->needFixing($files['one']->getRealpath(), file_get_contents($files['one']->getRealpath())));
+        $this->assertFalse($fileCacheManager->needFixing($files['two']->getRealpath(), file_get_contents($files['two']->getRealpath())));
+
+        // This unset() calls FileCacheManager::saveToFile() and let the tearDown clean
+        // everything after the test has ended; otherwise FileCacheManager::__destruct()
+        // would leave some files after the run
+        unset($fileCacheManager);
+    }
+
+    public function provideScenarios()
+    {
+        return array(
+            'cache-stored-with-pathname-relative-to-cachefile-if-in-subfolder' => array(true),
+            'cache-stored-with-common-pathname-relative-to-cachefile-if-outside-cachefile-folder' => array(false),
+        );
+    }
+}


### PR DESCRIPTION
When using a finder like this in the `.php_cs` file:

``` php
$finder = Symfony\CS\Finder\DefaultFinder::create()
    ->in(__DIR__ . '/path_one')
    ->in(__DIR__ . '/path_two')
;
```

And in both path you have the same file name (e.g. `bootstrap.php`) the `php-cs-fix` keeps trying to fix the second one (and subsequents) because the cache is saved using the relative pathname instead of the absolute, and so this https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v1.11.4/Symfony/CS/FileCacheManager.php#L65-L67 keeps beeing triggered if the files are different.
