### PR TITLE
composer.json - disallow to run on PHP 7.2+

### DIFF
--- a/Symfony/CS/Resources/phar-stub.php
+++ b/Symfony/CS/Resources/phar-stub.php
@@ -15,8 +15,8 @@ if (defined('HHVM_VERSION_ID')) {
         fwrite(STDERR, "HHVM needs to be a minimum version of HHVM 3.9.0\n");
         exit(1);
     }
-} elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50306) {
-    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.3.6\n");
+} elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50306 || PHP_VERSION_ID >= 70200) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.3.6 and maximum version of PHP 7.1.*\n");
     exit(1);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.6 || ^7.0",
+        "php": "^5.3.6 || >=7.0 <7.2",
         "ext-tokenizer": "*",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/event-dispatcher": "^2.1 || ^3.0",

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -20,8 +20,8 @@ if (defined('HHVM_VERSION_ID')) {
         fwrite(STDERR, "HHVM needs to be a minimum version of HHVM 3.9.0\n");
         exit(1);
     }
-} elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50306) {
-    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.3.6\n");
+} elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50306 || PHP_VERSION_ID >= 70200) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.3.6 and maximum version of PHP 7.1.*\n");
     exit(1);
 }
 


### PR DESCRIPTION
Requesting for comments.

As all new 7.X versions could brings new tokens (or reuse existing token in different place) it's impossible to say that we will properly handle those new tokens with existing code.
That could lead to wrong changes in file, ignoring file or crashing the fixer.
Instead, let not guess that probably we will works on 7.2+ code, but when we will be sure we do just update supported PHP versions.

Nice side effect is that we would be able to introduce new transformers for new tokens without breaking BC and bumping MAJOR version.