### PR TITLE
FixCommand: allow ConfigInterface injection

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -73,14 +73,14 @@ final class FixCommand extends Command
      */
     private $defaultConfig;
 
-    public function __construct()
+    public function __construct(ConfigInterface $config = null)
     {
-        parent::__construct();
-
-        $this->defaultConfig = new Config();
+        $this->defaultConfig = $config ?: new Config();
         $this->errorsManager = new ErrorsManager();
         $this->eventDispatcher = new EventDispatcher();
         $this->stopwatch = new Stopwatch();
+
+        parent::__construct();
     }
 
     /**
@@ -105,7 +105,7 @@ final class FixCommand extends Command
                 )
             )
             ->setDescription('Fixes a directory or a file.')
-            ->setHelp(FixCommandHelp::getHelpCopy())
+            ->setHelp(FixCommandHelp::getHelpCopy($this->defaultConfig))
         ;
     }
 

--- a/src/Console/Command/FixCommandHelp.php
+++ b/src/Console/Command/FixCommandHelp.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Console\Command;
 
+use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
@@ -30,7 +31,7 @@ final class FixCommandHelp
     /**
      * @return string
      */
-    public static function getHelpCopy()
+    public static function getHelpCopy(ConfigInterface $config)
     {
         $template =
             <<<EOF
@@ -220,16 +221,18 @@ EOF
 
         return str_replace(
            '%%%FIXERS_DETAILS%%%',
-            self::getFixersHelp(),
+            self::getFixersHelp($config),
             $template
         );
     }
 
-    private static function getFixersHelp()
+    private static function getFixersHelp(ConfigInterface $config)
     {
         $help = '';
         $fixerFactory = new FixerFactory();
-        $fixers = $fixerFactory->registerBuiltInFixers()->getFixers();
+        $fixerFactory->registerBuiltInFixers();
+        $fixerFactory->registerCustomFixers($config->getCustomFixers());
+        $fixers = $fixerFactory->getFixers();
 
         // sort fixers by name
         usort(

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -56,4 +56,41 @@ final class FixCommandTest extends \PHPUnit_Framework_TestCase
             array(76, true, true, true, true),
         );
     }
+
+    public function testUsePreregisteredCustomFixers()
+    {
+        $mockMethod = 'createMock';
+        if (version_compare(\PHPUnit_Runner_Version::id(), '5.4.0') < 0) {
+            $mockMethod = 'getMock';
+        }
+
+        $fixerName = uniqid('My/custom_fixer_');
+
+        $fixer = $this->{$mockMethod}('PhpCsFixer\Fixer\FixerInterface');
+
+        $fixer
+            ->expects($this->atLeastOnce())
+            ->method('getName')
+            ->willReturn($fixerName)
+        ;
+        $fixer
+            ->expects($this->any())
+            ->method('getPriority')
+            ->willReturn(0)
+        ;
+
+        $config = $this->{$mockMethod}('PhpCsFixer\ConfigInterface');
+
+        $config
+            ->expects($this->once())
+            ->method('getCustomFixers')
+            ->willReturn(array(
+                $fixer,
+            ))
+        ;
+
+        $command = new FixCommand($config);
+
+        $this->assertContains($fixerName, $command->getHelp());
+    }
 }


### PR DESCRIPTION
Hi, version 1 allowed [custom building](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v1.13.1/Symfony/CS/Console/Command/FixCommand.php#L85) of FixCommand, functionality lost in version 2.

In our company we have dozens of application using this (awesome) project, and we make available a set of custom fixers for all this project through a custom `php-cs-fixer` bin trivially customized.

If the command cannot be touched, all the customization have to be done in the `.php_cs` file, a not maintainable way for dozens of apps.

This PR retain current behaviour, allowing for custom config injection during instantiation, and allowing to serve help also for custom fixers.