### PR TITLE
SingleLineAfterImportsFixer - Do not remove lines between use cases

### DIFF
--- a/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
+++ b/Symfony/CS/Fixer/PSR2/SingleLineAfterImportsFixer.php
@@ -61,8 +61,8 @@ class SingleLineAfterImportsFixer extends AbstractFixer
                     ++$insertIndex;
                 }
 
-                // Do not add newline after inline T_COMMENT as it is part of T_COMMENT already
-                if ($tokens[$insertIndex]->isGivenKind(T_COMMENT)) {
+                // Do not add newline after inline T_COMMENT as it is part of T_COMMENT already (note: not needed on 2.x line )
+                if ($tokens[$insertIndex]->isGivenKind(T_COMMENT) && false !== strpos($tokens[$insertIndex]->getContent(), "\n")) {
                     $newline = '';
                 }
 
@@ -78,9 +78,18 @@ class SingleLineAfterImportsFixer extends AbstractFixer
 
                 if ($tokens[$insertIndex]->isWhitespace()) {
                     $nextToken = $tokens[$insertIndex];
-                    $nextToken->setContent($newline.$indent.ltrim($nextToken->getContent()));
+                    $nextMeaningfulAfterUseIndex = $tokens->getNextMeaningfulToken($insertIndex);
+                    if (null !== $nextMeaningfulAfterUseIndex && $tokens[$nextMeaningfulAfterUseIndex]->isGivenKind(T_USE)) {
+                        if (substr_count($nextToken->getContent(), "\n") < 2) {
+                            $nextToken->setContent($newline.$indent.ltrim($nextToken->getContent()));
+                        }
+                    } else {
+                        $nextToken->setContent($newline.$indent.ltrim($nextToken->getContent()));
+                    }
                 } else {
-                    $tokens->insertAt($insertIndex, new Token(array(T_WHITESPACE, $newline.$indent)));
+                    if ('' !== $newline.$indent) { // (note: check not needed on 2.x line)
+                        $tokens->insertAt($insertIndex, new Token(array(T_WHITESPACE, $newline.$indent)));
+                    }
                 }
             }
         }

--- a/Symfony/CS/Tests/Fixer/PSR2/SingleLineAfterImportsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/SingleLineAfterImportsFixerTest.php
@@ -30,6 +30,42 @@ class SingleLineAfterImportsFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php
+use D;
+use E;
+use DP;   /**/
+use EZ; //
+use DAZ;
+use EGGGG; /**/
+use A\B;
+
+use C\DE;
+
+
+use E\F;
+
+
+
+use G\H;
+
+',
+                '<?php
+use D;         use E;
+use DP;   /**/      use EZ; //
+use DAZ;         use EGGGG; /**/
+use A\B;
+
+use C\DE;
+
+
+use E\F;
+
+
+
+use G\H;
+',
+            ),
+            array(
                 '<?php use \Exception;
 
 ?>
@@ -255,23 +291,6 @@ use B1;// need to import this !
 use B2;
 
 class C1 {}
-',
-            ),
-            array(
-                '<?php
-    namespace A1;
-    use B1; // need to import this !
-    use B2;
-
-    class C1 {}
-',
-                '<?php
-    namespace A1;
-    use B1; // need to import this !
-
-    use B2;
-
-    class C1 {}
 ',
             ),
             array(


### PR DESCRIPTION
PSR2 doesn't state empty lines between `use` imports are not allowed (sadly imo), it state only that there must be one import per line and there must be 1 empty line after the block (so nothing about in the block).

Lucky we have a contrib fixer to remove empty lines between `use`'s (`remove_lines_between_uses`) so no functionality is lost.

Note @keradus the merge to master is a bit tricky. I did the fix on master first so if you want the 2 files for master let me know.

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2074