### PR TITLE
[WIP] Fixed ClassDefinitionFixer behavior for single interfaces on multiple lines.

### DIFF
--- a/Symfony/CS/Fixer/PSR2/ClassDefinitionFixer.php
+++ b/Symfony/CS/Fixer/PSR2/ClassDefinitionFixer.php
@@ -68,7 +68,7 @@ final class ClassDefinitionFixer extends AbstractFixer
         $implementsInfo = $this->getMultiLineInfo($tokens, $start, $classyOpen);
 
         // 4.1 The extends and implements keywords MUST be declared on the same line as the class name.
-        if ($implementsInfo['numberOfInterfaces'] > 1 && $implementsInfo['multiLine']) {
+        if ($implementsInfo['multiLine']) {
             $classyOpen += $this->ensureWhiteSpaceSeparation($tokens, $start, $implementsInfo['breakAt']);
             $this->fixMultiLineImplements($tokens, $implementsInfo['breakAt'], $classyOpen);
         } else {
@@ -82,7 +82,6 @@ final class ClassDefinitionFixer extends AbstractFixer
      *
      * Returns array:
      * * int  'breakAt'            index of the Token of type T_IMPLEMENTS for the definition, or 0
-     * * int  'numberOfInterfaces'
      * * bool 'multiLine'
      *
      * @param Tokens $tokens
@@ -93,7 +92,7 @@ final class ClassDefinitionFixer extends AbstractFixer
      */
     private function getMultiLineInfo(Tokens $tokens, $start, $classyOpen)
     {
-        $implementsInfo = array('breakAt' => 0, 'numberOfInterfaces' => 0, 'multiLine' => false);
+        $implementsInfo = array('breakAt' => 0, 'multiLine' => false);
         $breakAtToken = $tokens->findGivenKind($tokens[$start]->isGivenKind(T_INTERFACE) ? T_EXTENDS : T_IMPLEMENTS, $start, $classyOpen);
         if (count($breakAtToken) < 1) {
             return $implementsInfo;
@@ -103,7 +102,6 @@ final class ClassDefinitionFixer extends AbstractFixer
         $classyOpen = $tokens->getPrevNonWhitespace($classyOpen);
         for ($j = $implementsInfo['breakAt'] + 1; $j < $classyOpen; ++$j) {
             if ($tokens[$j]->isGivenKind(T_STRING)) {
-                ++$implementsInfo['numberOfInterfaces'];
                 continue;
             }
 

--- a/Symfony/CS/Tests/Fixer/PSR2/ClassDefinitionFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/PSR2/ClassDefinitionFixerTest.php
@@ -201,7 +201,15 @@ class Aaa implements
     \Ccc,
     \CFdd
 {
-}', ),
+}',
+            ),
+            array(
+                '<?php
+class Aaa implements
+    \CFb
+{
+}',
+            ),
         );
     }
 


### PR DESCRIPTION
@keradus This is a re-submit of #2054 targeted against the 1.12 branch. Original PR text:

@SpacePossum Here's my attempt at a fix for #2053.

The breaking test is this example:

```php
<?php
class/**/Test123
extends  /**/        \RuntimeException    implements

TestZ{
}
```

I'm actually not sure whether this should be treated as multi-line, or single-line. It could probably go either way I guess.