### PR TITLE
Fix priorities between declare_strict_types and blank_line_after_opening_tag

### DIFF
--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -75,8 +75,8 @@ final class DeclareStrictTypesFixer extends AbstractFixer implements Whitespaces
      */
     public function getPriority()
     {
-        // must ran before SingleBlankLineBeforeNamespaceFixer.
-        return 1;
+        // must ran before SingleBlankLineBeforeNamespaceFixer and BlankLineAfterOpeningTagFixer.
+        return 2;
     }
 
     /**

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -292,6 +292,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
             array($fixers['no_useless_else'], $fixers['no_trailing_whitespace']), // tested also in: no_useless_else,no_trailing_whitespace.test
             array($fixers['no_useless_else'], $fixers['no_whitespace_in_blank_line']), // tested also in: no_useless_else,no_whitespace_in_blank_line.test
             array($fixers['declare_strict_types'], $fixers['single_blank_line_before_namespace']), // tested also in: declare_strict_types,single_blank_line_before_namespace.test
+            array($fixers['declare_strict_types'], $fixers['blank_line_after_opening_tag']), // tested also in: declare_strict_types,blank_line_after_opening_tag.test
             array($fixers['array_syntax'], $fixers['binary_operator_spaces']), // tested also in: array_syntax,binary_operator_spaces.test
             array($fixers['array_syntax'], $fixers['ternary_operator_spaces']), // tested also in: array_syntax,ternary_operator_spaces.test
             array($fixers['class_keyword_remove'], $fixers['no_unused_imports']), // tested also in: class_keyword_remove,no_unused_imports.test

--- a/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
+++ b/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: declare_strict_types,blank_line_after_opening_tag.
 --RULESET--
-{"blank_line_after_opening_tag" : true, "declare_strict_types": true}
+{"declare_strict_types" : true, "blank_line_after_opening_tag": true}
 --REQUIREMENTS--
 {"php": 70000}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
+++ b/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
@@ -1,0 +1,19 @@
+--TEST--
+Integration of fixers: declare_strict_types,blank_line_after_opening_tag.
+--RULESET--
+{"blank_line_after_opening_tag" : true, "declare_strict_types": true}
+--REQUIREMENTS--
+{"php": 70000}
+--EXPECT--
+<?php
+
+declare(strict_types=1);
+namespace A\B\C;
+class A {
+}
+
+--INPUT--
+<?php
+namespace A\B\C;
+class A {
+}


### PR DESCRIPTION
declare_strict_types must be run before blank_line_after_opening_tag is run.
Otherwise it will add a new line after the php tag and then add declare(strict_type=1); right after the php tag

PS: I didn't run php-cs-fixer fix because lots of tests files would be modified.

fixes #2492