### PR TITLE
Specified line endings in .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 .travis.yml export-ignore
 appveyor.yml export-ignore
 phpunit.xml.dist export-ignore
+*.php text eol=lf
+*.test text eol=lf


### PR DESCRIPTION
I suggest specifing line endings into `.gitattributes` file, otherwise hundreds of tests don't pass.