### PR TITLE
add no_yoda_contition to contrib fixers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -532,6 +532,10 @@ Choose from the list of available fixers:
 * **no_useless_return** [contrib]
    There should not be an empty return statement at the end of a function.
 
+* **no_yoda_condition** [contrib]
+   No Yoda condition for ==, !=, ===, and !==. Warning! This could change
+   code behavior.
+
 * **ordered_use** [contrib]
    Ordering use statements.
 

--- a/Symfony/CS/Fixer/Contrib/NoYodaConditionFixer.php
+++ b/Symfony/CS/Fixer/Contrib/NoYodaConditionFixer.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+
+/**
+ * @author Nicola Pietroluongo <nik.longstone@gmail.com>
+ */
+class NoYodaConditionFixer extends AbstractFixer
+{
+    private $conditions = array(
+        array(T_IS_EQUAL),
+        array(T_IS_NOT_EQUAL),
+        array(T_IS_IDENTICAL),
+        array(T_IS_NOT_IDENTICAL),
+    );
+
+    private $yodaToken = array(
+        array(T_LNUMBER),
+        array(T_STRING),
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        foreach ($tokens as $index => $token) {
+            if ($token->equalsAny($this->conditions)) {
+                $previousTokenNonWhiteIndex = $tokens->getPrevNonWhitespace($index);
+                $previousToken = $tokens[$previousTokenNonWhiteIndex];
+                if ($previousToken->equalsAny($this->yodaToken)) {
+                    $nextNonWhiteIndex = $tokens->getNextNonWhitespace($index);
+                    $nextToken = $tokens[$nextNonWhiteIndex];
+                    if (!$nextToken->equalsAny($this->yodaToken)) {
+                        $tokens[$previousTokenNonWhiteIndex] = $nextToken;
+                        $tokens[$nextNonWhiteIndex] = $previousToken;
+                    }
+                }
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'No Yoda condition for ==, !=, ===, and !==. Warning! This could change code behavior.';
+    }
+}

--- a/Symfony/CS/Tests/Fixer/Contrib/NoYodaConditionFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/NoYodaConditionFixerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+/**
+ * @author Nicola Pietroluongo <nik.longstone@gmail.com>
+ */
+class NoYodaConditionFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideExamples()
+    {
+        $yodaOperators = array('==', '===', '!=', '!==');
+        $excludedOperators = array('<>', '<=', '>=',
+
+        );
+
+        $correctData = array();
+        foreach (array_merge($yodaOperators, $excludedOperators) as $operator) {
+            $correctData = array_merge($correctData, $this->getCorrectDataWithOperator($operator));
+        }
+
+        $incorrectData = array();
+        foreach (array_merge($yodaOperators) as $operator) {
+            $incorrectData = array_merge($incorrectData, $this->getIncorrectDataWithOperator($operator));
+        }
+
+        return array_merge(
+            $correctData,
+            $incorrectData
+        );
+    }
+
+    /**
+     * What is incorrect should be changed.
+     */
+    private function getIncorrectDataWithOperator($operator)
+    {
+        return array(
+            array('<?php if ( $theForce '.$operator.' 1 ) { }  ;', '<?php if ( 1 '.$operator.' $theForce ) { }  ;'),
+            array('<?php if ( $theForce '.$operator.' null ) { }  ;', '<?php if ( null '.$operator.' $theForce ) { }  ;'),
+            array('<?php if ( $theForce '.$operator.' true ) { }  ;', '<?php if ( true '.$operator.' $theForce ) { }  ;'),
+            array('<?php if ( $theForce '.$operator.' false ) { }  ;', '<?php if ( false '.$operator.' $theForce ) { }  ;'),
+        );
+    }
+
+    /**
+     * What is correct should not be changed.
+     */
+    private function getCorrectDataWithOperator($operator)
+    {
+        return array(
+            array('<?php if ( $theForce '.$operator.' 1 ) { }  ;'),
+            array('<?php if ( $theForce '.$operator.' 1 && $sith '.$operator.' 0) { }  ;'),
+            array('<?php if ( $theForce '.$operator.' "be with you" ) { }  ;'),
+            array('<?php if ( 0 '.$operator.' 1 ) { }  ;'),
+            array('<?php if ( true '.$operator.' false ) { }  ;'),
+            array('<?php if ( "Yoda" '.$operator.' "Jedi" ) { }  ;'),
+            array('<?php if ( $yoda '.$operator.' $jedi ) { }  ;'),
+            array("<?php if ( 'may the force' '.$operator.' 'be with you' ) { }  ;"),
+        );
+    }
+}


### PR DESCRIPTION
No Yoda condition for ==, !=, ===, and !==

example:
Given: `1 === $mayTheForceBeWithYou`
The result should be: `$mayTheForceBeWithYou === 1`  
