### PR TITLE
UnneededControlParenthesesFixer - Fix more return cases.

### DIFF
--- a/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/UnneededControlParenthesesFixer.php
@@ -42,7 +42,7 @@ final class UnneededControlParenthesesFixer extends AbstractFixer
         'continue' => array('lookupTokens' => T_CONTINUE, 'neededSuccessors' => array(';')),
         'clone' => array('lookupTokens' => T_CLONE, 'neededSuccessors' => array(';', ':', ',', ')'), 'forbiddenContents' => array('?', ':')),
         'echo_print' => array('lookupTokens' => array(T_ECHO, T_PRINT), 'neededSuccessors' => array(';', array(T_CLOSE_TAG))),
-        'return' => array('lookupTokens' => T_RETURN, 'neededSuccessors' => array(';')),
+        'return' => array('lookupTokens' => T_RETURN, 'neededSuccessors' => array(';', array(T_CLOSE_TAG))),
         'switch_case' => array('lookupTokens' => T_CASE, 'neededSuccessors' => array(';', ':')),
     );
 

--- a/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/UnneededControlParenthesesFixerTest.php
@@ -313,6 +313,14 @@ final class UnneededControlParenthesesFixerTest extends AbstractFixerTestBase
             ),
             array(
                 '<?php
+                return 2?>
+                ',
+                '<?php
+                return(2)?>
+                ',
+            ),
+            array(
+                '<?php
                 switch ($a) {
                     case "prod":
                         break;


### PR DESCRIPTION
Cases like these can be fixed as well:

```php
<?php
//
return(2)?>
```

This solves a not tested priority issue on master with the `semicolon_after_instruction`