### PR TITLE
Remove temporary files not deleted by destructor on failure

### DIFF
--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -28,10 +28,23 @@ class LintManager
      */
     private $temporaryFile;
 
+    /**
+     * Shutdown files removal handler.
+     *
+     * @var ShutdownFileRemoval
+     */
+    private $shutdownFileRemoval;
+
+    public function __construct()
+    {
+        $this->shutdownFileRemoval = new ShutdownFileRemoval();
+    }
+
     public function __destruct()
     {
         if (null !== $this->temporaryFile) {
             unlink($this->temporaryFile);
+            $this->shutdownFileRemoval->detach($this->temporaryFile);
         }
     }
 
@@ -67,6 +80,7 @@ class LintManager
     {
         if (null === $this->temporaryFile) {
             $this->temporaryFile = tempnam('.', 'cs_fixer_tmp_');
+            $this->shutdownFileRemoval->attach($this->temporaryFile);
         }
 
         file_put_contents($this->temporaryFile, $source);

--- a/Symfony/CS/ShutdownFileRemoval.php
+++ b/Symfony/CS/ShutdownFileRemoval.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the PHP CS utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS;
+
+/**
+ * Handles left over temporary files removal.
+ *
+ * @author Adam Klvač <adam@klva.cz>
+ *
+ * @internal
+ */
+final class ShutdownFileRemoval
+{
+    /**
+     * List of files to be removed.
+     *
+     * @var array
+     */
+    private $files = array();
+
+    public function __construct()
+    {
+        register_shutdown_function(array($this, 'clean'));
+    }
+
+    /**
+     * Adds a file to be removed.
+     *
+     * @param string $path
+     */
+    public function attach($path)
+    {
+        $this->files[] = $path;
+    }
+
+    /**
+     * Removes a file from shutdown removal.
+     *
+     * @param string $path
+     */
+    public function detach($path)
+    {
+        $key = array_search($path, $this->files, true);
+
+        if ($key) {
+            unset($this->files[$key]);
+        }
+    }
+
+    /**
+     * Removes attached files.
+     */
+    public function clean()
+    {
+        foreach ($this->files as $file) {
+            @unlink($file); // @ - file might be deleted already
+        }
+
+        $this->files = array();
+    }
+}

--- a/Symfony/CS/Tests/AbstractIntegrationTest.php
+++ b/Symfony/CS/Tests/AbstractIntegrationTest.php
@@ -17,6 +17,7 @@ use Symfony\CS\ErrorsManager;
 use Symfony\CS\FileCacheManager;
 use Symfony\CS\Fixer;
 use Symfony\CS\FixerInterface;
+use Symfony\CS\ShutdownFileRemoval;
 
 /**
  * Integration test base class.
@@ -54,10 +55,13 @@ use Symfony\CS\FixerInterface;
 abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
 {
     private static $builtInFixers;
+    private static $shutdownFileRemoval;
 
     public static function setUpBeforeClass()
     {
         $tmpFile = static::getTempFile();
+        self::$shutdownFileRemoval = new ShutdownFileRemoval();
+        self::$shutdownFileRemoval->attach($tmpFile);
         if (!is_file($tmpFile)) {
             $dir = dirname($tmpFile);
             if (!is_dir($dir)) {
@@ -69,7 +73,9 @@ abstract class AbstractIntegrationTest extends \PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
-        @unlink(static::getTempFile());
+        $tmpFile = static::getTempFile();
+        @unlink($tmpFile);
+        self::$shutdownFileRemoval->detach($tmpFile);
     }
 
     /**


### PR DESCRIPTION
This PR should fix #2022

LintManager creates temporary files and deletes them in destructor. In certain circumstances (i. e. fatal error), the destructor not get called. I have solved this by registering shutdown function, which unlinks files left in index.

I'm aware this is not _clean_ solution and atm I have no idea how to write utest for this behavior. Any suggestions are welcome.