### PR TITLE
PhpdocAnnotationWithoutDotFixer - fix crash on odd character

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocAnnotationWithoutDotFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocAnnotationWithoutDotFixer.php
@@ -43,7 +43,12 @@ class PhpdocAnnotationWithoutDotFixer extends AbstractFixer
             foreach ($annotations as $annotation) {
                 if ($annotation->getTag()->valid()) {
                     $line = $doc->getLine($annotation->getEnd());
-                    $line->setContent(preg_replace('/[.。](\s+)$/u', '\1', $line->getContent()));
+
+                    $content = preg_replace('/[.。](\s+)$/u', '\1', $line->getContent());
+
+                    if (null !== $content) {
+                        $line->setContent($content);
+                    }
                 }
             }
             $token->setContent($doc->getContent());

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
@@ -62,6 +62,17 @@ class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestBase
      * @SomeCustomAnnotation This is important sentence that must not be modified.
      */',
             ),
+            array(
+                // very fancy non-UTF friendly char in description...
+                '<?php
+    /**
+     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character
+     */',
+                '<?php
+    /**
+     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character.
+     */',
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
@@ -66,8 +66,8 @@ class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestBase
                 // invalid char inside line won't crash the fixer
                 '<?php
     /**
-     * @var string This: '.chr(174).' is and odd character.
-     * @var string This: '.chr(174).' is and odd character 2nd time。
+     * @var string This: '.chr(174).' is an odd character.
+     * @var string This: '.chr(174).' is an odd character 2nd time。
      */',
             ),
         );

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
@@ -66,8 +66,8 @@ class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestBase
                 // invalid char inside line won't crash the fixer
                 '<?php
     /**
-     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character A.
-     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character B。
+     * @var string This: '.chr(174).' is and odd character.
+     * @var string This: '.chr(174).' is and odd character 2nd time。
      */',
             ),
         );

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocAnnotationWithoutDotFixerTest.php
@@ -63,14 +63,11 @@ class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestBase
      */',
             ),
             array(
-                // very fancy non-UTF friendly char in description...
+                // invalid char inside line won't crash the fixer
                 '<?php
     /**
-     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character
-     */',
-                '<?php
-    /**
-     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character.
+     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character A.
+     * @var string This: '.chr(62).' '.chr(174).' '.chr(60).' is and odd character B。
      */',
             ),
         );


### PR DESCRIPTION
Replaces and fixes #2038