### PR TITLE
PhpdocSeparationFixer - Ignore incorrect PHPDoc

### DIFF
--- a/src/DocBlock/Line.php
+++ b/src/DocBlock/Line.php
@@ -131,7 +131,11 @@ class Line
      */
     public function addBlank()
     {
-        preg_match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
+        $matched = preg_match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
+
+        if (1 !== $matched) {
+            return;
+        }
 
         $this->content .= $matches[1].$matches[2];
     }

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -24,6 +24,11 @@ final class PhpdocSeparationFixerTest extends AbstractFixerTestCase
 {
     public function testFix()
     {
+        $this->doTest('<?php
+/** @param EngineInterface $templating 
+*@return void
+*/');
+
         $expected = <<<'EOF'
 <?php
     /**


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2365

@GrahamCampbell happy debugging!