### PR TITLE
IntegrationCase - no longer internal

### DIFF
--- a/Symfony/CS/Test/IntegrationCase.php
+++ b/Symfony/CS/Test/IntegrationCase.php
@@ -16,8 +16,6 @@ use Symfony\CS\FixerInterface;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
- *
- * @internal
  */
 final class IntegrationCase
 {


### PR DESCRIPTION
`IntegrationCase` is part of `AbstractIntegrationTestCase` interface, which is not internal, so `IntegrationCase` cannot be internal as well.
`IntegrationCaseFactory` is not part of internal implementation of `AbstractIntegrationTestCase`, so it could still be internal