### PR TITLE
Added a fixer to add a New Line before phpdoc (white list).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -576,6 +576,10 @@ Choose from the list of available rules:
 * **single_blank_line_before_namespace** [@Symfony]
    | There should be exactly one blank line before a namespace declaration.
 
+* **single_blank_line_before_phpdoc**
+   | Adds a blank line before phpdoc, if preceded by a ";" or a "}" or a
+   | comment or a docblock, unless that docblock is an inline @var.
+
 * **single_class_element_per_statement** [@PSR2, @Symfony]
    | There MUST NOT be more than one property or constant declared per
    | statement.

--- a/src/Fixer/Phpdoc/SingleBlankLineBeforePhpdocFixer.php
+++ b/src/Fixer/Phpdoc/SingleBlankLineBeforePhpdocFixer.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Phpdoc;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Adds a blank line before phpdoc.
+ *
+ * Adds a blank line before phpdoc,
+ * if preceded by a ";" or a "}" or a comment or a docblock, unless that docblock is an inline @var
+ *
+ * @author Jonathan Daigle
+ */
+final class SingleBlankLineBeforePhpdocFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
+            /** @var Token $token */
+            $token = $tokens[$index];
+
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            /* @var Token $previousToken */
+            $previousIndex = $tokens->getPrevNonWhitespace($index);
+            $previousToken = $tokens[$previousIndex];
+
+            // If the previous token token is a ; or a } or a comment but not an @var inline comment
+            // Then a blank line must passed
+            $requiredDistance = 1;
+            $content = $previousToken->getContent();
+            if ($content === ';' || $content === '}' || ($previousToken->isComment() && !$this->isInlineAtVar($content))) {
+                $requiredDistance = 2;
+            }
+
+            $distance = $this->getNbLinesInBetween($tokens, $previousIndex, $index);
+
+            $needDistance = $requiredDistance - $distance;
+            if ($needDistance > 0) {
+                $index += $this->addNewLineAt($tokens, $index, $needDistance);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return 'Adds a blank line before phpdoc, if preceded by a ";" or a "}" or a comment or a docblock, unless that docblock is an inline @var.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * Insert 1 line at $index.
+     *
+     * @return 0|1 Increment for the index
+     */
+    private function addNewLineAt(Tokens $tokens, $index, $nbLines = 1)
+    {
+        $prevToken = $tokens[$index - 1];
+
+        if ($prevToken->isWhitespace()) {
+            $parts = explode("\n", $prevToken->getContent());
+            $countParts = count($parts);
+
+            if (1 === $countParts) {
+                $prevToken->setContent(rtrim($prevToken->getContent(), " \t").str_repeat("\n", $nbLines));
+            } elseif (count($parts) <= 2) {
+                $prevToken->setContent(str_repeat("\n", $nbLines).$prevToken->getContent());
+            }
+
+            return 0;
+        }
+
+        $tokens->insertAt($index, new Token(array(T_WHITESPACE, str_repeat("\n", $nbLines))));
+
+        return 1;
+    }
+
+    /**
+     * Get number of lines Between Tokens index.
+     *
+     * @return int
+     */
+    private function getNbLinesInBetween(Tokens $tokens, $start, $end)
+    {
+        $distance = 0;
+        if (!$tokens[$start]->isComment()) {
+            $distance += substr_count($tokens[$start]->getContent(), "\n");
+        }
+
+        for ($i = $start + 1; $i < $end; ++$i) {
+            $token = $tokens[$i];
+            $distance += substr_count($token->getContent(), "\n");
+        }
+
+        return $distance;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return bool
+     */
+    private function isInlineAtVar($content)
+    {
+        return (bool) preg_match('|\/\*\* +@var +(\$?[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\\]* ?){1,2} *\*\/|', $content);
+    }
+}

--- a/tests/Fixer/Phpdoc/SingleBlankLineBeforePhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/SingleBlankLineBeforePhpdocFixerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\tests\Fixer\Phpdoc;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Jonathan Daigle
+ *
+ * @internal
+ */
+final class SingleBlankLineBeforePhpdocFixerTest extends AbstractFixerTestCase
+{
+    public function providePhpdocExample()
+    {
+        $return = array();
+
+        // All valid cases
+        $return[] = array('
+<?php
+/**
+ * I am a file doc-block
+ */
+
+/** @var array $var */
+$var1 = 1;
+
+if (true) {
+    /** @var int $var2 */
+    $var2 = 1;
+} else if (false) {
+    /** @var int $var3 */
+    $var3 = 1;
+} 
+else 
+{
+    /** @var int $var4 */
+    $var4 = 1;
+}
+
+/** @var int $key */
+/** @var int $value */
+foreach ($var2 as $key => $value) {
+    /** @var string $bob */
+    $bob = (string) $key + $value;
+}
+
+/**
+ * I am a class dockblock
+ */
+class MyClass
+{
+    /**
+     * I am the first property of a class
+     *
+     * @var int
+     */
+     public $prop1;
+     
+     /**
+      * @return void
+      */
+     public function foo()
+     {
+         /** @var bool $bar */
+         $bar = false;
+     }
+}
+');
+        $return[] = array("#!/bin/php\n<?php\n/**\n * File Doc\n */");
+        $return[] = array("#!/usr/bin/env php\n<?php\n/**\n * File Doc\n */");
+
+        // Test that a NL is added if docblock start on same line a previous token.
+        $return[] = array(
+            "<?php \n/** @var int \$foo */\n\$foo=1;\n\n/** @var bool \$bar */\n",
+            "<?php /** @var int \$foo */\n\$foo=1; /** @var bool \$bar */\n",
+        );
+
+        $return[] = array(
+'<?php
+/**
+ * File Doc
+ */
+ 
+/**
+ * Class Doc
+ */
+abstract class MyClass {
+    /**
+     * PropertyDoc
+     */
+     public $prop1;
+
+    /**
+     * PropertyDoc2
+     *
+     * @var int
+     */
+     public static $prop2;
+
+     /**
+      * Function Doc
+      */
+      static public function myMethod()
+      {
+        $this->prop2 = 1;
+      }
+
+      /**
+       * Function Doc
+       */
+      abstract static public function myMethod2();
+}',
+'<?php
+/**
+ * File Doc
+ */ 
+/**
+ * Class Doc
+ */
+abstract class MyClass {
+    /**
+     * PropertyDoc
+     */
+     public $prop1;
+    /**
+     * PropertyDoc2
+     *
+     * @var int
+     */
+     public static $prop2;
+     /**
+      * Function Doc
+      */
+      static public function myMethod()
+      {
+        $this->prop2 = 1;
+      }
+      /**
+       * Function Doc
+       */
+      abstract static public function myMethod2();
+}',
+        );
+
+        return $return;
+    }
+
+    /**
+     * @dataProvider providePhpdocExample
+     */
+    public function testSingleLineBeforePhpdoc($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+}


### PR DESCRIPTION
Adds a blank line before a phpDoc block.
If the previous token is ; or } or a comment
or a doc block, unless that docblock is an inline @var 

So this is version of the fixer, where the element that should have a blank line are white listed.

The original version here : https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2248 took the reverse approach, where it was blacklisting the element that should not be followed by a blank line before a dockblock
