### PR TITLE
ConcatWithoutSpacesFixer, OperatorsSpacesFixer- fix too many spaces, fix incorrect fixing of lines with comments

### DIFF
--- a/Symfony/CS/Fixer/Symfony/ConcatWithoutSpacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/ConcatWithoutSpacesFixer.php
@@ -29,11 +29,13 @@ class ConcatWithoutSpacesFixer extends AbstractFixer
 
         foreach ($tokens as $index => $token) {
             if ($token->equals('.')) {
-                if (!$tokens[$tokens->getPrevNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
+                $previousNonWhiteIndex = $tokens->getPrevNonWhitespace($index);
+                if (!$tokens[$previousNonWhiteIndex]->isGivenKind(T_LNUMBER) && false === strpos($tokens[$previousNonWhiteIndex]->getContent(), "\n")) {
                     $tokens->removeLeadingWhitespace($index, $whitespaces);
                 }
 
-                if (!$tokens[$tokens->getNextNonWhitespace($index)]->isGivenKind(T_LNUMBER)) {
+                $nextNonWhiteIndex = $tokens->getNextNonWhitespace($index);
+                if (!$tokens[$nextNonWhiteIndex]->isGivenKind(array(T_LNUMBER, T_COMMENT, T_DOC_COMMENT))) {
                     $tokens->removeTrailingWhitespace($index, $whitespaces);
                 }
             }

--- a/Symfony/CS/Fixer/Symfony/OperatorsSpacesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/OperatorsSpacesFixer.php
@@ -44,13 +44,27 @@ class OperatorsSpacesFixer extends AbstractFixer
                 }
             }
 
-            if (!$tokens[$index + 1]->isWhitespace()) {
+            // fix white space after operator
+            if ($tokens[$index + 1]->isWhitespace()) {
+                $content = $tokens[$index + 1]->getContent();
+                if (' ' !== $content && false === strpos($content, "\n") && !$tokens[$tokens->getNextNonWhitespace($index + 1)]->isComment()) {
+                    $tokens[$index + 1]->setContent(' ');
+                }
+            } else {
                 $tokens->insertAt($index + 1, new Token(array(T_WHITESPACE, ' ')));
             }
 
-            if (!$tokens[$index - 1]->isWhitespace()) {
+            // fix white space before operator
+            if ($tokens[$index - 1]->isWhitespace()) {
+                $content = $tokens[$index - 1]->getContent();
+                if (' ' !== $content && false === strpos($content, "\n") && !$tokens[$tokens->getPrevNonWhitespace($index - 1)]->isComment()) {
+                    $tokens[$index - 1]->setContent(' ');
+                }
+            } else {
                 $tokens->insertAt($index, new Token(array(T_WHITESPACE, ' ')));
             }
+
+            --$index; // skip check for binary operator on the whitespace token that is fixed.
         }
 
         return $tokens->generateCode();

--- a/Symfony/CS/Tests/Fixer/Contrib/ConcatWithSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ConcatWithSpacesFixerTest.php
@@ -30,6 +30,24 @@ class ConcatWithSpacesFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php
+                    $a =   //
+                    $c .   /**/
+                    $d     #
+                    . $e   /**  */
+                    . $f . //
+                    $z;
+                ',
+                '<?php
+                    $a =   //
+                    $c   .   /**/
+                    $d     #
+                    .   $e   /**  */
+                    .   $f   . //
+                    $z;
+                ',
+            ),
+            array(
                 '<?php $foo = "a" . \'b\' . "c" . "d" . $e . ($f + 1);',
                 '<?php $foo = "a" . \'b\' ."c". "d"    .  $e.($f + 1);',
             ),

--- a/Symfony/CS/Tests/Fixer/Symfony/ConcatWithoutSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/ConcatWithoutSpacesFixerTest.php
@@ -51,6 +51,58 @@ class ConcatWithoutSpacesFixerTest extends AbstractFixerTestBase
                 '<?php $a = "foobar"
     ."baz";',
             ),
+            array(
+                '<?php $a = "foobar" //
+    ."baz";',
+            ),
+            array(
+                '<?php $a = "foobar" //
+                            ."baz"//
+                            ."cex"/**/
+                            ."dev"/**  */
+                            ."baz"      //
+                            ."cex"      /**/
+                            ."ewer23"           '.'
+                            ."dev"      /**  */
+                    ;',
+            ),
+            array(
+                '<?php $a = "foobar" //
+    ."baz" /**/
+    ."something";',
+            ),
+            array(
+                '<?php $a = "foobar"
+    ."baz".      //
+    "something";',
+            ),
+            array(
+                '<?php $a = "foobar"
+    ."baz".      /**  */
+    "something";',
+            ),
+            array(
+                "<?php
+                \$longString = '*'
+                    .'*****'
+                    .'*****'
+                    .'*****'
+                    // Comment about next line
+                    .'*****'
+                    // Other comment
+                    .'*****';
+                ",
+                "<?php
+                \$longString = '*'
+                    . '*****'
+                    .  '*****'
+                    .   '*****'
+                    // Comment about next line
+                    .  '*****'
+                    // Other comment
+                    .  '*****';
+                ",
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/OperatorsSpacesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/OperatorsSpacesFixerTest.php
@@ -31,6 +31,42 @@ class OperatorsSpacesFixerTest extends AbstractFixerTestBase
     {
         return array(
             array(
+                '<?php $d = $c + $a +     //
+                $b;',
+                '<?php $d =    $c+$a+     //
+                $b;',
+            ),
+            array(
+                '<?php $a +      /** */
+                $b;',
+                '<?php $a    +      /** */
+                $b;',
+            ),
+            array(
+                '<?php 
+                    $a
+                    + $b
+                    + $d;
+                ;',
+                '<?php 
+                    $a
+                    +$b
+                    +  $d;
+                ;',
+            ),
+            array(
+                '<?php
+                    $a
+               /***/ + $b
+            /***/   + $d;
+                ;',
+                '<?php
+                    $a
+               /***/+   $b
+            /***/   +$d;
+                ;',
+            ),
+            array(
                 '<?php $a + $b;',
                 '<?php $a+$b;',
             ),
@@ -76,8 +112,6 @@ class OperatorsSpacesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php $a &= $b;',
-            ),
-            array(
                 '<?php $a  &=   $b;',
             ),
             array(
@@ -159,6 +193,16 @@ $b;',
             array(
                 '<?php [1, 2] + [3, 4];',
                 '<?php [1, 2]+[3, 4];',
+            ),
+            array(
+                '<?php [1, 2] + [3, 4];',
+                '<?php [1, 2]   +   [3, 4];',
+            ),
+            array(
+                '<?php [1, 2] + //   
+                [3, 4];',
+                '<?php [1, 2]   + //   
+                [3, 4];',
             ),
         );
     }

--- a/Symfony/CS/Tests/Fixer/Symfony/SpacesCastFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/SpacesCastFixerTest.php
@@ -73,7 +73,7 @@ class SpacesCastFixerTest extends AbstractFixerTestBase
                 "<?php \$bar = (int)\n \$foo;",
             ),
             array(
-                "<?php \$bar = (int)\r \$foo;",
+                "<?php \$bar = (int)\r\n \$foo;",
             ),
         );
     }


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1589

Should apply without any problems on 1.12, 
however on 1.12 there are two fixers with a CS problem that will be fixed by the fixers changed in this PR. So on merging upstream please fix the CS there (guess who the author is of those two fixers with the CS problem... ;) ).