### PR TITLE
UnusedUseFixer - fix handling whitespaces around removed import

### DIFF
--- a/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnusedUseFixer.php
@@ -189,8 +189,8 @@ class UnusedUseFixer extends AbstractFixer
 
     private function removeUseDeclaration(Tokens $tokens, array $useDeclaration)
     {
-        for ($index = $useDeclaration['start']; $index < $useDeclaration['end']; ++$index) {
-            $tokens[$index]->clear();
+        for ($index = $useDeclaration['end'] - 1; $index >= $useDeclaration['start']; --$index) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
         }
 
         if ($tokens[$useDeclaration['end']]->equals(';')) {

--- a/Symfony/CS/Tests/Fixer/Symfony/UnusedUseFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnusedUseFixerTest.php
@@ -471,6 +471,35 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
+    public function testFoo()
+    {
+        $expected = <<<'EOF'
+<?php
+namespace Aaa;
+
+
+class Ddd
+{
+}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+namespace Aaa;
+
+use Aaa\Bbb;
+use Ccc;
+
+class Ddd
+{
+}
+
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+
     /**
      * @dataProvider provideCloseTagCases
      */


### PR DESCRIPTION
Fixes #2001
Integration test added in #2061 as on 1.11 line there are some edge cases with fixtures and `->supports` as @SpacePossum pointed previously