### PR TITLE
Add TernaryToNullCoalescingFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -620,6 +620,9 @@ Choose from the list of available rules:
 * **ternary_operator_spaces** [@Symfony]
    | Standardize spaces around ternary operator.
 
+* **ternary_to_null_coalescing**
+   | Use null coalescing operator ``??`` wherever possible.
+
 * **trailing_comma_in_multiline_array** [@Symfony]
    | PHP multi-line arrays should have a trailing comma.
 

--- a/README.rst
+++ b/README.rst
@@ -621,7 +621,7 @@ Choose from the list of available rules:
    | Standardize spaces around ternary operator.
 
 * **ternary_to_null_coalescing**
-   | Use null coalescing operator ``??`` wherever possible.
+   | Use ``null`` coalescing operator ``??`` where possible.
 
 * **trailing_comma_in_multiline_array** [@Symfony]
    | PHP multi-line arrays should have a trailing comma.

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Operator;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class TernaryToNullCoalescingFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $issets = array_keys($tokens->findGivenKind(T_ISSET));
+
+        while ($issetIndex = array_pop($issets)) {
+            $prevTokenIndex = $tokens->getPrevMeaningfulToken($issetIndex);
+            if ($this->isHigherPrecedenceAssociativityOperator($tokens[$prevTokenIndex])) {
+                continue;
+            }
+
+            $startBraceIndex = $tokens->getNextTokenOfKind($issetIndex, array('('));
+            $endBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startBraceIndex);
+
+            $ternaryQuestionMarkIndex = $tokens->getNextMeaningfulToken($endBraceIndex);
+            if (!$tokens[$ternaryQuestionMarkIndex]->equals('?')) {
+                // we are not in a ternary operator
+                continue;
+            }
+
+            // search what is inside the isset()
+            $issetTokens = $this->getMeaningfulSequence($tokens, $startBraceIndex, $endBraceIndex);
+
+            // search what is inside the middle argument of ternary operator
+            $ternaryColonIndex = $tokens->getNextTokenOfKind($ternaryQuestionMarkIndex, array(':'));
+            $ternaryFirstOperandTokens = $this->getMeaningfulSequence($tokens, $ternaryQuestionMarkIndex, $ternaryColonIndex);
+
+            if ($issetTokens->generateCode() !== $ternaryFirstOperandTokens->generateCode()) {
+                // regardless of non-meaningful tokens, the operands are different
+                continue;
+            }
+
+            if ($this->hasChangingContent($issetTokens)) {
+                // some weird stuff inside the isset
+                continue;
+            }
+
+            $ternaryFirstOperandIndex = $tokens->getNextMeaningfulToken($ternaryQuestionMarkIndex);
+
+            // preserve comments and spaces after them
+            $comments = array();
+            $commentStarted = false;
+            for ($index = $issetIndex; $index < $ternaryFirstOperandIndex; ++$index) {
+                if ($tokens[$index]->isComment()) {
+                    $comments[] = $tokens[$index];
+                    $commentStarted = true;
+                } elseif ($commentStarted) {
+                    if ($tokens[$index]->isWhitespace()) {
+                        $comments[] = $tokens[$index];
+                    }
+                    $commentStarted = false;
+                }
+            }
+
+            $tokens[$ternaryColonIndex]->override(array(T_COALESCE, '??'));
+            $tokens->overrideRange($issetIndex, $ternaryFirstOperandIndex - 1, $comments);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Use null coalescing operator `??` wherever possible.',
+            array(
+                new VersionSpecificCodeSample(
+                    "<?php\n\$sample = isset(\$a) ? \$a : \$b;",
+                    new VersionSpecification(70000)
+                ),
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return PHP_VERSION_ID >= 70000 && $tokens->isTokenKindFound(T_ISSET);
+    }
+
+    /**
+     * Get the sequence of meaningful tokens and returns a new Tokens instance.
+     *
+     * @param Tokens $tokens The original token list
+     * @param int    $start  start index
+     * @param int    $end    end index
+     *
+     * @return Tokens
+     */
+    private function getMeaningfulSequence(Tokens $tokens, $start, $end)
+    {
+        $sequence = array();
+        $index = $start;
+        while ($index < $end) {
+            $index = $tokens->getNextMeaningfulToken($index);
+            if ($index >= $end || null === $index) {
+                break;
+            }
+
+            $sequence[] = $tokens[$index];
+        }
+
+        return Tokens::fromArray($sequence);
+    }
+
+    /**
+     * Check if the requested token is an operator computed
+     * before the ternary operator along with the isset().
+     *
+     * @param Token $token The original token
+     *
+     * @return bool
+     */
+    private function isHigherPrecedenceAssociativityOperator(Token $token)
+    {
+        static $operatorsPerId = array(
+            T_ARRAY_CAST => true,
+            T_BOOLEAN_AND => true,
+            T_BOOLEAN_OR => true,
+            T_BOOL_CAST => true,
+            T_COALESCE => true,
+            T_DEC => true,
+            T_DOUBLE_CAST => true,
+            T_INC => true,
+            T_INT_CAST => true,
+            T_IS_EQUAL => true,
+            T_IS_GREATER_OR_EQUAL => true,
+            T_IS_IDENTICAL => true,
+            T_IS_NOT_EQUAL => true,
+            T_IS_NOT_IDENTICAL => true,
+            T_IS_SMALLER_OR_EQUAL => true,
+            T_OBJECT_CAST => true,
+            T_POW => true,
+            T_SL => true,
+            T_SPACESHIP => true,
+            T_SR => true,
+            T_STRING_CAST => true,
+            T_UNSET_CAST => true,
+        );
+
+        static $operatorsPerContent = array(
+            '!',
+            '%',
+            '&',
+            '*',
+            '+',
+            '-',
+            '/',
+            ':',
+            '^',
+            '|',
+            '~',
+        );
+
+        return isset($operatorsPerId[$token->getId()]) || $token->equalsAny($operatorsPerContent);
+    }
+
+    /**
+     * Check if the isset() content may change if called multiple times.
+     *
+     * @param Tokens $tokens The original token list
+     *
+     * @return bool
+     */
+    private function hasChangingContent(Tokens $tokens)
+    {
+        static $operatorsPerId = array(
+            T_DEC,
+            T_INC,
+            T_STRING,
+            T_YIELD,
+        );
+
+        foreach ($tokens as $token) {
+            if ($token->isGivenKind($operatorsPerId) || $token->equals('(')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Operator;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ */
+final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideCases
+     * @requires PHP 7.0
+     *
+     * @param mixed      $expected
+     * @param null|mixed $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideCases()
+    {
+        return array(
+            array('<?php $x = isset($a) ? $a[1] : null;'),
+            array('<?php $x = isset($a) and $a ? $a : "";'),
+            array('<?php $x = "isset($a) ? $a : null";'),
+            array('<?php $x = isset($a) ? $$a : null;'),
+            array('<?php $x = isset($a) ? "$a" : null;'),
+            array('<?php $x = isset($a) ?: false;'),
+            array('<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'),
+            array('<?php $x = $y ?? isset($a) ? $a : null;'),
+            array('<?php $x = isset($a) ?: $b;'),
+            array('<?php $x = isset($a, $b) ? $a : null;'),
+            array('<?php $x = $a && isset($b) ? $b : null;'),
+            array('<?php $x = $a & isset($b) ? $b : null;'),
+            array('<?php $x = ! isset($a) ? $a : null;'),
+            array('<?php $x = false === isset($a) ? $a : 2;'),
+            array('<?php $x = 4 * isset($a) ? $a : 2;'),
+            array('<?php $x = 3 ** isset($a) ? $a : 2;'),
+            array('<?php $x = 1 | isset($a) ? $a : 2;'),
+            array('<?php $x = (array) isset($a) ? $a : 2;'),
+            array('<?php $x = isset($a[++$i]) ? $a[++$i] : null;'),
+            array('<?php $x = function(){isset($a[yield]) ? $a[yield] : null;};'),
+            array('<?php $x = isset($a[foo()]) ? $a[foo()] : null;'),
+            array('<?php $x = isset($a[$callback()]) ? $a[$callback()] : null;'),
+
+            array(
+                '<?php $x = $a ?? null;',
+                '<?php $x = isset($a) ? $a : null;',
+            ),
+            array(
+                '<?php $x = $a ?? 1; $y = isset($b) ? "b" : 2; $x = $c ?? 3;',
+                '<?php $x = isset($a) ? $a : 1; $y = isset($b) ? "b" : 2; $x = isset($c) ? $c : 3;',
+            ),
+            array(
+                '<?php $x = $a[ $b[ "c"  ]]   ?? null;',
+                '<?php $x = isset   (  $a[$b["c"]]) ?$a[ $b[ "c"  ]]   : null;',
+            ),
+            array(
+                '<?php $x = $a ?? $b[func(1, true)];',
+                '<?php $x = isset($a) ? $a : $b[func(1, true)];',
+            ),
+            array(
+                '<?php $x = $a ?? ($b ?? "");',
+                '<?php $x = isset($a) ? $a : (isset($b) ? $b : "");',
+            ),
+            array(
+                '<?php $x = ($a ?? isset($b)) ? $b : "";',
+                '<?php $x = (isset($a) ? $a : isset($b)) ? $b : "";',
+            ),
+            array(
+                '<?php $x = $a ?? isset($b) ? $b : isset($c) ? $c : "";',
+                '<?php $x = isset($a) ? $a : isset($b) ? $b : isset($c) ? $c : "";',
+            ),
+            array(
+                '<?php $x = /*a1*//*a2*/ /*b*/ $a /*c*/ ?? /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+                '<?php $x = isset($a) /*a1*//*a2*/ ? /*b*/ $a /*c*/ : /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+            ),
+            array(
+                '<?php $x = (
+// c1
+// c2
+// c3
+$a
+// c4
+??
+// c5
+null
+// c6
+)
+// c7
+;',
+                '<?php $x = (
+// c1
+isset($a)
+// c2
+?
+// c3
+$a
+// c4
+:
+// c5
+null
+// c6
+)
+// c7
+;',
+            ),
+        );
+    }
+}

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -17,16 +17,17 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  *
+ * @requires PHP 7.0
+ *
  * @internal
  */
 final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideCases
-     * @requires PHP 7.0
      *
-     * @param mixed      $expected
-     * @param null|mixed $input
+     * @param string      $expected
+     * @param null|string $input
      */
     public function testFix($expected, $input = null)
     {
@@ -36,6 +37,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
     public function provideCases()
     {
         return array(
+            // Do not fix cases.
             array('<?php $x = isset($a) ? $a[1] : null;'),
             array('<?php $x = isset($a) and $a ? $a : "";'),
             array('<?php $x = "isset($a) ? $a : null";'),
@@ -58,10 +60,21 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             array('<?php $x = function(){isset($a[yield]) ? $a[yield] : null;};'),
             array('<?php $x = isset($a[foo()]) ? $a[foo()] : null;'),
             array('<?php $x = isset($a[$callback()]) ? $a[$callback()] : null;'),
-
-            array(
+            array('<?php $y = isset($a) ? 2**3 : 3**2;'),
+            // Fix cases.
+            'Common fix case (I).' => array(
                 '<?php $x = $a ?? null;',
                 '<?php $x = isset($a) ? $a : null;',
+            ),
+            'Common fix case (II).' => array(
+                '<?php $x = $a[0] ?? 1;',
+                '<?php $x = isset($a[0]) ? $a[0] : 1;',
+            ),
+            'Minimal number of tokens case.' => array(
+                '<?php
+$x=$a??null?>',
+                '<?php
+$x=isset($a)?$a:null?>',
             ),
             array(
                 '<?php $x = $a ?? 1; $y = isset($b) ? "b" : 2; $x = $c ?? 3;',
@@ -101,9 +114,9 @@ $a
 ??
 // c5
 null
-// c6
+/* c6 */
 )
-// c7
+# c7
 ;',
                 '<?php $x = (
 // c1
@@ -116,9 +129,9 @@ $a
 :
 // c5
 null
-// c6
+/* c6 */
 )
-// c7
+# c7
 ;',
             ),
         );


### PR DESCRIPTION
Change wherever possible [ternary operator to null coalescing operator](http://php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op):

``` php
// Before
$x = isset($var) ? $var : 'ops';
// After
$x = $var ?? 'ops';
```

It reduces code duplication, so it should always be favoured.

The fixer is marked as **risky** because of this example (https://3v4l.org/Fjddg):

``` php
// Before
$a = 1;
var_dump(isset($a) ? $a : isset($b) ? $b : false);
// Outputs:
// Notice: Undefined variable: b
// NULL

// After
$a = 1;
var_dump($a ?? $b ?? false);
// Outputs:
// int(1)
```

This only occurs if you concatenate ternary operator without parenthesis, that is an insane usage of ternary operator: the fixer actually fix the code to the right intent, but has to be marked as risky.
