### PR TITLE
FileCacheManager - fix exception message and undefined property

### DIFF
--- a/Symfony/CS/FileCacheManager.php
+++ b/Symfony/CS/FileCacheManager.php
@@ -153,7 +153,7 @@ class FileCacheManager
         );
 
         if (false === @file_put_contents($this->dir.self::CACHE_FILE, $data, LOCK_EX)) {
-            throw new IOException(sprintf('Failed to write file "%s".', $this->cacheFile), 0, null, $this->cacheFile);
+            throw new IOException(sprintf('Failed to write file "%s".', self::CACHE_FILE), 0, null, $this->dir.self::CACHE_FILE);
         }
     }
 }


### PR DESCRIPTION
It occurs when the cache can't be written.