### PR TITLE
Mysql to Mysqli fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -525,8 +525,17 @@ Choose from the list of available fixers:
    Multi-line whitespace before closing semicolon are prohibited.
 
 * **mysql_to_mysqli** [contrib]
-   Replace deprecated `mysql_*` functions with mysqli_* equivalents.
-   Warning: This could change code behaviour.
+   Replace deprecated `mysql_*` functions with mysqli_* equivalents. Not
+   all functions are supported since there are a few functions that don't
+   have a direct mysqli translation. The unsupported ones are:
+   `mysql_create_db`, `mysql_db_name`, `mysql_db_query`, `mysql_drop_db`,
+   `mysql_escape_string`, `mysql_field_flags`, `mysql_field_len`,
+   `mysql_field_name`, `mysql_field_table`, `mysql_field_type`,
+   `mysql_list_dbs`, `mysql_list_fields`, `mysql_list_processes`,
+   `mysql_list_tables`, `mysql_pconnect`, `mysql_query`,
+   `mysql_real_escape_string`, `mysql_result`, `mysql_select_db`,
+   `mysql_tablename`, `mysql_unbuffered_query`. Warning: This could change
+   code behaviour.
 
 * **newline_after_open_tag** [contrib]
    Ensure there is no code on the same line as the PHP open tag.

--- a/README.rst
+++ b/README.rst
@@ -524,6 +524,10 @@ Choose from the list of available fixers:
 * **multiline_spaces_before_semicolon** [contrib]
    Multi-line whitespace before closing semicolon are prohibited.
 
+* **mysql_to_mysqli** [contrib]
+   Replace deprecated `mysql_*` functions with mysqli_* equivalents.
+   Warning: This could change code behaviour.
+
 * **newline_after_open_tag** [contrib]
    Ensure there is no code on the same line as the PHP open tag.
 

--- a/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
@@ -13,9 +13,9 @@ class MysqlToMysqliFixer extends AbstractFixer
      */
     public function fix(SplFileInfo $file, $content)
     {
-        $tokens             = Tokens::fromCode($content);
-        $startPosition      = 0;
-        $end                = $tokens->count() - 1;
+        $tokens = Tokens::fromCode($content);
+        $startPosition = 0;
+        $end = $tokens->count() - 1;
 
         foreach ($this->deprecatedMysqlFunctions() as $deprecatedMysqlFunction => $replacementInformation) {
             while ($match = $tokens->findSequence(array(array(T_STRING, $deprecatedMysqlFunction), '('), $startPosition, $end, false)) {
@@ -59,7 +59,7 @@ class MysqlToMysqliFixer extends AbstractFixer
             return $numberOfArguments;
         }
 
-        $numberOfArguments++;
+        ++$numberOfArguments;
         $dontBreakLoop = false;
 
         while (!$dontBreakLoop) {
@@ -71,7 +71,7 @@ class MysqlToMysqliFixer extends AbstractFixer
                 $position = $index;
 
                 if ($tokens[$index]->equals(',')) {
-                    $numberOfArguments++;
+                    ++$numberOfArguments;
                 }
             }
         }

--- a/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Symfony\CS\Fixer\Contrib;
+
+use Symfony\CS\AbstractFixer;
+use Symfony\CS\Tokenizer\Tokens;
+use SplFileInfo;
+
+class MysqlToMysqliFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, $content)
+    {
+        $tokens     = Tokens::fromCode($content);
+        $position   = 0;
+        $end        = $tokens->count() - 1;
+
+        foreach ($this->deprecatedMysqlFunctions() as $deprecatedMysqlFunction => $replacementInformation) {
+            $match = $tokens->findSequence(array(array(T_STRING, $deprecatedMysqlFunction), '('), $position, $end, false);
+
+            if (null === $match) {
+                continue;
+            }
+
+            $meaningfulPositions = array_keys($match);
+            $position = end($meaningfulPositions);
+            $replaceIf = $replacementInformation['replaceIf'];
+            $numberOfArguments = $this->numberOfArgumentsFrom($position, $tokens);
+
+            if ($replaceIf($numberOfArguments)) {
+                $tokens[$meaningfulPositions[0]]->setContent($replacementInformation['replaceFor']);
+            }
+        }
+
+        return $tokens->generateCode();
+    }
+
+    public function getName()
+    {
+        return 'mysql_to_mysqli';
+    }
+
+    /**
+     * Returns the description of the fixer.
+     *
+     * A short one-line description of what the fixer does.
+     *
+     * @return string The description of the fixer
+     */
+    public function getDescription()
+    {
+        return 'Replace deprecated `mysql_*` functions with mysqli_* equivalents. Warning: This could change code behaviour.';
+    }
+
+    private function numberOfArgumentsFrom($position, Tokens $tokens)
+    {
+        $numberOfArguments = 0;
+        $index = $tokens->getNextMeaningfulToken($position);
+
+        if ($tokens[$index]->equals(')')) {
+            return $numberOfArguments;
+        }
+
+        $numberOfArguments++;
+        $dontBreakLoop = false;
+
+        while (!$dontBreakLoop) {
+            $index = $tokens->getNextMeaningfulToken($position);
+
+            $dontBreakLoop = $tokens[$index]->equals(')');
+
+            if (!$dontBreakLoop) {
+                $position = $index;
+
+                if ($tokens[$index]->equals(',')) {
+                    $numberOfArguments++;
+                }
+            }
+        }
+
+        return $numberOfArguments;
+    }
+
+    private function deprecatedMysqlFunctions()
+    {
+        return array(
+            'mysql_connect' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments <= 3;
+                },
+                'replaceFor' => 'mysqli_connect',
+            ),
+            'mysql_affected_rows' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_affected_rows',
+            ),
+            'mysql_client_encoding' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_character_set_name',
+            ),
+            'mysql_close' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_close',
+            ),
+            'mysql_data_seek' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_data_seek',
+            ),
+            'mysql_errno' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_errno',
+            ),
+            'mysql_error' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_error',
+            ),
+            'mysql_fetch_array' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_fetch_array',
+            ),
+            'mysql_fetch_assoc' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_fetch_assoc',
+            ),
+            'mysql_fetch_field' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return $numberOfArguments === 1;
+                },
+                'replaceFor' => 'mysqli_fetch_field',
+            ),
+            'mysql_fetch_lengths' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_fetch_lengths',
+            ),
+            'mysql_fetch_object' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_fetch_object',
+            ),
+            'mysql_fetch_row' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_fetch_row',
+            ),
+            'mysql_field_seek' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_field_seek',
+            ),
+            'mysql_free_result' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_free_result',
+            ),
+            'mysql_get_host_info' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_get_host_info',
+            ),
+            'mysql_get_proto_info' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_get_proto_info',
+            ),
+            'mysql_get_server_info' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_get_server_info',
+            ),
+            'mysql_info' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_info',
+            ),
+            'mysql_insert_id' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_insert_id',
+            ),
+            'mysql_num_fields' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_num_fields',
+            ),
+            'mysql_num_rows' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return true;
+                },
+                'replaceFor' => 'mysqli_num_rows',
+            ),
+            'mysql_ping' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_ping',
+            ),
+            'mysql_stat' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_stat',
+            ),
+            'mysql_thread_id' => array(
+                'replaceIf' => function ($numberOfArguments) {
+                    return 1 === $numberOfArguments;
+                },
+                'replaceFor' => 'mysqli_thread_id',
+            ),
+        );
+    }
+}

--- a/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
@@ -1,10 +1,20 @@
 <?php
 
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Symfony\CS\Fixer\Contrib;
 
+use SplFileInfo;
 use Symfony\CS\AbstractFixer;
 use Symfony\CS\Tokenizer\Tokens;
-use SplFileInfo;
 
 class MysqlToMysqliFixer extends AbstractFixer
 {

--- a/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
@@ -47,7 +47,7 @@ class MysqlToMysqliFixer extends AbstractFixer
      */
     public function getDescription()
     {
-        return 'Replace deprecated `mysql_*` functions with mysqli_* equivalents. Warning: This could change code behaviour.';
+        return 'Replace deprecated `mysql_*` functions with mysqli_* equivalents. Not all functions are supported since there are a few functions that don\'t have a direct mysqli translation. The unsupported ones are: `mysql_create_db`, `mysql_db_name`, `mysql_db_query`, `mysql_drop_db`, `mysql_escape_string`, `mysql_field_flags`, `mysql_field_len`, `mysql_field_name`, `mysql_field_table`, `mysql_field_type`, `mysql_list_dbs`, `mysql_list_fields`, `mysql_list_processes`, `mysql_list_tables`, `mysql_pconnect`, `mysql_query`, `mysql_real_escape_string`, `mysql_result`, `mysql_select_db`, `mysql_tablename`, `mysql_unbuffered_query`. Warning: This could change code behaviour.';
     }
 
     private function numberOfArgumentsFrom($position, Tokens $tokens)

--- a/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
+++ b/Symfony/CS/Fixer/Contrib/MysqlToMysqliFixer.php
@@ -84,25 +84,25 @@ class MysqlToMysqliFixer extends AbstractFixer
         return array(
             'mysql_connect' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments <= 3;
+                    return 3 >= $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_connect',
             ),
             'mysql_affected_rows' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_affected_rows',
             ),
             'mysql_client_encoding' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_character_set_name',
             ),
             'mysql_close' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_close',
             ),
@@ -114,31 +114,31 @@ class MysqlToMysqliFixer extends AbstractFixer
             ),
             'mysql_errno' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_errno',
             ),
             'mysql_error' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_error',
             ),
             'mysql_fetch_array' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_fetch_array',
             ),
             'mysql_fetch_assoc' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_fetch_assoc',
             ),
             'mysql_fetch_field' => array(
                 'replaceIf' => function ($numberOfArguments) {
-                    return $numberOfArguments === 1;
+                    return 1 === $numberOfArguments;
                 },
                 'replaceFor' => 'mysqli_fetch_field',
             ),

--- a/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
@@ -93,4 +93,12 @@ class MysqlToMysqliFixerTest extends AbstractFixerTestBase
             array('<?php mysqli_thread_id($link);', '<?php mysql_thread_id($link);'),
         );
     }
+
+    public function testMultipleOcurrences()
+    {
+        $this->makeTest(
+            '<?php $x = mysqli_connect(); $y = mysqli_connect(); $z = mysqli_connect();',
+            '<?php $x = mysql_connect(); $y = mysqli_connect(); $z = mysql_connect();'
+        );
+    }
 }

--- a/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
@@ -1,5 +1,15 @@
 <?php
 
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Symfony\CS\Tests\Fixer\Contrib;
 
 use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;

--- a/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
+++ b/Symfony/CS/Tests/Fixer/Contrib/MysqlToMysqliFixerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Symfony\CS\Tests\Fixer\Contrib;
+
+use Symfony\CS\Tests\Fixer\AbstractFixerTestBase;
+
+class MysqlToMysqliFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->makeTest($expected, $input);
+    }
+
+    public function provideExamples()
+    {
+        return array(
+            array('<?php $x = 1;'),
+            array('<?php $x = "mysql";'),
+            // mysql_connect
+            array('<?php $x = mysqli_connect();', '<?php $x = mysql_connect();'),
+            array('<?php $x = mysqli_connect(\'127.0.0.1\');', '<?php $x = mysql_connect(\'127.0.0.1\');'),
+            array('<?php $x = mysqli_connect(\'127.0.0.1\', \'myUser\');', '<?php $x = mysql_connect(\'127.0.0.1\', \'myUser\');'),
+            array('<?php $x = mysqli_connect(\'127.0.0.1\', \'myUser\', \'myP4ssw0rd\');', '<?php $x = mysql_connect(\'127.0.0.1\', \'myUser\', \'myP4ssw0rd\');'),
+            array('<?php $x = mysql_connect(\'127.0.0.1\', \'myUser\', \'myP4ssw0rd\', true);'),
+            array('<?php $x = mysql_connect(\'127.0.0.1\', \'myUser\', \'myP4ssw0rd\', true, MYSQL_CLIENT_SSL);'),
+            // mysql_affected_rows
+            array('<?php mysql_affected_rows();'),
+            array('<?php mysqli_affected_rows($link);', '<?php mysql_affected_rows($link);'),
+            // mysql_client_encoding
+            array('<?php mysql_client_encoding();'),
+            array('<?php mysqli_character_set_name($link);', '<?php mysql_client_encoding($link);'),
+            // mysql_close
+            array('<?php mysql_close();'),
+            array('<?php mysqli_close($link);', '<?php mysql_close($link);'),
+            // mysql_data_seek
+            array('<?php mysqli_data_seek($result, $offset);', '<?php mysql_data_seek($result, $offset);'),
+            // mysql_errno
+            array('<?php mysql_errno();'),
+            array('<?php mysqli_errno($link);', '<?php mysql_errno($link);'),
+            // mysql_errno
+            array('<?php mysql_error();'),
+            array('<?php mysqli_error($link);', '<?php mysql_error($link);'),
+            // mysql_fetch_array
+            array('<?php mysql_fetch_array($result, MYSQL_BOTH);'),
+            array('<?php mysqli_fetch_array($result);', '<?php mysql_fetch_array($result);'),
+            // mysql_fetch_assoc
+            array('<?php mysqli_fetch_assoc($result);', '<?php mysql_fetch_assoc($result);'),
+            // mysql_fetch_field
+            array('<?php mysql_fetch_field($result, 0);'),
+            array('<?php mysqli_fetch_field($result);', '<?php mysql_fetch_field($result);'),
+            // mysql_fetch_lengths
+            array('<?php mysqli_fetch_lengths($result);', '<?php mysql_fetch_lengths($result);'),
+            // mysql_fetch_object
+            array('<?php mysqli_fetch_object($result);', '<?php mysql_fetch_object($result);'),
+            array('<?php mysqli_fetch_object($result, \'AClassName\');', '<?php mysql_fetch_object($result, \'AClassName\');'),
+            array('<?php mysqli_fetch_object($result, \'AClassName\', array(1, "test"));', '<?php mysql_fetch_object($result, \'AClassName\', array(1, "test"));'),
+            // mysql_fetch_row
+            array('<?php mysqli_fetch_row($result);', '<?php mysql_fetch_row($result);'),
+            // mysql_field_seek
+            array('<?php mysqli_field_seek($result, 0);', '<?php mysql_field_seek($result, 0);'),
+            // mysql_free_result
+            array('<?php mysqli_free_result($result);', '<?php mysql_free_result($result);'),
+            // mysql_get_host_info
+            array('<?php mysql_get_host_info();'),
+            array('<?php mysqli_get_host_info($link);', '<?php mysql_get_host_info($link);'),
+            // mysql_get_proto_info
+            array('<?php mysql_get_proto_info();'),
+            array('<?php mysqli_get_proto_info($link);', '<?php mysql_get_proto_info($link);'),
+            // mysql_get_server_info
+            array('<?php mysql_get_server_info();'),
+            array('<?php mysqli_get_server_info($link);', '<?php mysql_get_server_info($link);'),
+            // mysql_info
+            array('<?php mysql_info();'),
+            array('<?php mysqli_info($link);', '<?php mysql_info($link);'),
+            // mysql_insert_id
+            array('<?php mysql_insert_id();'),
+            array('<?php mysqli_insert_id($link);', '<?php mysql_insert_id($link);'),
+            // mysql_num_fields
+            array('<?php mysqli_num_fields($result);', '<?php mysql_num_fields($result);'),
+            // mysql_num_rows
+            array('<?php mysqli_num_rows($result);', '<?php mysql_num_rows($result);'),
+            // mysql_ping
+            array('<?php mysql_ping();'),
+            array('<?php mysqli_ping($link);', '<?php mysql_ping($link);'),
+            // mysql_ping
+            array('<?php mysql_stat();'),
+            array('<?php mysqli_stat($link);', '<?php mysql_stat($link);'),
+            // mysql_thread_id
+            array('<?php mysql_thread_id();'),
+            array('<?php mysqli_thread_id($link);', '<?php mysql_thread_id($link);'),
+        );
+    }
+}


### PR DESCRIPTION
Hi,

I've created a fixer to translate ```mysql_*``` style functions to ```mysqli_*``` style functions. Since not all mysql functions have a direct mysqli translation there're a few unsupported functions that don't get touched:

* `mysql_create_db`
* `mysql_db_name`
* `mysql_db_query`
* `mysql_drop_db`
* `mysql_escape_string`
* `mysql_field_flags`
* `mysql_field_len`
* `mysql_field_name`
* `mysql_field_table`
* `mysql_field_type`
* `mysql_list_dbs`
* `mysql_list_fields`
* `mysql_list_processes`
* `mysql_list_tables`
* `mysql_pconnect`
* `mysql_query`
* `mysql_real_escape_string`
* `mysql_result`
* `mysql_select_db`
* `mysql_tablename`
* `mysql_unbuffered_query`

Hope you find it useful!

Best,
Christian.