### PR TITLE
Stop using the deprecated DefaultFinder on Config

### DIFF
--- a/Symfony/CS/Config.php
+++ b/Symfony/CS/Config.php
@@ -12,8 +12,6 @@
 
 namespace Symfony\CS;
 
-use Symfony\CS\Finder\DefaultFinder;
-
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Katsuhiro Ogawa <ko.fivestar@gmail.com>
@@ -37,7 +35,7 @@ class Config implements ConfigInterface
         $this->description = $description;
         $this->level = FixerInterface::SYMFONY_LEVEL;
         $this->fixers = array();
-        $this->finder = new DefaultFinder();
+        $this->finder = new Finder();
         $this->customFixers = array();
     }
 


### PR DESCRIPTION
You deprecated this class but you are still using it.

This produce not wanted and not solvable deprecation errors like this: https://travis-ci.org/Soullivaneuh/php-cs-fixer-styleci-bridge/jobs/153204311#L392

Related failing PR from my bridge: https://github.com/Soullivaneuh/php-cs-fixer-styleci-bridge/pull/74