### PR TITLE
Enhancement: Allow to configure return_type_declaration rule

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -538,8 +538,9 @@ Choose from the list of available rules:
    | *Rule is: configurable, risky.*
 
 * **return_type_declaration** [@Symfony]
-   | There should be no space before colon and one space after it in return
-   | type declaration. Requires PHP >= 7.
+   | There should be one or no space before colon, and one space after it in
+   | return type declarations, according to configuration.
+   | *Rule is: configurable.*
 
 * **self_accessor** [@Symfony]
    | Inside a classy element "self" should be preferred to the class name

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -13,6 +13,8 @@
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
@@ -22,8 +24,44 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class ReturnTypeDeclarationFixer extends AbstractFixer
+final class ReturnTypeDeclarationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    /**
+     * @var string
+     */
+    private $config;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        if (null === $configuration) {
+            $this->config = 'none';
+
+            return;
+        }
+
+        $key = 'space_before';
+        $values = array(
+            'one',
+            'none',
+        );
+
+        if (!array_key_exists($key, $configuration) || !in_array($configuration[$key], $values, true)) {
+            throw new InvalidFixerConfigurationException(
+                $this->getName(),
+                sprintf(
+                    'Configuration must define "%s" being "%s".',
+                    $key,
+                    implode('" or "', $values)
+                )
+            );
+        }
+
+        $this->config = $configuration[$key];
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -36,8 +74,17 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer
                 continue;
             }
 
-            if ($tokens[$index - 1]->isWhitespace()) {
-                $tokens[$index - 1]->clear();
+            $previousToken = $tokens[$index - 1];
+
+            if ($previousToken->isWhitespace()) {
+                if ('none' === $this->config) {
+                    $previousToken->clear();
+                } else {
+                    $previousToken->setContent(' ');
+                }
+            } elseif ('one' === $this->config) {
+                $tokens->ensureWhitespaceAtIndex($index, 0, ' ');
+                ++$index;
             }
 
             ++$index;
@@ -50,14 +97,29 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer
      */
     public function getDefinition()
     {
+        $versionSpecification = new VersionSpecification(70000);
+
         return new FixerDefinition(
-            'There should be no space before colon and one space after it in return type declaration. Requires PHP >= 7.',
+            'There should be one or no space before colon, and one space after it in return type declarations, according to configuration.',
             array(
                 new VersionSpecificCodeSample(
-                    '<?php function foo(int $a):string {}',
-                    new VersionSpecification(70000)
+                    "<?php\nfunction foo(int \$a):string {};",
+                    $versionSpecification
                 ),
-            )
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction foo(int \$a): string {};",
+                    $versionSpecification,
+                    array('space_before' => 'none')
+                ),
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction foo(int \$a): string {};",
+                    $versionSpecification,
+                    array('space_before' => 'one')
+                ),
+            ),
+            null,
+            "Configuration must have one element 'space_before' with value 'none' (default) or 'one'.",
+            array('space_before' => 'none')
         );
     }
 

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -107,12 +107,12 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
                     $versionSpecification
                 ),
                 new VersionSpecificCodeSample(
-                    "<?php\nfunction foo(int \$a): string {};",
+                    "<?php\nfunction foo(int \$a):string {};",
                     $versionSpecification,
                     array('space_before' => 'none')
                 ),
                 new VersionSpecificCodeSample(
-                    "<?php\nfunction foo(int \$a): string {};",
+                    "<?php\nfunction foo(int \$a):string {};",
                     $versionSpecification,
                     array('space_before' => 'one')
                 ),

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -27,6 +27,13 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class ReturnTypeDeclarationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     /**
+     * @var array
+     */
+    private static $defaultConfiguration = array(
+        'space_before' => 'none',
+    );
+
+    /**
      * @var string
      */
     private $config;
@@ -119,7 +126,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
             ),
             'Rule is applied only in a PHP 7+ environment.',
             "Configuration must have one element 'space_before' with value 'none' (default) or 'one'.",
-            array('space_before' => 'none')
+            self::$defaultConfiguration
         );
     }
 

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -117,7 +117,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
                     array('space_before' => 'one')
                 ),
             ),
-            null,
+            'Rule is applied only in a PHP 7+ environment.',
             "Configuration must have one element 'space_before' with value 'none' (default) or 'one'.",
             array('space_before' => 'none')
         );

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -36,7 +36,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
     /**
      * @var string
      */
-    private $config;
+    private $configuration;
 
     /**
      * {@inheritdoc}
@@ -44,7 +44,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->config = 'none';
+            $this->configuration = 'none';
 
             return;
         }
@@ -63,7 +63,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
             );
         }
 
-        $this->config = $configuration[$key];
+        $this->configuration = $configuration[$key];
     }
 
     /**
@@ -81,12 +81,12 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
             $previousToken = $tokens[$index - 1];
 
             if ($previousToken->isWhitespace()) {
-                if ('none' === $this->config) {
+                if ('none' === $this->configuration) {
                     $previousToken->clear();
                 } else {
                     $previousToken->setContent(' ');
                 }
-            } elseif ('one' === $this->config) {
+            } elseif ('one' === $this->configuration) {
                 $tokens->ensureWhitespaceAtIndex($index, 0, ' ');
                 ++$index;
             }

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -50,10 +50,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
         }
 
         $key = 'space_before';
-        $values = array(
-            'one',
-            'none',
-        );
+        $values = array('one', 'none');
 
         if (!array_key_exists($key, $configuration) || !in_array($configuration[$key], $values, true)) {
             throw new InvalidFixerConfigurationException(

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -23,6 +23,11 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfiguration()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[return_type_declaration\] Configuration must define "space_before" being "one" or "none".$#'
+        );
+
         $this->fixer->configure(array('s' => 9000));
     }
 

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -18,6 +18,8 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @internal
+ *
+ * @requires PHP 7.0
  */
 final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
@@ -36,8 +38,6 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
      *
      * @param string      $expected
      * @param null|string $input
-     *
-     * @requires PHP 7.0
      */
     public function testFixWithDefaultConfiguration($expected, $input = null)
     {
@@ -51,8 +51,6 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
      *
      * @param string      $expected
      * @param null|string $input
-     *
-     * @requires PHP 7.0
      */
     public function testFixWithSpaceBeforeNone($expected, $input = null)
     {
@@ -93,8 +91,6 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
      *
      * @param string      $expected
      * @param null|string $input
-     *
-     * @requires PHP 7.0
      */
     public function testFixWithSpaceBeforeOne($expected, $input = null)
     {

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -21,19 +21,44 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
+    public function testInvalidConfiguration()
+    {
+        $this->fixer->configure(array('s' => 9000));
+    }
+
     /**
+     * @dataProvider testFixProviderWithSpaceBeforeNone
+     *
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider testFixProvider
      * @requires PHP 7.0
      */
-    public function testFix($expected, $input = null)
+    public function testFixWithDefaultConfiguration($expected, $input = null)
     {
+        $this->fixer->configure(null);
+
         $this->doTest($expected, $input);
     }
 
-    public function testFixProvider()
+    /**
+     * @dataProvider testFixProviderWithSpaceBeforeNone
+     *
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.0
+     */
+    public function testFixWithSpaceBeforeNone($expected, $input = null)
+    {
+        $this->fixer->configure(array(
+            'space_before' => 'none',
+        ));
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixProviderWithSpaceBeforeNone()
     {
         return array(
             array(
@@ -53,6 +78,47 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
             ),
             array(
                 '<?php function foo(int $a) /**/: /**/ string {}',
+                '<?php function foo(int $a) /**/ : /**/ string {}',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider testFixProviderWithSpaceBeforeOne
+     *
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.0
+     */
+    public function testFixWithSpaceBeforeOne($expected, $input = null)
+    {
+        $this->fixer->configure(array(
+            'space_before' => 'one',
+        ));
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixProviderWithSpaceBeforeOne()
+    {
+        return array(
+            array(
+                '<?php function foo(int $a) {}',
+            ),
+            array(
+                '<?php function foo(int $a) : string {}',
+                '<?php function foo(int $a):string {}',
+            ),
+            array(
+                '<?php function foo(int $a)/**/ : /**/string {}',
+                '<?php function foo(int $a)/**/:/**/string {}',
+            ),
+            array(
+                '<?php function foo(int $a) : string {}',
+                '<?php function foo(int $a)  :  string {}',
+            ),
+            array(
                 '<?php function foo(int $a) /**/ : /**/ string {}',
             ),
         );


### PR DESCRIPTION
This PR

* [x] allows to configure the `return_type_declaration` rule

💁‍♂️ Some people prefer to have a space before `:`, hehe. For reference, also see https://github.com/php-fig/fig-standards/pull/733.