### PR TITLE
Added fixer for PHPUnit's @expectedException annotation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -349,6 +349,10 @@ Choose from the list of available fixers:
 * **operators_spaces** [symfony]
    Binary operators should be surrounded by at least one space.
 
+* **php_unit_fqcn_annotation** [symfony]
+   PHPUnit @expectedException annotation should be a FQCN including a root
+   namespace.
+
 * **phpdoc_annotation_without_dot** [symfony]
    Phpdocs annotation descriptions should not end with a full stop.
 

--- a/Symfony/CS/Fixer/Symfony/PhpUnitFqcnAnnotationFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpUnitFqcnAnnotationFixer.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Symfony;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+final class PhpUnitFqcnAnnotationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens as $token) {
+            if ($token->isGivenKind(T_DOC_COMMENT)) {
+                $token->setContent(preg_replace('~^(\s*\*\s*@expectedException\h+)(\w.*)$~m', '$1\\\\$2', $token->getContent()));
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'PHPUnit @expectedException annotation should be a FQCN including a root namespace.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run before UnusedUseFixer
+        return -9;
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpUnitFqcnAnnotationFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpUnitFqcnAnnotationFixerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Symfony;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @internal
+ */
+final class PhpUnitFqcnAnnotationFixerTest extends AbstractFixerTestBase
+{
+    public function testFix()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @ExpectedException Value
+     * @expectedException \X
+     * @expectedException
+     * @expectedException \Exception
+         * @expectedException \Some\Exception\ClassName
+ * @expectedExceptionCode 123
+     * @expectedExceptionMessage Foo bar
+     */
+EOF;
+        $input = <<<'EOF'
+<?php
+    /**
+     * @ExpectedException Value
+     * @expectedException X
+     * @expectedException
+     * @expectedException \Exception
+         * @expectedException Some\Exception\ClassName
+ * @expectedExceptionCode 123
+     * @expectedExceptionMessage Foo bar
+     */
+EOF;
+
+        $this->makeTest($expected, $input);
+    }
+}

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -251,6 +251,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['no_useless_else'], $fixers['whitespacy_lines']), // tested also in: no_useless_else,whitespacy_lines.test
             array($fixers['short_array_syntax'], $fixers['unalign_equals']), // tested also in: short_array_syntax,unalign_equals.test
             array($fixers['short_array_syntax'], $fixers['ternary_spaces']), // tested also in: short_array_syntax,ternary_spaces.test
+            array($fixers['php_unit_fqcn_annotation'], $fixers['unused_use']), // tested also in: php_unit_fqcn_annotation,unused_use.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,unused_use.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,unused_use.test
@@ -1,0 +1,29 @@
+--TEST--
+Integration of fixers: php_unit_fqcn_annotation,unused_use.
+--CONFIG--
+level=none
+fixers=php_unit_fqcn_annotation,unused_use
+--EXPECT--
+<?php
+
+class Foo extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Exception
+     */
+    public function testBar()
+    { }
+}
+
+--INPUT--
+<?php
+use Some\Exception;
+
+class Foo extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Exception
+     */
+    public function testBar()
+    { }
+}

--- a/Symfony/CS/Tests/Fixtures/Integration/set/@Symfony.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/set/@Symfony.test
@@ -77,3 +77,13 @@ class FooBar
         return !$value;
     }
 }
+
+class FooBarTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \Exception
+     */
+    public function testFooBar()
+    {
+    }
+}


### PR DESCRIPTION
In favor of #2200
- [x] Rename to `PhpUnitFqcnAnnotationFixer`
