### PR TITLE
LintManager - use best effort approach when cleaning up

### DIFF
--- a/Symfony/CS/LintManager.php
+++ b/Symfony/CS/LintManager.php
@@ -31,7 +31,7 @@ class LintManager
     public function __destruct()
     {
         if (null !== $this->temporaryFile) {
-            unlink($this->temporaryFile);
+            @unlink($this->temporaryFile);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2156

If the file cannot be unlinked PHP will raise a warning which becomes an exception.