### PR TITLE
Explicitly set finder when using directory in args

### DIFF
--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -337,6 +337,7 @@ EOF
         } elseif ($stdin) {
             $config->finder(new \ArrayIterator(array(new StdinFileInfo())));
         } elseif (null !== $path) {
+            $config->finder(new \DirectoryIterator($path));
             $config->setDir($path);
         }
 


### PR DESCRIPTION
When you use a `.php_cs` config file which set a finder plus you pass a path as argument of the fix command, the behavior differ if that path is a file or a directory.

For instance using the PHP-CS-Fixer project:

```bash
# This will apply the rules from the config file to a **single** PHP file.
./php-cs-fixer fix --config-file .php_cs Symfony/CS/Console/Command/FixCommand.php
```

```bash
# When using a directory the rules are applied on the **whole project**
# (and not just the path given in args).
./php-cs-fixer fix --config-file .php_cs Symfony/CS/Console/Command/
```

This patch force the finder to be overridden when specifying a directory in args.