### PR TITLE
MethodArgumentSpaceFixer: allow to retain multiple spaces after comma

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -413,6 +413,11 @@ Choose from the list of available rules:
   In method arguments and method call, there MUST NOT be a space before
   each comma and there MUST be one space after each comma.
 
+  Configuration options:
+
+  - ``keep_multiple_spaces_after_comma`` (``bool``): whether keep multiple spaces
+    after comma; defaults to ``false``
+
 * **method_separation** [@Symfony]
 
   Methods must be separated with one blank line.

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -25,105 +25,124 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
     /**
      * @param string      $expected
      * @param null|string $input
+     * @param null|array  $configuration
      *
      * @dataProvider testFixProvider
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $configuration = null)
     {
+        if (null !== $configuration) {
+            $this->fixer->configure($configuration);
+        }
+
         $this->doTest($expected, $input);
     }
 
     public function testFixProvider()
     {
         return array(
-            array(
+            'default' => array(
                 '<?php xyz("", "", "", "");',
                 '<?php xyz("","","","");',
             ),
-            // test method arguments
-            array(
+            'test method arguments' => array(
                 '<?php function xyz($a=10, $b=20, $c=30) {}',
                 '<?php function xyz($a=10,$b=20,$c=30) {}',
             ),
-            // test method arguments with multiple spaces
-            array(
+            'test method arguments with multiple spaces' => array(
                 '<?php function xyz($a=10, $b=20, $c=30) {}',
                 '<?php function xyz($a=10,         $b=20 , $c=30) {}',
             ),
-            // test method call
-            array(
+            'test method arguments with multiple spaces (kmsac)' => array(
+                '<?php function xyz($a=10,         $b=20, $c=30) {}',
+                '<?php function xyz($a=10,         $b=20 , $c=30) {}',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'test method call (I)' => array(
                 '<?php xyz($a=10, $b=20, $c=30);',
                 '<?php xyz($a=10 ,$b=20,$c=30);',
             ),
-            // test method call with multiple spaces
-            array(
-                '<?php xyz($a=10, $b=20, $c=30);',
-                '<?php xyz($a=10 , $b=20 ,          $c=30);',
-            ),
-            // test method call with tab
-            array(
-                '<?php xyz($a=10, $b=20, $c=30);',
-                "<?php xyz(\$a=10 , \$b=20 ,\t \$c=30);",
-            ),
-            // test method call with \n not affected
-            array(
-                "<?php xyz(\$a=10, \$b=20,\n                    \$c=30);",
-            ),
-            // test method call with \r\n not affected
-            array(
-                "<?php xyz(\$a=10, \$b=20,\r\n                    \$c=30);",
-            ),
-            // test method call
-            array(
+            'test method call (II)' => array(
                 '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
                 '<?php xyz($a=10,$b=20 ,$this->foo() ,$c=30);',
             ),
-            // test method call with multiple spaces
-            array(
+            'test method call with multiple spaces (I)' => array(
+                '<?php xyz($a=10, $b=20, $c=30);',
+                '<?php xyz($a=10 , $b=20 ,          $c=30);',
+            ),
+            'test method call with multiple spaces (I) (kmsac)' => array(
+                '<?php xyz($a=10, $b=20,          $c=30);',
+                '<?php xyz($a=10 , $b=20 ,          $c=30);',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'test method call with tab' => array(
+                '<?php xyz($a=10, $b=20, $c=30);',
+                "<?php xyz(\$a=10 , \$b=20 ,\t \$c=30);",
+            ),
+            'test method call with tab (kmsac)' => array(
+                "<?php xyz(\$a=10, \$b=20,\t \$c=30);",
+                "<?php xyz(\$a=10 , \$b=20 ,\t \$c=30);",
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'test method call with \n not affected' => array(
+                "<?php xyz(\$a=10, \$b=20,\n                    \$c=30);",
+            ),
+            'test method call with \r\n not affected' => array(
+                "<?php xyz(\$a=10, \$b=20,\r\n                    \$c=30);",
+            ),
+            'test method call with multiple spaces (II)' => array(
                 '<?php xyz($a=10, $b=20, $this->foo(), $c=30);',
                 '<?php xyz($a=10,$b=20 ,         $this->foo() ,$c=30);',
             ),
-            // test receiving data in list context with omitted values
-            array(
+            'test method call with multiple spaces (II) (kmsac)' => array(
+                '<?php xyz($a=10, $b=20,         $this->foo(), $c=30);',
+                '<?php xyz($a=10,$b=20 ,         $this->foo() ,$c=30);',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'test receiving data in list context with omitted values' => array(
                 '<?php list($a, $b, , , $c) = foo();',
                 '<?php list($a, $b,, ,$c) = foo();',
             ),
-            // test receiving data in list context with omitted values and multiple spaces
-            array(
+            'test receiving data in list context with omitted values and multiple spaces' => array(
                 '<?php list($a, $b, , , $c) = foo();',
                 '<?php list($a, $b,,    ,$c) = foo();',
             ),
-            // skip array
-            array(
+            'test receiving data in list context with omitted values and multiple spaces (kmsac)' => array(
+                '<?php list($a, $b, ,    , $c) = foo();',
+                '<?php list($a, $b,,    ,$c) = foo();',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'skip array' => array(
                 '<?php array(10 , 20 ,30);',
             ),
-            // list call with trailing comma
-            array(
+            'list call with trailing comma' => array(
                 '<?php list($path, $mode, ) = foo();',
                 '<?php list($path, $mode,) = foo();',
             ),
-            //inline comments with spaces
-            array(
+            'inline comments with spaces' => array(
                 '<?php xyz($a=10, /*comment1*/ $b=2000, /*comment2*/ $c=30);',
                 '<?php xyz($a=10,    /*comment1*/ $b=2000,/*comment2*/ $c=30);',
             ),
-            // must keep align comments
-            array(
+            'inline comments with spaces (kmsac)' => array(
+                '<?php xyz($a=10,    /*comment1*/ $b=2000, /*comment2*/ $c=30);',
+                '<?php xyz($a=10,    /*comment1*/ $b=2000,/*comment2*/ $c=30);',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'must keep align comments' => array(
                 '<?php function xyz(
                     $a=10,      //comment1
                     $b=20,      //comment2
                     $c=30) {
                 }',
             ),
-            array(
+            'must keep align comments (2)' => array(
                 '<?php function xyz(
                     $a=10,  //comment1
                     $b=2000,//comment2
                     $c=30) {
                 }',
             ),
-            //multiline comments also must be ignored
-            array(
+            'multiline comments also must be ignored (I)' => array(
                 '<?php function xyz(
                     $a=10,  /* comment1a
                                comment1b
@@ -134,8 +153,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                     $c=30) {
                 }',
             ),
-            // multiline comments also must be ignored
-            array(
+            'multiline comments also must be ignored (II)' => array(
                 '<?php
                     function xyz(
                         $a=10, /* multiline comment
@@ -157,8 +175,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                         $c=30) {
                     }',
             ),
-            // multi line testing method arguments
-            array(
+            'multi line testing method arguments' => array(
                 '<?php function xyz(
                     $a=10,
                     $b=20,
@@ -170,8 +187,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                     $c=30) {
                 }',
             ),
-            // multi line testing method call
-            array(
+            'multi line testing method call' => array(
                 '<?php xyz(
                     $a=10,
                     $b=20,
@@ -183,17 +199,19 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                     $c=30
                     );',
             ),
-            // skip arrays but replace arg methods
-            array(
+            'skip arrays but replace arg methods' => array(
                 '<?php fnc(1, array(2, func2(6, 7) ,4), 5);',
                 '<?php fnc(1,array(2, func2(6,    7) ,4),    5);',
             ),
-            // ignore commas inside call argument
-            array(
+            'skip arrays but replace arg methods (kmsac)' => array(
+                '<?php fnc(1, array(2, func2(6,    7) ,4),    5);',
+                '<?php fnc(1,array(2, func2(6,    7) ,4),    5);',
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
+            'ignore commas inside call argument' => array(
                 '<?php fnc(1, array(2, 3 ,4), 5);',
             ),
-            // skip multi line array
-            array(
+            'skip multi line array' => array(
                 '<?php
                     array(
                         10 ,
@@ -201,15 +219,13 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                         30
                     );',
             ),
-            // skip short array
-            array(
+            'skip short array' => array(
                 '<?php
     $foo = ["a"=>"apple", "b"=>"bed" ,"c"=>"car"];
     $bar = ["a" ,"b" ,"c"];
     ',
             ),
-            // don't change HEREDOC and NOWDOC
-            array(
+            'don\'t change HEREDOC and NOWDOC' => array(
                 "<?php
     \$this->foo(
         <<<EOTXTa


### PR DESCRIPTION
PR https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/998 changed `MethodArgumentSpaceFixer` with a BC break. We have tons of code like this one:
```php
// Symfony command specifications
$this
    ->setName('company:command')
    ->setDescription('Our command')
    ->addOption('xxxxxyyy',             null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxxyyyyyy',          null, InputOption::VALUE_REQUIRED,  'desc [...]')
    ->addOption('xxxxxyyyy',            null, InputOption::VALUE_REQUIRED,  'desc [...]')
    ->addOption('xxxxxauto',            null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxx',                null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxxi',               null, InputOption::VALUE_REQUIRED,  'desc [...]')
    ->addOption('xxxxxyyyyyyyyyyy',     null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxxyyyyyyyyyy',      null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxxyyyyyyyyyy',      null, InputOption::VALUE_NONE,      'desc [...]')
    ->addOption('xxxxxyyyyyyyyyyyyy',   null, InputOption::VALUE_NONE,      'desc [...]')
;

// Values objects
$columns = new Excel\Collection(array(
    new Excel\Column('xxx',                        'DESC 1111',             5, new Excel\Style\Text()),
    new Excel\Column('xxxx',                       'DESC',                 15, new Excel\Style\Text()),
    new Excel\Column('xxx',                        'DES',                  15, new Excel\Style\Text()),
    new Excel\Column('xxxxxxxxxxxxxxxxxxxxxx',     'DESC 2222222',         20, new Excel\Style\CC()),
    new Excel\Column('xxxxxxxxxxxxxxxxxxxxxxx',    'DESC 333333333333',    40, new Excel\Style\Text()),
    new Excel\Column('xxxxxxxxxxx',                'DESC 444444',          15, new Excel\Style\Text()),
    new Excel\Column('xxxxxxxxxxxxxxxxxxxx',       'DESC 5555555555555',   10, new Excel\Style\Text()),
    new Excel\Column('xxxxxxxxxxxxxxxo',           'DESC 66666666666',     15, new Excel\Style\Number()),
    new Excel\Column('xxxxxxxxxxxxx',              'DESC 77777777',        15, new Excel\Style\Data()),
    new Excel\Column('xxxxxxxxxxxxxxxxxxxxxx',     'DESC 8888888',         15, new Excel\Style\CC()),
    new Excel\Column('xxxxxxxxxxxxxxxxxxxxxxx',    'DESC 999999999999',    40, new Excel\Style\Text()),
    new Excel\Column('xxxxxxxxxxx',                'DESC 000000',          15, new Excel\Style\Text()),
    new Excel\Column('xxxx',                       'DESC',                 15, new Excel\Style\Data()),
    new Excel\Column('xxxxxxxxxxxxxxxxx',          'DESC             ',    15, new Excel\Style\Data()),
    new Excel\Column('xxxxxxxxxxxxxxx',            'DESC xxxxxxxxxx',      15, new Excel\Style\Data()),
));
```
and without retaining the extra spaces after commas these are almost unreadable.

This PR keeps the current new (BC break) behaviour, allowing with a configuration to step back with retaining the extra commas, but with at least one.