### PR TITLE
DX: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     "require": {
         "php": "^5.3.6 || >=7.0 <7.2",
         "ext-tokenizer": "*",
+        "sebastian/diff": "^1.1",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/event-dispatcher": "^2.1 || ^3.0",
         "symfony/filesystem": "^2.4 || ^3.0",
         "symfony/finder": "^2.2 || ^3.0",
         "symfony/polyfill-php54": "^1.0",
         "symfony/process": "^2.3 || ^3.0",
-        "symfony/stopwatch": "^2.5 || ^3.0",
-        "sebastian/diff": "^1.1"
+        "symfony/stopwatch": "^2.5 || ^3.0"
     },
     "require-dev": {
         "gecko-packages/gecko-php-unit": "^2.0",
@@ -32,6 +32,9 @@
     },
     "conflict": {
         "hhvm": "<3.9"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": { "PhpCsFixer\\": "src/" }


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.