### PR TITLE
Added SilencedDeprecationErrorFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -551,6 +551,11 @@ Choose from the list of available fixers:
                         "(double)" and "(real)" as
                         "(float)".
 
+* **silenced_deprecation_error** [symfony]
+                        Ensures deprecation notices
+                        are silenced. Warning! This
+                        could change code behavior.
+
 * **single_array_no_trailing_comma** [symfony]
                         PHP single-line arrays should
                         not have trailing comma.

--- a/Symfony/CS/Fixer/Symfony/SilencedDeprecationErrorFixer.php
+++ b/Symfony/CS/Fixer/Symfony/SilencedDeprecationErrorFixer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+final class SilencedDeprecationErrorFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+            if (!$token->equals(array(T_STRING, 'trigger_error'), false)) {
+                continue;
+            }
+
+            $start = $index;
+            $prev = $tokens->getPrevMeaningfulToken($start);
+            if ($tokens[$prev]->isGivenKind(T_NS_SEPARATOR)) {
+                $start = $prev;
+                $prev = $tokens->getPrevMeaningfulToken($start);
+            }
+
+            if ($tokens[$prev]->isGivenKind(T_STRING) || $tokens[$prev]->equals('@')) {
+                continue;
+            }
+
+            $end = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextTokenOfKind($index, array(T_STRING, '(')));
+            if ($tokens[$tokens->getPrevMeaningfulToken($end)]->equals(array(T_STRING, 'E_USER_DEPRECATED'))) {
+                $tokens->insertAt($start, new Token('@'));
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Ensures deprecation notices are silenced. Warning! This could change code behavior.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/SilencedDeprecationErrorFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SilencedDeprecationErrorFixerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ *
+ * @internal
+ */
+final class SilencedDeprecationErrorFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            array(
+                '<?php trigger_error("This is a deprecation warning."); ?>',
+            ),
+            array(
+                '<?php trigger_error("This is a deprecation warning.", E_USER_WARNING); ?>',
+            ),
+            array(
+                '<?php A\B\trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ),
+            array(
+                '<?php \A\B/* */\trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ),
+            array(
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ),
+            array(
+                '<?php @\trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php \trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ),
+            array(
+                '<?php echo "test";@trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php echo "test";trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ),
+            array(
+                '<?php //
+@Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>',
+                '<?php //
+Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
The `SilencedDeprecationErrorFixer` prepends the silent operator `@` to
`trigger_error` calls only using `E_USER_DEPRECATED`.