### PR TITLE
IncludeFixerTest - failing cases

### DIFF
--- a/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
@@ -33,12 +33,12 @@ class IncludeFixerTest extends AbstractFixerTestBase
         $template = '<?php %s';
         $tests = array();
         foreach (array('require', 'require_once', 'include', 'include_once') as $statement) {
-            $test[] = array(
+            $tests[] = array(
                 sprintf($template.' "foo.php" ?>', $statement),
                 sprintf($template.' ("foo.php") ?>', $statement),
             );
 
-            $test[] = array(
+            $tests[] = array(
                 sprintf($template.' /**/ "foo.php" // test
                     ?>', $statement),
                 sprintf($template.' /**/ ("foo.php") // test


### PR DESCRIPTION
`$test` vs `$tests`

```diff
λ git show 45f3304
'45f3304 2016-01-10 19:17:41 - IncludeFixer - Add missing test case [Possum]'
diff --git a/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php b/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
index 3c85622..541f3c4 100644
--- a/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/IncludeFixerTest.php
@@ -32,6 +32,18 @@ class IncludeFixerTest extends AbstractFixerTestBase
         $template = '<?php %s';
         $tests = array();
         foreach (array('require', 'require_once', 'include', 'include_once') as $statement) {
+            $test[] = array(
+                sprintf($template.' "foo.php" ?>', $statement),
+                sprintf($template.' ("foo.php") ?>', $statement),
+            );
+
+            $test[] = array(
+                sprintf($template.' /**/ "foo.php" // test
+                    ?>', $statement),
+                sprintf($template.' /**/ ("foo.php") // test
+                    ?>', $statement),
+            );
+
             $tests[] = array(
                 sprintf($template.' $a;', $statement),
                 sprintf($template.'$a;', $statement),
```

@SpacePossum please, could you take a look ? tests are failing