### PR TITLE
Better handling of file name that is the same in multiple finder paths

### DIFF
--- a/src/Cache/Directory.php
+++ b/src/Cache/Directory.php
@@ -36,7 +36,10 @@ final class Directory implements DirectoryInterface
     {
         $file = $this->normalizePath($file);
 
-        if (0 !== stripos($file, $this->directoryName.DIRECTORY_SEPARATOR)) {
+        if (
+            '' === $this->directoryName
+            || 0 !== stripos($file, $this->directoryName.DIRECTORY_SEPARATOR)
+        ) {
             return $file;
         }
 

--- a/src/Cache/DirectoryInterface.php
+++ b/src/Cache/DirectoryInterface.php
@@ -14,8 +14,6 @@ namespace PhpCsFixer\Cache;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
- *
- * @internal
  */
 interface DirectoryInterface
 {

--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -70,7 +70,7 @@ final class FileCacheManager implements CacheManagerInterface
         $this->handler = $handler;
         $this->signature = $signature;
         $this->isDryRun = $isDryRun;
-        $this->cacheDirectory = $cacheDirectory ?: new Directory(dirname(realpath($handler->getFile())));
+        $this->cacheDirectory = $cacheDirectory ?: new Directory('');
 
         $this->readCache();
     }

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -167,7 +167,8 @@ final class FixCommand extends Command
             $this->errorsManager,
             $resolver->getLinter(),
             $resolver->isDryRun(),
-            $resolver->getCacheManager()
+            $resolver->getCacheManager(),
+            $resolver->getDirectory()
         );
 
         $progressOutput = $showProgress && $stdErr

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -13,6 +13,8 @@
 namespace PhpCsFixer\Console;
 
 use PhpCsFixer\Cache\CacheManagerInterface;
+use PhpCsFixer\Cache\Directory;
+use PhpCsFixer\Cache\DirectoryInterface;
 use PhpCsFixer\Cache\FileCacheManager;
 use PhpCsFixer\Cache\FileHandler;
 use PhpCsFixer\Cache\NullCacheManager;
@@ -116,6 +118,7 @@ final class ConfigurationResolver
     private $cacheFile;
     private $cacheManager;
     private $differ;
+    private $directory;
     private $finder;
     private $format;
     private $linter;
@@ -178,7 +181,8 @@ final class ConfigurationResolver
                         ToolInfo::getVersion(),
                         $this->getRules()
                     ),
-                    $this->isDryRun()
+                    $this->isDryRun(),
+                    $this->getDirectory()
                 );
             } else {
                 $this->cacheManager = new NullCacheManager();
@@ -246,6 +250,25 @@ final class ConfigurationResolver
         }
 
         return $this->differ;
+    }
+
+    /**
+     * @return DirectoryInterface
+     */
+    public function getDirectory()
+    {
+        if (null === $this->directory) {
+            $path = $this->getCacheFile();
+            $filesystem = new Filesystem();
+
+            $absolutePath = $filesystem->isAbsolutePath($path)
+                ? $path
+                : $this->cwd.DIRECTORY_SEPARATOR.$path;
+
+            $this->directory = new Directory(dirname($absolutePath));
+        }
+
+        return $this->directory;
     }
 
     /**

--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -16,7 +16,6 @@ use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\FixerFileProcessedEvent;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -75,7 +74,7 @@ final class FileFilterIterator extends \FilterIterator
             // file uses __halt_compiler() on ~5.3.6 due to broken implementation of token_get_all
             || (PHP_VERSION_ID >= 50306 && PHP_VERSION_ID < 50400 && false !== stripos($content, '__halt_compiler()'))
             // file that does not need fixing due to cache
-            || !$this->cacheManager->needFixing($this->getFileRelativePathname($file), $content)
+            || !$this->cacheManager->needFixing($file->getPathname(), $content)
         ) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,
@@ -101,14 +100,5 @@ final class FileFilterIterator extends \FilterIterator
         }
 
         $this->eventDispatcher->dispatch($name, $event);
-    }
-
-    private function getFileRelativePathname(\SplFileInfo $file)
-    {
-        if ($file instanceof SymfonySplFileInfo) {
-            return $file->getRelativePathname();
-        }
-
-        return $file->getPathname();
     }
 }

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Runner;
 
+use PhpCsFixer\Cache\Directory;
 use PhpCsFixer\Cache\NullCacheManager;
 use PhpCsFixer\Differ\NullDiffer;
 use PhpCsFixer\Error\Error;
@@ -55,20 +56,21 @@ final class RunnerTest extends \PHPUnit_Framework_TestCase
             }
         }
 
+        $path = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix';
         $runner = new Runner(
-            Finder::create()->in(
-                __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix'
-            ),
+            Finder::create()->in($path),
             $fixers,
             new NullDiffer(),
             null,
             new ErrorsManager(),
             $linterProphecy->reveal(),
             true,
-            new NullCacheManager()
+            new NullCacheManager(),
+            new Directory($path)
         );
 
         $changed = $runner->fix();
+
         $pathToInvalidFile = 'somefile.php';
 
         $this->assertCount(1, $changed);
@@ -85,10 +87,9 @@ final class RunnerTest extends \PHPUnit_Framework_TestCase
     {
         $errorsManager = new ErrorsManager();
 
+        $path = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid';
         $runner = new Runner(
-            Finder::create()->in(
-                __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid'
-            ),
+            Finder::create()->in($path),
             array(
                 new Fixer\ClassNotation\VisibilityRequiredFixer(),
                 new Fixer\Import\NoUnusedImportsFixer(), // will be ignored cause of test keyword in namespace
@@ -100,9 +101,8 @@ final class RunnerTest extends \PHPUnit_Framework_TestCase
             true,
             new NullCacheManager()
         );
-
         $changed = $runner->fix();
-        $pathToInvalidFile = 'somefile.php';
+        $pathToInvalidFile = $path.DIRECTORY_SEPARATOR.'somefile.php';
 
         $this->assertCount(0, $changed);
 


### PR DESCRIPTION
There are 2 files (with different content):
- `mirror-a\somefile.php`
- `mirror-b\somefile.php`

With this PR files can be distinguished in:
1. CLI output which file was fixed
2. cache file (used paths are still relative, not absolute)

```
D:\GIT\fork\test\ex2
λ cat .php_cs.dist
<?php

return PhpCsFixer\Config::create()
    ->setRiskyAllowed(true)
    ->setRules(array(
        "no_mixed_echo_print"=> ["use" => "echo"],
    ))
    ->setFinder(
        PhpCsFixer\Finder::create()
            ->in(__DIR__.DIRECTORY_SEPARATOR.'mirror-a')
            ->in(__DIR__.DIRECTORY_SEPARATOR.'mirror-b')
    )
;

D:\GIT\fork\test\ex2
λ ll -R
.:
total 5
drwxr-xr-x    1 Dariusz  Administ     4096 Dec  5 02:27 .
drwxr-xr-x    1 Dariusz  Administ     4096 Dec  4 22:41 ..
-rw-r--r--    1 Dariusz  Administ      325 Dec  5 02:27 .php_cs.dist
drwxr-xr-x    1 Dariusz  Administ        0 Dec  4 21:33 mirror-a
drwxr-xr-x    1 Dariusz  Administ        0 Dec  5 00:21 mirror-b
drwxr-xr-x    1 Dariusz  Administ        0 Dec  4 23:48 mirror-c

./mirror-a:
total 3
drwxr-xr-x    1 Dariusz  Administ        0 Dec  4 21:33 .
drwxr-xr-x    1 Dariusz  Administ     4096 Dec  5 02:27 ..
-rw-r--r--    1 Dariusz  Administ       26 Dec  5 01:03 somefile.php

./mirror-b:
total 3
drwxr-xr-x    1 Dariusz  Administ        0 Dec  5 00:21 .
drwxr-xr-x    1 Dariusz  Administ     4096 Dec  5 02:27 ..
-rw-r--r--    1 Dariusz  Administ       27 Dec  5 02:28 somefile.php

./mirror-c:
total 3
drwxr-xr-x    1 Dariusz  Administ        0 Dec  4 23:48 .
drwxr-xr-x    1 Dariusz  Administ     4096 Dec  5 02:27 ..
-rw-r--r--    1 Dariusz  Administ       55 Dec  5 00:38 somefile.php

D:\GIT\fork\test\ex2
λ php-cs-fixer fix -v
Loaded config default from "D:\GIT\fork\test\ex2\.php_cs.dist".
.F
Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error
   1) mirror-b\somefile.php (no_mixed_echo_print)

Fixed all files in 0.045 seconds, 6.000 MB memory used

D:\GIT\fork\test\ex2
λ php-cs-fixer fix -v
Loaded config default from "D:\GIT\fork\test\ex2\.php_cs.dist".
Using cache file ".php_cs.cache".
SS
Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error

Fixed all files in 0.009 seconds, 6.000 MB memory used

D:\GIT\fork\test\ex2
λ cat .php_cs.cache
{"php":"7.0.13","version":"2.0.1-DEV:dev-2_same_name#4e07d8b818b918d4c049f3a63b4af3a3c19360fe","rules":{"no_mixed_echo_print":{"use":"echo"}},"hashes":{"mirror-a\\somefile.php":361259098,"mirror-b\\somefile.php":121491380}}
```

-------------

Replaces #2003, #1998, #2004

-------------

@Slamdunk, @localheinz , you may be interested in this PR