### PR TITLE
NoExtraConsecutiveBlankLinesFixer - fix bug that removes empty line already after scope end

### DIFF
--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -251,7 +251,10 @@ final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements W
         // find the line break
         $tokenCount = count($this->tokens);
         for ($end = $index; $end < $tokenCount; ++$end) {
-            if (false !== strpos($this->tokens[$end]->getContent(), "\n")) {
+            if (
+                $this->tokens[$end]->equals('}')
+                || false !== strpos($this->tokens[$end]->getContent(), "\n")
+            ) {
                 break;
             }
         }

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -771,6 +771,26 @@ $c
         }
     }',
             ),
+            array(
+                'return',
+                '<?php
+class Foo
+{
+    public function bar() {return 1;}
+
+    public function baz() {return 2;
+    }
+}',
+                '<?php
+class Foo
+{
+    public function bar() {return 1;}
+
+    public function baz() {return 2;
+
+    }
+}',
+            ),
         );
     }
 


### PR DESCRIPTION
Proving the bug from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2282#discussion_r87481482

@GrahamCampbell could you take a look to fix it ?