### PR TITLE
Tests - Do not use annotations for asserting exceptions

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -107,12 +107,13 @@ final class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($config, $config->setCacheFile('some-directory/some.file'));
     }
 
-    /**
-     * @expectedException              \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^Argument must be an array or a Traversable, got "\w+"\.$/
-     */
     public function testRegisterCustomFixersWithInvalidArgument()
     {
+        $this->setExpectedExceptionRegExp(
+            'InvalidArgumentException',
+            '/^Argument must be an array or a Traversable, got "\w+"\.$/'
+        );
+
         $config = new Config();
         $config->registerCustomFixers('foo');
     }

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -41,12 +41,13 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         unset($this->config);
     }
 
-    /**
-     * @expectedException              \PhpCsFixer\ConfigurationException\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^Unknown option name: "foo"\.$/
-     */
     public function testSetOptionWithUndefinedOption()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '/^Unknown option name: "foo"\.$/'
+        );
+
         new ConfigurationResolver(
             $this->config,
             array('foo' => 'bar'),
@@ -213,12 +214,13 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException              \PhpCsFixer\ConfigurationException\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^The config file: ".+[\/\\]Fixtures[\/\\]ConfigurationResolverConfigFile[\/\\]case_5[\/\\].php_cs.dist" does not return a "PhpCsFixer\\ConfigInterface" instance\. Got: "string"\.$/
-     */
     public function testResolveConfigFileChooseFileWithInvalidFile()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '#^The config file: ".+[\/\\\]Fixtures[\/\\\]ConfigurationResolverConfigFile[\/\\\]case_5[\/\\\]\.php_cs.dist" does not return a "PhpCsFixer\\\ConfigInterface" instance\. Got: "string"\.$#'
+        );
+
         $dirBase = $this->getFixtureDir();
 
         $resolver = new ConfigurationResolver(
@@ -230,12 +232,13 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $resolver->getConfig();
     }
 
-    /**
-     * @expectedException              \PhpCsFixer\ConfigurationException\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^The format "xls" is not defined, supported are json, junit, txt, xml.$/
-     */
     public function testResolveConfigFileChooseFileWithInvalidFormat()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '/^The format "xls" is not defined, supported are json, junit, txt, xml.$/'
+        );
+
         $dirBase = $this->getFixtureDir();
 
         $resolver = new ConfigurationResolver(
@@ -247,12 +250,13 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $resolver->getReporter();
     }
 
-    /**
-     * @expectedException              \PhpCsFixer\ConfigurationException\InvalidConfigurationException
-     * @expectedExceptionMessageRegExp /^For multiple paths config parameter is required.$/
-     */
     public function testResolveConfigFileChooseFileWithPathArrayWithoutConfig()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '/^For multiple paths config parameter is required.$/'
+        );
+
         $dirBase = $this->getFixtureDir();
 
         $resolver = new ConfigurationResolver(

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -241,23 +241,25 @@ final class AnnotationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage This tag does not support types
-     */
     public function testGetTypesOnBadTag()
     {
+        $this->setExpectedException(
+            'RuntimeException',
+            'This tag does not support types'
+        );
+
         $tag = new Annotation(array(new Line(' * @deprecated since 1.2')));
 
         $tag->getTypes();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage This tag does not support types
-     */
     public function testSetTypesOnBadTag()
     {
+        $this->setExpectedException(
+            'RuntimeException',
+            'This tag does not support types'
+        );
+
         $tag = new Annotation(array(new Line(' * @author Chuck Norris')));
 
         $tag->setTypes(array('string'));

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -19,12 +19,13 @@ use PhpCsFixer\Finder;
  */
 final class FinderTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException              \LogicException
-     * @expectedExceptionMessageRegExp /^You must call (?:the in\(\) method)|(?:one of in\(\) or append\(\)) methods before iterating over a Finder\.$/
-     */
     public function testThatDefaultFinderDoesNotSpecifyAnyDirectory()
     {
+        $this->setExpectedExceptionRegExp(
+            'LogicException',
+            '/^You must call (?:the in\(\) method)|(?:one of in\(\) or append\(\)) methods before iterating over a Finder\.$/'
+        );
+
         $finder = Finder::create();
         $finder->getIterator();
     }

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -21,21 +21,23 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[random_api_migration\] "is_null" is not handled by the fixer.$#
-     */
     public function testConfigureCheckSearchFunction()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[random_api_migration\] "is_null" is not handled by the fixer.$#'
+        );
+
         $this->fixer->configure(array('is_null' => 'random_int'));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[random_api_migration\] Expected string got "NULL".$#
-     */
     public function testConfigureCheckReplacementType()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[random_api_migration\] Expected string got "NULL".$#'
+        );
+
         $this->fixer->configure(array('rand' => null));
     }
 

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -23,12 +23,13 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class ArraySyntaxFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[array_syntax\] Configuration must define "syntax" being "short" or "long".$#
-     */
     public function testInvalidConfiguration()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[array_syntax\] Configuration must define "syntax" being "short" or "long".$#'
+        );
+
         $this->fixer->configure(array('a' => 1));
     }
 

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -112,22 +112,24 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[class_definition\] Unknown configuration item "a", expected any of "singleLine, singleItemSingleLine, multiLineExtendsEachSingleLine".$/
-     */
     public function testInvalidConfigurationKey()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[class_definition\] Unknown configuration item "a", expected any of "singleLine, singleItemSingleLine, multiLineExtendsEachSingleLine".$/'
+        );
+
         $fixer = new ClassDefinitionFixer();
         $fixer->configure(array('a' => false));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[class_definition\] Configuration value for item "singleLine" must be a bool, got "string".$/
-     */
     public function testInvalidConfigurationValueType()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[class_definition\] Configuration value for item "singleLine" must be a bool, got "string".$/'
+        );
+
         $fixer = new ClassDefinitionFixer();
         $fixer->configure(array('singleLine' => 'z'));
     }

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -567,12 +567,13 @@ EOT
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [ordered_class_elements] Unknown class element type "foo".
-     */
     public function testWrongConfig()
     {
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '[ordered_class_elements] Unknown class element type "foo".'
+        );
+
         $this->fixer->configure(array('foo'));
     }
 }

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -656,12 +656,13 @@ EOT
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[single_class_element_per_statement\] Unknown configuration option "foo"\. Expected any of "property", "const"\.$/
-     */
     public function testWrongConfig()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[single_class_element_per_statement\] Unknown configuration option "foo"\. Expected any of "property", "const"\.$/'
+        );
+
         $this->fixer->configure(array('foo'));
     }
 

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -429,33 +429,37 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[visibility_required\] Expected string got "NULL".$/
-     */
     public function testInvalidConfigurationType()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[visibility_required\] Expected string got "NULL".$/'
+        );
+
         $this->fixer->configure(array(null));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[visibility_required\] Unknown configuration item "_unknown_", expected any of "property", "method", "const".$/
-     */
     public function testInvalidConfigurationValue()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[visibility_required\] Unknown configuration item "_unknown_", expected any of "property", "method", "const".$/'
+        );
+
         $this->fixer->configure(array('_unknown_'));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[visibility_required\] Invalid configuration item "const" for PHP ".+".$/
-     */
     public function testInvalidConfigurationValueForPHPVersion()
     {
         if (PHP_VERSION_ID >= 70100) {
             $this->markTestSkipped('PHP version to high.');
         }
+
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[visibility_required\] Invalid configuration item "const" for PHP ".+".$/'
+        );
+
 
         $this->fixer->configure(array('const'));
     }

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -460,7 +460,6 @@ EOF;
             '/^\[visibility_required\] Invalid configuration item "const" for PHP ".+".$/'
         );
 
-
         $this->fixer->configure(array('const'));
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -343,21 +343,23 @@ $b;',
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[binary_operator_spaces\] Unknown configuration option "foo"\. Expected any of "align_equals", "align_double_arrow"\.$/
-     */
     public function testWrongConfigItem()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[binary_operator_spaces\] Unknown configuration option "foo"\. Expected any of "align_equals", "align_double_arrow"\.$/'
+        );
+
         $this->fixer->configure(array('foo' => true));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[binary_operator_spaces\] Invalid value type for configuration option "align_double_arrow"\. Expected "bool" or "null" got "integer"\.$/
-     */
     public function testWrongConfigValue()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[binary_operator_spaces\] Invalid value type for configuration option "align_double_arrow"\. Expected "bool" or "null" got "integer"\.$/'
+        );
+
         $this->fixer->configure(array('align_double_arrow' => 123));
     }
 

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -22,21 +22,23 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class ConcatSpaceFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[concat_space\] Missing "spacing" configuration.$#
-     */
     public function testInvalidConfigMissingKey()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[concat_space\] Missing "spacing" configuration.$#'
+        );
+
         $this->fixer->configure(array('a' => 1));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[concat_space\] "spacing" configuration must be "one" or "none".$#
-     */
     public function testInvalidConfigValue()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[concat_space\] "spacing" configuration must be "one" or "none".$#'
+        );
+
         $this->fixer->configure(array('spacing' => 'tabs'));
     }
 

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -21,12 +21,13 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Configured method "MyTest" cannot be fixed by this fixer.
-     */
     public function testInvalidConfiguration()
     {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Configured method "MyTest" cannot be fixed by this fixer.'
+        );
+
         $this->fixer->configure(array('MyTest'));
     }
 
@@ -95,12 +96,13 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [php_unit_construct] Configured method "__TEST__" cannot be fixed by this fixer.
-     */
     public function testInvalidConfig()
     {
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '[php_unit_construct] Configured method "__TEST__" cannot be fixed by this fixer.'
+        );
+
         $this->fixer->configure(array('__TEST__'));
     }
 

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -200,12 +200,13 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[php_unit_dedicate_assert\] Unknown configuration method "_unknown_".$/
-     */
     public function testInvalidConfig()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[php_unit_dedicate_assert\] Unknown configuration method "_unknown_".$/'
+        );
+
         $this->fixer->configure(array('_unknown_'));
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -23,39 +23,43 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[phpdoc_no_alias_tag\] Tag to replace must be a string.$#
-     */
     public function testInvalidConfigCase1()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Tag to replace must be a string.$#'
+        );
+
         $this->fixer->configure(array(1 => 'abc'));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[phpdoc_no_alias_tag\] Tag to replace to from "a" must be a string.$#
-     */
     public function testInvalidConfigCase2()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Tag to replace to from "a" must be a string.$#'
+        );
+
         $this->fixer->configure(array('a' => null));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[phpdoc_no_alias_tag\] Tag "see" cannot be replaced by invalid tag "link\*\/".$#
-     */
     public function testInvalidConfigCase3()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Tag "see" cannot be replaced by invalid tag "link\*\/".$#'
+        );
+
         $this->fixer->configure(array('see' => 'link*/'));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[phpdoc_no_alias_tag\] Cannot change tag "link" to tag "see", as the tag is set configured to be replaced to "link".$#
-     */
     public function testInvalidConfigCase4()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Cannot change tag "link" to tag "see", as the tag is set configured to be replaced to "link".$#'
+        );
+
         $this->fixer->configure(array(
             'see' => 'link',
             'a' => 'b',
@@ -63,12 +67,13 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         ));
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp #^\[phpdoc_no_alias_tag\] Cannot change tag "b" to tag "see", as the tag is set configured to be replaced to "link".$#
-     */
     public function testInvalidConfigCase5()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Cannot change tag "b" to tag "see", as the tag is set configured to be replaced to "link".$#'
+        );
+
         $this->fixer->configure(array(
             'see' => 'link',
             'link' => 'b',

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -419,12 +419,13 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessage [no_extra_consecutive_blank_lines] Unknown configuration item "__TEST__" passed.
-     */
     public function testWrongConfig()
     {
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '[no_extra_consecutive_blank_lines] Unknown configuration item "__TEST__" passed.'
+        );
+
         $this->fixer->configure(array('__TEST__'));
     }
 

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -326,12 +326,13 @@ EOT
         );
     }
 
-    /**
-     * @expectedException \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException
-     * @expectedExceptionMessageRegExp /^\[no_spaces_around_offset\] Unknown configuration option "foo"\.$/
-     */
     public function testWrongConfig()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '/^\[no_spaces_around_offset\] Unknown configuration option "foo"\.$/'
+        );
+
         $this->fixer->configure(array('foo'));
     }
 }

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -121,11 +121,14 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \PhpCsFixer\FixerFactory::registerFixer
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage Fixer named "non_unique_name" is already registered.
      */
     public function testRegisterFixerWithOccupiedName()
     {
+        $this->setExpectedException(
+                 'UnexpectedValueException',
+            'Fixer named "non_unique_name" is already registered.'
+        );
+
         $factory = new FixerFactory();
 
         $f1 = $this->createFixerDouble('non_unique_name');
@@ -156,11 +159,14 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \PhpCsFixer\FixerFactory::useRuleSet
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage Rule "non_existing_rule" does not exist.
      */
     public function testUseRuleSetWithNonExistingRule()
     {
+        $this->setExpectedException(
+            'UnexpectedValueException',
+            'Rule "non_existing_rule" does not exist.'
+        );
+
         $factory = FixerFactory::create()
             ->registerBuiltInFixers()
             ->useRuleSet(new RuleSet(array('non_existing_rule' => true)))
@@ -481,11 +487,14 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideConflictingFixersRules
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessageRegExp #^Rule contains conflicting fixers:\n#
      */
     public function testConflictingFixers(RuleSet $ruleSet)
     {
+        $this->setExpectedExceptionRegExp(
+            'UnexpectedValueException',
+            '#^Rule contains conflicting fixers:\n#'
+        );
+
         FixerFactory::create()->registerBuiltInFixers()->useRuleSet($ruleSet);
     }
 

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -83,12 +83,13 @@ final class ReporterFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('r1', 'r2', 'r3'), $builder->getFormats());
     }
 
-    /**
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage Reporter for format "non_unique_name" is already registered.
-     */
     public function testRegisterReportWithOccupiedFormat()
     {
+        $this->setExpectedException(
+            'UnexpectedValueException',
+            'Reporter for format "non_unique_name" is already registered.'
+        );
+
         $factory = new ReporterFactory();
 
         $r1 = $this->createReporterDouble('non_unique_name');
@@ -97,12 +98,13 @@ final class ReporterFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->registerReporter($r2);
     }
 
-    /**
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage Reporter for format "non_registered_format" is not registered.
-     */
     public function testGetNonRegisteredReport()
     {
+        $this->setExpectedException(
+            'UnexpectedValueException',
+            'Reporter for format "non_registered_format" is not registered.'
+        );
+
         $builder = new ReporterFactory();
 
         $builder->getReporter('non_registered_format');

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -63,23 +63,25 @@ final class RuleSetTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Set "@foo" does not exist.
-     */
     public function testResolveRulesWithInvalidSet()
     {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Set "@foo" does not exist.'
+        );
+
         RuleSet::create(array(
             '@foo' => true,
         ));
     }
 
-    /**
-     * @expectedException        \InvalidArgumentException
-     * @expectedExceptionMessage Missing value for "braces" rule/set.
-     */
     public function testResolveRulesWithMissingRuleValue()
     {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'Missing value for "braces" rule/set.'
+        );
+
         RuleSet::create(array(
             'braces',
         ));

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -701,11 +701,12 @@ $b;',
      * @param string $source
      * @param int    $tokenIndex
      *
-     * @expectedException \InvalidArgumentException
      * @dataProvider provideArrayExceptions
      */
     public function testIsMultiLineArrayException($source, $tokenIndex)
     {
+        $this->setExpectedException('InvalidArgumentException');
+
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $tokensAnalyzer->isArrayMultiLine($tokenIndex);

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -243,18 +243,17 @@ final class TokensTest extends \PHPUnit_Framework_TestCase
      * @param string $message
      * @param array  $sequence
      *
-     * @expectedException \InvalidArgumentException
      * @dataProvider provideFindSequenceExceptions
      */
     public function testFindSequenceException($message, array $sequence)
     {
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            $message
+        );
+
         $tokens = Tokens::fromCode('<?php $x = 1;');
-        try {
-            $tokens->findSequence($sequence);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertSame($message, $e->getMessage());
-            throw $e;
-        }
+        $tokens->findSequence($sequence);
     }
 
     public function provideFindSequenceExceptions()
@@ -703,23 +702,25 @@ PHP;
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^Invalid param type: -1\.$/
-     */
     public function testFindBlockEndInvalidType()
     {
+        $this->setExpectedExceptionRegExp(
+            'InvalidArgumentException',
+            '/^Invalid param type: -1\.$/'
+        );
+
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');
         $tokens->findBlockEnd(-1, 0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /^Invalid param \$startIndex - not a proper block start\.$/
-     */
     public function testFindBlockEndInvalidStart()
     {
+        $this->setExpectedExceptionRegExp(
+            'InvalidArgumentException',
+            '/^Invalid param \$startIndex - not a proper block start\.$/'
+        );
+
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');
         $tokens->findBlockEnd(Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE, 0);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -145,12 +145,13 @@ final class UtilsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The given token must be whitespace, got "T_STRING".
-     */
     public function testCalculateTrailingWhitespaceIndentFail()
     {
+        $this->setExpectedException(
+             'InvalidArgumentException',
+            'The given token must be whitespace, got "T_STRING".'
+        );
+
         $token = new Token(array(T_STRING, 'foo'));
 
         Utils::calculateTrailingWhitespaceIndent($token);


### PR DESCRIPTION
This PR

* [x] uses `setExpectedException()` and siblings instead of annotations for asserting exceptions to be thrown

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2351#pullrequestreview-12317080.