### PR TITLE
Add JSON output to describe command

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -123,7 +123,16 @@ $negative = function ($item) {
             ),
             null,
             'The `allow_single_line_closure` key could be set to `true` to allow for single line lambda notation.',
-            self::$defaultConfiguration
+            self::$defaultConfiguration,
+            null,
+            array(
+                'properties' => array(
+                    'allow_single_line_closure' => array(
+                        'type' => 'boolean',
+                    ),
+                ),
+                'additionalProperties' => false,
+            )
         );
     }
 

--- a/src/FixerDefinition/FixerDefinition.php
+++ b/src/FixerDefinition/FixerDefinition.php
@@ -23,6 +23,7 @@ final class FixerDefinition implements FixerDefinitionInterface
     private $codeSamples;
     private $summary;
     private $description;
+    private $configurationSchema;
 
     /**
      * @param string                $summary
@@ -31,6 +32,7 @@ final class FixerDefinition implements FixerDefinitionInterface
      * @param null|string           $configurationDescription null for non-configurable fixer
      * @param null|array            $defaultConfiguration     null for non-configurable fixer
      * @param null|string           $riskyDescription         null for non-risky fixer
+     * @param array|null|false      $configurationSchema      Configuration Schema (null for non-configurable fixer, false if not implemented) 
      */
     public function __construct(
         $summary,
@@ -38,7 +40,8 @@ final class FixerDefinition implements FixerDefinitionInterface
         $description = null,
         $configurationDescription = null,
         array $defaultConfiguration = null,
-        $riskyDescription = null
+        $riskyDescription = null,
+        $configurationSchema = false
     ) {
         $this->summary = $summary;
         $this->codeSamples = $codeSamples;
@@ -46,6 +49,11 @@ final class FixerDefinition implements FixerDefinitionInterface
         $this->configurationDescription = $configurationDescription;
         $this->defaultConfiguration = $defaultConfiguration;
         $this->riskyDescription = $riskyDescription;
+        if ($defaultConfiguration === null) {
+            $this->configurationSchema = null;
+        } else {
+            $this->configurationSchema = $configurationSchema;
+        }
     }
 
     public function getSummary()
@@ -76,5 +84,10 @@ final class FixerDefinition implements FixerDefinitionInterface
     public function getCodeSamples()
     {
         return $this->codeSamples;
+    }
+
+    public function getConfigurationSchema()
+    {
+        return $this->configurationSchema;
     }
 }

--- a/src/FixerDefinition/FixerDefinitionInterface.php
+++ b/src/FixerDefinition/FixerDefinitionInterface.php
@@ -48,4 +48,11 @@ interface FixerDefinitionInterface
      * @return CodeSampleInterface[]
      */
     public function getCodeSamples();
+
+    /**
+     * Configuration Schema (null for non-configurable fixer, false if not implemented)
+     *
+     *  @return array|null|false
+     */
+    public function getConfigurationSchema();
 }


### PR DESCRIPTION
[This is more a feature request than a real pull request]

What about adding an option to the describe command to make it output details in JSON format?
This could be very helpful in some automated environment.

I also added a new `configurationSchema` property to the `FixerDefinitionInterface`: it can be used by automated tools to know the format of the fixers configuration (using the [JSON Schema notation](http://json-schema.org/)).

Here's a sample output of `php-cs-fixer describe --json @Symfony`:

```json
{
    "ruleset": "@Symfony",
    "rules": {
        "binary_operator_spaces": {
            "align_double_arrow": false,
            "align_equals": false
        },
        "blank_line_after_namespace": true,
        "blank_line_after_opening_tag": true,
        "blank_line_before_return": true,
        "braces": {
            "allow_single_line_closure": true
        },
        [...omissis...]
    }
}
```

And a sample output of `php-cs-fixer describe --json braces`:

```json
{
    "name": "braces",
    "summary": "The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.",
    "description": "",
    "priority": -25,
    "risky": false,
    "riskyDescription": "",
    "configurationDescription": "The `allow_single_line_closure` key could be set to `true` to allow for single line lambda notation.",
    "defaultConfiguration": {
        "allow_single_line_closure": false,
        "codeSamples": {
            "code": "<?php\n$positive = function ($item) { return $item >= 0; };\n$negative = function ($item) {\n                return $item < 0; };\n",
            "configuration": {
                "allow_single_line_closure": true
            }
        }
    },
    "configurationSchema": {
        "properties": {
            "allow_single_line_closure": {
                "type": "boolean"
            }
        },
        "additionalProperties": false
    },
    "codeSamples": []
}
```
