### PR TITLE
Travis - run nightly PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ matrix:
     include:
         - php: 5.3
           env: DEPLOY=yes COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - php: 7.0
-          env: LINT_TEST_CASES=1
         - php: 5.4
         - php: 5.5
         - php: 5.6
         - php: 7.0
           env: SYMFONY_VERSION="~2.8"
+        - php: 7.0
+          env: LINT_TEST_CASES=1
+        - php: nightly
+          env: LINT_TEST_CASES=1
         # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
         - php: hhvm-3.9
           sudo: required


### PR DESCRIPTION
Let us run 7.1@dev on Travis, as we already have few cases for it.
master branch check: https://travis-ci.org/keradus/PHP-CS-Fixer/builds/143149413 