### PR TITLE
Add dollar sign prefix for consistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,13 @@ your system:
 
 .. code-block:: bash
 
-    \$ wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.12.0/php-cs-fixer.phar -O php-cs-fixer
+    $ wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.12.0/php-cs-fixer.phar -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    \$ curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.12.0/php-cs-fixer.phar -o php-cs-fixer
+    $ curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v1.12.0/php-cs-fixer.phar -o php-cs-fixer
 
 then:
 
@@ -67,7 +67,7 @@ you're good to go:
 
 .. code-block:: bash
 
-    export PATH="$PATH:$HOME/.composer/vendor/bin"
+    $ export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~
@@ -127,8 +127,8 @@ problems as possible on a given file or files in a given directory and its subdi
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir
-    php php-cs-fixer.phar fix /path/to/file
+    $ php php-cs-fixer.phar fix /path/to/dir
+    $ php php-cs-fixer.phar fix /path/to/file
 
 The ``--format`` option for the output format. Supported formats are ``txt`` (default one), ``json`` and ``xml``.
 
@@ -139,10 +139,10 @@ project:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/project --level=psr0
-    php php-cs-fixer.phar fix /path/to/project --level=psr1
-    php php-cs-fixer.phar fix /path/to/project --level=psr2
-    php php-cs-fixer.phar fix /path/to/project --level=symfony
+    $ php php-cs-fixer.phar fix /path/to/project --level=psr0
+    $ php php-cs-fixer.phar fix /path/to/project --level=psr1
+    $ php php-cs-fixer.phar fix /path/to/project --level=psr2
+    $ php php-cs-fixer.phar fix /path/to/project --level=symfony
 
 By default, all PSR-2 fixers and some additional ones are run. The "contrib
 level" fixers cannot be enabled via this option; you should instead set them
@@ -153,20 +153,20 @@ apply (the fixer names must be separated by a comma):
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,short_tag,indentation
+    $ php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,short_tag,indentation
 
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using ``-name_of_fixer``:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=-short_tag,-indentation
+    $ php php-cs-fixer.phar fix /path/to/dir --fixers=-short_tag,-indentation
 
 When using combination with exact and blacklist fixers, apply exact fixers along with above blacklisted result:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag
+    $ php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag
 
 A combination of ``--dry-run`` and ``--diff`` will
 display summary of proposed fixes, leaving your files unchanged.
@@ -176,7 +176,7 @@ automatically fix anything:
 
 .. code-block:: bash
 
-    cat foo.php | php php-cs-fixer.phar fix --diff -
+    $ cat foo.php | php php-cs-fixer.phar fix --diff -
 
 Choose from the list of available fixers:
 
@@ -779,7 +779,7 @@ on some well-known directory structures:
 .. code-block:: bash
 
     # For the Symfony 2.3+ branch
-    php php-cs-fixer.phar fix /path/to/sf23 --config=sf23
+    $ php php-cs-fixer.phar fix /path/to/sf23 --config=sf23
 
 Choose from the list of available configurations:
 
@@ -794,7 +794,7 @@ fixed but without actually modifying them:
 
 .. code-block:: bash
 
-    php php-cs-fixer.phar fix /path/to/code --dry-run
+    $ php php-cs-fixer.phar fix /path/to/code --dry-run
 
 Instead of using command line options to customize the fixer, you can save the
 configuration in a ``.php_cs`` file in the root directory of

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -122,8 +122,8 @@ class FixCommand extends Command
 The <info>%command.name%</info> command tries to fix as much coding standards
 problems as possible on a given file or files in a given directory and its subdirectories:
 
-    <info>php %command.full_name% /path/to/dir</info>
-    <info>php %command.full_name% /path/to/file</info>
+    <info>$ php %command.full_name% /path/to/dir</info>
+    <info>$ php %command.full_name% /path/to/file</info>
 
 The <comment>--format</comment> option for the output format. Supported formats are ``txt`` (default one), ``json`` and ``xml``.
 
@@ -132,10 +132,10 @@ The <comment>--verbose</comment> option will show the applied fixers. When using
 The <comment>--level</comment> option limits the fixers to apply on the
 project:
 
-    <info>php %command.full_name% /path/to/project --level=psr0</info>
-    <info>php %command.full_name% /path/to/project --level=psr1</info>
-    <info>php %command.full_name% /path/to/project --level=psr2</info>
-    <info>php %command.full_name% /path/to/project --level=symfony</info>
+    <info>$ php %command.full_name% /path/to/project --level=psr0</info>
+    <info>$ php %command.full_name% /path/to/project --level=psr1</info>
+    <info>$ php %command.full_name% /path/to/project --level=psr2</info>
+    <info>$ php %command.full_name% /path/to/project --level=symfony</info>
 
 By default, all PSR-2 fixers and some additional ones are run. The "contrib
 level" fixers cannot be enabled via this option; you should instead set them
@@ -144,16 +144,16 @@ manually by their name via the <comment>--fixers</comment> option.
 The <comment>--fixers</comment> option lets you choose the exact fixers to
 apply (the fixer names must be separated by a comma):
 
-    <info>php %command.full_name% /path/to/dir --fixers=linefeed,short_tag,indentation</info>
+    <info>$ php %command.full_name% /path/to/dir --fixers=linefeed,short_tag,indentation</info>
 
 You can also blacklist the fixers you don't want by placing a dash in front of the fixer name, if this is more convenient,
 using <comment>-name_of_fixer</comment>:
 
-    <info>php %command.full_name% /path/to/dir --fixers=-short_tag,-indentation</info>
+    <info>$ php %command.full_name% /path/to/dir --fixers=-short_tag,-indentation</info>
 
 When using combination with exact and blacklist fixers, apply exact fixers along with above blacklisted result:
 
-    <info>php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag</info>
+    <info>$ php php-cs-fixer.phar fix /path/to/dir --fixers=linefeed,-short_tag</info>
 
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
 display summary of proposed fixes, leaving your files unchanged.
@@ -161,7 +161,7 @@ display summary of proposed fixes, leaving your files unchanged.
 The command can also read from standard input, in which case it won't
 automatically fix anything:
 
-    <info>cat foo.php | php %command.full_name% --diff -</info>
+    <info>$ cat foo.php | php %command.full_name% --diff -</info>
 
 Choose from the list of available fixers:
 
@@ -171,7 +171,7 @@ The <comment>--config</comment> option customizes the files to analyse, based
 on some well-known directory structures:
 
     <comment># For the Symfony 2.3+ branch</comment>
-    <info>php %command.full_name% /path/to/sf23 --config=sf23</info>
+    <info>$ php %command.full_name% /path/to/sf23 --config=sf23</info>
 
 Choose from the list of available configurations:
 
@@ -179,7 +179,7 @@ Choose from the list of available configurations:
 The <comment>--dry-run</comment> option displays the files that need to be
 fixed but without actually modifying them:
 
-    <info>php %command.full_name% /path/to/code --dry-run</info>
+    <info>$ php %command.full_name% /path/to/code --dry-run</info>
 
 Instead of using command line options to customize the fixer, you can save the
 configuration in a <comment>.php_cs</comment> file in the root directory of

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -70,13 +70,13 @@ your system:
 
 .. code-block:: bash
 
-    \$ wget %download.url% -O php-cs-fixer
+    $ wget %download.url% -O php-cs-fixer
 
 or with curl:
 
 .. code-block:: bash
 
-    \$ curl -L %download.url% -o php-cs-fixer
+    $ curl -L %download.url% -o php-cs-fixer
 
 then:
 
@@ -107,7 +107,7 @@ you're good to go:
 
 .. code-block:: bash
 
-    export PATH="$PATH:$HOME/.composer/vendor/bin"
+    $ export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 Globally (homebrew)
 ~~~~~~~~~~~~~~~~~~~

--- a/Symfony/CS/Console/Command/SelfUpdateCommand.php
+++ b/Symfony/CS/Console/Command/SelfUpdateCommand.php
@@ -38,7 +38,7 @@ class SelfUpdateCommand extends Command
 The <info>%command.name%</info> command replace your php-cs-fixer.phar by the
 latest version from cs.sensiolabs.org.
 
-<info>php php-cs-fixer.phar %command.name%</info>
+<info>$ php php-cs-fixer.phar %command.name%</info>
 
 EOT
             )


### PR DESCRIPTION
Replace: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2169

It's easier to remove the dollar sign in the readme than to add the dollar sign in the help texts of the commands.

The inline command help in symfony usually does not prefix commands with the dollar sign. 
