### PR TITLE
Update composer install in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global require fabpot/php-cs-fixer
+    $ ./composer.phar global require friendsofphp/php-cs-fixer
 
 Then, make sure you have ``~/.composer/vendor/bin`` in your ``PATH``, and
 you're good to go:
@@ -102,7 +102,7 @@ You can update ``php-cs-fixer`` through this command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global update fabpot/php-cs-fixer
+    $ ./composer.phar global update friendsofphp/php-cs-fixer
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When install with fabpot/php-cs-fixer, the composer suggests to use friendsofphp/php-cs-fixer instead.