### PR TITLE
TernarySpacesFixer - Remove multiple spaces

### DIFF
--- a/Symfony/CS/Fixer/Symfony/TernarySpacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/TernarySpacesFixer.php
@@ -46,24 +46,24 @@ class TernarySpacesFixer extends AbstractFixer
                     }
                 } else {
                     // for `$a ? $b : $c` ensure space after `?`
-                    $this->ensureWhitespaceExistance($tokens, $index + 1, true);
+                    $this->ensureWhitespaceExistence($tokens, $index + 1, true);
                 }
 
                 // for `$a ? $b : $c` ensure space before `?`
-                $this->ensureWhitespaceExistance($tokens, $index - 1, false);
+                $this->ensureWhitespaceExistence($tokens, $index - 1, false);
 
                 continue;
             }
 
             if ($ternaryLevel && $token->equals(':')) {
                 // for `$a ? $b : $c` ensure space after `:`
-                $this->ensureWhitespaceExistance($tokens, $index + 1, true);
+                $this->ensureWhitespaceExistence($tokens, $index + 1, true);
 
                 $prevNonWhitespaceToken = $tokens[$tokens->getPrevNonWhitespace($index)];
 
                 if (!$prevNonWhitespaceToken->equals('?')) {
                     // for `$a ? $b : $c` ensure space before `:`
-                    $this->ensureWhitespaceExistance($tokens, $index - 1, false);
+                    $this->ensureWhitespaceExistence($tokens, $index - 1, false);
                 }
 
                 --$ternaryLevel;
@@ -81,15 +81,25 @@ class TernarySpacesFixer extends AbstractFixer
         return 'Standardize spaces around ternary operator.';
     }
 
-    private function ensureWhitespaceExistance(Tokens $tokens, $index, $after)
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param bool   $after
+     */
+    private function ensureWhitespaceExistence(Tokens $tokens, $index, $after)
     {
-        $indexChange = $after ? 0 : 1;
-        $token = $tokens[$index];
+        if ($tokens[$index]->isWhitespace()) {
+            if (false === strpos($tokens[$index]->getContent(), "\n")) {
+                // comment with trailing line break check, on 1.x line only
+                if (!$tokens[$index - 1]->isComment() || false === strpos($tokens[$index - 1]->getContent(), "\n")) {
+                    $tokens[$index]->setContent(' ');
+                }
+            }
 
-        if ($token->isWhitespace()) {
             return;
         }
 
-        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ', $token->getLine())));
+        $indexChange = $after ? 0 : 1;
+        $tokens->insertAt($index + $indexChange, new Token(array(T_WHITESPACE, ' ', $tokens[$index]->getLine())));
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/TernarySpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/TernarySpacesFixerTest.php
@@ -30,6 +30,10 @@ class TernarySpacesFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php $a = $a ? 1 : 0;',
+                '<?php $a = $a  ? 1 : 0;',
+            ),
+            array(
                 '<?php $val = (1===1) ? true : false;',
                 '<?php $val = (1===1)?true:false;',
             ),
@@ -39,8 +43,11 @@ class TernarySpacesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
-$a = $b  ? 2 : 3;
+$a = $b ? 2 : ($bc ? 2 : 3);
 $a = $bc ? 2 : 3;',
+                '<?php
+$a = $b   ?   2  :    ($bc?2:3);
+$a = $bc?2:3;',
             ),
             array(
                 '<?php $config = $config ?: new Config();',
@@ -62,6 +69,16 @@ $a = $b
                 '<?php
 $a = $b
     ?$c
+    :$d;',
+            ),
+            array(
+                '<?php
+$a = $b  //
+    ? $c  /**/
+    : $d;',
+                '<?php
+$a = $b  //
+    ?$c  /**/
     :$d;',
             ),
             array(


### PR DESCRIPTION
I'm not sure if this is a bug report or not. I would like cases like the following to be fixed by the fixer as well:
```php
$a = $b    ?   1   :   2;
```

Currently the fixer won't touch these cases and a [test](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.11/Symfony/CS/Tests/Fixer/Symfony/TernarySpacesFixerTest.php#L42
) exists to make sure of that. 
This PR change the fixer so it will fix the example to:
```php
$a = $b ? 1 : 2;
```
