### PR TITLE
Consistently provide a default configuration field

### DIFF
--- a/src/Fixer/Alias/RandomApiMigrationFixer.php
+++ b/src/Fixer/Alias/RandomApiMigrationFixer.php
@@ -29,6 +29,9 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
      */
     private $configuration;
 
+    /**
+     * @var array
+     */
     private static $defaultConfiguration = array(
         'getrandmax' => array('alternativeName' => 'mt_getrandmax', 'argumentCount' => array(0)),
         'mt_rand' => array('alternativeName' => 'mt_rand', 'argumentCount' => array(1, 2)),

--- a/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+++ b/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -31,6 +31,13 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    /**
+     * @var array
+     */
+    private static $defaultConfiguration = array(
+        'syntax' => 'long',
+    );
+
     private $config = array();
     private $candidateTokenKind;
     private $fixCallback;
@@ -45,11 +52,7 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->config = 'long';
-            $this->resolveCandidateTokenKind();
-            $this->resolveFixCallback();
-
-            return;
+            $configuration = self::$defaultConfiguration;
         }
 
         if (!array_key_exists('syntax', $configuration) || !in_array($configuration['syntax'], array('long', 'short'), true)) {
@@ -101,7 +104,7 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
             ),
             null,
             'Configure to use "long" or "short" array declaration syntax.',
-            array('syntax' => 'long')
+            self::$defaultConfiguration
         );
     }
 

--- a/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+++ b/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -52,7 +52,11 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $configuration = self::$defaultConfiguration;
+            $this->config = 'long';
+            $this->resolveCandidateTokenKind();
+            $this->resolveFixCallback();
+
+            return;
         }
 
         if (!array_key_exists('syntax', $configuration) || !in_array($configuration['syntax'], array('long', 'short'), true)) {

--- a/src/Fixer/Basic/Psr0Fixer.php
+++ b/src/Fixer/Basic/Psr0Fixer.php
@@ -24,6 +24,11 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class Psr0Fixer extends AbstractPsrAutoloadingFixer implements ConfigurableFixerInterface
 {
+    /**
+     * @var array
+     */
+    private static $defaultConfiguration = array();
+
     private $configuration = array();
 
     /**
@@ -32,7 +37,7 @@ final class Psr0Fixer extends AbstractPsrAutoloadingFixer implements Configurabl
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->configuration = array();
+            $this->configuration = self::$defaultConfiguration;
 
             return;
         }

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -159,7 +159,7 @@ interface Bar extends
             ),
             null,
             'Configure to have extra whitespace around the keywords of a class, trait or interface definition removed.',
-            self::$defaultConfig
+            self::$defaultConfiguration
         );
     }
 

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -34,7 +34,7 @@ final class ClassDefinitionFixer extends AbstractFixer implements ConfigurableFi
     /**
      * @var array<string, bool>
      */
-    private static $defaultConfig = array(
+    private static $defaultConfiguration = array(
         // put class declaration on one line
         'singleLine' => false,
         // if a classy extends or implements only one element than put it on the same line
@@ -56,16 +56,16 @@ final class ClassDefinitionFixer extends AbstractFixer implements ConfigurableFi
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->config = self::$defaultConfig;
+            $this->config = self::$defaultConfiguration;
 
             return;
         }
 
-        $configuration = array_merge(self::$defaultConfig, $configuration);
+        $configuration = array_merge(self::$defaultConfiguration, $configuration);
 
         foreach ($configuration as $item => $value) {
-            if (!array_key_exists($item, self::$defaultConfig)) {
-                throw new InvalidFixerConfigurationException('class_definition', sprintf('Unknown configuration item "%s", expected any of "%s".', $item, implode(', ', array_keys(self::$defaultConfig))));
+            if (!array_key_exists($item, self::$defaultConfiguration)) {
+                throw new InvalidFixerConfigurationException('class_definition', sprintf('Unknown configuration item "%s", expected any of "%s".', $item, implode(', ', array_keys(self::$defaultConfiguration))));
             }
 
             if (!is_bool($value)) {

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -67,7 +67,7 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
     /**
      * @var string[] Default order/configuration
      */
-    private static $defaultOrder = array(
+    private static $defaultConfiguration = array(
         'use_trait',
         'constant_public',
         'constant_protected',
@@ -95,7 +95,7 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $configuration = self::$defaultOrder;
+            $configuration = self::$defaultConfiguration;
         }
 
         $this->typePosition = array();

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -33,6 +33,9 @@ final class BinaryOperatorSpacesFixer extends AbstractFixer implements Configura
      */
     private $configuration;
 
+    /**
+     * @var array
+     */
     private static $defaultConfiguration = array(
         'align_equals' => false,
         'align_double_arrow' => false,

--- a/src/Fixer/Operator/ConcatSpaceFixer.php
+++ b/src/Fixer/Operator/ConcatSpaceFixer.php
@@ -43,7 +43,9 @@ final class ConcatSpaceFixer extends AbstractFixer implements ConfigurableFixerI
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $configuration = self::$defaultConfiguration;
+            $this->fixCallback = 'fixConcatenationToNoSpace';
+
+            return;
         }
 
         if (!array_key_exists('spacing', $configuration)) {

--- a/src/Fixer/Operator/ConcatSpaceFixer.php
+++ b/src/Fixer/Operator/ConcatSpaceFixer.php
@@ -26,6 +26,13 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class ConcatSpaceFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    /**
+     * @var array
+     */
+    private static $defaultConfiguration = array(
+        'spacing' => 'none',
+    );
+
     private $fixCallback;
 
     /**
@@ -36,9 +43,7 @@ final class ConcatSpaceFixer extends AbstractFixer implements ConfigurableFixerI
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->fixCallback = 'fixConcatenationToNoSpace';
-
-            return;
+            $configuration = self::$defaultConfiguration;
         }
 
         if (!array_key_exists('spacing', $configuration)) {

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -39,7 +39,9 @@ final class GeneralPhpdocAnnotationRemoveFixer extends AbstractFixer implements 
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $configuration = self::$defaultConfiguration;
+            $this->configuration = self::$defaultConfiguration;
+
+            return;
         }
 
         $this->configuration = $configuration;

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -29,14 +29,17 @@ final class GeneralPhpdocAnnotationRemoveFixer extends AbstractFixer implements 
     protected $configuration;
 
     /**
+     * @var array
+     */
+    private static $defaultConfiguration = array();
+
+    /**
      * {@inheritdoc}
      */
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->configuration = array();
-
-            return;
+            $configuration = self::$defaultConfiguration;
         }
 
         $this->configuration = $configuration;

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -30,6 +30,9 @@ final class PhpdocAddMissingParamAnnotationFixer extends AbstractFunctionReferen
      */
     private $configuration;
 
+    /**
+     * @var array
+     */
     private static $defaultConfiguration = array(
         'only_untyped' => true,
     );

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -32,6 +32,9 @@ final class PhpdocNoAliasTagFixer extends AbstractFixer implements ConfigurableF
      */
     private $configuration;
 
+    /**
+     * @var array
+     */
     private static $defaultConfiguration = array(
         'property-read' => 'property',
         'property-write' => 'property',

--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -32,14 +32,11 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
 final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface
 {
     /**
-     * @var array<int, string> key is token id, value is name of callback
+     * @var array
      */
-    private static $defaultTokenKindCallbackMap = array(T_WHITESPACE => 'removeMultipleBlankLines');
-
-    /**
-     * @var array<string, string> token prototype, value is name of callback
-     */
-    private static $defaultTokenEqualsMap = array();
+    private static $defaultConfiguration = array(
+        'extra',
+    );
 
     /**
      * @var array<int, string> key is token id, value is name of callback
@@ -81,10 +78,7 @@ final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements C
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->tokenKindCallbackMap = self::$defaultTokenKindCallbackMap;
-            $this->tokenEqualsMap = self::$defaultTokenEqualsMap;
-
-            return;
+            $configuration = self::$defaultConfiguration;
         }
 
         $this->tokenKindCallbackMap = array();

--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -78,7 +78,10 @@ final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements C
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $configuration = self::$defaultConfiguration;
+            $this->tokenKindCallbackMap = array(T_WHITESPACE => 'removeMultipleBlankLines');;
+            $this->tokenEqualsMap = array();
+
+            return;
         }
 
         $this->tokenKindCallbackMap = array();

--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -41,6 +41,16 @@ final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements C
     /**
      * @var array<int, string> key is token id, value is name of callback
      */
+    private static $defaultTokenKindCallbackMap = array(T_WHITESPACE => 'removeMultipleBlankLines');
+
+    /**
+     * @var array<string, string> token prototype, value is name of callback
+     */
+    private static $defaultTokenEqualsMap = array();
+
+    /**
+     * @var array<int, string> key is token id, value is name of callback
+     */
     private $tokenKindCallbackMap;
 
     /**
@@ -78,8 +88,8 @@ final class NoExtraConsecutiveBlankLinesFixer extends AbstractFixer implements C
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
-            $this->tokenKindCallbackMap = array(T_WHITESPACE => 'removeMultipleBlankLines');;
-            $this->tokenEqualsMap = array();
+            $this->tokenKindCallbackMap = self::$defaultTokenKindCallbackMap;
+            $this->tokenEqualsMap = self::$defaultTokenEqualsMap;
 
             return;
         }

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -39,7 +39,7 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $defaultConfigProperty = new \ReflectionProperty('PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer', 'defaultConfiguration');
         $defaultConfigProperty->setAccessible(true);
 
-        $this->assertAttributeSame($defaultConfigProperty->getValue($fixer), 'config', $fixer);
+        $this->assertAttributeSame($defaultConfigProperty->getValue(), 'config', $fixer);
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -36,10 +36,10 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
         $fixer->configure(self::$defaultTestConfig);
         $fixer->configure(null);
 
-        $defaultConfigProperty = new \ReflectionProperty('PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer', 'defaultConfig');
+        $defaultConfigProperty = new \ReflectionProperty('PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer', 'defaultConfiguration');
         $defaultConfigProperty->setAccessible(true);
 
-        $this->assertAttributeSame($defaultConfigProperty->getValue(), 'config', $fixer);
+        $this->assertAttributeSame($defaultConfigProperty->getValue($fixer), 'config', $fixer);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] consistently provides a `private` and `static` field that contains the default configuration for a fixer implementing the `ConfigurableFixerInterface`

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2351#discussion_r91833232.
Related to #2366.

💁‍♂️ The idea is to increase transparency (what does the expected configuration actually look like), as well as to reuse it for fixer definitions.