### PR TITLE
LowercaseKeywordsFixer - handle CT_CLASS_CONSTANT

### DIFF
--- a/Symfony/CS/Tests/Fixer/PSR2/LowercaseKeywordsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/LowercaseKeywordsFixerTest.php
@@ -32,6 +32,7 @@ class LowercaseKeywordsFixerTest extends AbstractFixerTestBase
             array('<?php $x = (1 and 2);', '<?php $x = (1 AND 2);'),
             array('<?php foreach(array(1, 2, 3) as $val) {}', '<?php foreach(array(1, 2, 3) AS $val) {}'),
             array('<?php echo "GOOD AS NEW";'),
+            array('<?php echo X::class ?>', '<?php echo X::ClASs ?>'),
         );
     }
 

--- a/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
+++ b/Symfony/CS/Tests/Tokenizer/Transformer/ClassConstantTest.php
@@ -42,6 +42,12 @@ class ClassConstantTest extends AbstractTransformerTestBase
                 ),
             ),
             array(
+                '<?php echo X::cLaSS;',
+                array(
+                    5 => 'CT_CLASS_CONSTANT',
+                ),
+            ),
+            array(
                 '<?php echo X::bar;',
                 array(),
             ),

--- a/Symfony/CS/Tokenizer/Token.php
+++ b/Symfony/CS/Tokenizer/Token.php
@@ -270,7 +270,7 @@ class Token
                 'T_INTERFACE', 'T_ISSET', 'T_LIST', 'T_LOGICAL_AND', 'T_LOGICAL_OR', 'T_LOGICAL_XOR',
                 'T_NAMESPACE', 'T_NEW', 'T_PRINT', 'T_PRIVATE', 'T_PROTECTED', 'T_PUBLIC', 'T_REQUIRE',
                 'T_REQUIRE_ONCE', 'T_RETURN', 'T_STATIC', 'T_SWITCH', 'T_THROW', 'T_TRAIT', 'T_TRY',
-                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD', 'CT_ARRAY_TYPEHINT',
+                'T_UNSET', 'T_USE', 'T_VAR', 'T_WHILE', 'T_YIELD', 'CT_ARRAY_TYPEHINT', 'CT_CLASS_CONSTANT',
             ));
         }
 

--- a/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
+++ b/Symfony/CS/Tokenizer/Transformer/ClassConstant.php
@@ -30,7 +30,7 @@ class ClassConstant extends AbstractTransformer
             if (!$token->equalsAny(array(
                 array(T_CLASS, 'class'),
                 array(T_STRING, 'class'),
-            ))) {
+            ), false)) {
                 continue;
             }
 


### PR DESCRIPTION
Two changes plus tests:
`CT_CLASS_CONSTANT ` is recognized case insensitive mode
`CT_CLASS_CONSTANT ` was added to list of known keywords

Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2070