### PR TITLE
Make .gitignore entries more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.php_cs
-composer.lock
-phpunit.xml
-vendor
+/.php_cs
+/composer.lock
+/phpunit.xml
+/vendor


### PR DESCRIPTION
- `vendor` is supposed to be a directory;
-  ignored targets are at the project's root only, also prevents some `.php_cs` files in the tests fixtures to be covered by the `.gitignore` while still being tracked.