### PR TITLE
Filename with spaces usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -787,7 +787,8 @@ Then, add the following command to your CI:
 
 .. code-block:: bash
 
-    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection `git diff --name-only --diff-filter=ACMRTUXB $COMMIT_RANGE`
+    $ IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")); unset IFS
+    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection "${COMMIT_SCA_FILES[@]}"
 
 Where ``$COMMIT_RANGE`` is your range of commits, eg ``$TRAVIS_COMMIT_RANGE`` or ``HEAD~..HEAD``.
 

--- a/src/Console/Command/FixCommandHelp.php
+++ b/src/Console/Command/FixCommandHelp.php
@@ -203,7 +203,8 @@ Require ``friendsofphp/php-cs-fixer`` as a ``dev`` dependency:
 
 Then, add the following command to your CI:
 
-    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection `git diff --name-only --diff-filter=ACMRTUXB \$COMMIT_RANGE`
+    $ IFS=\$'\\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "\${COMMIT_RANGE}")); unset IFS
+    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --path-mode=intersection "\${COMMIT_SCA_FILES[@]}"
 
 Where ``\$COMMIT_RANGE`` is your range of commits, eg ``\$TRAVIS_COMMIT_RANGE`` or ``HEAD~..HEAD``.
 


### PR DESCRIPTION
This PR is aimed to explain correct shell behaviour for files with spaces in the name.

Problem: If modified filename contains space, then the whole list sent to `intersection` is wrong.
Solution: escape it correctly before processing.