### PR TITLE
Add NativeFunctionInvocationFixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ install:
     - composer info -D | sort
 
 script:
-    - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules declare_strict_types -q; fi
+    - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules declare_strict_types,native_function_invocation -q; fi
 
     - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 0 ]; then vendor/bin/phpunit --verbose; fi
     - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 1 ]; then phpdbg -qrr vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml; fi

--- a/README.rst
+++ b/README.rst
@@ -308,6 +308,11 @@ Choose from the list of available rules:
 * **native_function_casing** [@Symfony]
    | Function defined by PHP should be called using the correct casing.
 
+* **native_function_invocation**
+   | Add leading ``\`` before function invocation of internal function within
+   | namespaces to speed up resolving.
+   | *Rule is: risky.*
+
 * **new_with_braces** [@Symfony]
    | All instances created with new keyword must be followed by braces.
 

--- a/README.rst
+++ b/README.rst
@@ -311,7 +311,7 @@ Choose from the list of available rules:
 * **native_function_invocation**
    | Add leading ``\`` before function invocation of internal function within
    | namespaces to speed up resolving.
-   | *Rule is: risky.*
+   | *Rule is: configurable, risky.*
 
 * **new_with_braces** [@Symfony]
    | All instances created with new keyword must be followed by braces.

--- a/README.rst
+++ b/README.rst
@@ -309,8 +309,8 @@ Choose from the list of available rules:
    | Function defined by PHP should be called using the correct casing.
 
 * **native_function_invocation**
-   | Add leading ``\`` before function invocation of internal function within
-   | namespaces to speed up resolving.
+   | Add leading ``\`` before function invocation of internal function to speed
+   | up resolving.
    | *Rule is: configurable, risky.*
 
 * **new_with_braces** [@Symfony]

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -141,7 +141,7 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
      */
     public function getDefinition()
     {
-        $riskyDescription = <<<TXT
+        $riskyDescription = <<<'TXT'
 Rule is risky when a function with the same name as a native function exists in the current namespace.
 +Two major situations when it could happen are:
 +* polyfill is used to provide function from higher PHP version, if PHP CS Fixer would been run also on that higher PHP version, but software is also desired to work on lower PHP version that naively doesn't have that polyfilled function

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -185,7 +185,7 @@ function baz($options)
                 ),
             ),
             null,
-            'Configure names of functions to exclude, for example, when using a polyfill.',
+            'Configure names of functions to exclude, for example, when mocking.',
             self::$defaultConfiguration,
             $riskyDescription
         );

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -141,6 +141,14 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
      */
     public function getDefinition()
     {
+        $riskyDescription = <<<TXT
+Rule is risky when a function with the same name as a native function exists in the current namespace.
++Two major situations when it could happen are:
++* polyfill is used to provide function from higher PHP version, if PHP CS Fixer would been run also on that higher PHP version, but software is also desired to work on lower PHP version that naively doesn't have that polyfilled function
++* function is mocked during tests execution, eg mocking `time` function - in that case after applying the rule src code will always use original, unmocked function
++To deal with described situation provide a configuration with function names you want to preserve unchanged.'
+TXT;
+
         return new FixerDefinition(
             'Add leading `\` before function invocation of internal function to speed up resolving.',
             array(
@@ -177,7 +185,7 @@ function baz($options)
             null,
             'Configure names of functions to exclude, for example, when using a polyfill.',
             self::$defaultConfiguration,
-            'Risky if a function with the same name as a native function exists in the current namespace, or a polyfill is used.'
+            $riskyDescription
         );
     }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -233,7 +233,7 @@ class Bar
                 ),
             ),
             null,
-            'Configure names of functions to exclude',
+            'Configure names of functions to exclude, for example, when using a polyfill.',
             self::$defaultConfiguration,
             'Risky if a function with the same name as a native function exists in the current namespace, or a polyfill is used.'
         );

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -154,7 +154,7 @@ class Bar
             null,
             null,
             null,
-            'Risky if a function with the same name as a native function exists in the current namespace'
+            'Risky if a function with the same name as a native function exists in the current namespace, or a polyfill is used.'
         );
     }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -204,8 +204,6 @@ function baz($options)
     {
         $definedFunctions = \get_defined_functions();
 
-        return \array_map(function ($name) {
-            return \strtolower($name);
-        }, $definedFunctions['internal']);
+        return \array_map('strtolower', $definedFunctions['internal']);
     }
 }

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\FunctionNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ */
+final class NativeFunctionInvocationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        static $internalFunctionNames = null;
+
+        if (null === $internalFunctionNames) {
+            $internalFunctionNames = $this->getInternalFunctionNames();
+        }
+
+        $indexes = array();
+
+        $openBracesCount = 0;
+        $isNamespaceWithBraces = false;
+        $isWithinNamespace = false;
+
+        for ($index = 0, $count = $tokens->count(); $index < $count; ++$index) {
+            $token = $tokens[$index];
+
+            $tokenContent = $token->getContent();
+
+            if ('{' === $tokenContent) {
+                ++$openBracesCount;
+
+                continue;
+            }
+
+            if ('}' === $tokenContent) {
+                --$openBracesCount;
+
+                if (true === $isWithinNamespace
+                    && true === $isNamespaceWithBraces
+                    && 0 === $openBracesCount
+                ) {
+                    $isWithinNamespace = false;
+                }
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_NAMESPACE)) {
+                $namespaceDeclarationEndIndex = $tokens->getNextTokenOfKind($index, array(
+                    ';',
+                    '{',
+                ));
+
+                if ($tokens[$namespaceDeclarationEndIndex]->getContent() === '{') {
+                    $isNamespaceWithBraces = true;
+                }
+
+                $isWithinNamespace = true;
+            }
+
+            if (!$isWithinNamespace) {
+                continue;
+            }
+
+            // test if we are at a function call
+            if (!$token->isGivenKind(T_STRING)) {
+                continue;
+            }
+
+            $next = $tokens->getNextMeaningfulToken($index);
+            if (!$tokens[$next]->equals('(')) {
+                continue;
+            }
+
+            $functionNamePrefix = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$functionNamePrefix]->isGivenKind(array(T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_FUNCTION))) {
+                continue;
+            }
+
+            if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
+                // skip if the call is to a constructor or to a function in a namespace other than the default
+                $prev = $tokens->getPrevMeaningfulToken($functionNamePrefix);
+                if ($tokens[$prev]->isGivenKind(array(T_STRING, T_NEW))) {
+                    continue;
+                }
+            }
+
+            if (!in_array(strtolower($tokenContent), $internalFunctionNames, true)) {
+                continue;
+            }
+
+            // do not bother if previous token is already namespace separator
+            if ($tokens[$index - 1]->isGivenKind(T_NS_SEPARATOR)) {
+                continue;
+            }
+
+            $indexes[] = $index;
+        }
+
+        $indexes = array_reverse($indexes);
+
+        $namespaceSeparator = new Token(array(
+            T_NS_SEPARATOR,
+            '\\',
+        ));
+
+        foreach ($indexes as $index) {
+            $tokens->insertAt($index, $namespaceSeparator);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Add leading `\` before function invocation of internal function within namespaces to speed up resolving.',
+            array(new CodeSample(
+'<?php
+
+namespace Foo;
+
+class Bar
+{
+    public function __construct($options) 
+    {
+        if (!array_key_exists("foo", $options)) {
+            throw new \InvalidArgumentException();
+        }
+    }
+    
+}'
+            )),
+            null,
+            null,
+            null,
+            'Risky if a function with the same name as a native function exists in the current namespace'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound(array(
+            T_NAMESPACE,
+            T_STRING,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getInternalFunctionNames()
+    {
+        $definedFunctions = get_defined_functions();
+
+        return array_map(function ($name) {
+            return strtolower($name);
+        }, $definedFunctions['internal']);
+    }
+}

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -59,12 +59,12 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
         }
 
         foreach ($configuration[$key] as $functionName) {
-            if (!\is_string($functionName) || \trim($functionName) === '' || trim($functionName) !== $functionName) {
+            if (!\is_string($functionName) || \trim($functionName) === '' || \trim($functionName) !== $functionName) {
                 throw new InvalidFixerConfigurationException(
                     $this->getName(),
                     \sprintf(
                         'Each element must be a non-empty string, got "%s" instead.',
-                        \is_object($functionName) ? get_class($functionName) : gettype($functionName)
+                        \is_object($functionName) ? \get_class($functionName) : \gettype($functionName)
                     )
                 );
             }
@@ -154,9 +154,9 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
                 }
             }
 
-            $lowerFunctionName = strtolower($tokenContent);
+            $lowerFunctionName = \strtolower($tokenContent);
 
-            if (!in_array($lowerFunctionName, $internalFunctionNames, true) || in_array($lowerFunctionName, $this->exclude, true)) {
+            if (!\in_array($lowerFunctionName, $internalFunctionNames, true) || \in_array($lowerFunctionName, $this->exclude, true)) {
                 continue;
             }
 
@@ -168,7 +168,7 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
             $indexes[] = $index;
         }
 
-        $indexes = array_reverse($indexes);
+        $indexes = \array_reverse($indexes);
 
         $namespaceSeparator = new Token(array(
             T_NS_SEPARATOR,
@@ -261,10 +261,10 @@ class Bar
      */
     private function getInternalFunctionNames()
     {
-        $definedFunctions = get_defined_functions();
+        $definedFunctions = \get_defined_functions();
 
-        return array_map(function ($name) {
-            return strtolower($name);
+        return \array_map(function ($name) {
+            return \strtolower($name);
         }, $definedFunctions['internal']);
     }
 }

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -171,14 +171,8 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
         }
 
         $indexes = \array_reverse($indexes);
-
-        $namespaceSeparator = new Token(array(
-            T_NS_SEPARATOR,
-            '\\',
-        ));
-
         foreach ($indexes as $index) {
-            $tokens->insertAt($index, $namespaceSeparator);
+            $tokens->insertAt($index, new Token(array(T_NS_SEPARATOR, '\\')));
         }
     }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -43,6 +43,8 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
     public function configure(array $configuration = null)
     {
         if (null === $configuration) {
+            $this->exclude = array();
+
             return;
         }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -26,7 +26,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class NativeFunctionInvocationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     /**
-     * @var array
+     * @var string[]
      */
     private $exclude = array();
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -63,7 +63,7 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
                 throw new InvalidFixerConfigurationException(
                     $this->getName(),
                     \sprintf(
-                        'Each element must be a non-empty string, got "%s" instead.',
+                        'Each element must be a non-empty, trimmed string, got "%s" instead.',
                         \is_object($functionName) ? \get_class($functionName) : \gettype($functionName)
                     )
                 );

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -143,8 +143,7 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
     {
         $riskyDescription = <<<'TXT'
 Rule is risky when a function with the same name as a native function exists in the current namespace.
-+Two major situations when it could happen are:
-+* polyfill is used to provide function from higher PHP version, if PHP CS Fixer would been run also on that higher PHP version, but software is also desired to work on lower PHP version that naively doesn't have that polyfilled function
++One major situation when it could happen is:
 +* function is mocked during tests execution, eg mocking `time` function - in that case after applying the rule src code will always use original, unmocked function
 +To deal with described situation provide a configuration with function names you want to preserve unchanged.'
 TXT;

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -171,8 +171,10 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
             $this->assertNull($fixResult, '->fix method must return null.');
         }
 
+        $actual = $tokens->generateCode();
+
         $this->assertThat(
-            $tokens->generateCode(),
+            $actual,
             new SameStringsConstraint($expected),
             'Code build on expected code must not change.'
         );

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -171,10 +171,8 @@ abstract class AbstractFixerTestCase extends \PHPUnit_Framework_TestCase
             $this->assertNull($fixResult, '->fix method must return null.');
         }
 
-        $actual = $tokens->generateCode();
-
         $this->assertThat(
-            $actual,
+            $tokens->generateCode(),
             new SameStringsConstraint($expected),
             'Code build on expected code must not change.'
         );

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -54,7 +54,7 @@ json_encode($foo);
             array(
 '<?php
 
-class Foo 
+class WithoutNamespace
 {
     public function bar($foo)
     {
@@ -66,18 +66,18 @@ class Foo
             array(
 '<?php
 
-namespace Foo {}
+namespace OneNamespaceWithBraces {}
 
 json_encode($foo);
 
-namespace Bar {}
+namespace AnotherNamespaceWithBraces {}
 ',
             ),
         );
     }
 
     /**
-     * @dataProvider provideCasesNotWithinNamespace
+     * @dataProvider provideCasesWithinNamespace
      *
      * @param string      $expected
      * @param null|string $input
@@ -96,9 +96,9 @@ namespace Bar {}
             array(
 '<?php
 
-namespace Foo;
+namespace WithoutClassPrefixed;
 
-if (isset($foo) {
+if (isset($foo)) {
     \json_encode($foo);
 }
 ',
@@ -106,17 +106,17 @@ if (isset($foo) {
             array(
 '<?php
 
-namespace Foo;
+namespace WithoutClassNotPrefixed;
 
-if (isset($foo) {
+if (isset($foo)) {
     \json_encode($foo);
 }
 ',
 '<?php
 
-namespace Foo;
+namespace WithoutClassNotPrefixed;
 
-if (isset($foo) {
+if (isset($foo)) {
     json_encode($foo);
 }
 ',
@@ -126,76 +126,75 @@ if (isset($foo) {
 
 namespace Foo;
 
-class Bar
+class WithClassPrefixed
 {
     public function baz($foo)
     {
-        if (isset($foo) {
+        if (isset($foo)) {
             \json_encode($foo);
         }
     }
-',
+}',
             ),
             array(
 '<?php
 
-namespace Foo;
+namespace WithClassNotPrefixed;
 
 class Bar
 {
     public function baz($foo)
     {
-        if (isset($foo) {
+        if (isset($foo)) {
             \json_encode($foo);
         }
     }
-',
+}',
 '<?php
 
-namespace Foo;
+namespace WithClassNotPrefixed;
 
 class Bar
 {
     public function baz($foo)
     {
-        if (isset($foo) {
+        if (isset($foo)) {
             json_encode($foo);
         }
     }
-',
+}',
             ),
             array(
 '<?php
 
-namespace Foo {}
+namespace OneNamespaceWithBraces {}
 
-namespace Bar
+namespace WithoutClassInNamespaceWithBracesNotPrefixed
 {
-    if (isset($foo) {
+    if (isset($foo)) {
         \json_encode($foo);
     }
-}
-',
+}',
             ),
             array(
 '<?php
 
-namespace Foo {}
+namespace OneNamespaceWithBraces {}
 
-namespace Bar
+namespace WithoutClassInNamespaceWithBracesPrefixed
 {
-    if (isset($foo) {
+    if (isset($foo)) {
         \json_encode($foo);
     }
 }
 ',
 '<?php
 
-namespace Foo {}
+namespace OneNamespaceWithBraces {}
 
-namespace Bar
+namespace WithoutClassInNamespaceWithBracesPrefixed
 {
-    if (isset($foo) {
+    if (isset($foo)) {
         json_encode($foo);
     }
 }

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -149,7 +149,7 @@ class Bar
 
 namespace OneNamespaceWithBraces {}
 
-namespace WithoutClassInNamespaceWithBracesNotPrefixed
+namespace WithoutClassInNamespaceWithBracesPrefixed
 {
     if (isset($foo)) {
         \json_encode($foo);
@@ -161,7 +161,7 @@ namespace WithoutClassInNamespaceWithBracesNotPrefixed
 
 namespace OneNamespaceWithBraces {}
 
-namespace WithoutClassInNamespaceWithBracesPrefixed
+namespace WithoutClassInNamespaceWithBracesNotPrefixed
 {
     if (isset($foo)) {
         \json_encode($foo);
@@ -172,7 +172,7 @@ namespace WithoutClassInNamespaceWithBracesPrefixed
 
 namespace OneNamespaceWithBraces {}
 
-namespace WithoutClassInNamespaceWithBracesPrefixed
+namespace WithoutClassInNamespaceWithBracesNotPrefixed
 {
     if (isset($foo)) {
         json_encode($foo);

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -21,16 +21,28 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
 {
-    public function testConfigureRejectsInvalidConfiguration()
+    public function testConfigureRejectsUnknownConfigurationKey()
+    {
+        $key = 'foo';
+
+        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
+            '"%s" is not handled by the fixer.',
+            $key
+        ));
+
+        $this->fixer->configure(array(
+            $key => 'bar',
+        ));
+    }
+
+    public function testConfigureRejectsEmptyConfiguration()
     {
         $this->setExpectedException(
             'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
             'Configuration must define "exclude" as an array.'
         );
 
-        $this->fixer->configure(array(
-            'foo' => 'bar',
-        ));
+        $this->fixer->configure(array());
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -29,12 +29,12 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideCasesNotWithinNamespace
+     * @dataProvider provideCases
      *
      * @param string      $expected
      * @param null|string $input
      */
-    public function testFixNotWithinNamespace($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
@@ -42,7 +42,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     /**
      * @return array
      */
-    public function provideCasesNotWithinNamespace()
+    public function provideCases()
     {
         return array(
             array(
@@ -73,26 +73,6 @@ json_encode($foo);
 namespace AnotherNamespaceWithBraces {}
 ',
             ),
-        );
-    }
-
-    /**
-     * @dataProvider provideCasesWithinNamespace
-     *
-     * @param string      $expected
-     * @param null|string $input
-     */
-    public function testFixWithinNamespace($expected, $input = null)
-    {
-        $this->doTest($expected, $input);
-    }
-
-    /**
-     * @return array
-     */
-    public function provideCasesWithinNamespace()
-    {
-        return array(
             array(
 '<?php
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -143,134 +143,49 @@ PHP;
             array(
 '<?php
 
+\json_encode($foo);
+',
+            ),
+            array(
+'<?php
+
+\json_encode($foo);
+',
+'<?php
+
 json_encode($foo);
 ',
             ),
             array(
 '<?php
 
-class WithoutNamespace
+class Foo
+{
+    public function bar($foo)
+    {
+        return \json_encode($foo);
+    }
+}
+',
+            ),
+            array(
+'<?php
+
+class Foo
+{
+    public function bar($foo)
+    {
+        return \json_encode($foo);
+    }
+}
+',
+'<?php
+
+class Foo
 {
     public function bar($foo)
     {
         return json_encode($foo);
-    }
-}
-',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-json_encode($foo);
-
-namespace AnotherNamespaceWithBraces {}
-',
-            ),
-            array(
-'<?php
-
-namespace WithoutClassPrefixed;
-
-if (isset($foo)) {
-    \json_encode($foo);
-}
-',
-            ),
-            array(
-'<?php
-
-namespace WithoutClassNotPrefixed;
-
-if (isset($foo)) {
-    \json_encode($foo);
-}
-',
-'<?php
-
-namespace WithoutClassNotPrefixed;
-
-if (isset($foo)) {
-    json_encode($foo);
-}
-',
-            ),
-            array(
-'<?php
-
-namespace Foo;
-
-class WithClassPrefixed
-{
-    public function baz($foo)
-    {
-        if (isset($foo)) {
-            \json_encode($foo);
-        }
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace WithClassNotPrefixed;
-
-class Bar
-{
-    public function baz($foo)
-    {
-        if (isset($foo)) {
-            \json_encode($foo);
-        }
-    }
-}',
-'<?php
-
-namespace WithClassNotPrefixed;
-
-class Bar
-{
-    public function baz($foo)
-    {
-        if (isset($foo)) {
-            json_encode($foo);
-        }
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-namespace WithoutClassInNamespaceWithBracesPrefixed
-{
-    if (isset($foo)) {
-        \json_encode($foo);
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-namespace WithoutClassInNamespaceWithBracesNotPrefixed
-{
-    if (isset($foo)) {
-        \json_encode($foo);
-    }
-}
-',
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-namespace WithoutClassInNamespaceWithBracesNotPrefixed
-{
-    if (isset($foo)) {
-        json_encode($foo);
     }
 }
 ',
@@ -310,96 +225,11 @@ json_encode($foo);
             array(
 '<?php
 
-class WithoutNamespace
+class Foo
 {
     public function bar($foo)
     {
         return json_encode($foo);
-    }
-}
-',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-json_encode($foo);
-
-namespace AnotherNamespaceWithBraces {}
-',
-            ),
-            array(
-'<?php
-
-namespace WithoutClassPrefixed;
-
-if (isset($foo)) {
-    \json_encode($foo);
-}
-',
-            ),
-            array(
-'<?php
-
-namespace WithoutClassNotPrefixed;
-
-if (isset($foo)) {
-    json_encode($foo);
-}
-',
-            ),
-            array(
-'<?php
-
-namespace Foo;
-
-class WithClassPrefixed
-{
-    public function baz($foo)
-    {
-        if (isset($foo)) {
-            \json_encode($foo);
-        }
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace WithClassNotPrefixed;
-
-class Bar
-{
-    public function baz($foo)
-    {
-        if (isset($foo)) {
-            json_encode($foo);
-        }
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-namespace WithoutClassInNamespaceWithBracesPrefixed
-{
-    if (isset($foo)) {
-        \json_encode($foo);
-    }
-}',
-            ),
-            array(
-'<?php
-
-namespace OneNamespaceWithBraces {}
-
-namespace WithoutClassInNamespaceWithBracesNotPrefixed
-{
-    if (isset($foo)) {
-        json_encode($foo);
     }
 }
 ',

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -78,7 +78,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         ));
 
         $before = <<<'PHP'
-'<?php
+<?php
 
 namespace WithClassNotPrefixed;
 
@@ -94,7 +94,7 @@ class Bar
 PHP;
 
         $after = <<<'PHP'
-'<?php
+<?php
 
 namespace WithClassNotPrefixed;
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ */
+final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
+{
+    public function testIsRisky()
+    {
+        $fixer = $this->createFixer();
+
+        $this->assertTrue($fixer->isRisky());
+    }
+
+    /**
+     * @dataProvider provideCasesNotWithinNamespace
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixNotWithinNamespace($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideCasesNotWithinNamespace()
+    {
+        return array(
+            array(
+'<?php
+
+json_encode($foo);
+',
+            ),
+            array(
+'<?php
+
+class Foo 
+{
+    public function bar($foo)
+    {
+        return json_encode($foo);
+    }
+}
+',
+            ),
+            array(
+'<?php
+
+namespace Foo {}
+
+json_encode($foo);
+
+namespace Bar {}
+',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideCasesNotWithinNamespace
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithinNamespace($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideCasesWithinNamespace()
+    {
+        return array(
+            array(
+'<?php
+
+namespace Foo;
+
+if (isset($foo) {
+    \json_encode($foo);
+}
+',
+            ),
+            array(
+'<?php
+
+namespace Foo;
+
+if (isset($foo) {
+    \json_encode($foo);
+}
+',
+'<?php
+
+namespace Foo;
+
+if (isset($foo) {
+    json_encode($foo);
+}
+',
+            ),
+            array(
+'<?php
+
+namespace Foo;
+
+class Bar
+{
+    public function baz($foo)
+    {
+        if (isset($foo) {
+            \json_encode($foo);
+        }
+    }
+',
+            ),
+            array(
+'<?php
+
+namespace Foo;
+
+class Bar
+{
+    public function baz($foo)
+    {
+        if (isset($foo) {
+            \json_encode($foo);
+        }
+    }
+',
+'<?php
+
+namespace Foo;
+
+class Bar
+{
+    public function baz($foo)
+    {
+        if (isset($foo) {
+            json_encode($foo);
+        }
+    }
+',
+            ),
+            array(
+'<?php
+
+namespace Foo {}
+
+namespace Bar
+{
+    if (isset($foo) {
+        \json_encode($foo);
+    }
+}
+',
+            ),
+            array(
+'<?php
+
+namespace Foo {}
+
+namespace Bar
+{
+    if (isset($foo) {
+        \json_encode($foo);
+    }
+}
+',
+'<?php
+
+namespace Foo {}
+
+namespace Bar
+{
+    if (isset($foo) {
+        json_encode($foo);
+    }
+}
+',
+            ),
+        );
+    }
+}

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -41,7 +41,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     public function testConfigureRejectsInvalidConfigurationElement($element)
     {
         $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
-            'Each element must be a non-empty string, got "%s" instead.',
+            'Each element must be a non-empty, trimmed string, got "%s" instead.',
             \is_object($element) ? \get_class($element) : \gettype($element)
         ));
 
@@ -65,6 +65,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
             'array' => array(array()),
             'float' => array(0.1),
             'object' => array(new \stdClass()),
+            'not-trimmed' => array('  json_encode  '),
         );
     }
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -69,6 +69,53 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
         );
     }
 
+    public function testConfigureResetsExclude()
+    {
+        $this->fixer->configure(array(
+            'exclude' => array(
+                'json_encode',
+            ),
+        ));
+
+        $before = <<<'PHP'
+'<?php
+
+namespace WithClassNotPrefixed;
+
+class Bar
+{
+    public function baz($foo)
+    {
+        if (isset($foo)) {
+            json_encode($foo);
+        }
+    }
+}
+PHP;
+
+        $after = <<<'PHP'
+'<?php
+
+namespace WithClassNotPrefixed;
+
+class Bar
+{
+    public function baz($foo)
+    {
+        if (isset($foo)) {
+            \json_encode($foo);
+        }
+    }
+}
+PHP;
+
+        $this->doTest($before);
+
+        $this->fixer->configure(null);
+
+        $this->doTest($after, $before);
+    }
+
     public function testIsRisky()
     {
         $fixer = $this->createFixer();


### PR DESCRIPTION
This PR

* [x] implements a configurable`NativeFunctionInvocationFixer`

Related to #2420.

💁‍♂️ For reference, see 

* https://twitter.com/Ocramius/status/811504929357660160
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* http://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

>Function or constant names that do not contain a backslash like name can be resolved in 2 different ways.
>
>First, the current namespace name is prepended to _name_.
>
>Finally, if the constant or function _name_ does not exist in the current namespace, a global constant or function _name_ is used if it exists.