### PR TITLE
NoEmptyLinesAfterPhpdocs, SingleBlankLineBeforeNamespace - Fix priority

### DIFF
--- a/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyLinesAfterPhpdocsFixer.php
@@ -61,6 +61,15 @@ class NoEmptyLinesAfterPhpdocsFixer extends AbstractFixer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be ran before the SingleBlankLineBeforeNamespaceFixer.
+        return 1;
+    }
+
+    /**
      * Cleanup a whitespace token.
      *
      * @param Token $token

--- a/Symfony/CS/Tests/FixerTest.php
+++ b/Symfony/CS/Tests/FixerTest.php
@@ -251,6 +251,7 @@ class FixerTest extends \PHPUnit_Framework_TestCase
             array($fixers['no_useless_else'], $fixers['whitespacy_lines']), // tested also in: no_useless_else,whitespacy_lines.test
             array($fixers['short_array_syntax'], $fixers['unalign_equals']), // tested also in: short_array_syntax,unalign_equals.test
             array($fixers['short_array_syntax'], $fixers['ternary_spaces']), // tested also in: short_array_syntax,ternary_spaces.test
+            array($fixers['no_empty_lines_after_phpdocs'], $fixers['single_blank_line_before_namespace']), // tested also in: no_empty_lines_after_phpdocs,single_blank_line_before_namespace.test
         );
 
         $docFixerNames = array_filter(

--- a/Symfony/CS/Tests/Fixtures/Integration/priority/no_empty_lines_after_phpdocs,single_blank_line_before_namespace.test
+++ b/Symfony/CS/Tests/Fixtures/Integration/priority/no_empty_lines_after_phpdocs,single_blank_line_before_namespace.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: no_empty_lines_after_phpdocs,single_blank_line_before_namespace.
+--CONFIG--
+level=none
+fixers=no_empty_lines_after_phpdocs,single_blank_line_before_namespace
+--EXPECT--
+<?php
+/**
+ * Header
+ */
+
+namespace A\B;
+
+class A {}
+
+--INPUT--
+<?php
+/**
+ * Header
+ */
+
+
+namespace A\B;
+
+class A {}


### PR DESCRIPTION
closes: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2222

The priority can go both ways, I just picked one to prove the prio issue.