### PR TITLE
ConfigurationResolver - Reject unknown rules

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -128,6 +128,11 @@ final class ConfigurationResolver
     private $usingCache;
 
     /**
+     * @var FixerFactory
+     */
+    private $fixerFactory;
+
+    /**
      * ConfigurationResolver constructor.
      *
      * @param ConfigInterface $config
@@ -513,15 +518,15 @@ final class ConfigurationResolver
      */
     private function createFixerFactory()
     {
-        static $fixerFactory = null;
-
-        if (null === $fixerFactory) {
+        if (null === $this->fixerFactory) {
             $fixerFactory = new FixerFactory();
             $fixerFactory->registerBuiltInFixers();
             $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
+
+            $this->fixerFactory = $fixerFactory;
         }
 
-        return $fixerFactory;
+        return $this->fixerFactory;
     }
 
     /**

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -279,11 +279,7 @@ final class ConfigurationResolver
     public function getFixers()
     {
         if (null === $this->fixers) {
-            $fixerFactory = new FixerFactory();
-            $fixerFactory->registerBuiltInFixers();
-            $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
-
-            $this->fixers = $fixerFactory
+            $this->fixers = $this->createFixerFactory()
                 ->useRuleSet($this->getRuleSet())
                 ->setWhitespacesConfig(new WhitespacesFixerConfig($this->config->getIndent(), $this->config->getLineEnding()))
                 ->getFixers();
@@ -510,6 +506,18 @@ final class ConfigurationResolver
         }
 
         return $candidates;
+    }
+
+    /**
+     * @return FixerFactory
+     */
+    private function createFixerFactory()
+    {
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+        $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
+
+        return $fixerFactory;
     }
 
     /**

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -513,9 +513,13 @@ final class ConfigurationResolver
      */
     private function createFixerFactory()
     {
-        $fixerFactory = new FixerFactory();
-        $fixerFactory->registerBuiltInFixers();
-        $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
+        static $fixerFactory = null;
+
+        if (null === $fixerFactory) {
+            $fixerFactory = new FixerFactory();
+            $fixerFactory->registerBuiltInFixers();
+            $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
+        }
 
         return $fixerFactory;
     }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -615,15 +615,10 @@ final class ConfigurationResolver
         /* @var string[] $availableFixers */
         $configuredFixers = array_keys($ruleSet->getRules());
 
-        $fixerFactory = new FixerFactory();
-        $fixerFactory->registerBuiltInFixers();
-        $fixerFactory->registerCustomFixers($this->getConfig()->getCustomFixers());
-
-        $reflection = new \ReflectionProperty('PhpCsFixer\FixerFactory', 'fixersByName');
-        $reflection->setAccessible(true);
-
         /* @var string[] $availableFixers */
-        $availableFixers = array_keys($reflection->getValue($fixerFactory));
+        $availableFixers = array_map(function (FixerInterface $fixer) {
+            return $fixer->getName();
+        }, $this->createFixerFactory()->getFixers());
 
         $unknownFixers = array_diff(
             $configuredFixers,

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -868,12 +868,13 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidConfigurationException
-     * @expectedExceptionMessage The rules contain unknown fixers (foo, bar).
-     */
     public function testResolveRulesWithUnknownRules()
     {
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            'The rules contain unknown fixers (foo, bar).'
+        );
+
         $resolver = new ConfigurationResolver(
             $this->config,
             array('rules' => 'foo,-bar'),

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -867,17 +867,17 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             $resolver->getRules()
         );
     }
-
+    
     public function testResolveRulesWithUnknownRules()
     {
         $this->setExpectedException(
             'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            'The rules contain unknown fixers (foo, bar).'
+            'The rules contain unknown fixers (bar).'
         );
 
         $resolver = new ConfigurationResolver(
             $this->config,
-            array('rules' => 'foo,-bar'),
+            array('rules' => 'braces,-bar'),
             ''
         );
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -867,7 +867,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             $resolver->getRules()
         );
     }
-    
+
     public function testResolveRulesWithUnknownRules()
     {
         $this->setExpectedException(

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -856,7 +856,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
     {
         $resolver = new ConfigurationResolver(
             $this->config,
-            array('rules' => 'braces,-strict'),
+            array('rules' => 'braces,-strict_comparison'),
             ''
         );
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -868,6 +868,21 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @expectedException \PhpCsFixer\ConfigurationException\InvalidConfigurationException
+     * @expectedExceptionMessage The rules contain unknown fixers (foo, bar).
+     */
+    public function testResolveRulesWithUnknownRules()
+    {
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array('rules' => 'foo,-bar'),
+            ''
+        );
+
+        $resolver->getRules();
+    }
+
     public function testResolveRulesWithConfigAndOption()
     {
         $this->config->setRules(array(


### PR DESCRIPTION
This PR

* [x] asserts that unknown rules are rejected by the `ConfigurationResolver`
* [x] rejects unknown rules 
* [x] adjusts an unrelated test that references an unknown (possibly renamed) rule

💁‍♂️ Not sure if this is the nicest way, but at least it is a way without breaking BC!