### PR TITLE
Enhancement: Provide edge case for is_null fixer

### DIFF
--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -96,10 +96,18 @@ final class IsNullFixer extends AbstractFixer implements ConfigurationDefinition
                 }
             }
 
+            /* edge cases: is_null() followed/preceded by ==, ===, !=, !==, <> */
+            $parentLeftToken = $tokens[$tokens->getPrevMeaningfulToken($isNullIndex)];
+            $parentRightToken = $tokens[$tokens->getNextMeaningfulToken($referenceEnd)];
+            $parentOperations = array(T_IS_EQUAL, T_IS_NOT_EQUAL, T_IS_IDENTICAL, T_IS_NOT_IDENTICAL);
+            $wrapIntoParentheses = $parentLeftToken->isGivenKind($parentOperations) || $parentRightToken->isGivenKind($parentOperations);
+
             if (!$isContainingDangerousConstructs) {
-                // closing parenthesis removed with leading spaces
-                $tokens->removeLeadingWhitespace($referenceEnd);
-                $tokens[$referenceEnd]->clear();
+                if (!$wrapIntoParentheses) {
+                    // closing parenthesis removed with leading spaces
+                    $tokens->removeLeadingWhitespace($referenceEnd);
+                    $tokens[$referenceEnd]->clear();
+                }
 
                 // opening parenthesis removed with trailing spaces
                 $tokens->removeLeadingWhitespace($matches[1]);
@@ -116,6 +124,10 @@ final class IsNullFixer extends AbstractFixer implements ConfigurationDefinition
             );
 
             if (true === $this->configuration['use_yoda_style']) {
+                if ($wrapIntoParentheses) {
+                    array_unshift($replacement, new Token('('));
+                }
+
                 $tokens->overrideRange($isNullIndex, $isNullIndex, $replacement);
             } else {
                 $replacement = array_reverse($replacement);
@@ -123,8 +135,14 @@ final class IsNullFixer extends AbstractFixer implements ConfigurationDefinition
                     array_unshift($replacement, new Token(array(')')));
                 }
 
-                $tokens[$isNullIndex]->clear();
-                $tokens->removeTrailingWhitespace($referenceEnd);
+                if ($wrapIntoParentheses) {
+                    $replacement[] = new Token(')');
+                    $tokens[$isNullIndex]->setContent('(');
+                } else {
+                    $tokens[$isNullIndex]->clear();
+                    $tokens->removeTrailingWhitespace($referenceEnd);
+                }
+
                 $tokens->overrideRange($referenceEnd, $referenceEnd, $replacement);
             }
 

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -126,6 +126,9 @@ FIXED;
             array('<?php $x = null !== json_decode($x);', '<?php $x = ! is_null(json_decode($x));'),
             array('<?php $x = null !== json_decode($x);', '<?php $x = ! is_null( json_decode($x) );'),
 
+            array('<?php $x = null === json_decode($x);', '<?php $x = is_null(json_decode($x)) === true;'),
+            array('<?php $x = null !== json_decode($x);', '<?php $x = is_null(json_decode($x)) !== true;'),
+
             array('<?php $x = null === json_decode($x);', '<?php $x = \\is_null(json_decode($x));'),
             array('<?php $x = null !== json_decode($x);', '<?php $x = !\\is_null(json_decode($x));'),
             array('<?php $x = null !== json_decode($x);', '<?php $x = ! \\is_null(json_decode($x));'),

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -163,6 +163,48 @@ FIXED;
             array(
                 '<?php is_null()?>',
             ),
+
+            /* edge cases: is_null wrapped into a binary operations */
+            array(
+                '<?php $result = (false === (null === $a)); ?>',
+                '<?php $result = (false === is_null($a)); ?>',
+            ),
+            array(
+                '<?php $result = ((null === $a) === false); ?>',
+                '<?php $result = (is_null($a) === false); ?>',
+            ),
+            array(
+                '<?php $result = (false !== (null === $a)); ?>',
+                '<?php $result = (false !== is_null($a)); ?>',
+            ),
+            array(
+                '<?php $result = ((null === $a) !== false); ?>',
+                '<?php $result = (is_null($a) !== false); ?>',
+            ),
+            array(
+                '<?php $result = (false == (null === $a)); ?>',
+                '<?php $result = (false == is_null($a)); ?>',
+            ),
+            array(
+                '<?php $result = ((null === $a) == false); ?>',
+                '<?php $result = (is_null($a) == false); ?>',
+            ),
+            array(
+                '<?php $result = (false != (null === $a)); ?>',
+                '<?php $result = (false != is_null($a)); ?>',
+            ),
+            array(
+                '<?php $result = ((null === $a) != false); ?>',
+                '<?php $result = (is_null($a) != false); ?>',
+            ),
+            array(
+                '<?php $result = (false <> (null === $a)); ?>',
+                '<?php $result = (false <> is_null($a)); ?>',
+            ),
+            array(
+                '<?php $result = ((null === $a) <> false); ?>',
+                '<?php $result = (is_null($a) <> false); ?>',
+            ),
         );
     }
 }


### PR DESCRIPTION
This PR

* [x] provides an edge case for the `is_null` fixer

Follows #2415.

💁‍♂️ Came across this when enabling it for a legacy code base where example code was

```php
if (is_null($news_keywords_meta) == true || empty($news_keywords_meta) == true) {
    return false;
}
```

Code was then fixed to 

```php
if (null === $news_keywords_meta == true || empty($news_keywords_meta) == true) {
    return false;
}
```

but change was not applied because it resulted in a linting error.

@kalessil Do you have an idea?
