### PR TITLE
NoWhitespaceInBlankLineFixer - Fix more cases

### DIFF
--- a/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
+++ b/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
@@ -37,6 +37,34 @@ final class NoWhitespaceInBlankLineFixerTest extends AbstractFixerTestCase
     {
         return array(
             array(
+                '<?php',
+            ),
+            array(
+                '<?php  ',
+            ),
+            array(
+                '<?php
+',
+                '<?php
+  ',
+            ),
+            array(
+                '<?php
+
+',
+                '<?php
+     '.'
+  ',
+            ),
+            array(
+                '<?php
+
+$a = 1; ',
+                '<?php
+     '.'
+$a = 1; ',
+            ),
+            array(
                 '<?php
 $r = 5 +6;                   '.'
 


### PR DESCRIPTION
Fix cases like this as well (not trailing white space on line 1)
```php
<?php
    
$a = 1; 
```