### PR TITLE
Add BlankLineBeforeStatementFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -17,6 +17,7 @@ return PhpCsFixer\Config::create()
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'blank_line_before_statement' => true,
         'combine_consecutive_unsets' => true,
         // one should use PHPUnit methods to set up expected exception instead of annotations
         'general_phpdoc_annotation_remove' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],

--- a/README.rst
+++ b/README.rst
@@ -236,19 +236,20 @@ Choose from the list of available rules:
   Ensure there is no code on the same line as the PHP open tag and it is
   followed by a blank line.
 
-* **blank_line_before_control_statement** [@Symfony]
-
-  An empty line feed should precede a control statement.
-
-  Configuration options:
-
-  - ``statements`` (``array``): list of control statements to fix; defaults to
-    ``['return']``
-
 * **blank_line_before_return**
 
   An empty line feed should precede a return statement (deprecated, use
-  ``blank_line_before_control_statement`` instead).
+  ``blank_line_before_statement`` instead).
+
+* **blank_line_before_statement** [@Symfony]
+
+  An empty line feed must precede any configured statement.
+
+  Configuration options:
+
+  - ``statements`` (``array``): list of statements which must be must be preceded by
+    an empty line; defaults to ``['break', 'continue', 'declare', 'return',
+    'throw', 'try']``
 
 * **braces** [@PSR2, @Symfony]
 

--- a/README.rst
+++ b/README.rst
@@ -236,9 +236,19 @@ Choose from the list of available rules:
   Ensure there is no code on the same line as the PHP open tag and it is
   followed by a blank line.
 
-* **blank_line_before_return** [@Symfony]
+* **blank_line_before_control_statement** [@Symfony]
 
-  An empty line feed should precede a return statement.
+  An empty line feed should precede a control statement.
+
+  Configuration options:
+
+  - ``statements`` (``array``): list of control statements to fix; defaults to
+    ``['return']``
+
+* **blank_line_before_return**
+
+  An empty line feed should precede a return statement (deprecated, use
+  ``blank_line_before_control_statement`` instead).
 
 * **braces** [@PSR2, @Symfony]
 

--- a/src/AbstractFunctionReferenceFixer.php
+++ b/src/AbstractFunctionReferenceFixer.php
@@ -128,6 +128,7 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
 
             if (null !== $blockDefinitionProbe && true === $blockDefinitionProbe['isStart']) {
                 $paramContentIndex = $tokens->findBlockEnd($blockDefinitionProbe['type'], $paramContentIndex);
+
                 continue;
             }
 

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -92,6 +92,7 @@ final class DescribeCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
+
         try {
             if ('@' === $name[0]) {
                 $this->describeSet($output, $name);

--- a/src/Fixer/Alias/NoMixedEchoPrintFixer.php
+++ b/src/Fixer/Alias/NoMixedEchoPrintFixer.php
@@ -134,6 +134,7 @@ final class NoMixedEchoPrintFixer extends AbstractFixer implements Configuration
 
             if ($tokens[$i]->equals(',')) {
                 $canBeConverted = false;
+
                 break;
             }
         }

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -343,6 +343,7 @@ class Foo
 
                 if ($nestToken->equals(')')) {
                     $nestIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $nestIndex, false);
+
                     continue;
                 }
 
@@ -399,11 +400,13 @@ class Foo
 
                 if ($nestToken->equals('}')) {
                     ++$nestLevel;
+
                     continue;
                 }
 
                 if ($nestToken->equals('{')) {
                     --$nestLevel;
+
                     continue;
                 }
             }
@@ -641,6 +644,7 @@ class Foo
             // if there is some block in statement (eg lambda function) we need to skip it
             if ($token->equals('{')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
                 continue;
             }
 

--- a/src/Fixer/Casing/NativeFunctionCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionCasingFixer.php
@@ -62,6 +62,7 @@ final class NativeFunctionCasingFixer extends AbstractFixer
             $next = $tokens->getNextMeaningfulToken($index);
             if (!$tokens[$next]->equals('(')) {
                 $index = $next;
+
                 continue;
             }
 

--- a/src/Fixer/CastNotation/NoShortBoolCastFixer.php
+++ b/src/Fixer/CastNotation/NoShortBoolCastFixer.php
@@ -74,6 +74,7 @@ final class NoShortBoolCastFixer extends AbstractFixer
         for ($i = $index - 1; $i > 1; --$i) {
             if ($tokens[$i]->equals('!')) {
                 $this->fixShortCastToBoolCast($tokens, $i, $index);
+
                 break;
             }
 

--- a/src/Fixer/ClassNotation/MethodSeparationFixer.php
+++ b/src/Fixer/ClassNotation/MethodSeparationFixer.php
@@ -316,6 +316,7 @@ final class Sample
         for ($i = $commentIndex - 1; $i > 0; --$i) {
             if ($tokens[$i]->isComment()) {
                 $start = $i;
+
                 continue;
             }
 

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -93,12 +93,14 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
 
             if (!$parents) {
                 $this->typePosition[$type] = null;
+
                 continue;
             }
 
             foreach ($parents as $parent) {
                 if (isset($this->typePosition[$parent])) {
                     $this->typePosition[$type] = $this->typePosition[$parent];
+
                     continue 2;
                 }
             }
@@ -268,11 +270,13 @@ final class Example
 
                 if ($token->isGivenKind(T_STATIC)) {
                     $element['static'] = true;
+
                     continue;
                 }
 
                 if ($token->isGivenKind([T_PROTECTED, T_PRIVATE])) {
                     $element['visibility'] = strtolower($token->getContent());
+
                     continue;
                 }
 
@@ -289,6 +293,7 @@ final class Example
                 }
 
                 $element['end'] = $this->findElementEnd($tokens, $i);
+
                 break;
             }
 
@@ -391,6 +396,7 @@ final class Example
                     if ('phpunit' === $type) {
                         $element['position'] += $phpunitPositions[$element['name']];
                     }
+
                     continue;
                 }
 

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -95,6 +95,7 @@ final class Sample
         for ($index = $classOpenIndex + 1; $index < $classCloseIndex; ++$index) {
             if ($tokens[$index]->equals('{')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
                 continue;
             }
 

--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -105,6 +105,7 @@ class Sample
             ) {
                 $i = $tokens->getNextTokenOfKind($i, ['{']);
                 $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $i);
+
                 continue;
             }
 

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -170,11 +170,13 @@ final class Example
 
             if ($token->equals(')')) {
                 $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $i, false);
+
                 continue;
             }
 
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
                 $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $i, false);
+
                 continue;
             }
 

--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -117,6 +117,7 @@ $c = 3;',
             $commentContent = substr($content, 2, -2);
             if ($this->hashEnabled && '#' === $content[0]) {
                 $tokens[$index] = new Token([$token->getId(), '//'.substr($content, 1)]);
+
                 continue;
             }
             if (!$this->asteriskEnabled || '/*' !== substr($content, 0, 2) || 1 === preg_match('/[^\s\*].*\R.*[^\s\*]/s', $commentContent)) {

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
@@ -71,16 +71,19 @@ final class DoctrineAnnotationArrayAssignmentFixer extends AbstractDoctrineAnnot
         foreach ($tokens as $index => $token) {
             if ($token->isType(DocLexer::T_OPEN_PARENTHESIS)) {
                 $scopes[] = 'annotation';
+
                 continue;
             }
 
             if ($token->isType(DocLexer::T_OPEN_CURLY_BRACES)) {
                 $scopes[] = 'array';
+
                 continue;
             }
 
             if ($token->isType([DocLexer::T_CLOSE_PARENTHESIS, DocLexer::T_CLOSE_CURLY_BRACES])) {
                 array_pop($scopes);
+
                 continue;
             }
 

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
@@ -127,11 +127,13 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
 
             if ($token->isType([DocLexer::T_OPEN_PARENTHESIS, DocLexer::T_OPEN_CURLY_BRACES])) {
                 ++$lineBracesDelta;
+
                 continue;
             }
 
             if ($token->isType([DocLexer::T_CLOSE_PARENTHESIS, DocLexer::T_CLOSE_CURLY_BRACES])) {
                 --$lineBracesDelta;
+
                 continue;
             }
         }

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
@@ -213,16 +213,19 @@ final class DoctrineAnnotationSpacesFixer extends AbstractDoctrineAnnotationFixe
             $endScopeType = end($scopes);
             if (false !== $endScopeType && $token->isType($endScopeType)) {
                 array_pop($scopes);
+
                 continue;
             }
 
             if ($tokens[$index]->isType(DocLexer::T_AT)) {
                 $scopes[] = DocLexer::T_CLOSE_PARENTHESIS;
+
                 continue;
             }
 
             if ($tokens[$index]->isType(DocLexer::T_OPEN_CURLY_BRACES)) {
                 $scopes[] = DocLexer::T_CLOSE_CURLY_BRACES;
+
                 continue;
             }
 

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -167,6 +167,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 $this->fixSpace2($tokens, $index);
                 if (!$isMultiline && $this->isNewline($tokens[$index + 1])) {
                     $isMultiline = true;
+
                     break;
                 }
             }
@@ -210,12 +211,14 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             // skip nested method calls and arrays
             if ($token->equals(')')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index, false);
+
                 continue;
             }
 
             // skip nested arrays
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index, false);
+
                 continue;
             }
 

--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -95,6 +95,7 @@ function example($foo = "two words", $bar) {}
 
             if ($token->isGivenKind(T_VARIABLE)) {
                 $lastArgumentIndex = $i;
+
                 continue;
             }
 

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -123,6 +123,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
             foreach ($partials as $partial) {
                 if ($partial['start'] <= $index && $index <= $partial['end']) {
                     $allowToAppend = false;
+
                     break;
                 }
             }

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -343,6 +343,7 @@ use function CCC\AA;
                         for ($k = 0; $k < $namespaceTokensCount; ++$k) {
                             if ($namespaceTokens[$k]->isGivenKind(CT::T_GROUP_IMPORT_BRACE_OPEN)) {
                                 $namespace .= '{';
+
                                 break;
                             }
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -193,6 +193,7 @@ $className = Baz::class;
         foreach ($this->imports as $alias => $import) {
             if ($classString === $alias) {
                 $classImport = $import;
+
                 break;
             }
 
@@ -201,6 +202,7 @@ $className = Baz::class;
 
             if (0 === strcmp($namespaceToTest, substr($import, -strlen($namespaceToTest)))) {
                 $classImport = $import;
+
                 break;
             }
         }

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -64,6 +64,7 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
             $previousUnsetCall = $this->getPreviousUnsetCall($tokens, $index);
             if (is_int($previousUnsetCall)) {
                 $index = $previousUnsetCall;
+
                 continue;
             }
 

--- a/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+++ b/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
@@ -44,6 +44,7 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
             if ($token->isGivenKind([T_FOREACH, T_FOR, T_WHILE, T_IF, T_SWITCH])) {
                 $index = $tokens->getNextMeaningfulToken($index);
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
                 continue;
             }
 
@@ -53,6 +54,7 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
                 $index = $until;
 
                 $this->injectArrayAlignmentPlaceholders($tokens, $from, $until);
+
                 continue;
             }
 
@@ -67,6 +69,7 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
                 $index = $until;
 
                 $this->injectArrayAlignmentPlaceholders($tokens, $from + 1, $until - 1);
+
                 continue;
             }
 
@@ -82,12 +85,14 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
                 }
 
                 $tokens[$index] = new Token([T_DOUBLE_ARROW, $tokenContent]);
+
                 continue;
             }
 
             if ($token->equals(';')) {
                 ++$this->deepestLevel;
                 ++$this->currentLevel;
+
                 continue;
             }
 

--- a/src/Fixer/Operator/AlignEqualsFixerHelper.php
+++ b/src/Fixer/Operator/AlignEqualsFixerHelper.php
@@ -33,26 +33,31 @@ final class AlignEqualsFixerHelper extends AbstractAlignFixerHelper
 
             if ($token->equals('=')) {
                 $tokens[$index] = new Token(sprintf(self::ALIGNABLE_PLACEHOLDER, $this->deepestLevel).$token->getContent());
+
                 continue;
             }
 
             if ($token->isGivenKind(T_FUNCTION)) {
                 ++$this->deepestLevel;
+
                 continue;
             }
 
             if ($token->equals('(')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
                 continue;
             }
 
             if ($token->equals('[')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE, $index);
+
                 continue;
             }
 
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+
                 continue;
             }
         }

--- a/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
@@ -69,6 +69,7 @@ final class BlankLineAfterOpeningTagFixer extends AbstractFixer implements White
         foreach ($tokens as $token) {
             if ($token->isWhitespace() && false !== strpos($token->getContent(), "\n")) {
                 $newlineFound = true;
+
                 break;
             }
         }

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -94,6 +94,7 @@ echo "Hello!";
 
                 $tokensOldContent .= $tokenContent;
                 $tokensOldContentLength += strlen($tokenContent);
+
                 continue;
             }
 

--- a/src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
@@ -57,6 +57,7 @@ final class LinebreakAfterOpeningTagFixer extends AbstractFixer implements White
         foreach ($tokens as $token) {
             if ($token->isWhitespace() && false !== strpos($token->getContent(), "\n")) {
                 $newlineFound = true;
+
                 break;
             }
         }

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -211,6 +211,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurationDefin
                 if (null === $item['tag']) {
                     if ($item['desc'][0] === '@') {
                         $lines[$current + $j] = $item['indent'].' * '.$item['desc'].$lineEnding;
+
                         continue;
                     }
 

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -102,6 +102,7 @@ function fnc($foo, $bar) {}'
 
                 if ($next->containsATag()) {
                     $line->addBlank();
+
                     break;
                 }
             }

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -62,6 +62,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
                 $tokens[$index] = new Token([T_DOC_COMMENT, $this->fixTokenContent($token->getContent())]);
+
                 continue;
             }
 

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -97,6 +97,7 @@ foreach($connections as $key => $sqlite) {
 
             if (null === $nextToken || $nextToken->equals('}')) {
                 $tokens[$index] = new Token([T_COMMENT, '/*'.ltrim($token->getContent(), '/*')]);
+
                 continue;
             }
 

--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -13,14 +13,14 @@
 namespace PhpCsFixer\Fixer\ReturnNotation;
 
 use PhpCsFixer\AbstractProxyFixer;
-use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeControlStatementFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
- * @deprecated since 2.4, replaced by BlankLineBeforeControlStatementFixer
+ * @deprecated since 2.4, replaced by BlankLineBeforeStatementFixerTest
  *
  * @todo To be removed at 3.0
  *
@@ -35,7 +35,7 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Whi
     public function getDefinition()
     {
         return new FixerDefinition(
-            'An empty line feed should precede a return statement (deprecated, use `blank_line_before_control_statement` instead).',
+            'An empty line feed should precede a return statement (deprecated, use `blank_line_before_statement` instead).',
             [new CodeSample("<?php\nfunction A()\n{\n    echo 1;\n    return 1;\n}")]
         );
     }
@@ -53,7 +53,7 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Whi
      */
     protected function createProxyFixer()
     {
-        $fixer = new BlankLineBeforeControlStatementFixer();
+        $fixer = new BlankLineBeforeStatementFixer();
         $fixer->configure(['statements' => ['return']]);
 
         return $fixer;

--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -20,7 +20,9 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
- * @deprecated
+ * @deprecated since 2.4, replaced by BlankLineBeforeControlStatementFixer
+ *
+ * @todo To be removed at 3.0
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Andreas Möller <am@localheinz.com>
@@ -51,6 +53,9 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Whi
      */
     protected function createProxyFixer()
     {
-        return new BlankLineBeforeControlStatementFixer();
+        $fixer = new BlankLineBeforeControlStatementFixer();
+        $fixer->configure(['statements' => ['return']]);
+
+        return $fixer;
     }
 }

--- a/src/Fixer/Semicolon/NoEmptyStatementFixer.php
+++ b/src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -62,6 +62,7 @@ final class NoEmptyStatementFixer extends AbstractFixer
             // skip T_FOR parenthesis to ignore duplicated `;` like `for ($i = 1; ; ++$i) {...}`
             if ($tokens[$index]->isGivenKind(T_FOR)) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextMeaningfulToken($index)) + 1;
+
                 continue;
             }
 
@@ -74,6 +75,7 @@ final class NoEmptyStatementFixer extends AbstractFixer
             // A semicolon can always be removed if it follows a semicolon, '{' or opening tag.
             if ($tokens[$previousMeaningfulIndex]->equalsAny(['{', ';', [T_OPEN_TAG]])) {
                 $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
                 continue;
             }
 

--- a/src/Fixer/Strict/StrictParamFixer.php
+++ b/src/Fixer/Strict/StrictParamFixer.php
@@ -97,16 +97,19 @@ final class StrictParamFixer extends AbstractFixer
 
             if ($token->equals('(')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
                 continue;
             }
 
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+
                 continue;
             }
 
             if ($token->equals(',')) {
                 ++$commaCounter;
+
                 continue;
             }
         }
@@ -130,6 +133,7 @@ final class StrictParamFixer extends AbstractFixer
 
             if (!is_array($functionParams[$i])) {
                 $tokensToInsert[] = clone $functionParams[$i];
+
                 continue;
             }
 

--- a/src/Fixer/StringNotation/HeredocToNowdocFixer.php
+++ b/src/Fixer/StringNotation/HeredocToNowdocFixer.php
@@ -63,6 +63,7 @@ EOF
 
             if ($tokens[$index + 1]->isGivenKind(T_END_HEREDOC)) {
                 $tokens[$index] = $this->convertToNowdoc($token);
+
                 continue;
             }
 

--- a/src/Fixer/Whitespace/BlankLineBeforeControlStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeControlStatementFixer.php
@@ -1,0 +1,259 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Whitespace;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Andreas Möller <am@localheinz.com>
+ */
+final class BlankLineBeforeControlStatementFixer extends AbstractFixer implements ConfigurableFixerInterface, WhitespacesAwareFixerInterface
+{
+    /**
+     * @var array
+     */
+    private static $defaultConfiguration = [
+        'return',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $tokenMap = [
+        'break' => T_BREAK,
+        'continue' => T_CONTINUE,
+        'declare' => T_DECLARE,
+        'do' => T_DO,
+        'else' => T_ELSE,
+        'elseif' => T_ELSEIF,
+        'for' => T_FOR,
+        'foreach' => T_FOREACH,
+        'if' => T_IF,
+        'include' => T_INCLUDE,
+        'include_once' => T_INCLUDE_ONCE,
+        'require' => T_REQUIRE,
+        'require_once' => T_REQUIRE_ONCE,
+        'return' => T_RETURN,
+        'switch' => T_SWITCH,
+        'throw' => T_THROW,
+        'try' => T_TRY,
+        'while' => T_WHILE,
+    ];
+
+    /**
+     * @var array
+     */
+    private $fixTokenMap = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        if (null === $configuration) {
+            $configuration = self::$defaultConfiguration;
+        }
+
+        foreach ($configuration as $controlStatement) {
+            if (!is_string($controlStatement) || !array_key_exists($controlStatement, self::$tokenMap)) {
+                throw new InvalidFixerConfigurationException($this->getName(), sprintf(
+                    'Expected one of "%s", got "%s".',
+                    implode('", "', array_keys(self::$tokenMap)),
+                    is_object($controlStatement) ? get_class($controlStatement) : gettype($controlStatement)
+                ));
+            }
+
+            $this->fixTokenMap[$controlStatement] = self::$tokenMap[$controlStatement];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $lineEnding = $this->whitespacesConfig->getLineEnding();
+
+        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
+            $token = $tokens[$index];
+
+            if (!$token->isGivenKind(array_values($this->fixTokenMap))) {
+                continue;
+            }
+
+            $prevNonWhitespaceToken = $tokens[$tokens->getPrevNonWhitespace($index)];
+
+            if (!$prevNonWhitespaceToken->equalsAny([';', '}'])) {
+                continue;
+            }
+
+            $prevToken = $tokens[$index - 1];
+
+            if ($prevToken->isWhitespace()) {
+                $parts = explode("\n", $prevToken->getContent());
+                $countParts = count($parts);
+
+                if (1 === $countParts) {
+                    $prevToken->setContent(rtrim($prevToken->getContent(), " \t").$lineEnding.$lineEnding);
+                } elseif (count($parts) <= 2) {
+                    $prevToken->setContent($lineEnding.$prevToken->getContent());
+                }
+            } else {
+                $tokens->insertAt($index, new Token([T_WHITESPACE, $lineEnding.$lineEnding]));
+
+                ++$index;
+                ++$limit;
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'An empty line feed should precede a control statement.',
+            [
+                new CodeSample(
+                    '<?php
+function A() {
+    echo 1;
+    return 1;
+}'
+                ),
+                new CodeSample(
+                    '<?php
+switch ($foo) {
+    case 42:
+        $bar->process();
+        break;
+    case 44:
+        break;
+}',
+                    [
+                        'break',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+foreach ($foo as $bar) {
+    if ($bar->isTired()) {
+        $bar->sleep();
+        continue;
+    }
+}',
+                    [
+                        'continue',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+$i = 0;
+do {
+    echo $i;
+} while ($i > 0);
+',
+                    [
+                        'do',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+$a = 9000;
+if (true) {
+    $foo = $bar;
+}',
+                    [
+                        'if',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+
+if (true) {
+    $foo = $bar;
+    return;
+}',
+                    [
+                        'return',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+$a = 9000;
+switch ($a) {
+    case 42:
+        break;
+}',
+                    [
+                        'switch',
+                    ]
+                ),
+                new CodeSample(
+'<?php
+if (null === $a) {
+    $foo->bar();
+    throw new \UnexpectedValueException("A cannot be null");
+}',
+                    [
+                        'throw',
+                    ]
+                ),
+                new CodeSample(
+'<?php
+$a = 9000;
+try {
+    $foo->bar();
+} catch (\Exception $exception) {
+    $a = -1;
+}',
+                    [
+                        'try',
+                    ]
+                ),
+            ],
+            null,
+            sprintf(
+                'Provide an array with any of "%s".',
+                implode('", "', array_keys(self::$tokenMap))
+            ),
+            self::$defaultConfiguration
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run after NoUselessReturnFixer
+        return -19;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound(array_values($this->fixTokenMap));
+    }
+}

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -71,6 +71,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
                 $content = preg_replace('/^    /m', $this->whitespacesConfig->getIndent(), $content);
 
                 $tokens[$index] = new Token([$token->getId(), $content]);
+
                 continue;
             }
 

--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -412,6 +412,7 @@ switch($a) {
             if (false !== strpos($this->tokens[$i]->getContent(), "\n")) {
                 $this->removeEmptyLinesAfterLineWithTokenAt($i);
                 $this->removeEmptyLinesAfterLineWithTokenAt($index);
+
                 break;
             }
         }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -60,7 +60,7 @@ final class RuleSet implements RuleSetInterface
                 'align_equals' => false,
             ],
             'blank_line_after_opening_tag' => true,
-            'blank_line_before_control_statement' => [
+            'blank_line_before_statement' => [
                 'statements' => ['return'],
             ],
             'braces' => [

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -60,7 +60,9 @@ final class RuleSet implements RuleSetInterface
                 'align_equals' => false,
             ],
             'blank_line_after_opening_tag' => true,
-            'blank_line_before_return' => true,
+            'blank_line_before_control_statement' => [
+                'return',
+            ],
             'braces' => [
                 'allow_single_line_closure' => true,
             ],

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -61,7 +61,7 @@ final class RuleSet implements RuleSetInterface
             ],
             'blank_line_after_opening_tag' => true,
             'blank_line_before_control_statement' => [
-                'return',
+                'statements' => ['return'],
             ],
             'braces' => [
                 'allow_single_line_closure' => true,

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -59,21 +59,25 @@ final class TokensAnalyzer
 
             if (!$inClass) {
                 $inClass = $token->isClassy();
+
                 continue;
             }
 
             if ($token->equals('(')) {
                 ++$bracesLevel;
+
                 continue;
             }
 
             if ($token->equals(')')) {
                 --$bracesLevel;
+
                 continue;
             }
 
             if ($token->equals('{')) {
                 ++$curlyBracesLevel;
+
                 continue;
             }
 
@@ -93,6 +97,7 @@ final class TokensAnalyzer
 
             if (0 === $bracesLevel && $token->isGivenKind(T_VARIABLE)) {
                 $elements[$index] = ['token' => $token, 'type' => 'property'];
+
                 continue;
             }
 
@@ -198,6 +203,7 @@ final class TokensAnalyzer
 
             if ($blockType && $blockType['isStart']) {
                 $index = $tokens->findBlockEnd($blockType['type'], $index);
+
                 continue;
             }
 
@@ -250,16 +256,19 @@ final class TokensAnalyzer
 
             if ($token->isGivenKind([T_STATIC])) {
                 $attributes['static'] = true;
+
                 continue;
             }
 
             if ($token->isGivenKind([T_FINAL])) {
                 $attributes['final'] = true;
+
                 continue;
             }
 
             if ($token->isGivenKind([T_ABSTRACT])) {
                 $attributes['abstract'] = true;
+
                 continue;
             }
 
@@ -267,16 +276,19 @@ final class TokensAnalyzer
 
             if ($token->isGivenKind([T_PRIVATE])) {
                 $attributes['visibility'] = T_PRIVATE;
+
                 continue;
             }
 
             if ($token->isGivenKind([T_PROTECTED])) {
                 $attributes['visibility'] = T_PROTECTED;
+
                 continue;
             }
 
             if ($token->isGivenKind([T_PUBLIC])) {
                 $attributes['visibility'] = T_PUBLIC;
+
                 continue;
             }
 

--- a/src/Tokenizer/Transformer/CurlyBraceTransformer.php
+++ b/src/Tokenizer/Transformer/CurlyBraceTransformer.php
@@ -101,6 +101,7 @@ final class CurlyBraceTransformer extends AbstractTransformer
             // we count all kind of {
             if ($tokens[$nestIndex]->equals('{')) {
                 ++$level;
+
                 continue;
             }
 

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -39,6 +39,7 @@ final class ToolInfo
             foreach ($composerInstalled as $package) {
                 if (self::COMPOSER_PACKAGE_NAME === $package['name']) {
                     $result = $package['version'].'#'.$package['dist']['reference'];
+
                     break;
                 }
             }

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -107,6 +107,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_useless_return,no_whitespace_in_blank_line.test
             [$fixers['no_useless_return'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_useless_return,no_extra_consecutive_blank_lines.test
             [$fixers['no_useless_return'], $fixers['blank_line_before_return']], // tested also in: no_useless_return,blank_line_before_return.test
+            [$fixers['no_useless_return'], $fixers['blank_line_before_control_statement']], // tested also in: no_useless_return,blank_line_before_control_statement.test
             [$fixers['no_empty_phpdoc'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_empty_phpdoc,no_extra_consecutive_blank_lines.test
             [$fixers['no_empty_phpdoc'], $fixers['no_trailing_whitespace']], // tested also in: no_empty_phpdoc,no_trailing_whitespace.test
             [$fixers['no_empty_phpdoc'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_empty_phpdoc,no_whitespace_in_blank_line.test

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -107,7 +107,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_useless_return,no_whitespace_in_blank_line.test
             [$fixers['no_useless_return'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_useless_return,no_extra_consecutive_blank_lines.test
             [$fixers['no_useless_return'], $fixers['blank_line_before_return']], // tested also in: no_useless_return,blank_line_before_return.test
-            [$fixers['no_useless_return'], $fixers['blank_line_before_control_statement']],
+            [$fixers['no_useless_return'], $fixers['blank_line_before_statement']], // tested also in: no_useless_return,blank_line_before_statement.test
             [$fixers['no_empty_phpdoc'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_empty_phpdoc,no_extra_consecutive_blank_lines.test
             [$fixers['no_empty_phpdoc'], $fixers['no_trailing_whitespace']], // tested also in: no_empty_phpdoc,no_trailing_whitespace.test
             [$fixers['no_empty_phpdoc'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_empty_phpdoc,no_whitespace_in_blank_line.test

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -107,7 +107,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_useless_return,no_whitespace_in_blank_line.test
             [$fixers['no_useless_return'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_useless_return,no_extra_consecutive_blank_lines.test
             [$fixers['no_useless_return'], $fixers['blank_line_before_return']], // tested also in: no_useless_return,blank_line_before_return.test
-            [$fixers['no_useless_return'], $fixers['blank_line_before_control_statement']], // tested also in: no_useless_return,blank_line_before_control_statement.test
+            [$fixers['no_useless_return'], $fixers['blank_line_before_control_statement']],
             [$fixers['no_empty_phpdoc'], $fixers['no_extra_consecutive_blank_lines']], // tested also in: no_empty_phpdoc,no_extra_consecutive_blank_lines.test
             [$fixers['no_empty_phpdoc'], $fixers['no_trailing_whitespace']], // tested also in: no_empty_phpdoc,no_trailing_whitespace.test
             [$fixers['no_empty_phpdoc'], $fixers['no_whitespace_in_blank_line']], // tested also in: no_empty_phpdoc,no_whitespace_in_blank_line.test

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -931,13 +931,13 @@ final class ConfigurationResolverTest extends TestCase
 
         $resolver = new ConfigurationResolver(
             $this->config,
-            ['rules' => 'blank_line_before_control_statement'],
+            ['rules' => 'blank_line_before_statement'],
             ''
         );
 
         $this->assertSameRules(
             [
-                'blank_line_before_control_statement' => true,
+                'blank_line_before_statement' => true,
             ],
             $resolver->getRules()
         );

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -931,13 +931,13 @@ final class ConfigurationResolverTest extends TestCase
 
         $resolver = new ConfigurationResolver(
             $this->config,
-            ['rules' => 'blank_line_before_return'],
+            ['rules' => 'blank_line_before_control_statement'],
             ''
         );
 
         $this->assertSameRules(
             [
-                'blank_line_before_return' => true,
+                'blank_line_before_control_statement' => true,
             ],
             $resolver->getRules()
         );

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -35,6 +35,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         foreach ($fixer->getConfigurationDefinition()->getOptions() as $option) {
             if ('statements' === $option->getName()) {
                 self::$defaultStatements = $option->getDefault();
+
                 break;
             }
         }
@@ -503,6 +504,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
                 foreach (explode('_', $statement) as $singleStatement) {
                     if (false !== strpos($input, $singleStatement)) {
                         $withInput = true;
+
                         break;
                     }
                 }

--- a/tests/Fixer/Whitespace/BlankLineBeforeControlStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeControlStatementFixerTest.php
@@ -1,0 +1,1047 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Whitespace;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+use PhpCsFixer\WhitespacesFixerConfig;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ * @coversNothing
+ */
+final class BlankLineBeforeControlStatementFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider providerInvalidControlStatement
+     *
+     * @param mixed $controlStatement
+     */
+    public function testConfigureRejectsInvalidControlStatement($controlStatement)
+    {
+        $controlStatements = [
+            'break',
+            'continue',
+            'declare',
+            'do',
+            'else',
+            'elseif',
+            'for',
+            'foreach',
+            'if',
+            'include',
+            'include_once',
+            'require',
+            'require_once',
+            'return',
+            'switch',
+            'throw',
+            'try',
+            'while',
+        ];
+
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            sprintf(
+                'Expected one of "%s", got "%s".',
+                implode('", "', $controlStatements),
+                is_object($controlStatement) ? get_class($controlStatement) : gettype($controlStatement)
+            )
+        );
+
+        $this->fixer->configure([
+            $controlStatement,
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerInvalidControlStatement()
+    {
+        return [
+            'null' => [null],
+            'false' => [false],
+            'true' => [true],
+            'int' => [0],
+            'float' => [3.14],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+            'unknown' => ['foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithReturn
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithDefaultConfiguration($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @dataProvider providerFixWithBreak
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithBreak($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'break',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithBreak()
+    {
+        return [
+            [
+'<?php
+switch ($a) {
+    case 42:
+        break;
+}',
+            ],
+            [
+'<?php
+switch ($a) {
+    case 42:
+        $foo = $bar;
+
+        break;
+}',
+'<?php
+switch ($a) {
+    case 42:
+        $foo = $bar;
+        break;
+}',
+            ],
+            [
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        break;
+    }
+}',
+            ],
+            [
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        break 1;
+    }
+}',
+            ],
+            [
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        echo $baz;
+
+        break;
+    }
+}',
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        echo $baz;
+        break;
+    }
+}',
+            ],
+            [
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        echo $baz;
+
+        break 1;
+    }
+}',
+'<?php
+while (true) {
+    if ($foo === $bar) {
+        echo $baz;
+        break 1;
+    }
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithContinue
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithContinue($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'continue',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithContinue()
+    {
+        return [
+            [
+'<?php
+while (true) {
+    continue;
+}',
+            ],
+            [
+'<?php
+while (true) {
+    continue 1;
+}',
+            ],
+            [
+'<?php
+while (true) {
+    while (true) {
+        continue 2;
+    }
+}',
+            ],
+            [
+'<?php
+while (true) {
+    $foo = true;
+
+    continue;
+}',
+'<?php
+while (true) {
+    $foo = true;
+    continue;
+}',
+            ],
+            [
+'<?php
+while (true) {
+    $foo = true;
+
+    continue 1;
+}',
+'<?php
+while (true) {
+    $foo = true;
+    continue 1;
+}',
+            ],
+            [
+'<?php
+while (true) {
+    while (true) {
+        $foo = true;
+
+        continue 2;
+    }
+}',
+'<?php
+while (true) {
+    while (true) {
+        $foo = true;
+        continue 2;
+    }
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithDeclare
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithDeclare($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'declare',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithDeclare()
+    {
+        return [
+            [
+'<?php
+declare(ticks=1);',
+            ],
+            [
+'<?php
+
+$foo = "bar";
+
+declare(ticks=1);',
+'<?php
+
+$foo = "bar";
+declare(ticks=1);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithDo
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithDo($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'do',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithDo()
+    {
+        return [
+            [
+'<?php
+do {
+} while (true);',
+            ],
+            [
+'<?php
+$foo = "bar";
+
+do {
+} while (true);',
+'<?php
+$foo = "bar";
+do {
+} while (true);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithElse
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithElse($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'else',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithElse()
+    {
+        return [
+            [
+'<?php
+if (true) {
+    echo $b;
+}
+
+else {
+    echo $c;
+}',
+            ],
+            [
+'<?php
+if (true) {
+    echo $b;
+}
+
+else {
+    echo $c;
+}',
+'<?php
+if (true) {
+    echo $b;
+} else {
+    echo $c;
+}',
+            ],
+            [
+'<?php
+if (true)
+    echo $b;
+
+else
+    echo $c;',
+            ],
+            [
+'<?php
+if (true)
+    echo $b;
+
+else
+    echo $c;',
+'<?php
+if (true)
+    echo $b;
+else
+    echo $c;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithElseIf
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithElseIf($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'elseif',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithElseIf()
+    {
+        return [
+            [
+'<?php
+if ($c) {
+    echo $b;
+}
+
+elseif ($b) {
+    echo $c;
+}',
+            ],
+            [
+'<?php
+if ($c) {
+    echo $b;
+}
+
+elseif ($b) {
+    echo $c;
+}',
+'<?php
+if ($c) {
+    echo $b;
+} elseif ($b) {
+    echo $c;
+}',
+            ],
+            [
+'<?php
+if ($c)
+    echo $b;
+
+elseif ($b)
+    echo $c;',
+            ],
+            [
+'<?php
+if ($c)
+    echo $b;
+
+elseif ($b)
+    echo $c;',
+'<?php
+if ($c)
+    echo $b;
+elseif ($b)
+    echo $c;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithIf
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithIf($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'if',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithIf()
+    {
+        return [
+            [
+'<?php
+if (true) {
+    echo $bar;
+}',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+if (true) {
+    echo $bar;
+}',
+'<?php
+$foo = $bar;
+if (true) {
+    echo $bar;
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithInclude
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithInclude($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'include',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithInclude()
+    {
+        return [
+            [
+'<?php
+include "foo.php";',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+include "foo.php";',
+'<?php
+$foo = $bar;
+include "foo.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithIncludeOnce
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithIncludeOnce($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'include_once',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithIncludeOnce()
+    {
+        return [
+            [
+'<?php
+include_once "foo.php";',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+include_once "foo.php";',
+'<?php
+$foo = $bar;
+include_once "foo.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithRequire
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithRequire($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'require',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithRequire()
+    {
+        return [
+            [
+'<?php
+require "foo.php";',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+require "foo.php";',
+'<?php
+$foo = $bar;
+require "foo.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithRequireOnce
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithRequireOnce($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'require_once',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithRequireOnce()
+    {
+        return [
+            [
+'<?php
+require_once "foo.php";',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+require_once "foo.php";',
+'<?php
+$foo = $bar;
+require_once "foo.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithReturn
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithReturn($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'return',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithReturn()
+    {
+        return [
+            [
+'
+$a = $a;
+return $a;',
+            ],
+            [
+'<?php
+$a = $a;
+
+return $a;',
+'<?php
+$a = $a; return $a;',
+            ],
+            [
+'<?php
+$b = $b;
+
+return $b;',
+'<?php
+$b = $b;return $b;',
+            ],
+            [
+'<?php
+$c = $c;
+
+return $c;',
+'<?php
+$c = $c;
+return $c;',
+            ],
+            [
+'<?php
+$d = $d;
+
+return $d;',
+'<?php
+$d = $d;
+return $d;',
+            ],
+            [
+'<?php
+if (true) {
+    return 1;
+}',
+            ],
+            [
+'<?php
+if (true)
+    return 1;',
+            ],
+            [
+'<?php
+if (true) {
+    return 1;
+} else {
+    return 2;
+}',
+            ],
+            [
+'<?php
+if (true)
+    return 1;
+else
+    return 2;',
+            ],
+            [
+'<?php
+if (true) {
+    return 1;
+} elseif (false) {
+    return 2;
+}',
+            ],
+            [
+'<?php
+if (true)
+    return 1;
+elseif (false)
+    return 2;',
+            ],
+            [
+'<?php
+throw new Exception("return true;");',
+            ],
+            [
+'<?php
+function foo()
+{
+    // comment
+    return "foo";
+}',
+            ],
+            [
+'<?php
+function foo()
+{
+    // comment
+
+    return "bar";
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithReturnAndMessyWhitespaces
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithReturnAndMessyWhitespaces($expected, $input = null)
+    {
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithReturnAndMessyWhitespaces()
+    {
+        return [
+            [
+                "<?php\r\n\$a = \$a;\r\n\r\nreturn \$a;",
+                "<?php\r\n\$a = \$a; return \$a;",
+            ],
+            [
+                "<?php\r\n\$b = \$b;\r\n\r\nreturn \$b;",
+                "<?php\r\n\$b = \$b;return \$b;",
+            ],
+            [
+                "<?php\r\n\$c = \$c;\r\n\r\nreturn \$c;",
+                "<?php\r\n\$c = \$c;\r\nreturn \$c;",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithSwitch
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithSwitch($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'switch',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithSwitch()
+    {
+        return [
+            [
+'<?php
+switch ($a) {
+    case 42:
+        break;
+}',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+switch ($foo) {
+    case $bar:
+        break;
+}',
+'<?php
+$foo = $bar;
+switch ($foo) {
+    case $bar:
+        break;
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithThrow
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithThrow($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'throw',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithThrow()
+    {
+        return [
+            [
+'<?php
+if (false) {
+    throw new \Exception("Something unexpected happened");
+}',
+            ],
+            [
+'<?php
+if (false) {
+    $log->error("No");
+
+    throw new \Exception("Something unexpected happened");
+}',
+'<?php
+if (false) {
+    $log->error("No");
+    throw new \Exception("Something unexpected happened");
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithTry
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithTry($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'try',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithTry()
+    {
+        return [
+            [
+'<?php
+try {
+    $transaction->commit();
+} catch (\Exception $exception) {
+    $transaction->rollback();
+}',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+try {
+    $transaction->commit();
+} catch (\Exception $exception) {
+    $transaction->rollback();
+}',
+'<?php
+$foo = $bar;
+try {
+    $transaction->commit();
+} catch (\Exception $exception) {
+    $transaction->rollback();
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithWhile
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithWhile($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'while',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFixWithWhile()
+    {
+        return [
+            [
+'<?php
+while (true) {
+    $worker->work();
+}',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+while (true) {
+    $worker->work();
+}',
+'<?php
+$foo = $bar;
+while (true) {
+    $worker->work();
+}',
+            ],
+            [
+'<?php
+$foo = $bar;
+
+do {
+    $worker->work();
+}
+
+while (true);',
+'<?php
+$foo = $bar;
+
+do {
+    $worker->work();
+} while (true);',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Whitespace/BlankLineBeforeControlStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeControlStatementFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\Whitespace;
 
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Test\AbstractFixerTestCase;
 use PhpCsFixer\WhitespacesFixerConfig;
 
@@ -31,38 +32,10 @@ final class BlankLineBeforeControlStatementFixerTest extends AbstractFixerTestCa
      */
     public function testConfigureRejectsInvalidControlStatement($controlStatement)
     {
-        $controlStatements = [
-            'break',
-            'continue',
-            'declare',
-            'do',
-            'else',
-            'elseif',
-            'for',
-            'foreach',
-            'if',
-            'include',
-            'include_once',
-            'require',
-            'require_once',
-            'return',
-            'switch',
-            'throw',
-            'try',
-            'while',
-        ];
-
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            sprintf(
-                'Expected one of "%s", got "%s".',
-                implode('", "', $controlStatements),
-                is_object($controlStatement) ? get_class($controlStatement) : gettype($controlStatement)
-            )
-        );
+        $this->setExpectedException(InvalidFixerConfigurationException::class);
 
         $this->fixer->configure([
-            $controlStatement,
+            'statements' => [$controlStatement],
         ]);
     }
 
@@ -103,7 +76,7 @@ final class BlankLineBeforeControlStatementFixerTest extends AbstractFixerTestCa
     public function testFixWithBreak($expected, $input = null)
     {
         $this->fixer->configure([
-            'break',
+            'statements' => ['break'],
         ]);
 
         $this->doTest($expected, $input);
@@ -199,7 +172,7 @@ while (true) {
     public function testFixWithContinue($expected, $input = null)
     {
         $this->fixer->configure([
-            'continue',
+            'statements' => ['continue'],
         ]);
 
         $this->doTest($expected, $input);
@@ -286,7 +259,7 @@ while (true) {
     public function testFixWithDeclare($expected, $input = null)
     {
         $this->fixer->configure([
-            'declare',
+            'statements' => ['declare'],
         ]);
 
         $this->doTest($expected, $input);
@@ -325,7 +298,7 @@ declare(ticks=1);',
     public function testFixWithDo($expected, $input = null)
     {
         $this->fixer->configure([
-            'do',
+            'statements' => ['do'],
         ]);
 
         $this->doTest($expected, $input);
@@ -365,7 +338,7 @@ do {
     public function testFixWithElse($expected, $input = null)
     {
         $this->fixer->configure([
-            'else',
+            'statements' => ['else'],
         ]);
 
         $this->doTest($expected, $input);
@@ -436,7 +409,7 @@ else
     public function testFixWithElseIf($expected, $input = null)
     {
         $this->fixer->configure([
-            'elseif',
+            'statements' => ['elseif'],
         ]);
 
         $this->doTest($expected, $input);
@@ -507,7 +480,7 @@ elseif ($b)
     public function testFixWithIf($expected, $input = null)
     {
         $this->fixer->configure([
-            'if',
+            'statements' => ['if'],
         ]);
 
         $this->doTest($expected, $input);
@@ -550,7 +523,7 @@ if (true) {
     public function testFixWithInclude($expected, $input = null)
     {
         $this->fixer->configure([
-            'include',
+            'statements' => ['include'],
         ]);
 
         $this->doTest($expected, $input);
@@ -587,7 +560,7 @@ include "foo.php";',
     public function testFixWithIncludeOnce($expected, $input = null)
     {
         $this->fixer->configure([
-            'include_once',
+            'statements' => ['include_once'],
         ]);
 
         $this->doTest($expected, $input);
@@ -624,7 +597,7 @@ include_once "foo.php";',
     public function testFixWithRequire($expected, $input = null)
     {
         $this->fixer->configure([
-            'require',
+            'statements' => ['require'],
         ]);
 
         $this->doTest($expected, $input);
@@ -661,7 +634,7 @@ require "foo.php";',
     public function testFixWithRequireOnce($expected, $input = null)
     {
         $this->fixer->configure([
-            'require_once',
+            'statements' => ['require_once'],
         ]);
 
         $this->doTest($expected, $input);
@@ -698,7 +671,7 @@ require_once "foo.php";',
     public function testFixWithReturn($expected, $input = null)
     {
         $this->fixer->configure([
-            'return',
+            'statements' => ['return'],
         ]);
 
         $this->doTest($expected, $input);
@@ -857,7 +830,7 @@ function foo()
     public function testFixWithSwitch($expected, $input = null)
     {
         $this->fixer->configure([
-            'switch',
+            'statements' => ['switch'],
         ]);
 
         $this->doTest($expected, $input);
@@ -903,7 +876,7 @@ switch ($foo) {
     public function testFixWithThrow($expected, $input = null)
     {
         $this->fixer->configure([
-            'throw',
+            'statements' => ['throw'],
         ]);
 
         $this->doTest($expected, $input);
@@ -946,7 +919,7 @@ if (false) {
     public function testFixWithTry($expected, $input = null)
     {
         $this->fixer->configure([
-            'try',
+            'statements' => ['try'],
         ]);
 
         $this->doTest($expected, $input);
@@ -995,7 +968,7 @@ try {
     public function testFixWithWhile($expected, $input = null)
     {
         $this->fixer->configure([
-            'while',
+            'statements' => ['while'],
         ]);
 
         $this->doTest($expected, $input);

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -19,11 +19,13 @@ use PhpCsFixer\WhitespacesFixerConfig;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Andreas Möller <am@localheinz.com>
+ * @author SpacePossum
  *
  * @internal
- * @coversNothing
+ *
+ * @covers \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixerTest
  */
-final class BlankLineBeforeControlStatementFixerTest extends AbstractFixerTestCase
+final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider providerInvalidControlStatement
@@ -89,21 +91,21 @@ final class BlankLineBeforeControlStatementFixerTest extends AbstractFixerTestCa
     {
         return [
             [
-'<?php
+                '<?php
 switch ($a) {
     case 42:
         break;
 }',
             ],
             [
-'<?php
+                '<?php
 switch ($a) {
     case 42:
         $foo = $bar;
 
         break;
 }',
-'<?php
+                '<?php
 switch ($a) {
     case 42:
         $foo = $bar;
@@ -111,7 +113,7 @@ switch ($a) {
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         break;
@@ -119,7 +121,7 @@ while (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         break 1;
@@ -127,7 +129,7 @@ while (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         echo $baz;
@@ -135,7 +137,7 @@ while (true) {
         break;
     }
 }',
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         echo $baz;
@@ -144,7 +146,7 @@ while (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         echo $baz;
@@ -152,7 +154,7 @@ while (true) {
         break 1;
     }
 }',
-'<?php
+                '<?php
 while (true) {
     if ($foo === $bar) {
         echo $baz;
@@ -185,19 +187,19 @@ while (true) {
     {
         return [
             [
-'<?php
+                '<?php
 while (true) {
     continue;
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     continue 1;
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     while (true) {
         continue 2;
@@ -205,43 +207,54 @@ while (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     $foo = true;
 
     continue;
 }',
-'<?php
+                '<?php
 while (true) {
     $foo = true;
     continue;
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     $foo = true;
 
     continue 1;
 }',
-'<?php
+                '<?php
 while (true) {
     $foo = true;
     continue 1;
 }',
             ],
             [
-'<?php
+                '<?php
 while (true) {
     while (true) {
+        switch($a) {
+            case 1:
+                echo 1;
+
+                continue;
+        }
         $foo = true;
 
         continue 2;
     }
 }',
-'<?php
+                '<?php
 while (true) {
     while (true) {
+        switch($a) {
+            case 1:
+                echo 1;
+                continue;
+        }
         $foo = true;
         continue 2;
     }
@@ -272,17 +285,21 @@ while (true) {
     {
         return [
             [
-'<?php
+                '<?php
 declare(ticks=1);',
             ],
             [
-'<?php
-
+                '<?php
+$foo = "bar";
+do {
+} while (true);
 $foo = "bar";
 
 declare(ticks=1);',
-'<?php
-
+                '<?php
+$foo = "bar";
+do {
+} while (true);
 $foo = "bar";
 declare(ticks=1);',
             ],
@@ -311,17 +328,17 @@ declare(ticks=1);',
     {
         return [
             [
-'<?php
+                '<?php
 do {
 } while (true);',
             ],
             [
-'<?php
+                '<?php
 $foo = "bar";
 
 do {
 } while (true);',
-'<?php
+                '<?php
 $foo = "bar";
 do {
 } while (true);',
@@ -330,143 +347,33 @@ do {
     }
 
     /**
-     * @dataProvider providerFixWithElse
+     * @dataProvider providerFixWithFor
      *
      * @param string      $expected
      * @param string|null $input
      */
-    public function testFixWithElse($expected, $input = null)
+    public function testFixWithFor($expected, $input = null)
     {
         $this->fixer->configure([
-            'statements' => ['else'],
+            'statements' => ['for'],
         ]);
 
         $this->doTest($expected, $input);
     }
 
-    /**
-     * @return array
-     */
-    public function providerFixWithElse()
+    public function providerFixWithFor()
     {
         return [
             [
-'<?php
-if (true) {
-    echo $b;
-}
+                '<?php
+                    echo 1;
 
-else {
-    echo $c;
-}',
-            ],
-            [
-'<?php
-if (true) {
-    echo $b;
-}
-
-else {
-    echo $c;
-}',
-'<?php
-if (true) {
-    echo $b;
-} else {
-    echo $c;
-}',
-            ],
-            [
-'<?php
-if (true)
-    echo $b;
-
-else
-    echo $c;',
-            ],
-            [
-'<?php
-if (true)
-    echo $b;
-
-else
-    echo $c;',
-'<?php
-if (true)
-    echo $b;
-else
-    echo $c;',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider providerFixWithElseIf
-     *
-     * @param string      $expected
-     * @param string|null $input
-     */
-    public function testFixWithElseIf($expected, $input = null)
-    {
-        $this->fixer->configure([
-            'statements' => ['elseif'],
-        ]);
-
-        $this->doTest($expected, $input);
-    }
-
-    /**
-     * @return array
-     */
-    public function providerFixWithElseIf()
-    {
-        return [
-            [
-'<?php
-if ($c) {
-    echo $b;
-}
-
-elseif ($b) {
-    echo $c;
-}',
-            ],
-            [
-'<?php
-if ($c) {
-    echo $b;
-}
-
-elseif ($b) {
-    echo $c;
-}',
-'<?php
-if ($c) {
-    echo $b;
-} elseif ($b) {
-    echo $c;
-}',
-            ],
-            [
-'<?php
-if ($c)
-    echo $b;
-
-elseif ($b)
-    echo $c;',
-            ],
-            [
-'<?php
-if ($c)
-    echo $b;
-
-elseif ($b)
-    echo $c;',
-'<?php
-if ($c)
-    echo $b;
-elseif ($b)
-    echo $c;',
+                    for(;;){break;}
+                ',
+                '<?php
+                    echo 1;
+                    for(;;){break;}
+                ',
             ],
         ];
     }
@@ -487,29 +394,66 @@ elseif ($b)
     }
 
     /**
+     * @dataProvider providerFixWithForEach
+     *
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithForEach($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['foreach'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function providerFixWithForEach()
+    {
+        return [
+            [
+                '<?php
+                    echo 1;
+
+                    foreach($a as $b){break;}
+                ',
+                '<?php
+                    echo 1;
+                    foreach($a as $b){break;}
+                ',
+            ],
+        ];
+    }
+
+    /**
      * @return array
      */
     public function providerFixWithIf()
     {
         return [
             [
-'<?php
+                '<?php
 if (true) {
     echo $bar;
 }',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 if (true) {
     echo $bar;
 }',
-'<?php
+                '<?php
 $foo = $bar;
 if (true) {
     echo $bar;
 }',
+            ],
+            [
+                '<?php
+// foo
+if ($foo) { }',
             ],
         ];
     }
@@ -536,15 +480,15 @@ if (true) {
     {
         return [
             [
-'<?php
+                '<?php
 include "foo.php";',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 include "foo.php";',
-'<?php
+                '<?php
 $foo = $bar;
 include "foo.php";',
             ],
@@ -573,15 +517,15 @@ include "foo.php";',
     {
         return [
             [
-'<?php
+                '<?php
 include_once "foo.php";',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 include_once "foo.php";',
-'<?php
+                '<?php
 $foo = $bar;
 include_once "foo.php";',
             ],
@@ -610,15 +554,15 @@ include_once "foo.php";',
     {
         return [
             [
-'<?php
+                '<?php
 require "foo.php";',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 require "foo.php";',
-'<?php
+                '<?php
 $foo = $bar;
 require "foo.php";',
             ],
@@ -647,15 +591,15 @@ require "foo.php";',
     {
         return [
             [
-'<?php
+                '<?php
 require_once "foo.php";',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 require_once "foo.php";',
-'<?php
+                '<?php
 $foo = $bar;
 require_once "foo.php";',
             ],
@@ -684,57 +628,57 @@ require_once "foo.php";',
     {
         return [
             [
-'
+                '
 $a = $a;
 return $a;',
             ],
             [
-'<?php
+                '<?php
 $a = $a;
 
 return $a;',
-'<?php
+                '<?php
 $a = $a; return $a;',
             ],
             [
-'<?php
+                '<?php
 $b = $b;
 
 return $b;',
-'<?php
+                '<?php
 $b = $b;return $b;',
             ],
             [
-'<?php
+                '<?php
 $c = $c;
 
 return $c;',
-'<?php
+                '<?php
 $c = $c;
 return $c;',
             ],
             [
-'<?php
+                '<?php
 $d = $d;
 
 return $d;',
-'<?php
+                '<?php
 $d = $d;
 return $d;',
             ],
             [
-'<?php
+                '<?php
 if (true) {
     return 1;
 }',
             ],
             [
-'<?php
+                '<?php
 if (true)
     return 1;',
             ],
             [
-'<?php
+                '<?php
 if (true) {
     return 1;
 } else {
@@ -742,14 +686,14 @@ if (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 if (true)
     return 1;
 else
     return 2;',
             ],
             [
-'<?php
+                '<?php
 if (true) {
     return 1;
 } elseif (false) {
@@ -757,18 +701,18 @@ if (true) {
 }',
             ],
             [
-'<?php
+                '<?php
 if (true)
     return 1;
 elseif (false)
     return 2;',
             ],
             [
-'<?php
+                '<?php
 throw new Exception("return true;");',
             ],
             [
-'<?php
+                '<?php
 function foo()
 {
     // comment
@@ -776,7 +720,7 @@ function foo()
 }',
             ],
             [
-'<?php
+                '<?php
 function foo()
 {
     // comment
@@ -843,21 +787,21 @@ function foo()
     {
         return [
             [
-'<?php
+                '<?php
 switch ($a) {
     case 42:
         break;
 }',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 switch ($foo) {
     case $bar:
         break;
 }',
-'<?php
+                '<?php
 $foo = $bar;
 switch ($foo) {
     case $bar:
@@ -889,19 +833,19 @@ switch ($foo) {
     {
         return [
             [
-'<?php
+                '<?php
 if (false) {
     throw new \Exception("Something unexpected happened");
 }',
             ],
             [
-'<?php
+                '<?php
 if (false) {
     $log->error("No");
 
     throw new \Exception("Something unexpected happened");
 }',
-'<?php
+                '<?php
 if (false) {
     $log->error("No");
     throw new \Exception("Something unexpected happened");
@@ -932,7 +876,7 @@ if (false) {
     {
         return [
             [
-'<?php
+                '<?php
 try {
     $transaction->commit();
 } catch (\Exception $exception) {
@@ -940,7 +884,7 @@ try {
 }',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 try {
@@ -948,7 +892,7 @@ try {
 } catch (\Exception $exception) {
     $transaction->rollback();
 }',
-'<?php
+                '<?php
 $foo = $bar;
 try {
     $transaction->commit();
@@ -981,39 +925,123 @@ try {
     {
         return [
             [
-'<?php
+                '<?php
 while (true) {
     $worker->work();
 }',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 while (true) {
     $worker->work();
 }',
-'<?php
+                '<?php
 $foo = $bar;
 while (true) {
     $worker->work();
 }',
             ],
             [
-'<?php
+                '<?php
 $foo = $bar;
 
 do {
-    $worker->work();
-}
+    echo 1;
 
-while (true);',
-'<?php
-$foo = $bar;
-
-do {
+    while($a());
     $worker->work();
 } while (true);',
+                '<?php
+$foo = $bar;
+
+do {
+    echo 1;
+    while($a());
+    $worker->work();
+} while (true);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithMultipleConfigStatements
+     *
+     * @param string[]    $statements
+     * @param string      $expected
+     * @param string|null $input
+     */
+    public function testFixWithMultipleConfigStatements(array $statements, $expected, $input = null)
+    {
+        $this->fixer->configure(['statements' => $statements]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithMultipleConfigStatements()
+    {
+        $allStatements = [
+            'break',
+            'continue',
+            'declare',
+            'do',
+            'for',
+            'foreach',
+            'if',
+            'include',
+            'include_once',
+            'require',
+            'require_once',
+            'return',
+            'switch',
+            'throw',
+            'try',
+            'while',
+        ];
+
+        return [
+            [
+                $allStatements,
+                '<?php
+                    while($a) {
+                        if ($c) {
+                            switch ($d) {
+                                case $e:
+                                    continue 2;
+                                case 4:
+                                    break;
+                                case 5:
+                                    return 1;
+                            }
+                        }
+                    }
+                ',
+            ],
+            [
+                ['break', 'throw'],
+                '<?php
+do {
+    echo 0;
+    if ($a) {
+        echo 1;
+
+        break;
+    }
+    echo 2;
+
+    throw $f;
+} while(true);',
+                '<?php
+do {
+    echo 0;
+    if ($a) {
+        echo 1;
+        break;
+    }
+    echo 2;
+    throw $f;
+} while(true);',
             ],
         ];
     }

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -153,6 +153,7 @@ final class FixerConfigurationResolverTest extends TestCase
         ]);
 
         $catched = null;
+
         try {
             $configuration->resolve(['foo' => '1']);
         } catch (InvalidOptionsException $catched) {

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -147,7 +147,7 @@ final class FixerFactoryTest extends TestCase
 
         $factory = FixerFactory::create()
             ->registerBuiltInFixers()
-            ->useRuleSet(new RuleSet(['strict_comparison' => true, 'blank_line_before_control_statement' => false]))
+            ->useRuleSet(new RuleSet(['strict_comparison' => true, 'blank_line_before_statement' => false]))
         ;
         $fixers = $factory->getFixers();
         $this->assertCount(1, $fixers);

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -147,7 +147,7 @@ final class FixerFactoryTest extends TestCase
 
         $factory = FixerFactory::create()
             ->registerBuiltInFixers()
-            ->useRuleSet(new RuleSet(['strict_comparison' => true, 'blank_line_before_return' => false]))
+            ->useRuleSet(new RuleSet(['strict_comparison' => true, 'blank_line_before_control_statement' => false]))
         ;
         $fixers = $factory->getFixers();
         $this->assertCount(1, $fixers);

--- a/tests/Fixtures/Integration/priority/no_useless_return,blank_line_before_statement.test
+++ b/tests/Fixtures/Integration/priority/no_useless_return,blank_line_before_statement.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: no_useless_return,blank_line_before_statement.
+--RULESET--
+{"no_useless_return": true, "blank_line_before_statement": {"statements": ["return"]}}
+--EXPECT--
+<?php
+class Test {
+    private static function a($a) {
+        $a = 1;
+        //
+    }
+}
+
+--INPUT--
+<?php
+class Test {
+    private static function a($a) {
+        $a = 1;
+        return;//
+    }
+}


### PR DESCRIPTION
This PR

* [x] allows to configure the `ReturnNotation\BlankLineBeforeReturnFixer`
* [x] renames the `ReturnNotation\BlankLineBeforeReturnFixer` to  `Whitespace\BlankLineBeforeControlStatementFixer`
* [x] provides a deprecated `ReturnNotation\BlankLineBeforeReturnFixer`, proxying to the `Whitespace\BlankLineBeforeControlStatementFixer`