### PR TITLE
Fix issue where an exception is thrown if the cache file exists but is empty.

### DIFF
--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -123,7 +123,7 @@ class FileCacheManager
         $data = @unserialize($content);
 
         // ignore corrupted serialized data
-        if (null === $data) {
+        if (!is_array($data)) {
             return;
         }
 


### PR DESCRIPTION
If you attempt to use PHP CS Fixer and have it set to use a cache, and the cache file exists, but is empty, it will throw an exception about a missing array key since ```unserialize()``` does not fail for an empty string.