### PR TITLE
FileSpecificCodeSample - Specify class name relative to root namespace

### DIFF
--- a/src/FixerDefinition/FileSpecificCodeSample.php
+++ b/src/FixerDefinition/FileSpecificCodeSample.php
@@ -25,13 +25,13 @@ final class FileSpecificCodeSample implements FileSpecificCodeSampleInterface
     private $codeSample;
 
     /**
-     * @var SplFileInfo
+     * @var \SplFileInfo
      */
     private $splFileInfo;
 
     /**
      * @param string      $code
-     * @param SplFileInfo $splFileInfo
+     * @param \SplFileInfo $splFileInfo
      * @param null|array  $configuration
      */
     public function __construct(

--- a/src/FixerDefinition/FileSpecificCodeSample.php
+++ b/src/FixerDefinition/FileSpecificCodeSample.php
@@ -30,9 +30,9 @@ final class FileSpecificCodeSample implements FileSpecificCodeSampleInterface
     private $splFileInfo;
 
     /**
-     * @param string      $code
+     * @param string       $code
      * @param \SplFileInfo $splFileInfo
-     * @param null|array  $configuration
+     * @param null|array   $configuration
      */
     public function __construct(
         $code,

--- a/src/FixerDefinition/FileSpecificCodeSampleInterface.php
+++ b/src/FixerDefinition/FileSpecificCodeSampleInterface.php
@@ -20,7 +20,7 @@ namespace PhpCsFixer\FixerDefinition;
 interface FileSpecificCodeSampleInterface extends CodeSampleInterface
 {
     /**
-     * @return SplFileInfo
+     * @return \SplFileInfo
      */
     public function getSplFileInfo();
 }


### PR DESCRIPTION
This PR

* [x] specifies a class name relative to the root namespace

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2466.