### PR TITLE
Runner - No need to determine relative file name twice

### DIFF
--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -170,7 +170,6 @@ final class Runner
 
         $old = file_get_contents($file->getRealPath());
         $new = $old;
-        $name = $this->getFileRelativePathname($file);
 
         $appliedFixers = array();
 


### PR DESCRIPTION
This PR

* [x] determines the relative pathname for a file once only

Somewhat related to #1998.