### PR TITLE
Mimic the output of the original linter

### DIFF
--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -37,8 +37,17 @@ final class TokenizerLintingResult implements LintingResultInterface
      */
     public function check()
     {
-        if (null !== $this->error) {
-            throw new LintingException($this->error->getMessage(), $this->error->getCode(), $this->error);
+        if (null === $this->error) {
+            return;
         }
+
+        $message = $this->error->getMessage();
+        $trace = $this->error->getTrace();
+
+        throw new LintingException(
+            "PHP Parse error:  {$message} in {$trace[0]['file']} on line {$trace[0]['line']}",
+            $this->error->getCode(),
+            $this->error
+        );
     }
 }

--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -42,10 +42,10 @@ final class TokenizerLintingResult implements LintingResultInterface
         }
 
         $message = $this->error->getMessage();
-        $trace = $this->error->getTrace();
+        $detail = end($this->error->getTrace());
 
         throw new LintingException(
-            "PHP Parse error:  {$message} in {$trace[0]['file']} on line {$trace[0]['line']}",
+            "PHP Parse error:  {$message} in {$detail['file']} on line {$detail['line']}",
             $this->error->getCode(),
             $this->error
         );

--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -42,7 +42,8 @@ final class TokenizerLintingResult implements LintingResultInterface
         }
 
         $message = $this->error->getMessage();
-        $detail = end($this->error->getTrace());
+        $trace = $this->error->getTrace();
+        $detail = end($trace);
 
         throw new LintingException(
             "PHP Parse error:  {$message} in {$detail['file']} on line {$detail['line']}",


### PR DESCRIPTION
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2075 for full details. Also, note, as described in this issue that PHP has a bug that it's to string implementation has a different behaviour when called by the shutdown handler than in normal execution, hence the manual construction of the error text.