### PR TITLE
NoExtraConsecutiveBlankLinesFixer - Fix curly brace open false positive

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
         'combine_consecutive_unsets' => true,
         'header_comment' => array('header' => $header),
         'long_array_syntax' => true,
+        'no_extra_consecutive_blank_lines' => array('break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'),
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_class_elements' => true,
@@ -27,7 +28,6 @@ return PhpCsFixer\Config::create()
         'psr4' => true,
         'strict_comparison' => true,
         'strict_param' => true,
-        'no_extra_consecutive_blank_lines' => array('break', 'continue', 'extra', 'return', 'throw', 'use', 'curly_brace_open'),
     ))
     ->finder(
         PhpCsFixer\Finder::create()

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -73,7 +73,7 @@ final class RuleSet implements RuleSetInterface
             'no_empty_comment' => true,
             'no_empty_phpdoc' => true,
             'no_empty_statement' => true,
-            'no_extra_consecutive_blank_lines' => array('curly_brace_open', 'extra', 'throw', 'use'),
+            'no_extra_consecutive_blank_lines' => array('curly_brace_block', 'parenthesis_brace_block', 'square_brace_block', 'extra', 'throw', 'use'),
             'no_leading_import_slash' => true,
             'no_leading_namespace_whitespace' => true,
             'no_multiline_whitespace_around_double_arrow' => true,

--- a/src/Test/AbstractIntegrationTestCase.php
+++ b/src/Test/AbstractIntegrationTestCase.php
@@ -21,6 +21,7 @@ use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\Linter\NullLinter;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\ShutdownFileRemoval;
+use PhpCsFixer\Tokenizer\Transformers;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -108,6 +109,8 @@ abstract class AbstractIntegrationTestCase extends \PHPUnit_Framework_TestCase
      */
     public function getTests()
     {
+        Transformers::create();
+
         $fixturesDir = realpath(static::getFixturesDir());
         if (!is_dir($fixturesDir)) {
             throw new \UnexpectedValueException(sprintf('Given fixture dir "%s" is not a directory.', $fixturesDir));

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -264,7 +264,6 @@ abstract class Foo extends FooParent implements FooInterface1, FooInterface2
     }
 }
 EOT
-
             ),
             array(
                 <<<'EOT'

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -102,7 +102,6 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
             array(
                 '<?php xyz($a=10, /*comment1*/ $b=2000, /*comment2*/ $c=30);',
                 '<?php xyz($a=10,    /*comment1*/ $b=2000,/*comment2*/ $c=30);',
-
             ),
             // must keep align comments
             array(

--- a/tests/Fixer/Phpdoc/PhpdocInlineTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocInlineTagFixerTest.php
@@ -142,7 +142,6 @@ final class PhpdocInlineTagFixerTest extends AbstractFixerTestCase
      * inheritdocs
      */
 ',
-
         );
 
         // invalid syntax

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -60,7 +60,6 @@ final class UtilsTest extends \PHPUnit_Framework_TestCase
             array(
                 'utf8_encoder_fixer',
             ),
-
         );
     }
 


### PR DESCRIPTION
This fixes the wrong fixing of cases like:
```php
<?php

function test(){}
function test1(){}
echo $a;
```

It add the options:
- `square_brace_open`
- `parenthesis_brace_open`

All other changes are minor, such as adding missing docs and utest, optimize some stuff and up the DX by adding better exception messages. 