### PR TITLE
make fixers less risky

### DIFF
--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -24,18 +24,18 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
      * @var array the list of the string-related function names and their mb_ equivalent
      */
     private static $functions = array(
-        'strlen' => 'mb_strlen',
-        'strpos' => 'mb_strpos',
-        'strrpos' => 'mb_strrpos',
-        'substr' => 'mb_substr',
-        'strtolower' => 'mb_strtolower',
-        'strtoupper' => 'mb_strtoupper',
-        'stripos' => 'mb_stripos',
-        'strripos' => 'mb_strripos',
-        'strstr' => 'mb_strstr',
-        'stristr' => 'mb_stristr',
-        'strrchr' => 'mb_strrchr',
-        'substr_count' => 'mb_substr_count',
+        'strlen' => array('alternativeName' => 'mb_strlen', 'argumentCount' => array(1)),
+        'strpos' => array('alternativeName' => 'mb_strpos', 'argumentCount' => array(2, 3)),
+        'strrpos' => array('alternativeName' => 'mb_strrpos', 'argumentCount' => array(2, 3)),
+        'substr' => array('alternativeName' => 'mb_substr', 'argumentCount' => array(2, 3)),
+        'strtolower' => array('alternativeName' => 'mb_strtolower', 'argumentCount' => array(1)),
+        'strtoupper' => array('alternativeName' => 'mb_strtoupper', 'argumentCount' => array(1)),
+        'stripos' => array('alternativeName' => 'mb_stripos', 'argumentCount' => array(2, 3)),
+        'strripos' => array('alternativeName' => 'mb_strripos', 'argumentCount' => array(2, 3)),
+        'strstr' => array('alternativeName' => 'mb_strstr', 'argumentCount' => array(2, 3)),
+        'stristr' => array('alternativeName' => 'mb_stristr', 'argumentCount' => array(2, 3)),
+        'strrchr' => array('alternativeName' => 'mb_strrchr', 'argumentCount' => array(2)),
+        'substr_count' => array('alternativeName' => 'mb_substr_count', 'argumentCount' => array(2, 3, 4)),
     );
 
     /**
@@ -59,7 +59,7 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach (self::$functions as $functionIdentity => $newName) {
+        foreach (self::$functions as $functionIdentity => $functionReplacement) {
             $currIndex = 0;
             while (null !== $currIndex) {
                 // try getting function reference and translate boundaries for humans
@@ -69,12 +69,16 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
                     continue 2;
                 }
 
-                list($functionName, $openParenthesis) = $boundaries;
+                list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
+                $count = $this->countArguments($tokens, $openParenthesis, $closeParenthesis);
+                if (!in_array($count, $functionReplacement['argumentCount'], true)) {
+                    continue 2;
+                }
 
                 // analysing cursor shift, so nested calls could be processed
                 $currIndex = $openParenthesis;
 
-                $tokens[$functionName]->setContent($newName);
+                $tokens[$functionName]->setContent($functionReplacement['alternativeName']);
             }
         }
     }

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -58,12 +58,9 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
                 // analysing cursor shift
                 $currIndex = $openParenthesis;
 
-                // special case: intval with 2 parameters shall not be processed (base conversion)
-                if ('intval' === $functionIdentity) {
-                    $parametersCount = $this->countArguments($tokens, $openParenthesis, $closeParenthesis);
-                    if ($parametersCount > 1) {
-                        continue;
-                    }
+                // indicator that the function is overriden
+                if (1 !== $this->countArguments($tokens, $openParenthesis, $closeParenthesis)) {
+                    continue;
                 }
 
                 // check if something complex passed as an argument and preserve parenthesises then
@@ -90,6 +87,7 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
                     new Token($newToken),
                     new Token(array(T_WHITESPACE, ' ')),
                 );
+
                 if (!$preserveParenthesises) {
                     // closing parenthesis removed with leading spaces
                     $tokens->removeLeadingWhitespace($closeParenthesis);

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -40,11 +40,12 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
             array('<?php $x = Foo\strlen("bar");'),
             array('<?php $x = strlen::call("bar");'),
             array('<?php $x = $foo->strlen("bar");'),
-
+            array('<?php $x = strlen();'), // number of arguments mismatch
+            array('<?php $x = strlen($a, $b);'), // number of arguments mismatch
             array('<?php $x = mb_strlen("bar");', '<?php $x = strlen("bar");'),
             array('<?php $x = \mb_strlen("bar");', '<?php $x = \strlen("bar");'),
-            array('<?php $x = mb_strtolower(mb_strstr("bar"));', '<?php $x = strtolower(strstr("bar"));'),
-            array('<?php $x = mb_strtolower( \mb_strstr ("bar"));', '<?php $x = strtolower( \strstr ("bar"));'),
+            array('<?php $x = mb_strtolower(mb_strstr("bar", "a"));', '<?php $x = strtolower(strstr("bar", "a"));'),
+            array('<?php $x = mb_strtolower( \mb_strstr ("bar", "a"));', '<?php $x = strtolower( \strstr ("bar", "a"));'),
             array('<?php $x = mb_substr("bar", 2, 1);', '<?php $x = substr("bar", 2, 1);'),
         );
     }

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -23,7 +23,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 {
     /**
      * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [random_api_migration] "is_null" is not handled by the fixer.
+     * @expectedExceptionMessageRegExp #^\[random_api_migration\] "is_null" is not handled by the fixer.$#
      */
     public function testConfigureCheckSearchFunction()
     {
@@ -32,7 +32,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 
     /**
      * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [random_api_migration] Expected string got "NULL".
+     * @expectedExceptionMessageRegExp #^\[random_api_migration\] Expected string got "NULL".$#
      */
     public function testConfigureCheckReplacementType()
     {
@@ -46,7 +46,10 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 
         /** @var $replacements string[] */
         $replacements = static::getObjectAttribute($this->getFixer(), 'configuration');
-        static::assertSame($config, $replacements);
+        static::assertSame(
+            array('rand' => array('alternativeName' => 'random_int', 'argumentCount' => array(0, 2))),
+            $replacements
+        );
     }
 
     /**
@@ -123,8 +126,9 @@ class srand extends SrandClass{
     public function provideCasesForCustomConfiguration()
     {
         return array(
-            array('<?php random_int(random_int($a));', '<?php rand(rand($a));'),
-            array('<?php random_int(\Other\Scope\mt_rand($a));', '<?php rand(\Other\Scope\mt_rand($a));'),
+            array('<?php rand(rand($a));'),
+            array('<?php random_int($d, random_int($a,$b));', '<?php rand($d, rand($a,$b));'),
+            array('<?php random_int($a, \Other\Scope\mt_rand($a));', '<?php rand($a, \Other\Scope\mt_rand($a));'),
         );
     }
 }

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -120,7 +120,7 @@ OVERRIDDEN;
             array('<?php $x = (float) $x;', '<?php $x = floatval($x);'),
             array('<?php $x = (float) $x;', '<?php $x = doubleval($x);'),
             array('<?php $x = (string) $x;', '<?php $x = strval($x);'),
-            array('<?php $x = (bool) $x;', '<?php $x = boolval($x);'),
+            array('<?php $x = (bool) $x;', '<?php $x = boolval   (  $x  );'),
             array('<?php $x = (int) (mt_rand(0, 100));', '<?php $x = intval(mt_rand(0, 100));'),
             array('<?php $x = (int) (mt_rand(0, 100));', '<?php $x = \\intval(mt_rand(0, 100));'),
             array('<?php $x = (int) (mt_rand(0, 100)).".dist";', '<?php $x = intval(mt_rand(0, 100)).".dist";'),
@@ -136,6 +136,9 @@ OVERRIDDEN;
             array(
                 '<?php $x = (string) ((int) ((int) $x + (float) $x));',
                 '<?php $x = strval(intval(intval($x) + floatval($x)));',
+            ),
+            array(
+                '<?php intval();intval(1,2,3);',
             ),
         );
     }


### PR DESCRIPTION
Input:

```php
<?php

intval();
die;
```

Output:

```php
<?php

(int) ;
die;
```

This PR output:

```php
<?php

intval();
die;
```

(i.e. no change)

This PR makes some of the function replacement fixer less risky as these will now check if the number of arguments are as expected before changing the code.