### PR TITLE
NativeFunctionCasingFixer - call to constructor with default NS of class with name matching native function name fix

### DIFF
--- a/Symfony/CS/Fixer/Symfony/NativeFunctionCasingFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NativeFunctionCasingFixer.php
@@ -51,7 +51,7 @@ final class NativeFunctionCasingFixer extends AbstractFixer
             }
 
             if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
-                // do not touch the function call if it is to a function in a namespace other than the default
+                // skip if the call is to a constructor or to a function in a namespace other than the default
                 $prev = $tokens->getPrevMeaningfulToken($functionNamePrefix);
                 if ($tokens[$prev]->isGivenKind(array(T_STRING, T_NEW))) {
                     continue;

--- a/Symfony/CS/Fixer/Symfony/NativeFunctionCasingFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NativeFunctionCasingFixer.php
@@ -50,12 +50,12 @@ final class NativeFunctionCasingFixer extends AbstractFixer
                 continue;
             }
 
-            // do not though the function call if it is to a function in a namespace other than the default
-            if (
-                $tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)
-                && $tokens[$tokens->getPrevMeaningfulToken($functionNamePrefix)]->isGivenKind(T_STRING)
-            ) {
-                continue;
+            if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
+                // do not touch the function call if it is to a function in a namespace other than the default
+                $prev = $tokens->getPrevMeaningfulToken($functionNamePrefix);
+                if ($tokens[$prev]->isGivenKind(array(T_STRING, T_NEW))) {
+                    continue;
+                }
             }
 
             // test if the function call is to a native PHP function
@@ -65,7 +65,6 @@ final class NativeFunctionCasingFixer extends AbstractFixer
             }
 
             $tokens[$index]->setContent($nativeFunctionNames[$lower]);
-
             $index = $next;
         }
 
@@ -80,6 +79,9 @@ final class NativeFunctionCasingFixer extends AbstractFixer
         return 'Function defined by PHP should be called using the correct casing.';
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getNativeFunctionNames()
     {
         $allFunctions = get_defined_functions();

--- a/Symfony/CS/Tests/Fixer/Symfony/NativeFunctionCasingFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NativeFunctionCasingFixerTest.php
@@ -107,6 +107,16 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
+                    new \STRTOLOWER();
+                ',
+            ),
+            array(
+                '<?php
+                    new \A\B\STRTOLOWER();
+                ',
+            ),
+            array(
+                '<?php
                     a::STRTOLOWER();
                 ',
             ),


### PR DESCRIPTION
…prefix by default namespace.

replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2048 on 1.12 this time