### PR TITLE
no_empty_comment: preserve paragraphs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,7 @@ Choose from the list of available fixers:
    There should be no empty lines after class opening brace.
 
 * **no_empty_comment** [symfony]
-   There should not be an empty comments.
+   There should not be an empty comment.
 
 * **no_empty_lines_after_phpdocs** [symfony]
    There should not be blank lines between docblock and the documented

--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,7 @@ Choose from the list of available fixers:
    There should be no empty lines after class opening brace.
 
 * **no_empty_comment** [symfony]
-   There should not be an empty comment.
+   There should not be any empty comments.
 
 * **no_empty_lines_after_phpdocs** [symfony]
    There should not be blank lines between docblock and the documented

--- a/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
@@ -134,12 +134,33 @@ final class NoEmptyCommentFixer extends AbstractFixer
         $tokens->overrideAt($index, array(T_WHITESPACE, "\n", $tokens[$index]->getLine()));
     }
 
+    /**
+     * isSurroundedBySingleLineComments checks whether the preceding and
+     * succeeding lines of the token at $index contain a single-line comment.
+     *
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
     private function isSurroundedBySingleLineComments(Tokens $tokens, $index)
     {
         return $this->hasSingleLineCommentSibling($tokens, $index, -1) &&
                $this->hasSingleLineCommentSibling($tokens, $index,  1);
     }
 
+    /**
+     * hasSingleLineCommentSibling checks whether the preceding or succeeding
+     * line of the token at $index contains a single-line comment. Which line
+     * is checked depends on $direction.
+     *
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param int    $direction either -1 to check the preceding line, or +1 to
+     *                          check the succeeding line
+     *
+     * @return bool
+     */
     private function hasSingleLineCommentSibling(Tokens $tokens, $index, $direction)
     {
         do {

--- a/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
@@ -41,7 +41,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'There should not be an empty comment.';
+        return 'There should not be any empty comments.';
     }
 
     /**

--- a/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
@@ -164,11 +164,12 @@ final class NoEmptyCommentFixer extends AbstractFixer
             return false;
         }
 
-        if ($token->getContent()[0] === '#') {
+        $content = $token->getContent();
+        if ('#' === $content[0]) {
             return true;
         }
 
-        if ($token->getContent()[1] === '/') {
+        if ('/' === $content[1]) {
             return true;
         }
 

--- a/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
@@ -136,43 +136,26 @@ final class NoEmptyCommentFixer extends AbstractFixer
 
     private function isSurroundedBySingleLineComments(Tokens $tokens, $index)
     {
-        $line = $tokens[$index]->getLine();
-
-        $prev = $tokens->getPrevNonWhitespace($index);
-        if (false === $this->isSingleLineCommentOnLine($tokens, $prev, $line - 1)) {
-            return false;
-        }
-
-        $next = $tokens->getNextNonWhitespace($index);
-
-        return $this->isSingleLineCommentOnLine($tokens, $next, $line + 1);
+        return $this->hasSingleLineCommentSibling($tokens, $index, -1) &&
+               $this->hasSingleLineCommentSibling($tokens, $index,  1);
     }
 
-    private function isSingleLineCommentOnLine(Tokens $tokens, $index, $line)
+    private function hasSingleLineCommentSibling(Tokens $tokens, $index, $direction)
     {
-        if ($index === null) {
-            return false;
-        }
+        do {
+            $index += $direction;
+            if (false === isset($tokens[$index])) {
+                return false;
+            }
 
-        $token = $tokens[$index];
+            $token = $tokens[$index];
+            $content = $token->getContent();
+        } while (false === strpos($content, "\n"));
 
         if (false === $token->isComment()) {
             return false;
         }
 
-        if ($line !== $token->getLine()) {
-            return false;
-        }
-
-        $content = $token->getContent();
-        if ('#' === $content[0]) {
-            return true;
-        }
-
-        if ('/' === $content[1]) {
-            return true;
-        }
-
-        return false;
+        return '#' === $content[0] || '/' === $content[1];
     }
 }

--- a/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/NoEmptyCommentFixer.php
@@ -137,11 +137,15 @@ final class NoEmptyCommentFixer extends AbstractFixer
     private function isSurroundedBySingleLineComments(Tokens $tokens, $index)
     {
         $line = $tokens[$index]->getLine();
+
         $prev = $tokens->getPrevNonWhitespace($index);
+        if (false === $this->isSingleLineCommentOnLine($tokens, $prev, $line - 1)) {
+            return false;
+        }
+
         $next = $tokens->getNextNonWhitespace($index);
 
-        return $this->isSingleLineCommentOnLine($tokens, $prev, $line - 1) &&
-               $this->isSingleLineCommentOnLine($tokens, $next, $line + 1);
+        return $this->isSingleLineCommentOnLine($tokens, $next, $line + 1);
     }
 
     private function isSingleLineCommentOnLine(Tokens $tokens, $index, $line)

--- a/Symfony/CS/Tests/Fixer/Symfony/NoEmptyCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NoEmptyCommentFixerTest.php
@@ -174,6 +174,56 @@ echo 1;
                     //
                 ',
             ),
+            array(
+                '<?php
+                    '.'
+                    // comment one
+                    '.'
+                    /*
+                       comment two
+                    */
+                ',
+                '<?php
+                    //
+                    // comment one
+                    //
+                    /*
+                       comment two
+                    */
+                ',
+            ),
+            array(
+                '<?php
+                    '.'
+                    // comment one
+                    '.'
+                    // comment two
+                    '.'
+                ',
+                '<?php
+                    //
+                    // comment one
+                    '.'
+                    // comment two
+                    //
+                ',
+            ),
+            array(
+                '<?php
+                    // $a
+                    '.'
+                    '.'
+                    '.'
+                    '.'
+                ',
+                '<?php
+                    // $a
+                    '.'
+                    //
+                    '.'
+                    //
+                ',
+            ),
         );
     }
 }

--- a/Symfony/CS/Tests/Fixer/Symfony/NoEmptyCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/NoEmptyCommentFixerTest.php
@@ -142,6 +142,38 @@ echo 1;
                 '.'
                 ',
             ),
+            array(
+                '<?php
+                    '.'
+                    # paragraph one
+                    #
+                    # paragraph two
+                    '.'
+                ',
+                '<?php
+                    #
+                    # paragraph one
+                    #
+                    # paragraph two
+                    #
+                ',
+            ),
+            array(
+                '<?php
+                    '.'
+                    // paragraph one
+                    //
+                    // paragraph two
+                    '.'
+                ',
+                '<?php
+                    //
+                    // paragraph one
+                    //
+                    // paragraph two
+                    //
+                ',
+            ),
         );
     }
 }


### PR DESCRIPTION
Make NoEmptyCommentFixer preserve paragraphs in a sequence of single
line comments. E.g. do not change comments like the following

    // Introductory statement
    //
    // Lengthy description goes here.
    //
    // Descriptions may also be formatted as multiple paragraphs.

For all intents and purposes, this is a single comment that is clearly
not empty. It should not be changed into multiple comments that are
separated by blank lines.