### PR TITLE
HashToSlashCommentFixer - Fix range used by the fixer.

### DIFF
--- a/Symfony/CS/Fixer/Symfony/HashToSlashCommentFixer.php
+++ b/Symfony/CS/Fixer/Symfony/HashToSlashCommentFixer.php
@@ -28,7 +28,7 @@ final class HashToSlashCommentFixer extends AbstractFixer
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
-        for ($i = 0, $count = count($tokens); $i < $count - 1; ++$i) {
+        for ($i = 1, $count = count($tokens); $i < $count; ++$i) {
             if ($tokens[$i]->isGivenKind(T_COMMENT) && '#' === substr($tokens[$i]->getContent(), 0, 1)) {
                 $tokens[$i]->setContent('//'.substr($tokens[$i]->getContent(), 1));
             }

--- a/Symfony/CS/Tests/Fixer/Symfony/HashToSlashCommentFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Symfony/HashToSlashCommentFixerTest.php
@@ -70,6 +70,13 @@ final class HashToSlashCommentFixerTest extends AbstractFixerTestBase
                     # test 4
                 ',
             ),
+            array(
+                '<?php // a',
+                '<?php # a',
+            ),
+            array(
+                '<?php# a',
+            ),
         );
     }
 }


### PR DESCRIPTION
small bug fix

(cherry picked for master on https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2366)