### PR TITLE
Fixing newlines added after curly brace string index access

### DIFF
--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -215,7 +215,8 @@ class BracesFixer extends AbstractFixer
                         // and it is not a `${"a"}->...` and `${"b{$foo}"}->...` situation
                         !($nestToken->equals('}') && $tokens[$nestIndex - 1]->equalsAny(array('"', "'", array(T_CONSTANT_ENCAPSED_STRING)))) &&
                         // and it is not a `$var{0} = ` situation (character access on string)
-                        !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equals('='))
+                        // TODO: remove on 2.x line
+                        !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equalsAny(array('=', array(T_OBJECT_OPERATOR))))
                     ) {
                         if ($nextNonWhitespaceNestToken->isGivenKind($this->getControlContinuationTokens()) || $nextNonWhitespaceNestToken->isGivenKind(T_CLOSE_TAG)) {
                             $whitespace = ' ';

--- a/Symfony/CS/Fixer/PSR2/BracesFixer.php
+++ b/Symfony/CS/Fixer/PSR2/BracesFixer.php
@@ -213,7 +213,9 @@ class BracesFixer extends AbstractFixer
                         // and it is not a `Foo::{bar}()` situation
                         !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equals('(')) &&
                         // and it is not a `${"a"}->...` and `${"b{$foo}"}->...` situation
-                        !($nestToken->equals('}') && $tokens[$nestIndex - 1]->equalsAny(array('"', "'", array(T_CONSTANT_ENCAPSED_STRING))))
+                        !($nestToken->equals('}') && $tokens[$nestIndex - 1]->equalsAny(array('"', "'", array(T_CONSTANT_ENCAPSED_STRING)))) &&
+                        // and it is not a `$var{0} = ` situation (character access on string)
+                        !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equals('='))
                     ) {
                         if ($nextNonWhitespaceNestToken->isGivenKind($this->getControlContinuationTokens()) || $nextNonWhitespaceNestToken->isGivenKind(T_CLOSE_TAG)) {
                             $whitespace = ' ';

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1367,4 +1367,24 @@ if (true) {
             ),
         );
     }
+
+    /**
+     * @dataProvider provideDontAddNewLineAfterCurlyBraceOfStringCharacterAccess
+     */
+    public function testDontAddNewLineAfterCurlyBraceOfStringCharacterAccess($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideDontAddNewLineAfterCurlyBraceOfStringCharacterAccess()
+    {
+        return array(
+            array(
+                '<?php
+if (true) {
+    $property{0} = strtolower($property{0});
+}',
+            ),
+        );
+    }
 }

--- a/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/BracesFixerTest.php
@@ -1369,6 +1369,8 @@ if (true) {
     }
 
     /**
+     * TODO: remove on 2.x line.
+     *
      * @dataProvider provideDontAddNewLineAfterCurlyBraceOfStringCharacterAccess
      */
     public function testDontAddNewLineAfterCurlyBraceOfStringCharacterAccess($expected, $input = null)
@@ -1384,6 +1386,14 @@ if (true) {
 if (true) {
     $property{0} = strtolower($property{0});
 }',
+            ),
+            array(
+                '<?php
+if (1) {
+    echo $items{0}->foo;
+    echo $collection->items{1}->property;
+}
+',
             ),
         );
     }


### PR DESCRIPTION
Fixes #2018

This fixes my most basic use case where I ran into an issue of extra
new lines, so it only deals with assignment of a string character to
another value (see the test for an example of what I mean).  There may
be other cases where newlines are added for this string index access
syntax, though there are language limitations as to what you can do to
a string offset.