### PR TITLE
Make fixers ready to use directly after creation

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException;
 use PhpCsFixer\ConfigurationException\UnallowedFixerConfigurationException;
 
 /**
@@ -28,6 +29,12 @@ abstract class AbstractFixer implements FixerInterface
 
     public function __construct()
     {
+        try {
+            $this->configure(null);
+        } catch (RequiredFixerConfigurationException $e) {
+            // ignore
+        }
+
         if ($this instanceof WhitespacesFixerConfigAwareInterface) {
             $this->whitespacesConfig = $this->getDefaultWhitespacesFixerConfig();
         }

--- a/src/ConfigurationException/RequiredFixerConfigurationException.php
+++ b/src/ConfigurationException/RequiredFixerConfigurationException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\ConfigurationException;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class RequiredFixerConfigurationException extends InvalidFixerConfigurationException
+{
+}

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Fixer\Comment;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\WhitespacesFixerConfigAwareInterface;
@@ -72,6 +73,10 @@ final class HeaderCommentFixer extends AbstractFixer implements WhitespacesFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
+        if (null === $this->headerComment) {
+            throw new RequiredFixerConfigurationException($this->getName(), 'Configuration is required.');
+        }
+
         // figure out where the comment should be placed
         $headerNewIndex = $this->findHeaderCommentInsertionIndex($tokens);
 
@@ -274,7 +279,7 @@ final class HeaderCommentFixer extends AbstractFixer implements WhitespacesFixer
     private function parseConfiguration(array $configuration = null)
     {
         if (null === $configuration || !array_key_exists('header', $configuration)) {
-            throw new InvalidFixerConfigurationException($this->getName(), 'Configuration is required.');
+            throw new RequiredFixerConfigurationException($this->getName(), 'Configuration is required.');
         }
 
         $header = $configuration['header'];

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -13,7 +13,6 @@
 namespace PhpCsFixer\Fixer\Phpdoc;
 
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -34,7 +33,7 @@ final class GeneralPhpdocAnnotationRemoveFixer extends AbstractFixer
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            throw new InvalidFixerConfigurationException($this->getName(), sprintf('Configuration is required.'));
+            $this->configuration = array();
         }
 
         $this->configuration = $configuration;
@@ -63,6 +62,10 @@ final class GeneralPhpdocAnnotationRemoveFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
+        if (!count($this->configuration)) {
+            return;
+        }
+
         foreach ($tokens as $token) {
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
                 continue;

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRenameFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRenameFixer.php
@@ -13,7 +13,6 @@
 namespace PhpCsFixer\Fixer\Phpdoc;
 
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -34,7 +33,7 @@ final class GeneralPhpdocAnnotationRenameFixer extends AbstractFixer
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            throw new InvalidFixerConfigurationException($this->getName(), sprintf('Configuration is required.'));
+            $this->configuration = array();
         }
 
         $this->configuration = $configuration;
@@ -53,6 +52,10 @@ final class GeneralPhpdocAnnotationRenameFixer extends AbstractFixer
      */
     public function fix(\SplFileInfo $file, Tokens $tokens)
     {
+        if (!count($this->configuration)) {
+            return;
+        }
+
         $searchFor = array_keys($this->configuration);
 
         foreach ($tokens as $token) {

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -161,7 +161,11 @@ final class FixerFactory
             }
 
             $fixer = $this->fixersByName[$name];
-            $fixer->configure($ruleSet->getRuleConfiguration($name));
+
+            $config = $ruleSet->getRuleConfiguration($name);
+            if (null !== $config) {
+                $fixer->configure($config);
+            }
 
             $fixers[] = $fixer;
             $fixersByName[$name] = $fixer;

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -20,7 +20,6 @@ use PhpCsFixer\RuleSet;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
-use PhpCsFixer\WhitespacesFixerConfig;
 use Prophecy\Argument;
 
 /**
@@ -57,16 +56,6 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
         $fixerClassName = $this->getFixerClassName();
         $fixer = new $fixerClassName();
 
-        $fixer->configure(
-            is_array($this->getFixerConfiguration())
-                ? $this->getFixerConfiguration()
-                : null
-        );
-
-        if ($fixer instanceof WhitespacesFixerConfigAwareInterface) {
-            $fixer->setWhitespacesConfig($this->getDefaultWhitespacesFixerConfig());
-        }
-
         return $fixer;
     }
 
@@ -78,14 +67,6 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
     protected function createFixerFactory()
     {
         return FixerFactory::create()->registerBuiltInFixers();
-    }
-
-    /**
-     * @return bool|array
-     */
-    protected function getFixerConfiguration()
-    {
-        return true;
     }
 
     /**
@@ -250,17 +231,6 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
         return $linter;
     }
 
-    private function getDefaultWhitespacesFixerConfig()
-    {
-        static $defaultWhitespacesFixerConfig = null;
-
-        if (null === $defaultWhitespacesFixerConfig) {
-            $defaultWhitespacesFixerConfig = new WhitespacesFixerConfig('    ', "\n");
-        }
-
-        return $defaultWhitespacesFixerConfig;
-    }
-
     /**
      * @return string
      */
@@ -270,12 +240,9 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
             return $this->fixerClassName;
         }
 
-        $name = $this->getFixerName();
-        $configuration = $this->getFixerConfiguration();
-
         try {
             $fixers = $this->createFixerFactory()
-                ->useRuleSet(new RuleSet(array($name => $configuration)))
+                ->useRuleSet(new RuleSet(array($this->getFixerName() => true)))
                 ->getFixers()
             ;
         } catch (\UnexpectedValueException $e) {

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -50,6 +50,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      */
     public function testFixingAnonymousClasses($expected, $input)
     {
+        $this->fixer->configure(self::$defaultTestConfig);
+
         $this->doTest($expected, $input);
     }
 
@@ -61,6 +63,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      */
     public function testFixingClasses($expected, $input)
     {
+        $this->fixer->configure(self::$defaultTestConfig);
+
         $this->doTest($expected, $input);
     }
 
@@ -86,6 +90,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      */
     public function testFixingInterfaces($expected, $input)
     {
+        $this->fixer->configure(self::$defaultTestConfig);
+
         $this->doTest($expected, $input);
     }
 
@@ -100,6 +106,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         if (!defined('T_TRAIT')) {
             $this->markTestSkipped('Test requires traits.');
         }
+
+        $this->fixer->configure(self::$defaultTestConfig);
 
         $this->doTest($expected, $input);
     }
@@ -427,6 +435,8 @@ namespace {
      */
     public function testFixPHP7($expected, $input = null)
     {
+        $this->fixer->configure(self::$defaultTestConfig);
+
         $this->doTest($expected, $input);
     }
 
@@ -472,6 +482,7 @@ $a = new class implements
     public function testMessyWhitespaces($expected, $input = null)
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
+        $this->fixer->configure(self::$defaultTestConfig);
 
         $this->doTest($expected, $input);
     }
@@ -484,11 +495,6 @@ $a = new class implements
                 "<?php\r\nclass Aaa implements\r\n\tBbb, Ccc,\r\n\tDdd\r\n\t{\r\n\t}",
             ),
         );
-    }
-
-    protected function getFixerConfiguration()
-    {
-        return self::$defaultTestConfig;
     }
 
     private function provideClassyCases($classy)

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -29,6 +29,7 @@ final class HeaderCommentFixerTest extends AbstractFixerTestCase
     public function testFix(array $configuration, $expected, $input)
     {
         $this->fixer->configure($configuration);
+
         $this->doTest($expected, $input);
     }
 
@@ -452,13 +453,5 @@ declare(strict_types=1)?>',
                 "<?php\r\ndeclare(strict_types=1);\r\n\r\nnamespace A\\B;\r\n\r\necho 1;",
             ),
         );
-    }
-
-    /**
-     * @return bool|array
-     */
-    protected function getFixerConfiguration()
-    {
-        return array('header' => '');
     }
 }


### PR DESCRIPTION
Currently, if fixer is configurable then it's config claims to be an array, but actually it's a null until someone will call `configure`, so calling `->fix` will crash the execution.. This is bad and after mine change a default configuration is in use directly after instance creation.

Exception is header comment fixer, as the only possible default configuration is to drop the header, which is very dangerous.