### PR TITLE
PhpdocNoAliasTagFixer - Fix circular replacements detection

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -72,6 +72,9 @@ final class PhpdocNoAliasTagFixer extends AbstractFixer implements ConfigurableF
             }
 
             $this->configuration[trim($from)] = trim($to);
+        }
+
+        foreach ($this->configuration as $from => $to) {
             if (isset($this->configuration[$to])) {
                 throw new InvalidFixerConfigurationException(
                     $this->getName(),

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -75,7 +75,7 @@ final class PhpdocNoAliasTagFixer extends AbstractFixer implements ConfigurableF
             if (isset($this->configuration[$to])) {
                 throw new InvalidFixerConfigurationException(
                     $this->getName(),
-                    sprintf('Cannot change tag "%s" to tag "%s", as the tag is set configured to be replaced to "%s".', $from, $to, $this->configuration[$to])
+                    sprintf('Cannot change tag "%1$s" to tag "%2$s", as the tag "%2$s" is configured to be replaced to "%3$s".', $from, $to, $this->configuration[$to])
                 );
             }
         }

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -57,7 +57,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
     {
         $this->setExpectedExceptionRegExp(
             'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Cannot change tag "link" to tag "see", as the tag is set configured to be replaced to "link".$#'
+            '#^\[phpdoc_no_alias_tag\] Cannot change tag "link" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
         );
 
         $this->fixer->configure(array(
@@ -71,7 +71,7 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
     {
         $this->setExpectedExceptionRegExp(
             'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Cannot change tag "b" to tag "see", as the tag is set configured to be replaced to "link".$#'
+            '#^\[phpdoc_no_alias_tag\] Cannot change tag "b" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
         );
 
         $this->fixer->configure(array(

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -61,9 +61,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         );
 
         $this->fixer->configure(array(
-            'see' => 'link',
-            'a' => 'b',
             'link' => 'see',
+            'a' => 'b',
+            'see' => 'link',
         ));
     }
 
@@ -75,9 +75,22 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
         );
 
         $this->fixer->configure(array(
+            'b' => 'see',
             'see' => 'link',
             'link' => 'b',
-            'b' => 'see',
+        ));
+    }
+
+    public function testInvalidConfigCase6()
+    {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
+            '#^\[phpdoc_no_alias_tag\] Cannot change tag "see" to tag "link", as the tag "link" is configured to be replaced to "b"\.$#'
+        );
+
+        $this->fixer->configure(array(
+            'see' => 'link',
+            'link' => 'b',
         ));
     }
 


### PR DESCRIPTION
Using 
```php
['a' => 'b', 'c' => 'a']
```
triggers an error but using 
```php
['a' => 'b', 'b' => 'c']
```
does not.