### PR TITLE
README.rst - explain the usage of "--path-mode" parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,14 @@ problems as possible on a given file or files in a given directory and its subdi
     $ php php-cs-fixer.phar fix /path/to/dir
     $ php php-cs-fixer.phar fix /path/to/file
 
+By default ``--path-mode`` is set to ``override``, which means, that if you specify the path to a file or a directory via 
+command arguments, then the paths provided to a ``Finder`` in config file will be ignored. You can use ``--path-mode=intersection`` 
+to merge paths from the config file and from the argument:
+
+.. code-block:: bash
+
+    $ php php-cs-fixer.phar fix --path-mode=intersection /path/to/dir
+
 The ``--format`` option for the output format. Supported formats are ``txt`` (default one), ``json``, ``xml`` and ``junit``.
 
 NOTE: When using ``junit`` format report generates in accordance with JUnit xml schema from Jenkins (see docs/junit-10.xsd).

--- a/src/Console/Command/FixCommandHelp.php
+++ b/src/Console/Command/FixCommandHelp.php
@@ -40,6 +40,12 @@ problems as possible on a given file or files in a given directory and its subdi
     <info>$ php %command.full_name% /path/to/dir</info>
     <info>$ php %command.full_name% /path/to/file</info>
 
+By default <comment>--path-mode</comment> is set to ``override``, which means, that if you specify the path to a file or a directory via 
+command arguments, then the paths provided to a ``Finder`` in config file will be ignored. You can use <comment>--path-mode=intersection</comment> 
+to merge paths from the config file and from the argument:
+
+    <info>$ php %command.full_name% --path-mode=intersection /path/to/dir</info>
+
 The <comment>--format</comment> option for the output format. Supported formats are ``txt`` (default one), ``json``, ``xml`` and ``junit``.
 
 NOTE: When using ``junit`` format report generates in accordance with JUnit xml schema from Jenkins (see docs/junit-10.xsd).


### PR DESCRIPTION
I think, the meaning of `--path-mode` parameter is not clearly explained in the docs: I had struggled to understand why my excluded folders were not really excluded, until I found this issue #2465. 

So this MR adds explanation of the `--path-mode` parameter.