### PR TITLE
Added ProtectedToPrivateFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -560,9 +560,7 @@ Choose from the list of available fixers:
    @var should always be written as @type.
 
 * **protected_to_private** [contrib]
-                        Converts protected variables
-                        and methods to private where
-                        possible.
+   Converts protected variables and methods to private where possible.
 
 * **short_array_syntax** [contrib]
    PHP arrays should use the PHP 5.4 short-syntax.

--- a/README.rst
+++ b/README.rst
@@ -559,6 +559,11 @@ Choose from the list of available fixers:
 * **phpdoc_var_to_type** [contrib]
    @var should always be written as @type.
 
+* **protected_to_private** [contrib]
+                        Converts all protected
+                        variables and methods to
+                        private if needed.
+
 * **short_array_syntax** [contrib]
    PHP arrays should use the PHP 5.4 short-syntax.
 

--- a/README.rst
+++ b/README.rst
@@ -560,9 +560,9 @@ Choose from the list of available fixers:
    @var should always be written as @type.
 
 * **protected_to_private** [contrib]
-                        Converts all protected
-                        variables and methods to
-                        private if needed.
+                        Converts protected variables
+                        and methods to private where
+                        possible.
 
 * **short_array_syntax** [contrib]
    PHP arrays should use the PHP 5.4 short-syntax.

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -1,9 +1,10 @@
 <?php
 
 /*
- * This file is part of the PHP CS utility.
+ * This file is part of PHP CS Fixer.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -67,6 +67,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
      * Decide whether or not skip the fix for given class.
      *
      * @param Tokens $tokens the Tokens instance
+     * @param int    $classIndex the class start index
      *
      * @return bool
      */

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -18,7 +18,7 @@ use Symfony\CS\Tokenizer\Tokens;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  */
-class ProtectedToPrivateFixer extends AbstractFixer
+final class ProtectedToPrivateFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -88,17 +88,15 @@ final class ProtectedToPrivateFixer extends AbstractFixer
         }
 
         $extendsIndex = $classOpeningIndex;
-        $extendsPresent = false;
         while ($extendsIndex > $classIndex) {
             --$extendsIndex;
 
             if ($tokens[$extendsIndex]->isGivenKind(T_EXTENDS)) {
-                $extendsPresent = true;
-                break;
+                return true;
             }
         }
 
-        return $extendsPresent;
+        return false;
     }
 
     /**

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+class ProtectedToPrivateFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        if ($this->skipFix($tokens)) {
+            return $content;
+        }
+
+        $elements = $tokens->getClassyElements();
+
+        foreach (array_reverse($elements, true) as $index => $token) {
+            $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
+            $prevToken = $tokens[$prevTokenIndex];
+
+            if ($prevToken->isGivenKind(T_STATIC)) {
+                $prevTokenIndex = $tokens->getPrevMeaningfulToken($prevTokenIndex);
+                $prevToken = $tokens[$prevTokenIndex];
+            }
+
+            if (!$prevToken->isGivenKind(T_PROTECTED)) {
+                continue;
+            }
+
+            $prevToken->clear();
+            $tokens->insertAt(
+                $prevTokenIndex,
+                new Token(array(T_PRIVATE, 'private'))
+            );
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * Decide whether or not skip the fix.
+     *
+     * @param Tokens $tokens the Tokens instance
+     *
+     * @return bool
+     */
+    private function skipFix(Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
+            $prevToken = $tokens[$prevTokenIndex];
+
+            if ($prevToken->isGivenKind(T_ABSTRACT)) {
+                return true;
+            }
+
+            $useIndex = $tokens->getNextTokenOfKind($index, array(array(T_USE)));
+            if ($useIndex > 0) {
+                return true;
+            }
+
+            $classOpeningIndex = $tokens->getNextTokenOfKind($index, array('{'));
+            $extendsIndex = $classOpeningIndex;
+
+            $extendsPresent = false;
+            while ($extendsIndex > $index) {
+                --$extendsIndex;
+
+                if ($tokens[$extendsIndex]->isGivenKind(T_EXTENDS)) {
+                    $extendsPresent = true;
+                }
+            }
+
+            if ($extendsPresent or !$prevToken->isGivenKind(T_FINAL)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Converts all protected variables and methods to private if needed.';
+    }
+}

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -66,7 +66,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
     /**
      * Decide whether or not skip the fix for given class.
      *
-     * @param Tokens $tokens the Tokens instance
+     * @param Tokens $tokens     the Tokens instance
      * @param int    $classIndex the class start index
      *
      * @return bool

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -75,7 +75,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
         $prevTokenIndex = $tokens->getPrevMeaningfulToken($classIndex);
         $prevToken = $tokens[$prevTokenIndex];
 
-        if ($prevToken->isGivenKind(T_ABSTRACT) or !$prevToken->isGivenKind(T_FINAL)) {
+        if ($prevToken->isGivenKind(T_ABSTRACT) || !$prevToken->isGivenKind(T_FINAL)) {
             return true;
         }
 

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -92,7 +92,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
     private function skipClass(Tokens $tokens, $classIndex, $classOpenIndex, $classCloseIndex)
     {
         $prevToken = $tokens[$tokens->getPrevMeaningfulToken($classIndex)];
-        if ($prevToken->isGivenKind(T_ABSTRACT) || !$prevToken->isGivenKind(T_FINAL)) {
+        if (!$prevToken->isGivenKind(T_FINAL)) {
             return true;
         }
 

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -66,11 +66,6 @@ final class ProtectedToPrivateFixer extends AbstractFixer
             $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevTokenIndex];
 
-            if ($prevToken->isGivenKind(T_STATIC)) {
-                $prevTokenIndex = $tokens->getPrevMeaningfulToken($prevTokenIndex);
-                $prevToken = $tokens[$prevTokenIndex];
-            }
-
             if (!$prevToken->isGivenKind(T_PROTECTED)) {
                 continue;
             }

--- a/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ProtectedToPrivateFixer.php
@@ -63,14 +63,16 @@ final class ProtectedToPrivateFixer extends AbstractFixer
     private function fixClass(Tokens $tokens, $classIndex, $classOpenIndex, $classCloseIndex)
     {
         for ($index = $classOpenIndex + 1; $index < $classCloseIndex; ++$index) {
-            $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
-            $prevToken = $tokens[$prevTokenIndex];
-
-            if (!$prevToken->isGivenKind(T_PROTECTED)) {
+            if ($tokens[$index]->equals('{')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
                 continue;
             }
 
-            $tokens->overrideAt($prevTokenIndex, array(T_PRIVATE, 'private'));
+            if (!$tokens[$index]->isGivenKind(T_PROTECTED)) {
+                continue;
+            }
+
+            $tokens->overrideAt($index, array(T_PRIVATE, 'private'));
         }
     }
 
@@ -91,8 +93,8 @@ final class ProtectedToPrivateFixer extends AbstractFixer
             return true;
         }
 
-        for ($i = $classIndex; $i < $classOpenIndex; ++$i) {
-            if ($tokens[$i]->isGivenKind(T_EXTENDS)) {
+        for ($index = $classIndex; $index < $classOpenIndex; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_EXTENDS)) {
                 return true;
             }
         }

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -1,9 +1,10 @@
 <?php
 
 /*
- * This file is part of the PHP CS utility.
+ * This file is part of PHP CS Fixer.
  *
  * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -66,7 +66,7 @@ private static function f6(){}
                 "<?php final class MyClass { use MyTrait; $attributesAndMethodsOriginal }",
             ),
             'multiline-comment' => array(
-                "<?php final class MyClass { /* public protected private */ }",
+                '<?php final class MyClass { /* public protected private */ }',
             ),
             'inline-comment' => array(
                 "<?php final class MyClass { \n // public protected private \n }",

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        $from = function ($text, $traitText = '') {
+            return sprintf('<?php
+
+%s
+{
+    %s
+
+    public $v1;
+    protected $v2;
+    private $v3;
+    public static $v4;
+    protected static $v5;
+    private static $v6;
+    public function f1(){}
+    protected function f2(){}
+    private function f3(){}
+    public static function f4(){}
+    protected static function f5(){}
+    private static function f6(){}
+    // public $v1;
+    // protected $v2;
+    // private $v3;
+    // public static $v4;
+    // protected static $v5;
+    // private static $v6;
+    // public function f1(){}
+    // protected function f2(){}
+    // private function f3(){}
+    // public static function f4(){}
+    // protected static function f5(){}
+    // private static function f6(){}
+}', $text, $traitText);
+        };
+
+        $to = function ($text, $traitText = '') {
+            return sprintf('<?php
+
+%s
+{
+    %s
+
+    public $v1;
+    private $v2;
+    private $v3;
+    public static $v4;
+    private static $v5;
+    private static $v6;
+    public function f1(){}
+    private function f2(){}
+    private function f3(){}
+    public static function f4(){}
+    private static function f5(){}
+    private static function f6(){}
+    // public $v1;
+    // protected $v2;
+    // private $v3;
+    // public static $v4;
+    // protected static $v5;
+    // private static $v6;
+    // public function f1(){}
+    // protected function f2(){}
+    // private function f3(){}
+    // public static function f4(){}
+    // protected static function f5(){}
+    // private static function f6(){}
+}', $text, $traitText);
+        };
+
+        return array(
+            'final-extends' => array(
+                $from('final class MyClass extends MyAbstractClass'),
+            ),
+            'normal-extends' => array(
+                $from('class MyClass extends MyAbstractClass'),
+            ),
+            'abstract' => array(
+                $from('abstract class MyAbstractClass'),
+            ),
+            'normal' => array(
+                $from('class MyClass'),
+            ),
+            'trait' => array(
+                $from('trait MyTrait'),
+            ),
+            'final-with-trait' => array(
+                $from('final class MyClass', 'use MyTrait;'),
+            ),
+            'final' => array(
+                $to('final class MyClass'),
+                $from('final class MyClass'),
+            ),
+            'final-implements' => array(
+                $to('final class MyClass implements MyInterface'),
+                $from('final class MyClass implements MyInterface'),
+            ),
+            'final-use' => array(
+                $to("use stdClass;\nfinal class MyClass"),
+                $from("use stdClass;\nfinal class MyClass"),
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -30,104 +30,66 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
 
     public function provideCases()
     {
-        $from = function ($text, $traitText = '') {
-            return sprintf('<?php
-
-%s
-{
-    %s
-
-    public $v1;
-    protected $v2;
-    private $v3;
-    public static $v4;
-    protected static $v5;
-    private static $v6;
-    public function f1(){}
-    protected function f2(){}
-    private function f3(){}
-    public static function f4(){}
-    protected static function f5(){}
-    private static function f6(){}
-    // public $v1;
-    // protected $v2;
-    // private $v3;
-    // public static $v4;
-    // protected static $v5;
-    // private static $v6;
-    // public function f1(){}
-    // protected function f2(){}
-    // private function f3(){}
-    // public static function f4(){}
-    // protected static function f5(){}
-    // private static function f6(){}
-}', $text, $traitText);
-        };
-
-        $to = function ($text, $traitText = '') {
-            return sprintf('<?php
-
-%s
-{
-    %s
-
-    public $v1;
-    private $v2;
-    private $v3;
-    public static $v4;
-    private static $v5;
-    private static $v6;
-    public function f1(){}
-    private function f2(){}
-    private function f3(){}
-    public static function f4(){}
-    private static function f5(){}
-    private static function f6(){}
-    // public $v1;
-    // protected $v2;
-    // private $v3;
-    // public static $v4;
-    // protected static $v5;
-    // private static $v6;
-    // public function f1(){}
-    // protected function f2(){}
-    // private function f3(){}
-    // public static function f4(){}
-    // protected static function f5(){}
-    // private static function f6(){}
-}', $text, $traitText);
-        };
+        $attributesAndMethodsOriginal = '
+public $v1;
+protected $v2;
+private $v3;
+public static $v4;
+protected static $v5;
+private static $v6;
+public function f1(){}
+protected function f2(){}
+private function f3(){}
+public static function f4(){}
+protected static function f5(){}
+private static function f6(){}
+';
+        $attributesAndMethodsFixed = str_replace('protected', 'private', $attributesAndMethodsOriginal);
 
         return array(
             'final-extends' => array(
-                $from('final class MyClass extends MyAbstractClass'),
+                "<?php final class MyClass extends MyAbstractClass { $attributesAndMethodsOriginal }",
             ),
             'normal-extends' => array(
-                $from('class MyClass extends MyAbstractClass'),
+                "<?php class MyClass extends MyAbstractClass { $attributesAndMethodsOriginal }",
             ),
             'abstract' => array(
-                $from('abstract class MyAbstractClass'),
+                "<?php abstract class MyAbstractClass { $attributesAndMethodsOriginal }",
             ),
             'normal' => array(
-                $from('class MyClass'),
+                "<?php class MyClass { $attributesAndMethodsOriginal }",
             ),
             'trait' => array(
-                $from('trait MyTrait'),
+                "<?php trait MyTrait { $attributesAndMethodsOriginal }",
             ),
             'final-with-trait' => array(
-                $from('final class MyClass', 'use MyTrait;'),
+                "<?php final class MyClass { use MyTrait; $attributesAndMethodsOriginal }",
+            ),
+            'multiline-comment' => array(
+                "<?php final class MyClass { /* public protected private */ }",
+            ),
+            'inline-comment' => array(
+                "<?php final class MyClass { \n // public protected private \n }",
             ),
             'final' => array(
-                $to('final class MyClass'),
-                $from('final class MyClass'),
+                "<?php final class MyClass { $attributesAndMethodsFixed }",
+                "<?php final class MyClass { $attributesAndMethodsOriginal }",
             ),
             'final-implements' => array(
-                $to('final class MyClass implements MyInterface'),
-                $from('final class MyClass implements MyInterface'),
+                "<?php final class MyClass implements MyInterface { $attributesAndMethodsFixed }",
+                "<?php final class MyClass implements MyInterface { $attributesAndMethodsOriginal }",
             ),
-            'final-use' => array(
-                $to("use stdClass;\nfinal class MyClass"),
-                $from("use stdClass;\nfinal class MyClass"),
+            'final-with-use-before' => array(
+                "<?php use stdClass; final class MyClass { $attributesAndMethodsFixed }",
+                "<?php use stdClass; final class MyClass { $attributesAndMethodsOriginal }",
+            ),
+            'final-with-use-after' => array(
+                "<?php final class MyClass { $attributesAndMethodsFixed } use stdClass;",
+                "<?php final class MyClass { $attributesAndMethodsOriginal } use stdClass;",
+            ),
+            'multiple-classes' => array(
+                "<?php final class MyFirstClass { $attributesAndMethodsFixed } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsFixed } ",
+                "<?php final class MyFirstClass { $attributesAndMethodsOriginal } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsOriginal } ",
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -15,8 +15,10 @@ use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
 
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
  */
-class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
+final class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
 {
     /**
      * @dataProvider provideCases

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -31,21 +31,8 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
 
     public function provideCases()
     {
-        $attributesAndMethodsOriginal = '
-public $v1;
-protected $v2;
-private $v3;
-public static $v4;
-protected static $v5;
-private static $v6;
-public function f1(){}
-protected function f2(){}
-private function f3(){}
-public static function f4(){}
-protected static function f5(){}
-private static function f6(){}
-';
-        $attributesAndMethodsFixed = str_replace('protected', 'private', $attributesAndMethodsOriginal);
+        $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
+        $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
 
         return array(
             'final-extends' => array(
@@ -93,5 +80,73 @@ private static function f6(){}
                 "<?php final class MyFirstClass { $attributesAndMethodsOriginal } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsOriginal } ",
             ),
         );
+    }
+
+    /**
+     * @dataProvider provide70Cases
+     */
+    public function test70Fix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provide70Cases()
+    {
+        $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
+        $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
+
+        return array(
+            'anonymous-class-inside' => array(
+                "<?php
+final class Foo
+{
+    $attributesAndMethodsFixed
+
+    private function bar()
+    {
+        new class {
+            $attributesAndMethodsOriginal
+        };
+    }
+}
+",
+                "<?php
+final class Foo
+{
+    $attributesAndMethodsOriginal
+
+    protected function bar()
+    {
+        new class {
+            $attributesAndMethodsOriginal
+        };
+    }
+}
+",
+            ),
+        );
+    }
+
+    private function getAttributesAndMethods($original)
+    {
+        $attributesAndMethodsOriginal = '
+public $v1;
+protected $v2;
+private $v3;
+public static $v4;
+protected static $v5;
+private static $v6;
+public function f1(){}
+protected function f2(){}
+private function f3(){}
+public static function f4(){}
+protected static function f5(){}
+private static function f6(){}
+';
+        if ($original) {
+            return $attributesAndMethodsOriginal;
+        }
+
+        return str_replace('protected', 'private', $attributesAndMethodsOriginal);
     }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ProtectedToPrivateFixerTest.php
@@ -84,6 +84,7 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestBase
 
     /**
      * @dataProvider provide70Cases
+     * @requires PHP 7.0
      */
     public function test70Fix($expected, $input = null)
     {


### PR DESCRIPTION
This fixer converts all attributes and method from protected to private when possible, so if and only if the class:
1. Is final
2. Is not abstract
3. Does not extend any other classes
4. Is not a trait
5. Does not use traits

So only where inheritance is absent
