### PR TITLE
Properly build phar file for lowest supported PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     fast_finish: true
     include:
         - php: 5.3
-          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+          env: DEPLOY=yes COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 5.4
         - php: 5.5
         - php: 5.6
@@ -44,3 +44,20 @@ script:
 
 after_success:
     - php vendor/bin/coveralls -v
+
+before_deploy:
+    - 'sed -i "s/^{/\{\n    \"config\": {\"platform\": {\"php\": \"5.3.6\"}},/" composer.json'
+    - curl -LSs http://box-project.github.io/box2/installer.php | php
+    - composer update --no-dev --no-interaction --optimize-autoloader --prefer-stable
+    - php -d phar.readonly=false box.phar build
+
+deploy:
+    provider: releases
+    api_key:
+        secure: K9NKi7X1OPz898fxtVc1RfWrSI+4hTFFYOik932wTz1jC4dQJ64Khh1LV9frA1+JiDS3+R6TvmQtpzbkX3y4L75UrSnP1ADH5wfMYIVmydG3ZjTMo8SWQWHmRMh3ORAKTMMpjl4Q7EkRkLp6RncKe+FAFPP5mgv55mtIMaE4qUk=
+    file: php-cs-fixer.phar
+    skip_cleanup: true
+    on:
+        repo: FriendsOfPHP/PHP-CS-Fixer
+        tags: true
+        condition: $DEPLOY = yes

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ or with curl:
 
 .. code-block:: bash
 
-    $ curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+    $ curl -L http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 

--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,13 @@ your system:
 
 .. code-block:: bash
 
-    $ wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer
+    $ wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.11.4/php-cs-fixer.phar -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    $ curl -L http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+    $ curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.11.4/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 
@@ -793,7 +793,7 @@ scanned by the tool when run in the directory of your project. It is useful for
 projects that follow a well-known directory structures (like for Symfony
 projects for instance).
 
-.. _php-cs-fixer.phar: http://get.sensiolabs.org/php-cs-fixer.phar
+.. _php-cs-fixer.phar: https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.11.4/php-cs-fixer.phar
 .. _Atom:              https://github.com/Glavin001/atom-beautify
 .. _NetBeans:          http://plugins.netbeans.org/plugin/49042/php-cs-fixer
 .. _PhpStorm:          http://tzfrs.de/2015/01/automatically-format-code-to-match-psr-standards-with-phpstorm

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -75,7 +75,7 @@ or with curl:
 
 .. code-block:: bash
 
-    \$ curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+    \$ curl -L http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -230,7 +230,7 @@ EOF;
     {
         $currentMajor = (int) $this->getApplication()->getVersion();
 
-        $changelog = file_get_contents(__DIR__ . '/../../../../CHANGELOG.md');
+        $changelog = file_get_contents(__DIR__.'/../../../../CHANGELOG.md');
         preg_match('/Changelog for (v'.$currentMajor.'.\d+.\d+)/', $changelog, $matches);
 
         if (2 !== count($matches)) {

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -69,13 +69,13 @@ your system:
 
 .. code-block:: bash
 
-    \$ wget http://get.sensiolabs.org/php-cs-fixer.phar -O php-cs-fixer
+    \$ wget %download.url% -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    \$ curl -L http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer
+    \$ curl -L %download.url% -o php-cs-fixer
 
 then:
 
@@ -190,7 +190,7 @@ scanned by the tool when run in the directory of your project. It is useful for
 projects that follow a well-known directory structures (like for Symfony
 projects for instance).
 
-.. _php-cs-fixer.phar: http://get.sensiolabs.org/php-cs-fixer.phar
+.. _php-cs-fixer.phar: %download.url%
 .. _Atom:              https://github.com/Glavin001/atom-beautify
 .. _NetBeans:          http://plugins.netbeans.org/plugin/49042/php-cs-fixer
 .. _PhpStorm:          http://tzfrs.de/2015/01/automatically-format-code-to-match-psr-standards-with-phpstorm
@@ -199,6 +199,8 @@ projects for instance).
 .. _contribute:        https://github.com/FriendsOfPhp/php-cs-fixer/blob/master/CONTRIBUTING.md
 
 EOF;
+
+        $downloadUrl = $this->getLatestDownloadUrl();
 
         $command = $this->getApplication()->get('fix');
         $help = $command->getHelp();
@@ -218,7 +220,26 @@ EOF;
         );
         $help = preg_replace('#^                        #m', '  ', $help);
         $help = preg_replace('#\*\* +\[#', '** [', $help);
+        $header = str_replace('%download.url%', $downloadUrl, $header);
+        $footer = str_replace('%download.url%', $downloadUrl, $footer);
 
         $output->write($header."\n".$help."\n".$footer);
+    }
+
+    private function getLatestDownloadUrl()
+    {
+        $currentMajor = (int) $this->getApplication()->getVersion();
+
+        $changelog = file_get_contents(__DIR__ . '/../../../../CHANGELOG.md');
+        preg_match('/Changelog for (v'.$currentMajor.'.\d+.\d+)/', $changelog, $matches);
+
+        if (2 !== count($matches)) {
+            throw new \RuntimeException('Invalid changelog data!');
+        }
+
+        return sprintf(
+            'https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/%s/php-cs-fixer.phar',
+            $matches[1]
+        );
     }
 }

--- a/Symfony/CS/Console/Command/SelfUpdateCommand.php
+++ b/Symfony/CS/Console/Command/SelfUpdateCommand.php
@@ -63,7 +63,7 @@ EOT
             return;
         }
 
-        if ('v' . $this->getApplication()->getVersion() === $remoteTag) {
+        if ('v'.$this->getApplication()->getVersion() === $remoteTag) {
             $output->writeln('<info>php-cs-fixer is already up to date.</info>');
 
             return;

--- a/Symfony/CS/Console/Command/SelfUpdateCommand.php
+++ b/Symfony/CS/Console/Command/SelfUpdateCommand.php
@@ -55,33 +55,32 @@ EOT
             return 1;
         }
 
-        $currentVersion = explode('-', $this->getApplication()->getVersion());
-        $currentVersion = $currentVersion[0]; // ignore index #1 if exists (drop non-stable versions like `-DEV`)
-        $currentVersion = explode('.', $currentVersion);
-        if (!isset($currentVersion[2])) {
-            $currentVersion[2] = 0; // fill patch version if missing
+        $remoteTag = $this->getRemoteTag();
+
+        if (null === $remoteTag) {
+            $output->writeln('<error>Unable to determine newest version.</error>');
+
+            return;
         }
 
-        list($major, $minor, $patch) = $this->findBestVersion($currentVersion[0], $currentVersion[1], $currentVersion[2]);
-
-        if ($this->getApplication()->getVersion() === $this->buildVersionString($major, $minor, $patch)) {
+        if ('v' . $this->getApplication()->getVersion() === $remoteTag) {
             $output->writeln('<info>php-cs-fixer is already up to date.</info>');
 
             return;
         }
 
-        $remoteFilename = $this->buildVersionFileUrl($major, $minor, $patch);
+        $remoteFilename = $this->buildVersionFileUrl($remoteTag);
         $localFilename = $_SERVER['argv'][0];
         $tempFilename = basename($localFilename, '.phar').'-tmp.phar';
 
-        if (false === @file_get_contents($remoteFilename)) {
-            $output->writeln('<error>Unable to download new versions from the server.</error>');
-
-            return 1;
-        }
-
         try {
-            copy($remoteFilename, $tempFilename);
+            $copyResult = @copy($remoteFilename, $tempFilename);
+            if (false === $copyResult) {
+                $output->writeln('<error>Unable to download new versions from the server.</error>');
+
+                return 1;
+            }
+
             chmod($tempFilename, 0777 & ~umask());
 
             // test the phar validity
@@ -104,38 +103,33 @@ EOT
         }
     }
 
-    private function checkIfVersionFileExists($major, $minor, $patch)
+    private function buildVersionFileUrl($tag)
     {
-        $url = $this->buildVersionFileUrl($major, $minor, $patch);
-        $headers = get_headers($url);
-
-        return stripos($headers[0], '200 OK') ? true : false;
+        return sprintf('https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/%s/php-cs-fixer.phar', $tag);
     }
 
-    private function findBestVersion($major, $minor, $patch)
+    private function getRemoteTag()
     {
-        if ($this->checkIfVersionFileExists($major, $minor, $patch + 1)) {
-            return $this->findBestVersion($major, $minor, $patch + 1);
+        $raw = file_get_contents(
+            'https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/releases/latest',
+            null,
+            stream_context_create(array(
+                'http' => array(
+                    'header' => 'User-Agent: FriendsOfPHP/PHP-CS-Fixer',
+                ),
+            ))
+        );
+
+        if (false === $raw) {
+            return;
         }
 
-        if ($this->checkIfVersionFileExists($major, $minor + 1, 0)) {
-            return $this->findBestVersion($major, $minor + 1, 0);
+        $json = json_decode($raw, true);
+
+        if (null === $json) {
+            return;
         }
 
-        if ($this->checkIfVersionFileExists($major + 1, 0, 0)) {
-            return $this->findBestVersion($major + 1, 0, 0);
-        }
-
-        return array($major, $minor, $patch);
-    }
-
-    private function buildVersionFileUrl($major, $minor, $patch)
-    {
-        return sprintf('http://get.sensiolabs.org/php-cs-fixer-v%s.phar', $this->buildVersionString($major, $minor, $patch));
-    }
-
-    private function buildVersionString($major, $minor, $patch)
-    {
-        return sprintf('%d.%d.%d', $major, $minor, $patch);
+        return $json['tag_name'];
     }
 }


### PR DESCRIPTION
Closes #1968

- [X] build with platform configuration
- [X] store phar locally in repo
- [x] update self-update
- [x] update readme file