### PR TITLE
Application - adjust test to not depend on symfony/console version

### DIFF
--- a/Symfony/CS/Tests/Console/ApplicationTest.php
+++ b/Symfony/CS/Tests/Console/ApplicationTest.php
@@ -22,6 +22,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     public function testApplication()
     {
         $app = new Application();
-        $this->assertStringMatchesFormat('<info>PHP CS Fixer</info> version <comment>%d.%d%s</comment> by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>', $app->getLongVersion());
+        $this->assertStringMatchesFormat('%s by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>', $app->getLongVersion());
     }
 }


### PR DESCRIPTION
https://github.com/symfony/symfony/commit/fcddb3a9c944e16a920b14df88eaab8a0963aa6c

now we test only part that we added, not that comes from vendor code