### PR TITLE
Fix: Pass in real path to FileCacheManager

### DIFF
--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -75,7 +75,7 @@ final class FileFilterIterator extends \FilterIterator
             // file uses __halt_compiler() on ~5.3.6 due to broken implementation of token_get_all
             || (PHP_VERSION_ID >= 50306 && PHP_VERSION_ID < 50400 && false !== stripos($content, '__halt_compiler()'))
             // file that does not need fixing due to cache
-            || !$this->cacheManager->needFixing($this->getFileRelativePathname($file), $content)
+            || !$this->cacheManager->needFixing($file->getRealPath(), $content)
         ) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -246,7 +246,7 @@ final class Runner
             );
         }
 
-        $this->cacheManager->setFile($name, $new);
+        $this->cacheManager->setFile($file->getRealPath(), $new);
 
         $this->dispatchEvent(
             FixerFileProcessedEvent::NAME,


### PR DESCRIPTION
This PR
- [x] passes in the real path of a file to the `FileCacheManager`

Follows #1998, but fixes it for `master`.
