### PR TITLE
BracesFixer - Do not remove white space inside declare statement

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -633,15 +633,17 @@ class Foo {
         $tokens->removeTrailingWhitespace($index);
 
         $startParenthesisIndex = $tokens->getNextTokenOfKind($index, array('('));
+        $tokens->removeTrailingWhitespace($startParenthesisIndex);
+
         $endParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startParenthesisIndex);
+        $tokens->removeLeadingWhitespace($endParenthesisIndex);
+
         $startBraceIndex = $tokens->getNextTokenOfKind($endParenthesisIndex, array(';', '{'));
         $startBraceToken = $tokens[$startBraceIndex];
 
         if ($startBraceToken->equals('{')) {
             $this->fixSingleLineWhitespaceForDeclare($tokens, $startBraceIndex);
         }
-
-        $this->removeWhitespaceInParenthesis($tokens, $startParenthesisIndex, $endParenthesisIndex);
     }
 
     /**
@@ -658,20 +660,6 @@ class Foo {
             $tokens[$startBraceIndex - 1]->isWhitespace(" \t")
         ) {
             $tokens->ensureWhitespaceAtIndex($startBraceIndex - 1, 1, ' ');
-        }
-    }
-
-    /**
-     * @param Tokens $tokens
-     * @param int    $startParenthesisIndex
-     * @param int    $endParenthesisIndex
-     */
-    private function removeWhitespaceInParenthesis(Tokens $tokens, $startParenthesisIndex, $endParenthesisIndex)
-    {
-        for ($i = $startParenthesisIndex; $i < $endParenthesisIndex; ++$i) {
-            if ($tokens[$i]->isWhitespace()) {
-                $tokens[$i]->clear();
-            }
         }
     }
 }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -446,11 +446,12 @@ if (1) {
             ),
             array(
                 '<?php
-    declare(ticks=1) {
+    declare(ticks = 1) {
         $ticks = 1;
     }',
                 '<?php
-    declare(ticks=1) {
+    declare  (
+    ticks = 1  ) {
   $ticks = 1;
     }',
             ),
@@ -1438,7 +1439,7 @@ while (true) {
             ),
             array(
                 '<?php
-declare(ticks=1) {
+declare(ticks   =   1) {
 }',
                 '<?php
 declare   (   ticks   =   1   )   {


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2476

Side note (i.e. _not_ part of this PR)
Whitespace inside a declare statement can be controlled using `declare_equal_normalize`
(@ see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2478)