### PR TITLE
Added changed line numbers to Tokens and Text/JSON reporters

### DIFF
--- a/src/Report/JunitReporter.php
+++ b/src/Report/JunitReporter.php
@@ -125,7 +125,7 @@ final class JunitReporter implements ReporterInterface
         if ($shouldAddAppliedFixers) {
             $failureContent = "applied fixers:\n---------------\n";
 
-            foreach ($fixResult['appliedFixers'] as $appliedFixer) {
+            foreach (array_keys($fixResult['appliedFixers']) as $appliedFixer) {
                 $failureContent .= "* {$appliedFixer}\n";
             }
         } else {

--- a/src/Report/TextReporter.php
+++ b/src/Report/TextReporter.php
@@ -62,7 +62,16 @@ final class TextReporter implements ReporterInterface
     {
         return sprintf(
             $isDecoratedOutput ? ' (<comment>%s</comment>)' : ' (%s)',
-            implode(', ', $fixResult['appliedFixers'])
+            implode(
+                '; ',
+                array_map(
+                    function ($fixer, $lines) {
+                        return sprintf('%s line%s %s', $fixer, count($lines) !== 1 ? 's' : '', implode(', ', $lines));
+                    },
+                    array_keys($fixResult['appliedFixers']),
+                    $fixResult['appliedFixers']
+                )
+            )
         );
     }
 

--- a/src/Report/XmlReporter.php
+++ b/src/Report/XmlReporter.php
@@ -81,7 +81,7 @@ final class XmlReporter implements ReporterInterface
     {
         $appliedFixersXML = $dom->createElement('applied_fixers');
 
-        foreach ($fixResult['appliedFixers'] as $appliedFixer) {
+        foreach (array_keys($fixResult['appliedFixers']) as $appliedFixer) {
             $appliedFixerXML = $dom->createElement('applied_fixer');
             $appliedFixerXML->setAttribute('name', $appliedFixer);
             $appliedFixersXML->appendChild($appliedFixerXML);

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -169,9 +169,9 @@ final class Runner
                 $fixer->fix($file, $tokens);
 
                 if ($tokens->isChanged()) {
+                    $appliedFixers[$fixer->getName()] = $tokens->findChangedLines();
                     $tokens->clearEmptyTokens();
                     $tokens->clearChanged();
-                    $appliedFixers[] = $fixer->getName();
                 }
             }
         } catch (\Exception $e) {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -37,6 +37,13 @@ class Token
     private $id;
 
     /**
+     * Line number from which this token was parsed.
+     *
+     * @var int|null
+     */
+    private $line;
+
+    /**
      * If token prototype is an array.
      *
      * @var bool
@@ -61,6 +68,11 @@ class Token
             $this->isArray = true;
             $this->id = $token[0];
             $this->content = $token[1];
+
+            // Line number is unavailable for some tokens.
+            if (isset($token[2])) {
+                $this->line = $token[2];
+            }
         } else {
             $this->isArray = false;
             $this->content = $token;
@@ -232,6 +244,16 @@ class Token
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * Gets the line number from which this token was parsed.
+     *
+     * @return int|null Line number
+     */
+    public function getLineNumber()
+    {
+        return $this->line;
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -834,6 +834,9 @@ class Tokens extends \SplFixedArray
                 throw new \InvalidArgumentException('Must not add empty token to collection.');
             }
 
+            // Mark inserted token as changed.
+            $items[$i]->setChanged(true);
+
             $this[$i + $index] = $items[$i];
         }
     }
@@ -968,7 +971,7 @@ class Tokens extends \SplFixedArray
         $this->setSize(count($tokens));
 
         foreach ($tokens as $index => $token) {
-            $this[$index] = new Token($token);
+            $this[$index] = $previousToken = new Token($token, isset($previousToken) ? $previousToken : null);
         }
 
         $transformers = Transformers::create();

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -413,6 +413,24 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * Finds all unique changed lines numbers.
+     *
+     * @return int[] Line numbers
+     */
+    public function findChangedLines()
+    {
+        $lines = array();
+
+        foreach ($this as $index => $token) {
+            if ($token->isChanged()) {
+                $lines[] = $this->findNearestPrevTokenLineNumber($index);
+            }
+        }
+
+        return array_values(array_unique($lines));
+    }
+
+    /**
      * Find tokens of given kind.
      *
      * @param int|array $possibleKind kind or array of kind
@@ -1136,6 +1154,26 @@ class Tokens extends \SplFixedArray
         }
 
         $this[$nextIndex]->clear();
+    }
+
+    /**
+     * Finds the line number of the first token previous to the one at the specified index, including itself.
+     *
+     * @param int $index Token index
+     *
+     * @return int Line number
+     */
+    private function findNearestPrevTokenLineNumber($index)
+    {
+        if ($index <= 0) {
+            return 1;
+        }
+
+        if (null !== $line = $this[$index]->getLineNumber()) {
+            return $line;
+        }
+
+        return $this->findNearestPrevTokenLineNumber(--$index);
     }
 
     /**


### PR DESCRIPTION
Proof of concept for adding line numbers to output. Currently only text and JSON output shows the line numbers (XML and Junit are left to the interested programmer). Addresses #2529, #299.

### Sample text output

>   1) src\Console\Command\FixCommand.php (array_syntax lines 83, 280; class_definition line 39)

### Sample JSON output

```js
{
  "files": [
    {
      "name": "src\\Console\\Command\\FixCommand.php",
      "appliedFixers": {
        "array_syntax": [
          83,
          280
        ],
        "class_definition": [
          39
        ]
      }
    }
  ],
  "time": {
    "total": 4.032
  },
  "memory": 8
}
```

### BC breaks

⚠️ Breaks BC for modified formatters because `appliedFixers` structure was changed from a list of strings to a map of integers (line numbers) with string keys (fixer names). I think this is a better structure but if a BC break is unacceptable, or to back-port this feature to 2.x, we can copy this data to a different name (instead of `appliedFixers`). I still think modifying the structure of `appliedFixers` should be the preferred format for the next major version since it avoids duplication of fixer names.

### TODO
* Fix tests.

### Future enhancements

* Update the text formatter to list runs of consecutive lines as groups, e.g. instead of "lines 1, 2, 3, 4, 5", report: "lines 1-5".