### PR TITLE
Added MbStrFunctionsFixer (master)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,9 +339,7 @@ Choose from the list of available fixers:
 * **mb_str_functions**
                          Replace non multibyte-safe
                          functions with corresponding
-                         mb function. Warning! This
-                         could change code behavior.
-                         (Risky fixer!)
+                         mb function. (Risky fixer!)
 
 * **method_argument_space** [@PSR2, @Symfony]
                          In method arguments and

--- a/README.rst
+++ b/README.rst
@@ -336,6 +336,13 @@ Choose from the list of available fixers:
                          PHP keywords MUST be in lower
                          case.
 
+* **mb_str_functions**
+                         Replace non multibyte-safe
+                         functions with corresponding
+                         mb function. Warning! This
+                         could change code behavior.
+                         (Risky fixer!)
+
 * **method_argument_space** [@PSR2, @Symfony]
                          In method arguments and
                          method call, there MUST NOT

--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Alias;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class MbStrFunctionsFixer extends AbstractFixer
+{
+    /**
+     * @var array the list of the string-related function names and their mb_ equivalent
+     */
+    private static $functions = array(
+        'strlen' => 'mb_strlen',
+        'strpos' => 'mb_strpos',
+        'strrpos' => 'mb_strrpos',
+        'substr' => 'mb_substr',
+        'strtolower' => 'mb_strtolower',
+        'strtoupper' => 'mb_strtoupper',
+        'stripos' => 'mb_stripos',
+        'strripos' => 'mb_strripos',
+        'strstr' => 'mb_strstr',
+        'stristr' => 'mb_stristr',
+        'strrchr' => 'mb_strrchr',
+        'substr_count' => 'mb_substr_count',
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_STRING);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $end = $tokens->count() - 1;
+
+        foreach (self::$functions as $originalName => $mbFunctionName) {
+            // the sequence is the function name, followed by "(" and a quoted string
+            $seq = array(array(T_STRING, $originalName), '(');
+
+            $currIndex = 0;
+            while (null !== $currIndex) {
+                $match = $tokens->findSequence($seq, $currIndex, $end, false);
+
+                // did we find a match?
+                if (null === $match) {
+                    break;
+                }
+
+                // findSequence also returns the tokens, but we're only interested in the indexes, i.e.:
+                // 0 => function name,
+                // 1 => bracket "("
+                $match = array_keys($match);
+
+                // advance tokenizer cursor
+                $currIndex = $match[1];
+
+                // ensure it's a function call (not a method / static call)
+                $prev = $tokens->getPrevMeaningfulToken($match[0]);
+                if (null === $prev || $tokens[$prev]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NEW))) {
+                    continue;
+                }
+                $prev = $tokens->getPrevMeaningfulToken($prev);
+                if ($tokens[$prev]->isGivenKind(array(T_STRING))) {
+                    continue;
+                }
+
+                // modify function and argument
+                $tokens[$match[0]]->setContent($mbFunctionName);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Replace non multibyte-safe functions with corresponding mb function. Warning! This could change code behavior.';
+    }
+}

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -35,6 +35,7 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
             array('<?php $x = "strlen";'),
             array('<?php $x = Foo::strlen("bar");'),
             array('<?php $x = new strlen("bar");'),
+            array('<?php $x = new \strlen("bar");'),
             array('<?php $x = new Foo\strlen("bar");'),
             array('<?php $x = Foo\strlen("bar");'),
             array('<?php $x = strlen::call("bar");'),
@@ -42,6 +43,7 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
 
             array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
             array('<?php $x = \mb_strlen("bar");', '<?php $x = \strlen("bar");'),
+            array('<?php $x = mb_strtolower(mb_strstr("bar"));', '<?php $x = strtolower(strstr("bar"));'),
             array('<?php $x = mb_strtolower( \mb_strstr ("bar"));', '<?php $x = strtolower( \strstr ("bar"));'),
             array('<?php $x = mb_substr("bar", 2, 1);', '<?php $x = substr("bar", 2, 1);'),
         );

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Alias;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ */
+final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideExamples()
+    {
+        return array(
+            array('<?php $x = "strlen";'),
+            array('<?php $x = Foo::strlen("bar");'),
+            array('<?php $x = new strlen("bar");'),
+            array('<?php $x = new Foo\strlen("bar");'),
+            array('<?php $x = Foo\strlen("bar");'),
+            array('<?php $x = strlen::call("bar");'),
+            array('<?php $x = $foo->strlen("bar");'),
+
+            array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
+            array('<?php $x = \mb_strlen("bar");', '<?php $x = \strlen("bar");'),
+            array('<?php $x = mb_strtolower( \mb_strstr ("bar"));', '<?php $x = strtolower( \strstr ("bar"));'),
+            array('<?php $x = mb_substr("bar", 2, 1);', '<?php $x = substr("bar", 2, 1);'),
+        );
+    }
+}


### PR DESCRIPTION
`master` PR for https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2082

Instead of `1.11` manual search, here we use `AbstractFunctionReferenceFixer` help.