### PR TITLE
PhpdocToCommentFixer - fix false positive for docblock of variable

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -167,11 +167,7 @@ class PhpdocToCommentFixer extends AbstractFixer
     {
         $nextIndex = $tokens->getNextMeaningfulToken($variableIndex);
 
-        if (!$tokens[$nextIndex]->equals('=')) {
-            return false;
-        }
-
-        return false !== strpos($docsToken->getContent(), $tokens[$variableIndex]->getContent());
+        return $tokens[$nextIndex]->equals('=');
     }
 
     /**

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
@@ -216,6 +216,17 @@ $loader = require_once __DIR__."/vendor/autoload.php";
 $first = true;// needed because by default first docblock is never fixed.
 
 /**
+ * @var ClassLoader $loader
+ */
+$loader = require_once __DIR__."/../app/autoload.php";
+',
+        );
+
+        $cases[] = array(
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
  * Do not convert this
  *
  * @var Foo

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
@@ -179,6 +179,58 @@ $first = true;// needed because by default first docblock is never fixed.
 /**
  * Do not convert this
  *
+ * @var int
+ */
+$a = require "require.php";
+
+/**
+ * Do not convert this
+ *
+ * @var int
+ */
+$b = require_once "require_once.php";
+
+/**
+ * Do not convert this
+ *
+ * @var int
+ */
+$c = include "include.php";
+
+/**
+ * Do not convert this
+ *
+ * @var int
+ */
+$d = include_once "include_once.php";
+
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require_once __DIR__."/vendor/autoload.php";
+',
+        );
+
+        $cases[] = array(
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
+ * Do not convert this
+ *
+ * @var Foo
+ */
+$foo = createFoo();
+',
+        );
+
+        $cases[] = array(
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
+ * Do not convert this
+ *
  * @var bool $local
  */
 $local = true;
@@ -189,16 +241,8 @@ $local = true;
             '<?php
 $first = true;// needed because by default first docblock is never fixed.
 
-/*
- * This should be a normal comment
- */
-$local = true;
-',
-            '<?php
-$first = true;// needed because by default first docblock is never fixed.
-
 /**
- * This should be a normal comment
+ * Comment
  */
 $local = true;
 ',

--- a/Symfony/CS/Tests/Fixtures/Integration/misc/phpdoc_to_comment,phpdoc_var_without_name.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/misc/phpdoc_to_comment,phpdoc_var_without_name.test
@@ -1,0 +1,26 @@
+--TEST--
+Integration of fixers: phpdoc_to_comment,phpdoc_var_without_name.
+--CONFIG--
+level=none
+fixers=phpdoc_to_comment,phpdoc_var_without_name
+--SETTINGS--
+checkPriority=false
+--EXPECT--
+<?php
+
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
+ * @var ClassLoader
+ */
+$loader = require_once __DIR__.'/../app/autoload.php';
+
+--INPUT--
+<?php
+
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
+ * @var ClassLoader $loader
+ */
+$loader = require_once __DIR__.'/../app/autoload.php';


### PR DESCRIPTION
Fixes #1715

https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#description-21

> The `@var` tag MUST contain the name of the element it documents. An exception to this is when property declarations only refer to a single property. In this case the name of the property MAY be omitted.