### PR TITLE
don't register self-update command when running non-phar distribution

### DIFF
--- a/Symfony/CS/Console/Application.php
+++ b/Symfony/CS/Console/Application.php
@@ -17,6 +17,7 @@ use Symfony\CS\Console\Command\FixCommand;
 use Symfony\CS\Console\Command\ReadmeCommand;
 use Symfony\CS\Console\Command\SelfUpdateCommand;
 use Symfony\CS\Fixer;
+use Symfony\CS\ToolInfo;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -34,7 +35,9 @@ class Application extends BaseApplication
 
         $this->add(new FixCommand());
         $this->add(new ReadmeCommand());
-        $this->add(new SelfUpdateCommand());
+        if (ToolInfo::isInstalledAsPhar()) {
+            $this->add(new SelfUpdateCommand());
+        }
     }
 
     public function getLongVersion()


### PR DESCRIPTION
Just because this may looks strange:

```
$ php-cs-fixer list
  ...
  self-update  Update php-cs-fixer.phar to the latest stable version.
  selfupdate   Update php-cs-fixer.phar to the latest stable version.

$ php-cs-fixer self-update
Self-update is available only for PHAR version.
```