### PR TITLE
MethodArgumentSpaceFixer - add ensure_fully_multiline option

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,6 +23,7 @@ return PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
         'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
         'no_short_echo_tag' => true,
         'no_unreachable_default_argument_value' => true,

--- a/README.rst
+++ b/README.rst
@@ -541,10 +541,15 @@ Choose from the list of available rules:
 * **method_argument_space** [@PSR2, @Symfony]
 
   In method arguments and method call, there MUST NOT be a space before
-  each comma and there MUST be one space after each comma.
+  each comma and there MUST be one space after each comma. Argument lists
+  MAY be split across multiple lines, where each subsequent line is
+  indented once. When doing so, the first item in the list MUST be on the
+  next line, and there MUST be only one argument per line.
 
   Configuration options:
 
+  - ``ensure_fully_multiline`` (``bool``): ensure every argument of a multiline
+    argument list is on its own line; defaults to ``false``
   - ``keep_multiple_spaces_after_comma`` (``bool``): whether keep multiple spaces
     after comma; defaults to ``false``
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -56,12 +56,10 @@ final class Cache implements CacheInterface
     public function set($file, $hash)
     {
         if (!is_int($hash)) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Value needs to be an integer, got "%s".',
                 is_object($hash) ? get_class($hash) : gettype($hash)
-            )
-            );
+            ));
         }
 
         $this->hashes[$file] = $hash;

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -56,9 +56,11 @@ final class Cache implements CacheInterface
     public function set($file, $hash)
     {
         if (!is_int($hash)) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Value needs to be an integer, got "%s".',
-                is_object($hash) ? get_class($hash) : gettype($hash))
+                is_object($hash) ? get_class($hash) : gettype($hash)
+            )
             );
         }
 

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -106,7 +106,9 @@ final class DescribeCommand extends Command
 
             throw new \InvalidArgumentException(sprintf(
                 '%s %s not found.%s',
-                ucfirst($e->getType()), $name, null === $alternative ? '' : ' Did you mean "'.$alternative.'"?'
+                ucfirst($e->getType()),
+                $name,
+                null === $alternative ? '' : ' Did you mean "'.$alternative.'"?'
             ));
         }
     }

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -43,7 +43,8 @@ final class SelfUpdateCommand extends Command
                 ]
             )
             ->setDescription('Update php-cs-fixer.phar to the latest stable version.')
-            ->setHelp(<<<'EOT'
+            ->setHelp(
+                <<<'EOT'
 The <info>%command.name%</info> command replace your php-cs-fixer.phar by the
 latest version released on:
 <comment>https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases</comment>

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -37,7 +37,8 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
     $a = doubleval($b);
     $a = strval ($b);
     $a = boolval($b);
-'),
+'
+            ),
             ],
             null,
             'Risky if any of the functions `intval`, `floatval`, `doubleval`, `strval` or `boolval` are overridden.'

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -38,8 +38,7 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
     $a = strval ($b);
     $a = boolval($b);
 '
-            ),
-            ],
+            )],
             null,
             'Risky if any of the functions `intval`, `floatval`, `doubleval`, `strval` or `boolval` are overridden.'
         );

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -323,6 +323,6 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
      */
     private function isNewLine(Token $token)
     {
-        return $token->isWhitespace() && (false !== strpos($token->getContent(), "\n"));
+        return $token->isWhitespace() && false !== strpos($token->getContent(), "\n");
     }
 }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -248,7 +248,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
     }
 
     /**
-     * Makes sure there is a whitespace at the given location
+     * Makes sure there is a whitespace at the given location.
      *
      * @param Tokens $tokens      The token stream to modify
      * @param int    $index       where to insert the whitespace

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -103,7 +103,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             if ($token->equals('(')) {
                 $meaningfulTokenBeforeParenthesis = $tokens[$tokens->getPrevMeaningfulToken($index)];
                 if (!$meaningfulTokenBeforeParenthesis->isKeyword()
-                    || $meaningfulTokenBeforeParenthesis->isGivenKind(T_LIST)) {
+                    || $meaningfulTokenBeforeParenthesis->isGivenKind([T_LIST, T_FUNCTION])) {
                     if ($this->fixFunction($tokens, $index) && $this->configuration['ensure_fully_multiline']) {
                         if (!$meaningfulTokenBeforeParenthesis->isGivenKind(T_LIST)) {
                             $this->ensureFunctionFullyMultiline($tokens, $index);

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -113,14 +113,14 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('keep_multiple_spaces_after_comma', 'Whether keep multiple spaces after comma.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(false) // @TODO should be true at 3.0
+                ->setDefault(false)
                 ->getOption(),
             (new FixerOptionBuilder(
                 'ensure_fully_multiline',
                 'Ensure every argument of a multiline argument list is on its own line'
             ))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(false)
+                ->setDefault(false) // @TODO should be true at 3.0
                 ->getOption(),
         ]);
     }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -67,14 +67,14 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                     ['ensure_fully_multiline' => true]
                 ),
                 new CodeSample(
-                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample(1,  2);",
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample('foo',    'foobarbaz', 'baz');\nsample('foobar', 'bar',       'baz');",
                     [
                         'ensure_fully_multiline' => true,
                         'keep_multiple_spaces_after_comma' => true,
                     ]
                 ),
                 new CodeSample(
-                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample(1,  2);",
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample('foo',    'foobarbaz', 'baz');\nsample('foobar', 'bar',       'baz');",
                     [
                         'ensure_fully_multiline' => true,
                         'keep_multiple_spaces_after_comma' => false,

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -186,7 +186,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();
         $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
         if (!$this->isNewline($tokens[$endFunctionIndex - 1])) {
-            $tokens->addNewlineAndIndent(
+            $this->addNewlineAndIndent(
                 $tokens,
                 $endFunctionIndex,
                 $existingIndentation,

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
@@ -27,7 +28,7 @@ use PhpCsFixer\Tokenizer\Tokens;
  *
  * @author Kuanhung Chen <ericj.tw@gmail.com>
  */
-final class MethodArgumentSpaceFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+final class MethodArgumentSpaceFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface, WhitespacesAwareFixerInterface
 {
     /**
      * Method to insert space after comma and remove space before comma.
@@ -47,7 +48,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
     public function getDefinition()
     {
         return new FixerDefinition(
-            'In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma.',
+            'In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.',
             [
                 new CodeSample(
                     "<?php\nfunction sample(\$a=10,\$b=20,\$c=30) {}\nsample(1,  2);",
@@ -60,6 +61,17 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 new CodeSample(
                     "<?php\nfunction sample(\$a=10,\$b=20,\$c=30) {}\nsample(1,  2);",
                     ['keep_multiple_spaces_after_comma' => true]
+                ),
+                new CodeSample(
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,\n    2);",
+                    ['ensure_fully_multiline' => true]
+                ),
+                new CodeSample(
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);",
+                    [
+                        'ensure_fully_multiline' => true,
+                        'keep_multiple_spaces_after_comma' => true,
+                    ]
                 ),
             ]
         );
@@ -81,8 +93,14 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         for ($index = $tokens->count() - 1; $index > 0; --$index) {
             $token = $tokens[$index];
 
-            if ($token->equals('(') && !$tokens[$index - 1]->isGivenKind(T_ARRAY)) {
-                $this->fixFunction($tokens, $index);
+            if ($token->equals('(')) {
+                $meaningfulTokenBeforeParenthesis = $tokens[$tokens->getPrevMeaningfulToken($index)];
+                if (!$meaningfulTokenBeforeParenthesis->isKeyword()
+                    || $meaningfulTokenBeforeParenthesis->isGivenKind(T_LIST)) {
+                    if ($this->fixFunction($tokens, $index) && $this->configuration['ensure_fully_multiline']) {
+                        $this->ensureFunctionFullyMultiline($tokens, $index);
+                    }
+                }
             }
         }
     }
@@ -95,6 +113,13 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('keep_multiple_spaces_after_comma', 'Whether keep multiple spaces after comma.'))
                 ->setAllowedTypes(['bool'])
+                ->setDefault(false) // @TODO should be true at 3.0
+                ->getOption(),
+            (new FixerOptionBuilder(
+                'ensure_fully_multiline',
+                'Ensure every argument of a multiline argument list is on its own line'
+            ))
+                ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
         ]);
@@ -105,10 +130,14 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
      *
      * @param Tokens $tokens             Tokens to handle
      * @param int    $startFunctionIndex Start parenthesis position
+     *
+     * @return bool whether the function is multiline
      */
     private function fixFunction(Tokens $tokens, $startFunctionIndex)
     {
         $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
+        $isMultiline = $this->isNewline($tokens[$startFunctionIndex + 1])
+            || $this->isNewline($tokens[$endFunctionIndex - 1]);
 
         for ($index = $endFunctionIndex - 1; $index > $startFunctionIndex; --$index) {
             $token = $tokens[$index];
@@ -127,8 +156,101 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
 
             if ($token->equals(',')) {
                 $this->fixSpace2($tokens, $index);
+                if (!$isMultiline && $this->isNewline($tokens[$index + 1])) {
+                    $isMultiline = true;
+                    break;
+                }
             }
         }
+
+        return $isMultiline;
+    }
+
+    private function ensureFunctionFullyMultiline(Tokens $tokens, $startFunctionIndex)
+    {
+        // find out what the indentation is
+        $searchIndex = $startFunctionIndex;
+        do {
+            $prevWhitespaceTokenIndex = $tokens->getPrevTokenOfKind(
+                $searchIndex,
+                [[T_WHITESPACE]]
+            );
+            $searchIndex = $prevWhitespaceTokenIndex;
+        } while ($prevWhitespaceTokenIndex
+            && false === strpos($tokens[$prevWhitespaceTokenIndex]->getContent(), "\n")
+        );
+        $existingIndentation = $prevWhitespaceTokenIndex
+            ? ltrim($tokens[$prevWhitespaceTokenIndex]->getContent(), "\n\r")
+            : '';
+
+        $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();
+        $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
+        if (!$this->isNewline($tokens[$endFunctionIndex - 1])) {
+            $tokens->insertAt(
+                $endFunctionIndex,
+                new Token([
+                    T_WHITESPACE,
+                    $this->whitespacesConfig->getLineEnding().$existingIndentation,
+                ])
+            );
+            ++$endFunctionIndex;
+        }
+
+        for ($index = $endFunctionIndex - 1; $index > $startFunctionIndex; --$index) {
+            $token = $tokens[$index];
+
+            // skip nested method calls and arrays
+            if ($token->equals(')')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index, false);
+                continue;
+            }
+
+            // skip nested arrays
+            if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index, false);
+                continue;
+            }
+
+            if ($token->equals(',')) {
+                $this->fixNewline($tokens, $index, $indentation);
+            }
+        }
+        $this->fixNewLine($tokens, $startFunctionIndex, $indentation, false);
+    }
+
+    /**
+     * Method to insert newline after comma or opening parenthesis.
+     *
+     * @param Tokens $tokens
+     * @param int    $index       index of a comma
+     * @param string $indentation the indentation that should be used
+     * @param bool   $override    whether to override the existing character or not
+     */
+    private function fixNewline(Tokens $tokens, $index, $indentation, $override = true)
+    {
+        if ($this->isNewline($tokens[$index + 1]) || $tokens[$index + 1]->isComment()) {
+            return;
+        }
+        if ($tokens[$index + 2]->isComment()) {
+            $nextMeaningfulTokenIndex = $tokens->getNextMeaningfulToken($index + 2);
+            if (!$this->isNewLine($tokens[$nextMeaningfulTokenIndex - 1])) {
+                $tokens->insertAt(
+                    $nextMeaningfulTokenIndex,
+                    new Token([
+                        T_WHITESPACE,
+                        $this->whitespacesConfig->getLineEnding().$indentation,
+                    ])
+                );
+            }
+
+            return;
+        }
+        $method = $override ? 'overrideAt' : 'insertAt';
+
+        $tokens->$method($index + 1, new Token([
+            T_WHITESPACE,
+            $this->whitespacesConfig->getLineEnding().$indentation,
+        ]));
     }
 
     /**
@@ -190,5 +312,17 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         $content = $tokens[$index + 1]->getContent();
 
         return $content !== ltrim($content, "\r\n");
+    }
+
+    /**
+     * Checks if token is new line.
+     *
+     * @param Token $token
+     *
+     * @return bool
+     */
+    private function isNewLine(Token $token)
+    {
+        return $token->isWhitespace() && (false !== strpos($token->getContent(), "\n"));
     }
 }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -270,7 +270,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         ]);
 
         if ($override) {
-            $tokens->overrideAt($index, $whitespaceToken);
+            $tokens[$index] = $whitespaceToken;
 
             return;
         }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -186,7 +186,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();
         $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
         if (!$this->isNewline($tokens[$endFunctionIndex - 1])) {
-            $this->ensureWhitespaceAtIndex(
+            $tokens->addNewlineAndIndent(
                 $tokens,
                 $endFunctionIndex,
                 $existingIndentation,
@@ -233,7 +233,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         if ($tokens[$index + 2]->isComment()) {
             $nextMeaningfulTokenIndex = $tokens->getNextMeaningfulToken($index + 2);
             if (!$this->isNewLine($tokens[$nextMeaningfulTokenIndex - 1])) {
-                $this->ensureWhitespaceAtIndex(
+                $this->addNewlineAndIndent(
                     $tokens,
                     $nextMeaningfulTokenIndex,
                     $indentation,
@@ -244,7 +244,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             return;
         }
 
-        $this->ensureWhitespaceAtIndex($tokens, $index + 1, $indentation, $override);
+        $this->addNewlineAndIndent($tokens, $index + 1, $indentation, $override);
     }
 
     /**
@@ -255,7 +255,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
      * @param string $indentation the indentation that should be used
      * @param bool   $override    whether to override the existing character or not
      */
-    private function ensureWhitespaceAtIndex(Tokens $tokens, $index, $indentation, $override)
+    private function addNewlineAndIndent(Tokens $tokens, $index, $indentation, $override)
     {
         $whitespaceToken = new Token([
             T_WHITESPACE,

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -105,7 +105,9 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 if (!$meaningfulTokenBeforeParenthesis->isKeyword()
                     || $meaningfulTokenBeforeParenthesis->isGivenKind(T_LIST)) {
                     if ($this->fixFunction($tokens, $index) && $this->configuration['ensure_fully_multiline']) {
-                        $this->ensureFunctionFullyMultiline($tokens, $index);
+                        if (!$meaningfulTokenBeforeParenthesis->isGivenKind(T_LIST)) {
+                            $this->ensureFunctionFullyMultiline($tokens, $index);
+                        }
                     }
                 }
             }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -245,12 +245,15 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
 
             return;
         }
-        $method = $override ? 'overrideAt' : 'insertAt';
 
-        $tokens->$method($index + 1, new Token([
-            T_WHITESPACE,
-            $this->whitespacesConfig->getLineEnding().$indentation,
-        ]));
+        call_user_func(
+            [$tokens, $override ? 'overrideAt' : 'insertAt'],
+            $index + 1,
+            new Token([
+                T_WHITESPACE,
+                $this->whitespacesConfig->getLineEnding().$indentation,
+            ])
+        );
     }
 
     /**

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -67,10 +67,17 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                     ['ensure_fully_multiline' => true]
                 ),
                 new CodeSample(
-                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);",
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample(1,  2);",
                     [
                         'ensure_fully_multiline' => true,
                         'keep_multiple_spaces_after_comma' => true,
+                    ]
+                ),
+                new CodeSample(
+                    "<?php\nfunction sample(\$a=10,\n    \$b=20,\$c=30) {}\nsample(1,  \n    2);\nsample(1,  2);",
+                    [
+                        'ensure_fully_multiline' => true,
+                        'keep_multiple_spaces_after_comma' => false,
                     ]
                 ),
             ]

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -74,7 +74,8 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
                 $tokens[$index] = new Token([T_DOC_COMMENT, preg_replace(
-                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m', '$1\\\\$2',
+                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m',
+                    '$1\\\\$2',
                     $token->getContent()
                 )]);
             }

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -43,7 +43,8 @@ final class PhpdocReturnSelfReferenceFixer extends AbstractFixer implements Conf
     {
         return new FixerDefinition(
             'The type of `@return` annotations of methods returning a reference to itself must the configured one.',
-            [new CodeSample('
+            [new CodeSample(
+                '
 <?php
 class Sample
 {

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -33,8 +33,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
     {
         return new FixerDefinition(
             'Code MUST use configured indentation type.',
-            [new CodeSample("<?php\n\nif (true) {\n\techo 'Hello!';\n}"),
-        ]
+            [new CodeSample("<?php\n\nif (true) {\n\techo 'Hello!';\n}")]
         );
     }
 

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -34,7 +34,8 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
         return new FixerDefinition(
             'Code MUST use configured indentation type.',
             [new CodeSample("<?php\n\nif (true) {\n\techo 'Hello!';\n}"),
-        ]);
+        ]
+        );
     }
 
     /**

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -35,7 +35,8 @@ final class NoSpacesInsideParenthesisFixer extends AbstractFixer
             'There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis.',
             [
                 new CodeSample("<?php\nif ( \$a ) {\n    foo( );\n}"),
-                new CodeSample('<?php
+                new CodeSample(
+                    '<?php
 function foo( $bar, $baz )
 {
 }'

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -38,7 +38,7 @@ final class RuleSet implements RuleSetInterface
             'line_ending' => true,
             'lowercase_constants' => true,
             'lowercase_keywords' => true,
-            'method_argument_space' => true,
+            'method_argument_space' => ['ensure_fully_multiline' => true],
             'no_closing_tag' => true,
             'no_spaces_after_function_name' => true,
             'no_spaces_inside_parenthesis' => true,

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -72,6 +72,7 @@ final class RuleSet implements RuleSetInterface
             'include' => true,
             'lowercase_cast' => true,
             'magic_constant_casing' => true,
+            'method_argument_space' => true,
             'method_separation' => true,
             'native_function_casing' => true,
             'new_with_braces' => true,

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -128,13 +128,17 @@ final class IntegrationCase
         if (!is_string($name)) {
             throw new \InvalidArgumentException(sprintf(
                 'Requirement key must be a string, got "%s".',
-                is_object($name) ? get_class($name) : gettype($name).'#'.$name));
+                is_object($name) ? get_class($name) : gettype($name).'#'.$name
+            ));
         }
 
         if (!array_key_exists($name, $this->requirements)) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Unknown requirement key "%s", expected any of "%s".',
-                $name, implode('","', array_keys($this->requirements)))
+                $name,
+                implode('","', array_keys($this->requirements))
+            )
             );
         }
 

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -133,13 +133,11 @@ final class IntegrationCase
         }
 
         if (!array_key_exists($name, $this->requirements)) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Unknown requirement key "%s", expected any of "%s".',
                 $name,
                 implode('","', array_keys($this->requirements))
-            )
-            );
+            ));
         }
 
         return $this->requirements[$name];

--- a/src/Test/IntegrationCaseFactory.php
+++ b/src/Test/IntegrationCaseFactory.php
@@ -91,16 +91,20 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_string($parsed['indent'])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Expected string value for "indent", got "%s".',
-                is_object($parsed['indent']) ? get_class($parsed['indent']) : gettype($parsed['indent']).'#'.$parsed['indent'])
+                is_object($parsed['indent']) ? get_class($parsed['indent']) : gettype($parsed['indent']).'#'.$parsed['indent']
+            )
             );
         }
 
         if (!is_string($parsed['lineEnding'])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Expected string value for "lineEnding", got "%s".',
-                is_object($parsed['lineEnding']) ? get_class($parsed['lineEnding']) : gettype($parsed['lineEnding']).'#'.$parsed['lineEnding'])
+                is_object($parsed['lineEnding']) ? get_class($parsed['lineEnding']) : gettype($parsed['lineEnding']).'#'.$parsed['lineEnding']
+            )
             );
         }
 
@@ -121,9 +125,11 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_int($parsed['php'])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Expected int value like 50509 for "php", got "%s".',
-                is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php'])
+                is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php']
+            )
             );
         }
 
@@ -156,9 +162,11 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_bool($parsed['checkPriority'])) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(
+                sprintf(
                 'Expected bool value for "checkPriority", got "%s".',
-                is_object($parsed['checkPriority']) ? get_class($parsed['checkPriority']) : gettype($parsed['checkPriority']).'#'.$parsed['checkPriority'])
+                is_object($parsed['checkPriority']) ? get_class($parsed['checkPriority']) : gettype($parsed['checkPriority']).'#'.$parsed['checkPriority']
+            )
             );
         }
 

--- a/src/Test/IntegrationCaseFactory.php
+++ b/src/Test/IntegrationCaseFactory.php
@@ -91,21 +91,17 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_string($parsed['indent'])) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Expected string value for "indent", got "%s".',
                 is_object($parsed['indent']) ? get_class($parsed['indent']) : gettype($parsed['indent']).'#'.$parsed['indent']
-            )
-            );
+            ));
         }
 
         if (!is_string($parsed['lineEnding'])) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Expected string value for "lineEnding", got "%s".',
                 is_object($parsed['lineEnding']) ? get_class($parsed['lineEnding']) : gettype($parsed['lineEnding']).'#'.$parsed['lineEnding']
-            )
-            );
+            ));
         }
 
         return $parsed;
@@ -125,12 +121,10 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_int($parsed['php'])) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Expected int value like 50509 for "php", got "%s".',
                 is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php']
-            )
-            );
+            ));
         }
 
         return $parsed;
@@ -162,12 +156,10 @@ final class IntegrationCaseFactory
         ]);
 
         if (!is_bool($parsed['checkPriority'])) {
-            throw new \InvalidArgumentException(
-                sprintf(
+            throw new \InvalidArgumentException(sprintf(
                 'Expected bool value for "checkPriority", got "%s".',
                 is_object($parsed['checkPriority']) ? get_class($parsed['checkPriority']) : gettype($parsed['checkPriority']).'#'.$parsed['checkPriority']
-            )
-            );
+            ));
         }
 
         return $parsed;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -33,7 +33,8 @@ final class ConfigTest extends TestCase
     {
         $config = new Config();
         $configResolver = new ConfigurationResolver(
-            $config, [
+            $config,
+            [
                 'rules' => 'cast_spaces,braces',
             ],
             getcwd()
@@ -52,7 +53,8 @@ final class ConfigTest extends TestCase
     {
         $config = new Config();
         $configResolver = new ConfigurationResolver(
-            $config, [
+            $config,
+            [
                 'rules' => '{"array_syntax": {"syntax": "short"}, "cast_spaces": true}',
             ],
             getcwd()
@@ -75,7 +77,8 @@ final class ConfigTest extends TestCase
 
         $config = new Config();
         $configResolver = new ConfigurationResolver(
-            $config, [
+            $config,
+            [
                 'rules' => '{blah',
             ],
             getcwd()

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -54,7 +54,8 @@ final class ErrorOutputTest extends TestCase
         // based on the platform/console/terminal used
         $displayed = str_replace(PHP_EOL, "\n", $displayed);
 
-        $startWith = sprintf('
+        $startWith = sprintf(
+            '
 Files that were not fixed due to errors reported during %s:
    1) %s',
             $process,
@@ -62,7 +63,8 @@ Files that were not fixed due to errors reported during %s:
         );
 
         if ($verbosityLevel >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
-            $startWith .= sprintf('
+            $startWith .= sprintf(
+                '
 
                             '.'
         [%s]  '.'
@@ -76,7 +78,8 @@ Files that were not fixed due to errors reported during %s:
         }
 
         if ($verbosityLevel >= OutputInterface::VERBOSITY_DEBUG) {
-            $startWith .= sprintf('
+            $startWith .= sprintf(
+                '
       PhpCsFixer\Tests\Console\Output\ErrorOutputTest->getErrorAndLineNumber()
         in %s at line %d
       PhpCsFixer\Tests\Console\Output\ErrorOutputTest->provideTestCases()

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -713,7 +713,9 @@ $a = new class implements
 {}
 
 %s /**/ B //
-/**/\n{}", $classy, $classy
+/**/\n{}",
+                    $classy,
+                    $classy
                 ),
                 sprintf(
                     '<?php
@@ -722,22 +724,28 @@ $a = new class implements
 {}
 
 %s/**/B //
-/**/ {}', $classy, $classy
+/**/ {}',
+                    $classy,
+                    $classy
                 ),
             ],
             [
-                sprintf('<?php
+                sprintf(
+                    '<?php
 namespace {
     %s IndentedNameSpacedClass
 {
     }
-}', $classy
+}',
+                    $classy
                 ),
-                sprintf('<?php
+                sprintf(
+                    '<?php
 namespace {
     %s IndentedNameSpacedClass    {
     }
-}', $classy
+}',
+                    $classy
                 ),
             ],
         ];

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
 
 use PhpCsFixer\Test\AbstractFixerTestCase;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
  * @author Kuanhung Chen <ericj.tw@gmail.com>
@@ -36,8 +37,47 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
         }
+        $indent = '    ';
+        $lineEnding = "\n";
+        if (null !== $input) {
+            if (false !== strpos($input, "\t")) {
+                $indent = "\t";
+            } elseif (preg_match('/\n  \S/', $input)) {
+                $indent = '  ';
+            }
+            if (false !== strpos($input, "\r")) {
+                $lineEnding = "\r\n";
+            }
+        }
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig(
+            $indent,
+            $lineEnding
+        ));
 
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $configuration
+     *
+     * @dataProvider testFixProvider
+     */
+    public function testFixWithDifferentLineEndings(
+        $expected,
+        $input = null,
+        array $configuration = null
+    ) {
+        if (null !== $input) {
+            $input = str_replace("\n", "\r\n", $input);
+        }
+
+        return $this->testFix(
+            str_replace("\n", "\r\n", $expected),
+            $input,
+            $configuration
+        );
     }
 
     public function testFixProvider()
@@ -254,6 +294,276 @@ $a#
                 "<?php xyz(\$a=10,\n\$b=20);",
                 "<?php xyz(\$a=10,   \n\$b=20);",
                 ['keep_multiple_spaces_after_comma' => true],
+            ],
+            'test half-multiline function becomes fully-multiline' => [
+                <<<'EXPECTED'
+<?php
+functionCall(
+    'a',
+    'b',
+    'c'
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+functionCall(
+    'a', 'b',
+    'c'
+);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test barely multiline function with blank lines becomes fully-multiline' => [
+                <<<'EXPECTED'
+<?php
+functionCall(
+    'a',
+    'b',
+
+    'c'
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+functionCall('a', 'b',
+
+    'c');
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test indentation is preserved' => [
+                <<<'EXPECTED'
+<?php
+if (true) {
+    functionCall(
+        'a',
+        'b',
+        'c'
+    );
+}
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+if (true) {
+    functionCall(
+        'a', 'b',
+        'c'
+    );
+}
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test multiline array arguments do not trigger multiline' => [
+                <<<'EXPECTED'
+<?php
+defraculate(1, array(
+    'a',
+    'b',
+    'c',
+), 42);
+EXPECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test multiline function arguments do not trigger multiline' => [
+                <<<'EXPECTED'
+<?php
+defraculate(1, function () {
+    $a = 42;
+}, 42);
+EXPECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test violation after opening parenthesis' => [
+                <<<'EXPECTED'
+<?php
+defraculate(
+    1,
+    2,
+    3
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+defraculate(
+    1, 2, 3);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test violation after opening parenthesis, indented with two spaces' => [
+                <<<'EXPECTED'
+<?php
+defraculate(
+  1,
+  2,
+  3
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+defraculate(
+  1, 2, 3);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test violation after opening parenthesis, indented with tabs' => [
+                <<<'EXPECTED'
+<?php
+defraculate(
+	1,
+	2,
+	3
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+defraculate(
+	1, 2, 3);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test violation before closing parenthesis' => [
+                <<<'EXPECTED'
+<?php
+defraculate(
+    1,
+    2,
+    3
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+defraculate(1, 2, 3
+);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test violation before closing parenthesis in nested call' => [
+                <<<'EXPECTED'
+<?php
+getSchwifty('rick', defraculate(
+    1,
+    2,
+    3
+), 'morty');
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+getSchwifty('rick', defraculate(1, 2, 3
+), 'morty');
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test with comment between arguments' => [
+                <<<'EXPECTED'
+<?php
+functionCall(
+    'a', /* comment */
+    'b',
+    'c'
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+functionCall(
+    'a',/* comment */'b',
+    'c'
+);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test with deeply nested arguments' => [
+                <<<'EXPECTED'
+<?php
+foo(
+    'a',
+    'b',
+    [
+        'c',
+        'd', bar('e', 'f'),
+        baz(
+            'g',
+            ['h',
+                'i',
+            ]
+        ),
+    ]
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+foo('a',
+    'b',
+    [
+        'c',
+        'd', bar('e', 'f'),
+        baz('g',
+            ['h',
+                'i',
+            ]),
+    ]);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
+            'multiline string argument' => [
+                <<<'UNAFFECTED'
+<?php
+$this->with('<?php
+%s
+class FooClass
+{
+}', $comment, false);
+UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'arrays with whitespace inside' => [
+                <<<'UNAFFECTED'
+<?php
+$a = array/**/(  1);
+$a = array/**/( 12,
+7);
+$a = array/***/(123,  7);
+$a = array (        1,
+2);
+UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test code that should not be affected (because not a function nor a method)' => [
+            <<<'UNAFFECTED'
+<?php
+if (true &&
+    true
+    ) {
+    // do whatever
+}
+UNAFFECTED
             ],
         ];
     }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -593,7 +593,25 @@ UNAFFECTED
                 ['ensure_fully_multiline' => true],
             ],
             'test ungodly code' => [
-            <<<'UNAFFECTED'
+            <<<'EXPECTED'
+<?php
+$a = function#
+(#
+#
+$a#
+#
+,#
+#
+$b,
+    $c#
+#
+)#
+use ($b,
+$c,$d) {
+};
+EXPECTED
+            ,
+            <<<'INPUT'
 <?php
 $a = function#
 (#
@@ -608,9 +626,8 @@ $b,$c#
 use ($b,
 $c,$d) {
 };
-UNAFFECTED
+INPUT
             ,
-                null,
                 ['ensure_fully_multiline' => true],
             ],
             'test list' => [

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -588,6 +588,9 @@ if (true &&
     // do whatever
 }
 UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
             ],
         ];
     }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -315,6 +315,30 @@ INPUT
             ,
                 ['ensure_fully_multiline' => true],
             ],
+            'function calls with here doc cannot be anything but multiline' => [
+                <<<'EXPECTED'
+<?php
+str_replace(
+    "\n",
+    PHP_EOL,
+    <<<'TEXT'
+   1) someFile.php
+
+TEXT
+);
+EXPECTED
+            ,
+                <<<'INPUT'
+<?php
+str_replace("\n", PHP_EOL, <<<'TEXT'
+   1) someFile.php
+
+TEXT
+);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
             'test barely multiline function with blank lines becomes fully-multiline' => [
                 <<<'EXPECTED'
 <?php

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -592,6 +592,45 @@ UNAFFECTED
                 null,
                 ['ensure_fully_multiline' => true],
             ],
+            'test ungodly code' => [
+            <<<'UNAFFECTED'
+<?php
+$a = function#
+(#
+#
+$a#
+#
+,#
+#
+$b,$c#
+#
+)#
+use ($b,
+$c,$d) {
+};
+UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test list' => [
+            <<<'UNAFFECTED'
+<?php
+// no fix
+list($a,
+    $b, $c) = $a;
+isset($a,
+$b, $c);
+unset($a,
+$b, $c);
+array(1,
+    2,3
+);
+UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
         ];
     }
 

--- a/tests/Report/TextReporterTest.php
+++ b/tests/Report/TextReporterTest.php
@@ -63,7 +63,10 @@ TEXT;
 
     public function testGenerateSimple()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
 
 TEXT
@@ -90,7 +93,10 @@ TEXT
 
     public function testGenerateWithDiff()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
       ---------- begin diff ----------
 this text is a diff ;)
@@ -122,7 +128,10 @@ TEXT
 
     public function testGenerateWithAppliedFixers()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php (some_fixer_name_here)
 
 TEXT
@@ -149,7 +158,10 @@ TEXT
 
     public function testGenerateWithTimeAndMemory()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
 
 Fixed all files in 1.234 seconds, 2.500 MB memory used
@@ -178,7 +190,10 @@ TEXT
 
     public function testGenerateComplexWithDecoratedOutput()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php (<comment>some_fixer_name_here</comment>)
 <comment>      ---------- begin diff ----------</comment>
 this text is a diff ;)

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -132,7 +132,7 @@ final class RuleSetTest extends TestCase
                 'line_ending' => true,
                 'lowercase_constants' => true,
                 'lowercase_keywords' => true,
-                'method_argument_space' => true,
+                'method_argument_space' => ['ensure_fully_multiline' => true],
                 'no_closing_tag' => true,
                 'no_spaces_after_function_name' => true,
                 'no_spaces_inside_parenthesis' => true,
@@ -171,7 +171,7 @@ final class RuleSetTest extends TestCase
                 'line_ending' => true,
                 'lowercase_constants' => true,
                 'lowercase_keywords' => true,
-                'method_argument_space' => true,
+                'method_argument_space' => ['ensure_fully_multiline' => true],
                 'no_closing_tag' => true,
                 'no_spaces_after_function_name' => true,
                 'no_spaces_inside_parenthesis' => true,
@@ -258,7 +258,8 @@ final class RuleSetTest extends TestCase
             $fixerNames,
             sprintf(
                 'Set should only contain %s fixers, got: \'%s\'.',
-                $safe ? 'safe' : 'risky', implode('\', \'', $fixerNames)
+                $safe ? 'safe' : 'risky',
+                implode('\', \'', $fixerNames)
             )
         );
     }


### PR DESCRIPTION
Todo : 

- [x] fix broken tests
- [x] add more test cases
    - [x] for indented methods (currently indention is hardcoded and not preserved)
    - [x] for multiline arguments
        - [x] for multiline array arguments
        - [x] for multiline function arguments
    - [x] for fix needed near opening parenthesis
    - [x] for fix needed near closing parenthesis
    - [x] for different OS line endings
    - [x] for different indention chars
    - [x] for different indention levels
    - [x] for nested arrays
- [x] make the fixer optional