### PR TITLE
[WIP][PHP 7.1] Add ListSyntaxFixer

### DIFF
--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -688,7 +688,7 @@ $b;',
      * @param string $source
      * @param int[]  $tokenIndexes
      *
-     * @dataProvider provideIsArray70Cases
+     * @dataProvider provideIsArray71Cases
      * @requires PHP 7.1
      */
     public function testIsArray71($source, $tokenIndexes)
@@ -706,7 +706,7 @@ $b;',
         }
     }
 
-    public function provideIsArray70Cases()
+    public function provideIsArray71Cases()
     {
         return array(
             array(

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -605,20 +605,20 @@ $b;',
     /**
      * @param string $source
      * @param int    $tokenIndex
-     * @param bool   $isMultilineArray
+     * @param bool   $isMultiLineArray
      *
-     * @dataProvider provideIsArray
+     * @dataProvider provideIsArrayCases
      * @requires PHP 5.4
      */
-    public function testIsArray($source, $tokenIndex, $isMultilineArray = false)
+    public function testIsArray($source, $tokenIndex, $isMultiLineArray = false)
     {
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $this->assertTrue($tokensAnalyzer->isArray($tokenIndex), 'Expected to be an array.');
-        $this->assertSame($isMultilineArray, $tokensAnalyzer->isArrayMultiLine($tokenIndex), sprintf('Expected %sto be a multiline array', $isMultilineArray ? '' : 'not '));
+        $this->assertSame($isMultiLineArray, $tokensAnalyzer->isArrayMultiLine($tokenIndex), sprintf('Expected %sto be a multiline array', $isMultiLineArray ? '' : 'not '));
     }
 
-    public function provideIsArray()
+    public function provideIsArrayCases()
     {
         $cases = array(
             array(
@@ -682,6 +682,43 @@ $b;',
         );
 
         return $cases;
+    }
+
+    /**
+     * @param string $source
+     * @param int[]  $tokenIndexes
+     *
+     * @dataProvider provideIsArray70Cases
+     * @requires PHP 7.1
+     */
+    public function testIsArray71($source, $tokenIndexes)
+    {
+        $tokens = Tokens::fromCode($source);
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        foreach ($tokens as $index => $token) {
+            $expect = in_array($index, $tokenIndexes, true);
+            $this->assertSame(
+                $expect,
+                $tokensAnalyzer->isArray($index),
+                sprintf('Expected %sarray, got @ %d "%s".', $expect ? '' : 'no ', $index, var_export($token, true))
+            );
+        }
+    }
+
+    public function provideIsArray70Cases()
+    {
+        return array(
+            array(
+                '<?php
+                    [$a] = $z;
+                    ["a" => $a, "b" => $b] = $array;
+                    $c = [$d, $e] = $array[$a];
+                    [[$a, $b], [$c, $d]] = $d;
+                ',
+                array(51, 59)
+            ),
+        );
     }
 
     /**


### PR DESCRIPTION
question, should we add a new custom token for `[` (and its counter part `]`) of the [new short syntax](https://wiki.php.net/rfc/short_list_syntax) for array destructing assignment?
(I think so btw. ;) )