### PR TITLE
Fix: NativeFunctionCasingFixer should leave class name alone

### DIFF
--- a/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
@@ -107,6 +107,11 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
             ),
             array(
                 '<?php
+                    new \STRTOLOWER();
+                ',
+            ),
+            array(
+                '<?php
                     a::STRTOLOWER();
                 ',
             ),


### PR DESCRIPTION
This PR

* [x] adds a failing test for the `NativeFunctionCasingFixer`

🙎 Not sure, maybe it helps?