### PR TITLE
ShortArraySyntaxFixer, TernarySpacesFixer, UnalignEqualsFixer - fix priority bug

### DIFF
--- a/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
@@ -53,7 +53,7 @@ class ShortArraySyntaxFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        // should be run before the UnalignEqualsFixer.
+        // should be run before the UnalignEqualsFixer and TernarySpacesFixer.
         return 1;
     }
 }

--- a/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
+++ b/Symfony/CS/Fixer/Contrib/ShortArraySyntaxFixer.php
@@ -31,10 +31,10 @@ class ShortArraySyntaxFixer extends AbstractFixer
             $openIndex = $tokens->getNextTokenOfKind($index, array('('));
             $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openIndex);
 
-            $token->clear();
-
             $tokens->overrideAt($openIndex, '[');
             $tokens->overrideAt($closeIndex, ']');
+
+            $tokens->clearTokenAndMergeSurroundingWhitespace($index);
         }
 
         return $tokens->generateCode();
@@ -46,5 +46,14 @@ class ShortArraySyntaxFixer extends AbstractFixer
     public function getDescription()
     {
         return 'PHP arrays should use the PHP 5.4 short-syntax.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run before the UnalignEqualsFixer.
+        return 1;
     }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/ShortArraySyntaxFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/ShortArraySyntaxFixerTest.php
@@ -44,6 +44,7 @@ class ShortArraySyntaxFixerTest extends AbstractFixerTestBase
             array('<?php function(array $foo = []) {};', '<?php function(array $foo = array()) {};'),
             array('<?php function(array $foo) {};'),
             array('<?php function(array $foo = []) {};', '<?php function(array $foo = array()) {};'),
+            array('<?php $a  =   [  ];', '<?php $a  =  array (  );'),
         );
     }
 }

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -210,6 +210,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['unneeded_control_parentheses'], $fixers['trailing_spaces']), // tested also in: trailing_spaces,unneeded_control_parentheses.test
             array($fixers['blankline_after_open_tag'], $fixers['no_blank_lines_before_namespace']), // tested also in: blankline_after_open_tag,no_blank_lines_before_namespace.test
             array($fixers['short_array_syntax'], $fixers['unalign_equals']), // tested also in: short_array_syntax,unalign_equals.test
+            array($fixers['short_array_syntax'], $fixers['ternary_spaces']), // tested also in: short_array_syntax,ternary_spaces.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -209,6 +209,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['short_bool_cast'], $fixers['spaces_cast']),
             array($fixers['unneeded_control_parentheses'], $fixers['trailing_spaces']), // tested also in: trailing_spaces,unneeded_control_parentheses.test
             array($fixers['blankline_after_open_tag'], $fixers['no_blank_lines_before_namespace']), // tested also in: blankline_after_open_tag,no_blank_lines_before_namespace.test
+            array($fixers['short_array_syntax'], $fixers['unalign_equals']), // tested also in: short_array_syntax,unalign_equals.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,ternary_spaces.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,ternary_spaces.test
@@ -1,0 +1,14 @@
+--TEST--
+Integration of fixers: short_array_syntax,ternary_spaces.
+--CONFIG--
+level=none
+fixers=short_array_syntax,ternary_spaces
+--REQUIREMENTS--
+php=5.4
+--INPUT--
+<?php
+$a = $b ?   array ( ): 1;
+
+--EXPECT--
+<?php
+$a = $b ? [ ] : 1;

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,unalign_equals.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,unalign_equals.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: short_array_syntax,unalign_equals.test.
+Integration of fixers: short_array_syntax,unalign_equals.
 --CONFIG--
 level=none
 fixers=short_array_syntax,unalign_equals

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,unalign_equals.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/short_array_syntax,unalign_equals.test
@@ -1,0 +1,14 @@
+--TEST--
+Integration of fixers: short_array_syntax,unalign_equals.test.
+--CONFIG--
+level=none
+fixers=short_array_syntax,unalign_equals
+--REQUIREMENTS--
+php=5.4
+--INPUT--
+<?php
+$a =  array  ();
+
+--EXPECT--
+<?php
+$a = [];


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2106#issuecomment-237187939

turns out the token clear done by the `short_array_syntax` fixer causes problems because the `unalign_equals` expects one white space token (and not multiple in a row or with cleared tokens in between)