### PR TITLE
Use empty_return

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -16,6 +16,7 @@ return Symfony\CS\Config::create()
     // use default SYMFONY_LEVEL and extra fixers:
     ->fixers(array(
         'combine_consecutive_unsets',
+        'empty_return',
         'header_comment',
         'long_array_syntax',
         'no_useless_else',


### PR DESCRIPTION
Using a `return null` statement at the end of a function will make fabbot.io complain and suggest a patch. Using `empty_return` fixer will prevent this.