### PR TITLE
Add a test for style of varaible decalration : var

### DIFF
--- a/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/PhpdocToCommentFixer.php
@@ -110,6 +110,7 @@ class PhpdocToCommentFixer extends AbstractFixer
             T_PRIVATE,
             T_PROTECTED,
             T_PUBLIC,
+            T_VAR,
             T_FUNCTION,
             T_ABSTRACT,
             T_CONST,

--- a/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/PhpdocToCommentFixerTest.php
@@ -65,6 +65,11 @@ class DocBlocks
     /**
      * Do not convert this
      */
+    var $oldPublicStyle;
+
+    /**
+     * Do not convert this
+     */
     public function test() {}
 
     /**


### PR DESCRIPTION
Bug fix: 
Symfony\CS\Fixer\Symfony\PhpdocToCommentFixer 

Was converting doc-block from old style "var" property declaration


