### PR TITLE
DeclareStrictTypesFixer - Remove fix CS fix logic from fixer.

### DIFF
--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -51,8 +51,7 @@ final class DeclareStrictTypesFixer extends AbstractFixer
         $sequenceEndIndex = $tokens->getNextMeaningfulToken(key($sequenceLocation));
 
         if (1 === $sequenceStartIndex) {
-            // declaration already at the correct location, fix CS only
-            $this->fixCodeStyleOfSequence($tokens, $sequenceEndIndex);
+            // declaration already at the correct location, fix spacing only
             $this->fixWhiteSpaceAroundSequence($tokens, $sequenceEndIndex);
 
             return;
@@ -102,22 +101,6 @@ final class DeclareStrictTypesFixer extends AbstractFixer
     public function isRisky()
     {
         return true;
-    }
-
-    /**
-     * @param Tokens $tokens
-     * @param int    $endIndex
-     */
-    private function fixCodeStyleOfSequence(Tokens $tokens, $endIndex)
-    {
-        // start index of the sequence is always 1 here, 0 is always open tag
-        for ($i = 1; $i < $endIndex; ++$i) {
-            if ($tokens[$i]->isWhitespace()) {
-                $tokens[$i]->clear();
-            } elseif ($tokens[$i]->isGivenKind(array(T_DECLARE, T_STRING))) {
-                $tokens[$i]->setContent(strtolower($tokens[$i]->getContent()));
-            }
-        }
     }
 
     /**

--- a/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
@@ -50,7 +50,7 @@ class A {
 }',
             ),
             array(
-                '<?php declare/* A b C*/(strict_types=1);
+                '<?php DECLARE/* A b C*/(strict_types=1);
 //abc',
                 '<?php DECLARE/* A b C*/(strict_types=1);      //abc',
             ),


### PR DESCRIPTION
With the `DeclareEqualNormalizeFixer` (https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2067 :+1: ) in place the CS fixing part of the declare strict fixer can (and should) be removed to make it more atomic.