### PR TITLE
[POC/WIP] Add FunctionTypehintDefaultFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -648,6 +648,11 @@ Choose from the list of available fixers:
                         with preg. Warning! This could
                         change code behavior.
 
+* **function_typehint_default** [contrib]
+                        Function arguments with
+                        defaults should be typehinted.
+                        (Risky fixer!)
+
 * **header_comment** [contrib]
                         Add, replace or remove header
                         comment.

--- a/Symfony/CS/Fixer/Contrib/FunctionTypehintDefaultFixer.php
+++ b/Symfony/CS/Fixer/Contrib/FunctionTypehintDefaultFixer.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class FunctionTypehintDefaultFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            // check if function/method declaration
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            // find start index of argument list, but skip function imports
+            $startParenthesisIndex = $tokens->getNextTokenOfKind($index, array('(', ';', array(T_CLOSE_TAG)));
+            if (!$tokens[$startParenthesisIndex]->equals('(')) {
+                continue;
+            }
+
+            $this->fixFunctionDeclaration(
+                $tokens,
+                $startParenthesisIndex,
+                $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startParenthesisIndex)
+            );
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startParenthesisIndex
+     * @param int    $endParenthesisIndex
+     */
+    private function fixFunctionDeclaration(Tokens $tokens, $startParenthesisIndex, $endParenthesisIndex)
+    {
+        for ($i = $startParenthesisIndex; $i < $endParenthesisIndex; ++$i) {
+            if ($tokens[$i]->isGivenKind(CT_ARRAY_TYPEHINT)) {
+                // argument already type hinted, proceed to the next variable (if there is one)
+                $i = $tokens->getNextTokenOfKind($i, array(',', ')'));
+
+                continue;
+            }
+
+            if (!$tokens[$i]->isGivenKind(T_VARIABLE)) {
+                continue;
+            }
+
+            // check if the argument has a default value declared
+            $nextMeaningful = $tokens->getNextMeaningfulToken($i);
+            if (!$tokens[$nextMeaningful]->equals('=')) {
+                continue;
+            }
+
+            // default value token index
+            $nextMeaningful = $tokens->getNextMeaningfulToken($nextMeaningful);
+            if (!$tokens[$nextMeaningful]->equalsAny(array(array(T_ARRAY), '['))) {
+                continue;
+            }
+
+            $tokens->insertAt(
+                $i,
+                array(
+                    new Token(array(CT_ARRAY_TYPEHINT, 'array')),
+                    new Token(array(T_WHITESPACE, ' ')),
+                )
+            );
+
+            $i += 2;
+            $endParenthesisIndex += 2;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Function arguments with defaults should be typehinted. (Risky fixer!)';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/FunctionTypehintDefaultFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/FunctionTypehintDefaultFixerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+class FunctionTypehintDefaultFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider provideCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array(
+                '<?php function a( array $a1 = array()){}',
+                '<?php function a( $a1 = array()){}',
+            ),
+            array(
+                '<?php function b($b, array $a1 = array()){}',
+                '<?php function b($b, $a1 = array()){}',
+            ),
+            array(
+                '<?php function c($b, array $a1 = array(),   /**/ $c){}',
+                '<?php function c($b, $a1 = array(),   /**/ $c){}',
+            ),
+            array(
+                '<?php function d(array $a1 = array(), $z = null, array $b1 = array(), array $c = array(), $d = 1){}',
+                '<?php function d($a1 = array(), $z = null, $b1 = array(), $c = array(), $d = 1){}',
+            ),
+        );
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider provide54Cases
+     *
+     * @requires PHP 5.4
+     */
+    public function testFix54($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provide54Cases()
+    {
+        $cases = array(
+            array(
+                '<?php function a(array $a = []){}',
+                '<?php function a($a = []){}',
+            ),
+            array(
+                '<?php function mixed(array $a = [], array $b = array()){}',
+                '<?php function mixed($a = [], $b = array()){}',
+            ),
+        );
+
+        $longArraySyntaxCases = $this->provideCases();
+        foreach ($longArraySyntaxCases as $longCase) {
+            $cases[] = array(
+                str_replace('array()', '[]', $longCase[0]),
+                str_replace('array()', '[]', $longCase[1]),
+            );
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider provide56Cases
+     *
+     * @requires PHP 5.6
+     */
+    public function testFix56($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provide56Cases()
+    {
+        return array(
+            array(
+                '<?php function foo(...$param) {}',
+            ),
+            array(
+                '<?php function foo(&...$param) {}',
+            ),
+            array(
+                '<?php function foo(array ...$param) {}',
+            ),
+            array(
+                '<?php function foo(array & ...$param) {}',
+            ),
+        );
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider provide70Cases
+     *
+     * @requires PHP 7.0
+     */
+    public function testFix70($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provide70Cases()
+    {
+        return array(
+            array('<?php use function some\test\{fn_a, fn_b, fn_c};'),
+            array('<?php use function some\test\{fn_a, fn_b, fn_c} ?>'),
+        );
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider provideDoNotFixCases
+     */
+    public function testDoNotFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideDoNotFixCases()
+    {
+        return array(
+            array(
+                '<?php function e( ){}',
+            ),
+            array(
+                '<?php function f(){}',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Hi all,

Just an early opening to see how the test do, but more important to see what the community thinks :)
Currently the fixer does something like:
```php
<?php 
//expected
function a( array $a1 = array()){}
```

```php
<?php 
// input
function a( $a1 = array()){}
```

Next up would be for PHP7
```php
// expected
function a(int $a = 1) {
    return $a;
}
```

```php
// input
function a($a = 1) {
    return $a;
}
```

This is of cause all very risky.