### PR TITLE
PhpdocAlignFixer - Fix alignment of variadic params.

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -35,7 +35,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
 
         $indent = '(?P<indent>(?: {2}|\t)*)';
         // e.g. @param <hint> <$var>
-        $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>&?\$[^\s]+)';
+        $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>(?:&|\.{3})?\$[^\s]+)';
         // e.g. @return <hint>
         $otherTags = '(?P<tag2>return|throws|var|type)\s+(?P<hint2>[^\s]+?)';
         // optional <desc>

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -512,4 +512,78 @@ EOF;
 
         $this->doTest($expected, $input);
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @requires PHP 5.6
+     * @dataProvider provideVariadicCases
+     */
+    public function testVariadicParams($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideVariadicCases()
+    {
+        return array(
+            array(
+                '<?php
+final class Sample
+{
+    /**
+     * @param int[] $a    A
+     * @param int   &$b   B
+     * @param array ...$c C
+     */
+    public function sample2($a, &$b, ...$c)
+    {
+    }
+}
+',
+            '<?php
+final class Sample
+{
+    /**
+     * @param int[]       $a  A
+     * @param int          &$b B
+     * @param array ...$c    C
+     */
+    public function sample2($a, &$b, ...$c)
+    {
+    }
+}
+',
+            ),
+                        array(
+                '<?php
+final class Sample
+{
+    /**
+     * @param int     $a
+     * @param int     $b
+     * @param array[] ...$c
+     */
+    public function sample2($a, $b, ...$c)
+    {
+    }
+}
+',
+            '<?php
+final class Sample
+{
+    /**
+     * @param int       $a
+     * @param int    $b
+     * @param array[]      ...$c
+     */
+    public function sample2($a, $b, ...$c)
+    {
+    }
+}
+',
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Contrary to https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2254 I think the `...` are part of the variable, like `&` is, and therefor the alignment should not be done on the `$` but on `...`.
Making the fixer work case insensitive makes it atomic (i.e. no longer depended on `phpdoc_types`).
On a side note [PSR5](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#713-param) is not conclusive on this topic.