### PR TITLE
[Bug] NativeFunctionCasingFixer - call to constructor with default NS of class with name matching native function name fix

### DIFF
--- a/src/Fixer/Casing/NativeFunctionCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionCasingFixer.php
@@ -56,12 +56,12 @@ final class NativeFunctionCasingFixer extends AbstractFixer
                 continue;
             }
 
-            // do not though the function call if it is to a function in a namespace other than the default
-            if (
-                $tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)
-                && $tokens[$tokens->getPrevMeaningfulToken($functionNamePrefix)]->isGivenKind(T_STRING)
-            ) {
-                continue;
+            if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
+                // do not touch the function call if it is to a function in a namespace other than the default
+                $prev = $tokens->getPrevMeaningfulToken($functionNamePrefix);
+                if ($tokens[$prev]->isGivenKind(array(T_STRING, T_NEW))) {
+                    continue;
+                }
             }
 
             // test if the function call is to a native PHP function
@@ -84,6 +84,9 @@ final class NativeFunctionCasingFixer extends AbstractFixer
         return 'Function defined by PHP should be called using the correct casing.';
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getNativeFunctionNames()
     {
         $allFunctions = get_defined_functions();

--- a/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
@@ -107,6 +107,16 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
             ),
             array(
                 '<?php
+                    new \STRTOLOWER();
+                ',
+            ),
+            array(
+                '<?php
+                    new \A\B\STRTOLOWER();
+                ',
+            ),
+            array(
+                '<?php
                     a::STRTOLOWER();
                 ',
             ),


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2047
ping @localheinz 
thanks for reporting!