### PR TITLE
Fix: Do not use realpath() on non-existent cache file

### DIFF
--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -70,7 +70,7 @@ final class FileCacheManager implements CacheManagerInterface
         $this->handler = $handler;
         $this->signature = $signature;
         $this->isDryRun = $isDryRun;
-        $this->cacheDirectory = $cacheDirectory ?: new Directory(dirname(realpath($handler->getFile())));
+        $this->cacheDirectory = $cacheDirectory ?: new Directory(dirname($handler->getFile()));
 
         $this->readCache();
     }


### PR DESCRIPTION
This PR
- [x] asserts that actual directory of cache file is used even if cache file does not exist
- [x] skips using `realpath()`

Follows #1888.
Somewhat related to #1998.
