### PR TITLE
s/fabpot/friendsofphp in composer packages refs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ To install PHP-CS-Fixer, install Composer and issue the following command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global require fabpot/php-cs-fixer
+    $ ./composer.phar global require friendsofphp/php-cs-fixer
 
 Then, make sure you have ``~/.composer/vendor/bin`` in your ``PATH``, and
 you're good to go:
@@ -102,7 +102,7 @@ You can update ``php-cs-fixer`` through this command:
 
 .. code-block:: bash
 
-    $ ./composer.phar global update fabpot/php-cs-fixer
+    $ ./composer.phar global update friendsofphp/php-cs-fixer
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
According to https://packagist.org/packages/fabpot/php-cs-fixer: 

> This package is abandoned and no longer maintained. The author suggests using the friendsofphp/php-cs-fixer package instead.

---

I ran into this on a `composer update` warning. I swapped packages to friendsofphp/php-cs-fixer and all is in working order.