### PR TITLE
AppVeyor: enforce PHP version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,15 @@ version: dev-{build}
 shallow_clone: false
 clone_folder: C:\projects\php-cs-fixer
 
+environment:
+    matrix:
+        - php_ver: 7.0.9
+
 cache:
     - '%APPDATA%\Composer'
 
 install:
-    - choco install -y php
+    - choco install -y php -version %php_ver%
     - SET PATH=C:\tools\php;%PATH%
     - cd C:\tools\php
     - copy php.ini-production php.ini


### PR DESCRIPTION
newest PHP version on chocolatey (7.0.13) that was release at 28th is broken, let us use previous one