### PR TITLE
Add OpeningTagPlusEchoToShortEchoTagFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -462,6 +462,9 @@ Choose from the list of available rules:
    | There should not be space before or after object ``T_OBJECT_OPERATOR``
    | ``->``.
 
+* **opening_tag_plus_echo_to_short_echo_tag**
+   | Replace ``<?php echo`` with short-echo ``<?=`` syntax.
+
 * **ordered_class_elements**
    | Orders the elements of classes/interfaces/traits.
    | *Rule is: configurable.*

--- a/src/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixer.php
+++ b/src/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpTag;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Vincent Klaiber <hello@vinkla.com>
+ */
+final class OpeningTagPlusEchoToShortEchoTagFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $i = count($tokens);
+        $lastEcho = null;
+
+        while ($i--) {
+            $token = $tokens[$i];
+
+            if ($token->isWhitespace()) {
+                continue;
+            } elseif ($token->isGivenKind(T_ECHO)) {
+                $lastEcho = $i;
+                continue;
+            } elseif (!$token->isGivenKind(T_OPEN_TAG)) {
+                $lastEcho = null;
+                continue;
+            }
+
+            if ($lastEcho !== null) {
+                $tokens->overrideAt($i, array(T_OPEN_TAG_WITH_ECHO, '<?='));
+                for ($j = $i + 1; $j <= $lastEcho; ++$j) {
+                    $tokens[$j]->clear();
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Replace `<?php echo` with short-echo `<?=` syntax.',
+            array(new CodeSample('<?php echo "foo";'))
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_OPEN_TAG);
+    }
+}

--- a/src/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixer.php
+++ b/src/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixer.php
@@ -13,8 +13,9 @@
 namespace PhpCsFixer\Fixer\PhpTag;
 
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -35,7 +36,7 @@ final class OpeningTagPlusEchoToShortEchoTagFixer extends AbstractFixer
 
             if ($token->isWhitespace()) {
                 continue;
-            } elseif ($token->isGivenKind(T_ECHO)) {
+            } elseif ($token->equals(array(T_ECHO, 'echo'))) {
                 $lastEcho = $i;
                 continue;
             } elseif (!$token->isGivenKind(T_OPEN_TAG)) {
@@ -59,7 +60,7 @@ final class OpeningTagPlusEchoToShortEchoTagFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'Replace `<?php echo` with short-echo `<?=` syntax.',
-            array(new CodeSample('<?php echo "foo";'))
+            array(new VersionSpecificCodeSample('<?php echo "foo";', new VersionSpecification(50400)))
         );
     }
 

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -259,6 +259,7 @@ final class FixerFactory
     {
         static $conflictMap = array(
             'no_blank_lines_before_namespace' => array('single_blank_line_before_namespace'),
+            'no_short_echo_tag' => array('opening_tag_plus_echo_to_short_echo_tag'),
         );
 
         $fixerName = $fixer->getName();

--- a/tests/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixerTest.php
+++ b/tests/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixerTest.php
@@ -29,6 +29,18 @@ final class OpeningTagPlusEchoToShortEchoTagFixerTest extends AbstractFixerTestC
      */
     public function testOneLineFix($expected, $input = null)
     {
+        if (50400 > PHP_VERSION_ID && !ini_get('short_open_tag')) {
+            // On PHP <5.4 short echo tag is parsed as T_INLINE_HTML if short_open_tag is disabled
+            // On PHP >=5.4 short echo tag is always parsed properly regardless of short_open_tag  option
+            $this->markTestSkipped('PHP 5.4 (or later) or short_open_tag option is required.');
+        }
+
+        if (defined('HHVM_VERSION')) {
+            // HHVM parses '<?=' anywhere but at the beginning of file as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
+            // See https://github.com/facebook/hhvm/issues/7161
+            $this->markTestSkipped('HHVM compares the results incorrectly.');
+        }
+
         $this->doTest($expected, $input);
     }
 

--- a/tests/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixerTest.php
+++ b/tests/Fixer/PhpTag/OpeningTagPlusEchoToShortEchoTagFixerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpTag;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Vincent Klaiber <hello@vinkla.com>
+ *
+ * @internal
+ */
+final class OpeningTagPlusEchoToShortEchoTagFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideClosingTagExamples
+     */
+    public function testOneLineFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideClosingTagExamples()
+    {
+        return array(
+            array('<?= \'Foo\';', '<?php echo \'Foo\';'),
+            array('<?= \'Foo\'; ?> PLAIN TEXT', '<?php echo \'Foo\'; ?> PLAIN TEXT'),
+            array('PLAIN TEXT<?= \'Foo\'; ?>', 'PLAIN TEXT<?php echo \'Foo\'; ?>'),
+            array('<?= \'Foo\'; ?> <?= \'Bar\'; ?>', '<?php echo \'Foo\'; ?> <?php echo \'Bar\'; ?>'),
+            array("<?=\n\tfoo();", "<?php echo\n\tfoo();"),
+            array('<?= \'foo\'; echo \'bar\';', '<?php echo \'foo\'; echo \'bar\';'),
+            array('<?php foo(); echo \'bar\';'),
+        );
+    }
+}

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -479,6 +479,8 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
         return array(
             array(new RuleSet(array('no_blank_lines_before_namespace' => true, 'single_blank_line_before_namespace' => true))),
             array(new RuleSet(array('single_blank_line_before_namespace' => true, 'no_blank_lines_before_namespace' => true))),
+            array(new RuleSet(array('no_short_echo_tag' => true, 'opening_tag_plus_echo_to_short_echo_tag' => true))),
+            array(new RuleSet(array('opening_tag_plus_echo_to_short_echo_tag' => true, 'no_short_echo_tag' => true))),
         );
     }
 


### PR DESCRIPTION
This commit adds OpeningTagPlusEchoToShortEchoTagFixer which nicely complements the NoShortEchoTagFixer. This is useful for PHP templates.