### PR TITLE
[WIP] [bugfix] Check for file encoding before try to apply fixers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=5.3.6",
         "ext-tokenizer": "*",
+        "ext-mbstring": "*",
         "symfony/console": "~2.3|~3.0",
         "symfony/event-dispatcher": "~2.1|~3.0",
         "symfony/filesystem": "~2.1|~3.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

I think this breaks BC since it requires `ext-mbstring` in order to work. Also, I don't know how is this tool behaving under all cases where file encoding can be detected.
I've found this issue using `dev-master` version, but I think it applies here at `1.11` too.

```
PHP Fatal error:  Method PhpCsFixer\DocBlock\Line::__toString() must not throw an exception, caught ErrorException: Method PhpCsFixer\DocBlock\Line::__toString() must return a string value in vendor/friendsofphp/php-cs-fixer/src/DocBlock/DocBlock.php on line 177
PHP Stack trace:
PHP   1. {main}() vendor/friendsofphp/php-cs-fixer/php-cs-fixer:0
PHP   2. Symfony\Component\Console\Application->run() vendor/friendsofphp/php-cs-fixer/php-cs-fixer:45
PHP   3. Symfony\Component\Console\Application->doRun() vendor/symfony/console/Application.php:123
PHP   4. Symfony\Component\Console\Application->doRunCommand() vendor/symfony/console/Application.php:192
PHP   5. Symfony\Component\Console\Command\Command->run() vendor/symfony/console/Application.php:844
PHP   6. PhpCsFixer\Console\Command\FixCommand->execute() vendor/symfony/console/Command/Command.php:259
PHP   7. PhpCsFixer\Runner\Runner->fix() vendor/friendsofphp/php-cs-fixer/src/Console/Command/FixCommand.php:370
PHP   8. PhpCsFixer\Runner\Runner->fixFile() vendor/friendsofphp/php-cs-fixer/src/Runner/Runner.php:141
PHP   9. PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer->fix() vendor/friendsofphp/php-cs-fixer/src/Runner/Runner.php:198
PHP  10. PhpCsFixer\DocBlock\DocBlock->getContent() vendor/friendsofphp/php-cs-fixer/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php:55
PHP  11. implode() vendor/friendsofphp/php-cs-fixer/src/DocBlock/DocBlock.php:177
```
I only know it is an encoding issue since my IDE complains when I try to open it, but after I save the file the encoding is normalized and `php-cs-fixer` runs well.