### PR TITLE
PhpdocTypesFixer - support iterable type

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocTypesFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocTypesFixer.php
@@ -34,6 +34,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer
         'float',
         'int',
         'integer',
+        'iterable',
         'mixed',
         'null',
         'object',

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypesFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocTypesFixerTest.php
@@ -91,6 +91,30 @@ EOF;
         $this->makeTest($expected, $input);
     }
 
+    public function testIterableFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param iterable $foo
+     *
+     * @return Itter
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param Iterable $foo
+     *
+     * @return Itter
+     */
+
+EOF;
+        $this->makeTest($expected, $input);
+    }
+
     public function testMethodAndPropertyFix()
     {
         $expected = <<<'EOF'


### PR DESCRIPTION
PHP 7.1 will have the `iterable` type. We should treat it like the other types we normalize.

Refs:
* https://wiki.php.net/rfc/iterable
* https://github.com/php/php-src/pull/1941
* https://github.com/php/php-src/blob/php-7.1.0RC2/UPGRADING#L25-L27