### PR TITLE
ProtectedToPrivateFixer - Use backticks for visibility in description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -521,7 +521,7 @@ Choose from the list of available rules:
    | Pre incrementation/decrementation should be used if possible.
 
 * **protected_to_private**
-   | Converts protected variables and methods to private where possible.
+   | Converts `protected` variables and methods to `private` where possible.
 
 * **psr0**
    | Classes must be in a path that matches their namespace, be at least one

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -53,7 +53,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Converts protected variables and methods to private where possible.',
+            'Converts `protected` variables and methods to `private` where possible.',
             array(
                 new CodeSample(
                 '<?php


### PR DESCRIPTION
This PR

* [ ] encloses `protected` and `private` in backticks in the description of the `ProtectedToPrivateFixer`

Follows #2400.