### PR TITLE
Fix UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,8 +79,8 @@ Renamed rules
 
 Old name | New name | Note
 -------- | -------- | ----
-align_double_arrow                             | binary_operator_spaces                            | use configuration ['align_double_arrow' => 'true']
-align_equals                                   | binary_operator_spaces                            | use configuration ['align_equals' => 'true']
+align_double_arrow                             | binary_operator_spaces                            | use configuration ['align_double_arrow' => true]
+align_equals                                   | binary_operator_spaces                            | use configuration ['align_equals' => true]
 array_element_no_space_before_comma            | no_whitespace_before_comma_in_array
 array_element_white_space_after_comma          | whitespace_after_comma_in_array
 blankline_after_open_tag                       | blank_line_after_opening_tag


### PR DESCRIPTION
The current syntax `['align_double_arrow' => 'true']` is causing to get error:

```
  [PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException]                                                        
  [binary_operator_spaces] Invalid value type for configuration option "align_equals". Expected "bool" or "null" got "string". 
```