### PR TITLE
Improved specificity of gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.php_cs
-composer.lock
-phpunit.xml
-vendor
+/.php_cs
+/composer.lock
+/phpunit.xml
+/vendor/


### PR DESCRIPTION
These rules all specify files in the root directory so they should be preceded by a slash (`/`) so they do not match in any other directory. `vendor` is a directory specifier so it should be suffixed by a slash (`/`) so it does not match files.