### PR TITLE
Implement a ShortDiffer

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Console\Output\NullOutput;
 use PhpCsFixer\Console\Output\ProcessOutput;
 use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Differ\SebastianBergmannDiffer;
+use PhpCsFixer\Differ\ShortDiffer;
 use PhpCsFixer\Error\Error;
 use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\FixerFactory;
@@ -111,6 +112,7 @@ final class FixCommand extends Command
                     new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file'),
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats', 'txt'),
+                    new InputOption('differ', '', InputOption::VALUE_REQUIRED, 'Which differ to use', 'txt'),
                 )
             )
             ->setDescription('Fixes a directory or a file')
@@ -352,9 +354,18 @@ EOF
         }
 
         $showProgress = $resolver->getProgress();
+        if($input->getOption('diff')) {
+            if ($input->getOption('differ') == 'short') {
+                $differ = new ShortDiffer();
+            } else {
+                $differ = new SebastianBergmannDiffer();
+            }
+        } else {
+            $differ = new NullDiffer();
+        }
         $runner = new Runner(
             $config,
-            $input->getOption('diff') ? new SebastianBergmannDiffer() : new NullDiffer(),
+            $differ,
             $showProgress ? $this->eventDispatcher : null,
             $this->errorsManager,
             $linter,

--- a/src/Differ/ShortDiffer.php
+++ b/src/Differ/ShortDiffer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Phyks (Lucas Verney) <phyks@phyks.me>
+ *
+ * Based on SebastianBergmann Differ class.
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Differ;
+
+use SebastianBergmann\Diff\Differ;
+
+/**
+ * @author Phyks (Lucas Verney) <phyks@phyks.me>
+ */
+final class ShortDiffer implements DifferInterface
+{
+    /**
+     * @var Differ
+     */
+    private $differ;
+
+    public function __construct()
+    {
+        $this->differ = new Differ();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function diff($old, $new)
+    {
+        $full_diff = $this->differ->diff($old, $new);
+        $output_diff = array();
+        foreach (explode("\n", $full_diff) as $line) {
+            if (startswith($line, '+') || startswith($line, '-')) {
+                $output_diff[] = $line;
+            } else {
+                if (end($output_diff) != '...') {
+                    $output_diff[] = '...';
+                }
+            }
+        }
+
+        return implode("\n", $output_diff);
+    }
+
+    /**
+     * Private method to check if a string starts with another one.
+     */
+    private function _startswith($haystack, $needle)
+    {
+        // search backwards starting from haystack length characters from the end
+        return $needle === '' || strrpos($haystack, $needle, -strlen($haystack)) !== false;
+    }
+}


### PR DESCRIPTION
Implement a `ShortDiffer` as described in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1990.

I added a `ShortDiffer` class which will shorten the diff produced by `SebastianBergmannDiffer`, and a `--differ` option to choose the differ to use (`--differ=short` to use this new one).

I could not find any PHP Diff library which would output such a short log directly. Nor one that would output line numbers.
