### PR TITLE
ClassDefinitionFixer - Set configuration of the fixer in the RuleSet of SF.

### DIFF
--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -57,6 +57,7 @@ final class RuleSet implements RuleSetInterface
             'blank_line_after_opening_tag' => true,
             'blank_line_before_return' => true,
             'cast_spaces' => true,
+            'class_definition' => array('singleLine' => true),
             'concat_without_spaces' => true,
             'declare_equal_normalize' => true,
             'function_typehint_space' => true,

--- a/tests/Fixtures/Integration/set/@Symfony.test-in.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-in.php
@@ -85,7 +85,20 @@ class FooBar
     }
 }
 
-class FooBarTest extends \PHPUnit_Framework_TestCase
+interface Test1Interface
+{
+
+}
+
+interface Test2Interface
+{
+}
+
+class FooBarTest extends
+    \PHPUnit_Framework_TestCase
+implements
+    Test1Interface,
+    Test2Interface
 {
     /**
      * @expectedException Exception

--- a/tests/Fixtures/Integration/set/@Symfony.test-out.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-out.php
@@ -86,7 +86,15 @@ class FooBar
     }
 }
 
-class FooBarTest extends \PHPUnit_Framework_TestCase
+interface Test1Interface
+{
+}
+
+interface Test2Interface
+{
+}
+
+class FooBarTest extends \PHPUnit_Framework_TestCase implements Test1Interface, Test2Interface
 {
     /**
      * @expectedException \Exception


### PR DESCRIPTION
These are the last things for the master branch after #2155 was merged to 1.12
@ see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2155#issuecomment-257109271