### PR TITLE
Add custom dumper for Token.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5|^5",
-        "satooshi/php-coveralls": "^1.0"
+        "satooshi/php-coveralls": "^1.0",
+        "symfony/var-dumper": "^2.3|^3.0"
     },
     "conflict": {
         "hhvm": "<3.9"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="./vendor/autoload.php"
+         bootstrap="./tests/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/TokenCaster.php
+++ b/tests/TokenCaster.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests;
+
+use PhpCsFixer\Tokenizer\Token;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * @author SpacePossum
+ */
+final class TokenCaster
+{
+    public function castToken(Token $token, array $object, Stub $stub, $isNested)
+    {
+        $classPrefix = sprintf("\0%s\0", $stub->class);
+        return array(
+            $classPrefix.'id' => $token->getId(),
+            $classPrefix.'content' => $token->getContent(),
+            $classPrefix.'isArray' => $token->isArray(),
+            'name' => $token->getName(),
+            'isComment' => $token->isComment(),
+            'isEmpty' => $token->isEmpty(), // (cleared)
+            'isWhiteSpace' => $token->isWhitespace(),
+        );
+    }
+}

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use PhpCsFixer\Tests\TokenCaster;
+use PhpCsFixer\Tokenizer\Token;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+if (class_exists('\Symfony\Component\VarDumper\VarDumper')) {
+    $cloner = new VarCloner();
+    $cloner->addCasters(array(Token::class => TokenCaster::class.'::castToken'));
+    $dumper = new CliDumper();
+    VarDumper::setHandler(
+        function ($var) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var));
+        }
+    );
+}


### PR DESCRIPTION
![dump](https://cloud.githubusercontent.com/assets/10462973/20029498/ec9da10a-a34d-11e6-900d-7201539114b9.png)

left is new, right is default of SF dumper when using `dump($token)` in a unit test