### PR TITLE
Added MbStrFunctionsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -579,6 +579,12 @@ Choose from the list of available fixers:
                         Arrays should use the long
                         syntax.
 
+* **mb_str_functions** [contrib]
+                        Replace non multibyte-safe
+                        functions with corresponding
+                        mb function. Warning! This
+                        could change code behavior.
+
 * **multiline_spaces_before_semicolon** [contrib]
                         Multi-line whitespace before
                         closing semicolon are

--- a/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
@@ -17,7 +17,7 @@ use Symfony\CS\Tokenizer\Tokens;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  */
-class MbStrFunctionsFixer extends AbstractFixer
+final class MbStrFunctionsFixer extends AbstractFixer
 {
     /**
      * @var array the list of the string-related function names and their mb_ equivalent

--- a/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+class MbStrFunctionsFixer extends AbstractFixer
+{
+    /**
+     * @var array the list of the string-related function names and their mb_ equivalent
+     */
+    private static $functions = array(
+        'strlen' => 'mb_strlen',
+        'strpos' => 'mb_strpos',
+        'strrpos' => 'mb_strrpos',
+        'substr' => 'mb_substr',
+        'strtolower' => 'mb_strtolower',
+        'strtoupper' => 'mb_strtoupper',
+        'stripos' => 'mb_stripos',
+        'strripos' => 'mb_strripos',
+        'strstr' => 'mb_strstr',
+        'stristr' => 'mb_stristr',
+        'strrchr' => 'mb_strrchr',
+        'substr_count' => 'mb_substr_count',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        $end = $tokens->count() - 1;
+
+        foreach (self::$functions as $originalName => $mbFunctionName) {
+            // the sequence is the function name, followed by "(" and a quoted string
+            $seq = array(array(T_STRING, $originalName), '(');
+
+            $currIndex = 0;
+            while (null !== $currIndex) {
+                $match = $tokens->findSequence($seq, $currIndex, $end, false);
+
+                // did we find a match?
+                if (null === $match) {
+                    break;
+                }
+
+                // findSequence also returns the tokens, but we're only interested in the indexes, i.e.:
+                // 0 => function name,
+                // 1 => bracket "("
+                $match = array_keys($match);
+
+                // advance tokenizer cursor
+                $currIndex = $match[1];
+
+                // ensure it's a function call (not a method / static call)
+                $prev = $tokens->getPrevMeaningfulToken($match[0]);
+                if (null === $prev || $tokens[$prev]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON))) {
+                    continue;
+                }
+
+                // modify function and argument
+                $tokens[$match[0]]->setContent($mbFunctionName);
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Replace non multibyte-safe functions with corresponding mb function. Warning! This could change code behavior.';
+    }
+}

--- a/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
@@ -71,9 +71,11 @@ final class MbStrFunctionsFixer extends AbstractFixer
                 if (null === $prev || $tokens[$prev]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW))) {
                     continue;
                 }
-                $prev = $tokens->getPrevMeaningfulToken($prev);
-                if ($tokens[$prev]->isGivenKind(array(T_STRING))) {
-                    continue;
+                if ($tokens[$prev]->isGivenKind(T_NS_SEPARATOR)) {
+                    $nsPrev = $tokens->getPrevMeaningfulToken($prev);
+                    if ($tokens[$nsPrev]->isGivenKind(array(T_STRING, T_NEW))) {
+                        continue;
+                    }
                 }
 
                 // modify function and argument

--- a/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MbStrFunctionsFixer.php
@@ -68,7 +68,11 @@ final class MbStrFunctionsFixer extends AbstractFixer
 
                 // ensure it's a function call (not a method / static call)
                 $prev = $tokens->getPrevMeaningfulToken($match[0]);
-                if (null === $prev || $tokens[$prev]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON))) {
+                if (null === $prev || $tokens[$prev]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW))) {
+                    continue;
+                }
+                $prev = $tokens->getPrevMeaningfulToken($prev);
+                if ($tokens[$prev]->isGivenKind(array(T_STRING))) {
                     continue;
                 }
 

--- a/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
@@ -33,6 +33,10 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestBase
         return array(
             array('<?php $x = "strlen";'),
             array('<?php $x = Foo::strlen("bar");'),
+            array('<?php $x = new strlen("bar");'),
+            array('<?php $x = new Foo\strlen("bar");'),
+            array('<?php $x = Foo\strlen("bar");'),
+            array('<?php $x = strlen::call("bar");'),
             array('<?php $x = $foo->strlen("bar");'),
 
             array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),

--- a/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
@@ -34,6 +34,9 @@ class MbStrFunctionsFixerTest extends AbstractFixerTestBase
             array('<?php $x = $foo->strlen("bar");'),
 
             array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
+            array('<?php $x = \mb_strlen("bar");', '<?php $x = \strlen("bar");'),
+            array('<?php $x = mb_strtolower( \mb_strstr ("bar"));', '<?php $x = strtolower( \strstr ("bar"));'),
+            array('<?php $x = mb_substr("bar", 2, 1);', '<?php $x = substr("bar", 2, 1);'),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
@@ -34,6 +34,7 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestBase
             array('<?php $x = "strlen";'),
             array('<?php $x = Foo::strlen("bar");'),
             array('<?php $x = new strlen("bar");'),
+            array('<?php $x = new \strlen("bar");'),
             array('<?php $x = new Foo\strlen("bar");'),
             array('<?php $x = Foo\strlen("bar");'),
             array('<?php $x = strlen::call("bar");'),
@@ -41,6 +42,7 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestBase
 
             array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
             array('<?php $x = \mb_strlen("bar");', '<?php $x = \strlen("bar");'),
+            array('<?php $x = mb_strtolower(mb_strstr("bar"));', '<?php $x = strtolower(strstr("bar"));'),
             array('<?php $x = mb_strtolower( \mb_strstr ("bar"));', '<?php $x = strtolower( \strstr ("bar"));'),
             array('<?php $x = mb_substr("bar", 2, 1);', '<?php $x = substr("bar", 2, 1);'),
         );

--- a/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+class MbStrFunctionsFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array('<?php $x = "strlen";'),
+            array('<?php $x = Foo::strlen("bar");'),
+            array('<?php $x = $foo->strlen("bar");'),
+
+            array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
+        );
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MbStrFunctionsFixerTest.php
@@ -15,8 +15,10 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
  */
-class MbStrFunctionsFixerTest extends AbstractFixerTestBase
+final class MbStrFunctionsFixerTest extends AbstractFixerTestBase
 {
     /**
      * @dataProvider provideCases


### PR DESCRIPTION
This fixer acts like `mbstring.func_overload = 2`

Reference page: http://php.net/manual/en/mbstring.overload.php

Some notes:

1. `mbstring.func_overload = 4` related functions are left untouched since they are deprecated and removed from PHP 7
1. `mbstring.func_overload = 1` mail() to mb_send_mail() is left untouched since involves a more complex refactoring in the user application
1. Like [EregToPregFixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/974) this fixer does **not** handle namespaced overrided functions like: `namespace MyNamespace { function strlen() { return 1; } }` since it is impossible to distinguish, in another source file, if the function called refers to custom or native one.
1. The Fixer is marked Risky