### PR TITLE
[WIP] Add PhpdocMagicMethodReturnAnnotationFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -502,6 +502,11 @@ Choose from the list of available rules:
 * **phpdoc_inline_tag** [@Symfony]
    | Fix phpdoc inline tags, make inheritdoc always inline.
 
+* **phpdoc_magic_method_return_annotation**
+   | PHPDoc of magic methods returning ``void`` should not have a ``@return``
+   | annotation.
+   | *Rule is: configurable.*
+
 * **phpdoc_no_access** [@Symfony]
    | @access annotations should be omitted from phpdocs.
 

--- a/src/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixer.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Phpdoc;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class PhpdocMagicMethodReturnAnnotationFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    private static $defaultConfiguration = array(
+        'methods' => array(
+            '__construct',
+            '__destruct',
+        ),
+    );
+
+    private static $fixableMethods = array(
+        '__construct',
+        '__clone',
+        '__destruct',
+        '__set',
+        '__unset',
+        '__wakeUp',
+    );
+
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        if (null === $configuration) {
+            $this->config = self::$defaultConfiguration;
+
+            return;
+        }
+
+        if (!array_key_exists('methods', $configuration) || !is_array($configuration['methods'])) {
+            throw new InvalidFixerConfigurationException($this->getName(), 'Configuration "methods" must be provided as array.');
+        }
+
+        $this->config = array('methods' => array());
+        foreach ($configuration['methods'] as $method) {
+            if (!in_array($method, self::$fixableMethods, true)) {
+                throw new InvalidFixerConfigurationException(
+                    $this->getName(),
+                    sprintf(
+                        'Only the following magic method names can be configured for fixing "%s".',
+                        implode('", "', self::$fixableMethods)
+                    )
+                );
+            }
+
+            $this->config['methods'][] = strtolower($method);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        // lower count with 12, 1 for 0 index and 11 for minimal number of tokens for a candidate
+        for ($index = 1, $count = count($tokens) - 12; $index < $count; ++$index) {
+            if ($tokens[$index]->isClassy()) {
+                $index = $this->fixClassy($tokens, $index);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'PHPDoc of magic methods returning `void` should not have a `@return` annotation.',
+            array(new CodeSample(
+'<?php
+class Sample
+{
+    /**
+     * @return Sample
+     */
+    public function __construct()
+    {
+    }
+}
+'
+            )),
+            '',
+            sprintf(
+                'Configure any of the following magic methods of which the PHPDocs should be fixed "%s".',
+                implode('", "', self::$fixableMethods)
+            ),
+            self::$defaultConfiguration
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // FIXME must run before empty PHPDoc and maybe other requirements?
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return
+            $tokens->isAllTokenKindsFound(array(T_DOC_COMMENT, T_FUNCTION, T_STRING))
+            && $tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds())
+        ;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index  index of T_CLASS token
+     *
+     * @return int Token index until fixed
+     */
+    private function fixClassy(Tokens $tokens, $index)
+    {
+        // figure out where the class begins and end
+        $classOpen = $tokens->getNextTokenOfKind($index, array('{'));
+        $classClose = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classOpen);
+
+        $fixMethods = $this->config['methods'];
+        for ($i = $classOpen, $end = $classClose - 4; $i < $end; ++$i) {
+            if (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $n = $tokens->getNextMeaningfulToken($i);
+            if (!$tokens[$n]->isGivenKind(T_STRING)) {
+                continue;
+            }
+
+            $lowerMethodName = strtolower($tokens[$n]->getContent());
+            $key = array_search($lowerMethodName, $fixMethods, true);
+            if (false === $key) {
+                continue;
+            }
+
+            $this->fixMethod($tokens, $i);
+
+            unset($fixMethods[$key]);
+            if (0 === count($fixMethods)) {
+                break; // no more methods to fix, stop searching
+            }
+        }
+
+        return $classClose;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index  T_FUNCTION index of the method to fix
+     */
+    private function fixMethod(Tokens $tokens, $index)
+    {
+        $modifiers = array(T_PUBLIC, T_PROTECTED, T_PRIVATE, T_ABSTRACT, T_FINAL);
+        // loop back until PHPDoc (to fix), or method modifier (to skip), or other non-white space (not a candidate) found.
+        $prevBlock = $index;
+        do {
+            $prevBlock = $tokens->getPrevNonWhitespace($prevBlock);
+            if ($tokens[$prevBlock]->isGivenKind(T_DOC_COMMENT)) {
+                $this->removeReturnAnnotationFromToken($tokens, $prevBlock);
+
+                break;
+            }
+        } while ($tokens[$prevBlock]->isGivenKind($modifiers));
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index  T_DOC_COMMENT index
+     */
+    private function removeReturnAnnotationFromToken(Tokens $tokens, $index)
+    {
+        $doc = new DocBlock($tokens[$index]->getContent());
+        $annotation = $doc->getAnnotationsOfType('return');
+        if (!count($annotation)) {
+            return;
+        }
+
+        $annotation[0]->remove();
+        $content = $doc->getContent();
+        '' === $content
+            ? $tokens->clearTokenAndMergeSurroundingWhitespace($index)
+            : $tokens[$index]->setContent($doc->getContent())
+        ;
+    }
+}

--- a/src/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixer.php
@@ -125,7 +125,15 @@ class Sample
      */
     public function getPriority()
     {
-        // FIXME must run before empty PHPDoc and maybe other requirements?
+        // FIXME add to fixer factory test
+        // must run after phpdoc_to_comment
+        // must run before no_empty_phpdoc
+        // should (for speed only) before phpdoc_align, phpdoc_annotation_without_dot, phpdoc_return_self_reference, phpdoc_scalar.
+
+        // FIXME check these ones
+        // must before before phpdoc_trim, phpdoc_order (this can be the other way around)
+        // no_trailing_whitespace_in_comment, phpdoc_separation, phpdoc_trim, phpdoc_types
+
         return 1;
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixerTest.php
@@ -1,0 +1,323 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Phpdoc;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class PhpdocMagicMethodReturnAnnotationFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param array|null  $config
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix(array $config = null, $expected, $input = null)
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            'Minimal candidate' => array(
+                null,
+                '<?php class A{function __construct(){}}',
+                '<?php class A{/** @return A*/function __construct(){}}',
+            ),
+            'Single class' => array(
+                null,
+'<?php class B
+{
+    /**
+     */
+    private function __construct()
+    {
+        return 1;
+    }
+
+    /**
+     */
+    public function __destruct()
+    {
+        return 1;
+    }
+}',
+'<?php class B
+{
+    /**
+     * @return B
+     */
+    private function __construct()
+    {
+        return 1;
+    }
+
+    /**
+     * @return B
+     */
+    public function __destruct()
+    {
+        return 1;
+    }
+}',
+            ),
+            'Multiple classes in same file.' => array(
+                null,
+'<?php
+class C
+{
+    /**
+     */
+    final public function __construct()
+    {
+        return 1;
+    }
+}
+class D
+{
+    /**
+     */
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @return D
+     */
+    public function construct()
+    {
+    }
+}
+',
+'<?php
+class C
+{
+    /**
+     * @return int
+     */
+    final public function __construct()
+    {
+        return 1;
+    }
+}
+class D
+{
+    /**
+     * @return D
+     */
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @return D
+     */
+    public function construct()
+    {
+    }
+}
+',
+            ),
+            'Comments, casing and missing visibility.' => array(
+                null,
+'<?php class E
+{
+    /**
+     */
+    FUNCTION/**/__CONstruct# All your rebase are belong to us.
+    ()
+    {
+        return 1;
+    }
+}',
+'<?php class E
+{
+    /**
+     * @return E
+     */
+    FUNCTION/**/__CONstruct# All your rebase are belong to us.
+    ()
+    {
+        return 1;
+    }
+}',
+            ),
+            'Abstract constructor.' => array(
+                null,
+'<?php
+abstract class G
+{
+    '.'
+    abstract public function __construct();
+}',
+'<?php
+abstract class G
+{
+    /** @return G*/
+    abstract public function __construct();
+}',
+            ),
+            'Single interface multiple annotations.' => array(
+                null,
+'<?php interface I
+{
+    /**
+     * Some test.
+     *
+     * @param int $a
+     *
+     *
+     * @internal @final
+     */
+    function __construct($a = 1);
+}',
+'<?php interface I
+{
+    /**
+     * Some test.
+     *
+     * @param int $a
+     *
+     * @return B
+     *
+     * @internal @final
+     */
+    function __construct($a = 1);
+}',
+            ),
+            'Config test' => array(
+                array('methods' => array('__clone', '__set')),
+'<?php
+class A
+{
+    /**
+     * @return A
+     */
+    public function __construct(){}
+
+    /**
+     */
+    public function __clone(){}
+
+    /**
+     */
+    public function __set(){}
+}
+',
+'<?php
+class A
+{
+    /**
+     * @return A
+     */
+    public function __construct(){}
+
+    /**
+     * @return A
+     */
+    public function __clone(){}
+
+    /**
+     * @return A
+     */
+    public function __set(){}
+}
+',
+            ),
+            'Do not touch functions.' => array(
+                null,
+'<?php
+/**
+ * @return F
+ */
+function __construct()
+{
+}
+',
+            ),
+        );
+    }
+
+    /**
+     * @requires PHP 5.4
+     */
+    public function testTraitFixing()
+    {
+        $this->doTest(
+'<?php trait T
+{
+    /**
+     */
+    private function __construct()
+    {
+        return 1;
+    }
+}',
+'<?php trait T
+{
+    /**
+     * @return int
+     */
+    private function __construct()
+    {
+        return 1;
+    }
+}'
+            );
+    }
+
+    /**
+     * @param array  $config
+     * @param string $exceptionMessageRegExp
+     *
+     * @dataProvider provideInvalidConfig
+     */
+    public function testInvalidConfiguration(array $config, $exceptionMessageRegExp)
+    {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            $exceptionMessageRegExp
+        );
+
+        $this->fixer->configure($config);
+    }
+
+    public function provideInvalidConfig()
+    {
+        return array(
+            array(
+                array('a' => 1),
+                '#^\[phpdoc_magic_method_return_annotation\] Configuration "methods" must be provided as array\.$#',
+            ),
+            array(
+                array('methods' => 1),
+                '#^\[phpdoc_magic_method_return_annotation\] Configuration "methods" must be provided as array\.$#',
+            ),
+            array(
+                array('methods' => array('a')),
+                '#^\[phpdoc_magic_method_return_annotation\] Only the following magic method names can be configured for fixing "__construct", "__clone", "__destruct", "__set", "__unset", "__wakeUp"\.$#',
+            ),
+        );
+    }
+}

--- a/tests/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocMagicMethodReturnAnnotationFixerTest.php
@@ -222,7 +222,7 @@ class A
 
     /**
      */
-    public function __set(){}
+    public function __set($a, $b){}
 }
 ',
 '<?php
@@ -241,7 +241,7 @@ class A
     /**
      * @return A
      */
-    public function __set(){}
+    public function __set($a, $b){}
 }
 ',
             ),


### PR DESCRIPTION
[WIP] so please don't review as of yet, thanks!

ref.: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1859

@OskarStark as follow up on https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2511#issuecomment-277920446 I opened the PR early (it is more or less a raw copy paste from a custom fixer of mine). The fixer here can be used as example as it finds constructors with PHPDocs.


