### PR TITLE
bug #2341 ClassKeywordRemoveFixer incorrectly leaves leading Backslash

### DIFF
--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -159,7 +159,7 @@ final class ClassKeywordRemoveFixer extends AbstractFixer
         $classBeginIndex = $classEndIndex;
         while ($tokens[--$classBeginIndex]->isGivenKind(array(T_NS_SEPARATOR, T_STRING)));
         ++$classBeginIndex;
-        $classString = $tokens->generatePartialCode($classBeginIndex, $classEndIndex);
+        $classString = ltrim($tokens->generatePartialCode($classBeginIndex, $classEndIndex), '\\');
 
         $classImport = false;
         foreach ($this->imports as $alias => $import) {

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -90,7 +90,7 @@ final class ClassKeywordRemoveFixerTest extends AbstractFixerTestCase
             ),
             array(
                 "<?php
-                echo '\DateTime';
+                echo 'DateTime';
                 ",
                 "<?php
                 echo \DateTime::class;


### PR DESCRIPTION
I adjusted the test-case and removed the leading backslashes from the classname.