### PR TITLE
Added some failing PHP7 test cases for ordered_use

### DIFF
--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -639,6 +639,30 @@ use A\B;
 use const some\a\{ConstA, ConstB, ConstC};
 ',
             ),
+            array(
+                '<?php
+use A\B;
+use some\a\{  ClassA as A,ClassB, ClassC};
+use const some\a\{ConstA,ConstC,ConstB};
+use function some\a\{fn_a,  fn_b,fn_c   };
+',
+                '<?php
+use some\a\{  ClassB,ClassC, ClassA as A};
+use function some\a\{fn_c,  fn_a,fn_b   };
+use A\B;
+use const some\a\{ConstA,ConstB,ConstC};
+',
+            ),
+            array(
+                '<?php
+use Foo\Bar\Baz, Foo\Bir;
+use Foo\Bar\{ClassA,ClassB, ClassC};
+',
+                '<?php
+use Foo\Bar\Baz, Foo\Bir;
+use Foo\Bar\{ClassA, ClassB, ClassC};
+',
+            ),
         );
     }
 }


### PR DESCRIPTION
This PR adds two test cases for ordered_use fixer and group use declarations (PHP7).

Test case 1: Imports inside group use declarations should be ordered too.
Test case 2: The fixer generates invalid PHP.
