### PR TITLE
BinaryOperatorSpaces reworked

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,14 +231,18 @@ Choose from the list of available rules:
 
 * **binary_operator_spaces** [@Symfony]
 
-  Binary operators should be surrounded by at least one space.
+  Binary operators should be surrounded by space as configured.
 
   Configuration options:
 
-  - ``align_double_arrow`` (``false``, ``null``, ``true``): whether to apply, remove or
-    ignore double arrows alignment; defaults to ``false``
-  - ``align_equals`` (``false``, ``null``, ``true``): whether to apply, remove or ignore
-    equals alignment; defaults to ``false``
+  - ``align_double_arrow`` (``false``, ``null``, ``true``): (deprecated) Whether to apply,
+    remove or ignore double arrows alignment; defaults to ``false``
+  - ``align_equals`` (``false``, ``null``, ``true``): (deprecated) Whether to apply, remove
+    or ignore equals alignment; defaults to ``false``
+  - ``default`` (``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``,
+    ``'single_space'``, ``null``): default fix strategy; defaults to ``'single_space'``
+  - ``operators`` (``array``): dictionary of ``binary operator`` => ``fix strategy``
+    values that differ from the default strategy; defaults to ``[]``
 
 * **blank_line_after_namespace** [@PSR2, @Symfony]
 

--- a/src/AbstractAlignFixerHelper.php
+++ b/src/AbstractAlignFixerHelper.php
@@ -18,6 +18,8 @@ use PhpCsFixer\Tokenizer\Tokens;
  * @author Carlos Cirello <carlos.cirello.nl@gmail.com>
  *
  * @internal
+ *
+ * @deprecated
  */
 abstract class AbstractAlignFixerHelper
 {

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -28,6 +28,7 @@ use PhpCsFixer\RuleSet;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -160,7 +161,7 @@ final class DescribeCommand extends Command
             $output->writeln(sprintf('Fixer is configurable using following option%s:', 1 === count($options) ? '' : 's'));
 
             foreach ($options as $option) {
-                $line = '* <info>'.$option->getName().'</info>';
+                $line = '* <info>'.OutputFormatter::escape($option->getName()).'</info>';
 
                 $allowed = HelpCommand::getDisplayableAllowedValues($option);
                 if (null !== $allowed) {
@@ -175,7 +176,7 @@ final class DescribeCommand extends Command
                     $line .= ' (<comment>'.implode('</comment>, <comment>', $allowed).'</comment>)';
                 }
 
-                $description = preg_replace('/(`.+?`)/', '<info>$1</info>', $option->getDescription());
+                $description = preg_replace('/(`.+?`)/', '<info>$1</info>', OutputFormatter::escape($option->getDescription()));
                 $line .= ': '.lcfirst(preg_replace('/\.$/', '', $description)).'; ';
                 if ($option->hasDefault()) {
                     $line .= sprintf(

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet;
 use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -480,7 +481,7 @@ EOF
                     );
 
                     foreach ($configurationDefinitionOptions as $option) {
-                        $line = '<info>'.$option->getName().'</info>';
+                        $line = '<info>'.OutputFormatter::escape($option->getName()).'</info>';
 
                         $allowed = self::getDisplayableAllowedValues($option);
                         if (null !== $allowed) {
@@ -498,7 +499,7 @@ EOF
                         $line .= ': '.preg_replace(
                             '/(`.+?`)/',
                             '<info>$1</info>',
-                            lcfirst(preg_replace('/\.$/', '', $option->getDescription()))
+                            lcfirst(preg_replace('/\.$/', '', OutputFormatter::escape($option->getDescription())))
                         ).'; ';
                         if ($option->hasDefault()) {
                             $line .= 'defaults to <comment>'.self::toString($option->getDefault()).'</comment>';

--- a/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+++ b/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
@@ -21,6 +21,8 @@ use PhpCsFixer\Tokenizer\Tokens;
  * @author Carlos Cirello <carlos.cirello.nl@gmail.com>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  * @author Graham Campbell <graham@alt-three.com>
+ *
+ * @deprecated
  */
 final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
 {
@@ -32,6 +34,17 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
      * @var int
      */
     private $currentLevel = 0;
+
+    public function __construct()
+    {
+        @trigger_error(
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Fixer/Operator/AlignEqualsFixerHelper.php
+++ b/src/Fixer/Operator/AlignEqualsFixerHelper.php
@@ -20,9 +20,22 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Carlos Cirello <carlos.cirello.nl@gmail.com>
  * @author Graham Campbell <graham@alt-three.com>
+ *
+ * @deprecated
  */
 final class AlignEqualsFixerHelper extends AbstractAlignFixerHelper
 {
+    public function __construct()
+    {
+        @trigger_error(
+            sprintf(
+                'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
+                __CLASS__
+            ),
+            E_USER_DEPRECATED
+        );
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -12,13 +12,14 @@
 
 namespace PhpCsFixer\Fixer\Operator;
 
-use PhpCsFixer\AbstractAlignFixerHelper;
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -30,9 +31,123 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
 final class BinaryOperatorSpacesFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
-     * @var AbstractAlignFixerHelper[]
+     * @internal
      */
-    private $alignFixerHelpers = [];
+    const SINGLE_SPACE = 'single_space';
+
+    /**
+     * @internal
+     */
+    const ALIGN = 'align';
+
+    /**
+     * @internal
+     */
+    const ALIGN_SINGLE_SPACE = 'align_single_space';
+
+    /**
+     * @internal
+     */
+    const ALIGN_SINGLE_SPACE_MINIMAL = 'align_single_space_minimal';
+
+    /**
+     * @internal
+     * @const Placeholder used as anchor for right alignment.
+     */
+    const ALIGN_PLACEHOLDER = "\x2 ALIGNABLE%d \x3";
+
+    /**
+     * Keep track of the deepest level ever achieved while
+     * parsing the code. Used later to replace alignment
+     * placeholders with spaces.
+     *
+     * @var int
+     */
+    private $deepestLevel;
+
+    /**
+     * Level counter of the current nest level.
+     * So one level alignments are not mixed with
+     * other level ones.
+     *
+     * @var int
+     */
+    private $currentLevel;
+
+    private static $allowedValues = [
+        self::ALIGN,
+        self::ALIGN_SINGLE_SPACE,
+        self::ALIGN_SINGLE_SPACE_MINIMAL,
+        self::SINGLE_SPACE,
+        null,
+    ];
+
+    /**
+     * @var string[]
+     */
+    private static $supportedOperators = [
+        '=',
+        '*',
+        '/',
+        '%',
+        '<',
+        '>',
+        '|',
+        '^',
+        '+',
+        '-',
+        '&',
+        '&=',
+        '&&',
+        '||',
+        '.=',
+        '/=',
+        '=>',
+        '==',
+        '>=',
+        '===',
+        '!=',
+        '<>',
+        '!==',
+        '<=',
+        'and',
+        'or',
+        'xor',
+        '-=',
+        '%=',
+        '*=',
+        '|=',
+        '+=',
+        '<<',
+        '<<=',
+        '>>',
+        '>>=',
+        '^=',
+        '**',
+        '**=',
+        '<=>',
+        '??',
+    ];
+
+    /**
+     * @var TokensAnalyzer
+     */
+    private $tokensAnalyzer;
+
+    /**
+     * @var array<string, string>
+     */
+    private $alignOperatorTokens = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        parent::configure($configuration);
+
+        $this->resolveConfig(null === $configuration ? [] : $configuration);
+    }
 
     /**
      * {@inheritdoc}
@@ -40,58 +155,50 @@ final class BinaryOperatorSpacesFixer extends AbstractFixer implements Configura
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Binary operators should be surrounded by at least one space.',
+            'Binary operators should be surrounded by space as configured.',
             [
                 new CodeSample(
-'<?php
-
-$a   = 9000;
-$abc = 90001;
-
-$foo = array(
-    "a"   => 9000,
-    "abc" => 9001,
-);
-'
+                    "<?php\n\$a= 1  + \$b^ \$d !==  \$e or   \$f;\n"
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
+$aa=  1;
+$b=2;
 
-$a   = 9000;
-$abc = 90001;
+$c = $d    xor    $e;
+$f    -=  1;
 ',
-                    ['align_equals' => false]
+                    ['operators' => ['=' => 'align', 'xor' => null]]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
+$a = $b +=$c;
+$d = $ee+=$f;
 
-$a = 9000;
-$abc = 90001;
+$g = $b     +=$c;
+$h = $ee+=$f;
 ',
-                    ['align_equals' => true]
+                    ['operators' => ['+=' => 'align_single_space']]
                 ),
                 new CodeSample(
-'<?php
-
-$foo = array(
-    "a"   => 9000,
-    "abc" => 9001,
-);
+                    '<?php
+$a = $b===$c;
+$d = $f   ===  $g;
+$h = $i===  $j;
 ',
-                    ['align_double_arrow' => false]
-                ),
-                new CodeSample(
-'<?php
-
-$foo = array(
-    "a" => 9000,
-    "abc" => 9001,
-);
-',
-                    ['align_double_arrow' => true]
+                    ['operators' => ['===' => 'align_single_space_minimal']]
                 ),
             ]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must run after ArraySyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer and StrictComparisonFixer.
+        return -1;
     }
 
     /**
@@ -107,17 +214,21 @@ $foo = array(
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        $this->tokensAnalyzer = new TokensAnalyzer($tokens);
 
         // last and first tokens cannot be an operator
-        for ($index = $tokens->count() - 2; $index >= 0; --$index) {
-            if (!$tokensAnalyzer->isBinaryOperator($index)) {
+        for ($index = $tokens->count() - 2; $index > 0; --$index) {
+            if (!$this->tokensAnalyzer->isBinaryOperator($index)) {
                 continue;
             }
 
-            $isDeclare = $this->isDeclareStatement($tokens, $index);
-            if (false !== $isDeclare) {
-                $index = $isDeclare; // skip `declare(foo ==bar)`, see `declare_equal_normalize`
+            if ('=' === $tokens[$index]->getContent()) {
+                $isDeclare = $this->isEqualPartOfDeclareStatement($tokens, $index);
+                if (false === $isDeclare) {
+                    $this->fixWhiteSpaceAroundOperator($tokens, $index);
+                } else {
+                    $index = $isDeclare; // skip `declare(foo ==bar)`, see `declare_equal_normalize`
+                }
             } else {
                 $this->fixWhiteSpaceAroundOperator($tokens, $index);
             }
@@ -126,7 +237,9 @@ $foo = array(
             --$index;
         }
 
-        $this->runHelperFixers($file, $tokens);
+        if (count($this->alignOperatorTokens)) {
+            $this->fixAlignment($tokens, $this->alignOperatorTokens);
+        }
     }
 
     /**
@@ -135,11 +248,20 @@ $foo = array(
     protected function createConfigurationDefinition()
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('align_double_arrow', 'Whether to apply, remove or ignore double arrows alignment.'))
+            (new FixerOptionBuilder('default', 'Default fix strategy.'))
+                ->setDefault(self::SINGLE_SPACE)
+                ->setAllowedValues(self::$allowedValues)
+                ->getOption(),
+            (new FixerOptionBuilder('operators', 'Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy.'))
+                ->setAllowedTypes(['array'])
+                ->setDefault([])
+                ->getOption(),
+            // add deprecated options as BC layer
+            (new FixerOptionBuilder('align_double_arrow', '(deprecated) Whether to apply, remove or ignore double arrows alignment.'))
                 ->setDefault(false)
                 ->setAllowedValues([true, false, null])
                 ->getOption(),
-            (new FixerOptionBuilder('align_equals', 'Whether to apply, remove or ignore equals alignment.'))
+            (new FixerOptionBuilder('align_equals', '(deprecated) Whether to apply, remove or ignore equals alignment.'))
                 ->setDefault(false)
                 ->setAllowedValues([true, false, null])
                 ->getOption(),
@@ -152,30 +274,43 @@ $foo = array(
      */
     private function fixWhiteSpaceAroundOperator(Tokens $tokens, $index)
     {
-        if ($tokens[$index]->isGivenKind(T_DOUBLE_ARROW)) {
-            if (true === $this->configuration['align_double_arrow']) {
-                if (!isset($this->alignFixerHelpers['align_double_arrow'])) {
-                    $this->alignFixerHelpers['align_double_arrow'] = new AlignDoubleArrowFixerHelper();
-                }
+        $tokenContent = strtolower($tokens[$index]->getContent());
 
-                return;
-            }
-            if (null === $this->configuration['align_double_arrow']) {
-                return; // configured not to touch the whitespace around the operator
-            }
-        } elseif ($tokens[$index]->equals('=')) {
-            if (true === $this->configuration['align_equals']) {
-                if (!isset($this->alignFixerHelpers['align_equals'])) {
-                    $this->alignFixerHelpers['align_equals'] = new AlignEqualsFixerHelper();
-                }
-
-                return;
-            }
-            if (null === $this->configuration['align_equals']) {
-                return; // configured not to touch the whitespace around the operator
-            }
+        if (!array_key_exists($tokenContent, $this->configuration)) {
+            return; // not configured to be changed
         }
 
+        if (self::SINGLE_SPACE === $this->configuration[$tokenContent]) {
+            $this->fixWhiteSpaceAroundOperatorToSingleSpace($tokens, $index);
+
+            return;
+        }
+
+        // schedule for alignment
+        $this->alignOperatorTokens[$tokenContent] = $this->configuration[$tokenContent];
+
+        if (self::ALIGN === $this->configuration[$tokenContent]) {
+            return;
+        }
+
+        // fix white space after operator
+        if ($tokens[$index + 1]->isWhitespace()) {
+            if (self::ALIGN_SINGLE_SPACE_MINIMAL === $this->configuration[$tokenContent]) {
+                $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
+            }
+
+            return;
+        }
+
+        $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     */
+    private function fixWhiteSpaceAroundOperatorToSingleSpace(Tokens $tokens, $index)
+    {
         // fix white space after operator
         if ($tokens[$index + 1]->isWhitespace()) {
             $content = $tokens[$index + 1]->getContent();
@@ -201,9 +336,9 @@ $foo = array(
      * @param Tokens $tokens
      * @param int    $index
      *
-     * @return false|int
+     * @return false|int index of T_DECLARE where the `=` belongs to or `false`
      */
-    private function isDeclareStatement(Tokens $tokens, $index)
+    private function isEqualPartOfDeclareStatement(Tokens $tokens, $index)
     {
         $prevMeaningfulIndex = $tokens->getPrevMeaningfulToken($index);
         if ($tokens[$prevMeaningfulIndex]->isGivenKind(T_STRING)) {
@@ -219,15 +354,427 @@ $foo = array(
         return false;
     }
 
-    private function runHelperFixers(\SplFileInfo $file, Tokens $tokens)
+    private function resolveConfig(array $configuration)
     {
-        /** @var AbstractAlignFixerHelper $helper */
-        foreach ($this->alignFixerHelpers as $helper) {
-            if ($tokens->isChanged()) {
-                $tokens->clearEmptyTokens();
+        $this->configuration = [];
+
+        if (0 === count($configuration)) {
+            $this->resolveTokenDefaults(self::SINGLE_SPACE);
+
+            return;
+        }
+
+        $this->resolveTokenDefaults(array_key_exists('default', $configuration) ? $configuration['default'] : self::SINGLE_SPACE);
+
+        if (array_key_exists('align_equals', $configuration) || array_key_exists('align_double_arrow', $configuration)) {
+            $this->resolveOldConfig($configuration);
+
+            return;
+        }
+
+        if (!array_key_exists('operators', $configuration)) {
+            return;
+        }
+
+        foreach ($configuration['operators'] as $operator => $value) {
+            if (!in_array($operator, self::$supportedOperators, true)) {
+                throw new InvalidFixerConfigurationException(
+                    $this->getName(),
+                    sprintf(
+                        'Unexpected "operators" key, expected any of "%s", got "%s".',
+                        implode('", "', self::$supportedOperators),
+                        is_object($operator) ? get_class($operator) : gettype($operator).'#'.$operator
+                    )
+                );
             }
 
-            $helper->fix($tokens);
+            if (!in_array($value, self::$allowedValues, true)) {
+                throw new InvalidFixerConfigurationException(
+                    $this->getName(),
+                    sprintf(
+                        'Unexpected value for operator "%s", expected any of "%s", got "%s".',
+                        $operator,
+                        implode('", "', self::$allowedValues),
+                        is_object($value) ? get_class($value) : (null === $value ? 'null' : gettype($value).'#'.$value)
+                    )
+                );
+            }
+
+            if (null === $value) {
+                unset($this->configuration[$operator]);
+            } else {
+                $this->configuration[$operator] = $value;
+            }
         }
+
+        if (!defined('T_SPACESHIP')) {
+            unset($this->configuration['<=>']);
+        }
+
+        if (!defined('T_COALESCE')) {
+            unset($this->configuration['??']);
+        }
+    }
+
+    private function resolveOldConfig(array $configuration)
+    {
+        $message = 'Given configuration is deprecated and will be removed in 3.0.';
+
+        foreach ($configuration as $name => $setting) {
+            if ('align_equals' === $name) {
+                if (true === $configuration[$name]) {
+                    $this->configuration['='] = self::ALIGN;
+                    $message .= sprintf(" Use configuration: ['operators' => ['=' => '%s']] as replacement for ['%s' => true].", self::ALIGN, $name);
+                } elseif (false === $configuration[$name]) {
+                    $this->configuration['='] = self::SINGLE_SPACE;
+                    $message .= sprintf(" Use configuration: ['operators' => ['=' => '%s']] as replacement for ['%s' => false].", self::SINGLE_SPACE, $name);
+                } else { // === null
+                    unset($this->configuration['=']);
+                }
+            } elseif ('align_double_arrow' === $name) {
+                if (true === $configuration[$name]) {
+                    $this->configuration['=>'] = self::ALIGN;
+                    $message .= sprintf(" Use configuration: ['operators' => ['=>' => '%s']] as replacement for ['%s' => true].", self::ALIGN, $name);
+                } elseif (false === $configuration[$name]) {
+                    $this->configuration['=>'] = self::SINGLE_SPACE;
+                    $message .= sprintf(" Use configuration: ['operators' => ['=>' => '%s']] as replacement for ['%s' => false].", self::SINGLE_SPACE, $name);
+                } else { // === null
+                    unset($this->configuration['=>']);
+                }
+            } else {
+                throw new InvalidFixerConfigurationException($this->getName(), 'Mixing old configuration with new configuration is not allowed.');
+            }
+        }
+
+        @trigger_error($message, E_USER_DEPRECATED);
+    }
+
+    /**
+     * @param null|string $default
+     */
+    private function resolveTokenDefaults($default = null)
+    {
+        if (null === $default) {
+            return;
+        }
+
+        foreach (self::$supportedOperators as $operator) {
+            $this->configuration[$operator] = $default;
+        }
+
+        if (!defined('T_SPACESHIP')) {
+            unset($this->configuration['<=>']);
+        }
+
+        if (!defined('T_COALESCE')) {
+            unset($this->configuration['??']);
+        }
+    }
+
+    // Alignment logic related methods
+
+    /**
+     * @param Tokens                $tokens
+     * @param array<string, string> $toAlign
+     */
+    private function fixAlignment(Tokens $tokens, array $toAlign)
+    {
+        $this->deepestLevel = 0;
+        $this->currentLevel = 0;
+
+        foreach ($toAlign as $tokenContent => $alignStrategy) {
+            // This fixer works partially on Tokens and partially on string representation of code.
+            // During the process of fixing internal state of single Token may be affected by injecting ALIGN_PLACEHOLDER to its content.
+            // The placeholder will be resolved by `replacePlaceholders` method by removing placeholder or changing it into spaces.
+            // That way of fixing the code causes disturbances in marking Token as changed - if code is perfectly valid then placeholder
+            // still be injected and removed, which will cause the `changed` flag to be set.
+            // To handle that unwanted behavior we work on clone of Tokens collection and then override original collection with fixed collection.
+            $tokensClone = clone $tokens;
+
+            if ('=>' === $tokenContent) {
+                $this->injectAlignmentPlaceholdersForArrow($tokensClone, 0, count($tokens));
+            } else {
+                $this->injectAlignmentPlaceholders($tokensClone, 0, count($tokens), $tokenContent);
+            }
+
+            // for all tokens that should be aligned but do not have anything to align with, fix spacing if needed
+            if (self::ALIGN_SINGLE_SPACE === $alignStrategy || self::ALIGN_SINGLE_SPACE_MINIMAL === $alignStrategy) {
+                if ('=>' === $tokenContent) {
+                    for ($index = $tokens->count() - 2; $index > 0; --$index) {
+                        if ($tokens[$index]->isGivenKind(T_DOUBLE_ARROW)) { // always binary operator, never part of declare statement
+                            $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
+                        }
+                    }
+                } elseif ('=' === $tokenContent) {
+                    for ($index = $tokens->count() - 2; $index > 0; --$index) {
+                        if ('=' === $tokens[$index]->getContent() && !$this->isEqualPartOfDeclareStatement($tokens, $index) && $this->tokensAnalyzer->isBinaryOperator($index)) {
+                            $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
+                        }
+                    }
+                } else {
+                    for ($index = $tokens->count() - 2; $index > 0; --$index) {
+                        $content = $tokens[$index]->getContent();
+                        if (strtolower($content) === $tokenContent && $this->tokensAnalyzer->isBinaryOperator($index)) { // never part of declare statement
+                            $this->fixWhiteSpaceBeforeOperator($tokensClone, $index, $alignStrategy);
+                        }
+                    }
+                }
+            }
+
+            $tokens->setCode($this->replacePlaceholders($tokensClone, $alignStrategy));
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startAt
+     * @param int    $endAt
+     * @param string $tokenContent
+     */
+    private function injectAlignmentPlaceholders(Tokens $tokens, $startAt, $endAt, $tokenContent)
+    {
+        for ($index = $startAt; $index < $endAt; ++$index) {
+            $token = $tokens[$index];
+
+            $content = $token->getContent();
+            if (
+                strtolower($content) === $tokenContent
+                && $this->tokensAnalyzer->isBinaryOperator($index)
+                && ('=' !== $content || !$this->isEqualPartOfDeclareStatement($tokens, $index))
+            ) {
+                $tokens[$index] = new Token(sprintf(self::ALIGN_PLACEHOLDER, $this->deepestLevel).$content);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_FUNCTION)) {
+                ++$this->deepestLevel;
+
+                continue;
+            }
+
+            if ($token->equals('(')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
+                continue;
+            }
+
+            if ($token->equals('[')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE, $index);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+
+                continue;
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startAt
+     * @param int    $endAt
+     */
+    private function injectAlignmentPlaceholdersForArrow(Tokens $tokens, $startAt, $endAt)
+    {
+        for ($index = $startAt; $index < $endAt; ++$index) {
+            $token = $tokens[$index];
+
+            if ($token->isGivenKind([T_FOREACH, T_FOR, T_WHILE, T_IF, T_SWITCH])) {
+                $index = $tokens->getNextMeaningfulToken($index);
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_ARRAY)) { // don't use "$tokens->isArray()" here, short arrays are handled in the next case
+                $from = $tokens->getNextMeaningfulToken($index);
+                $until = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $from);
+                $index = $until;
+
+                $this->injectArrayAlignmentPlaceholders($tokens, $from + 1, $until - 1);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                $from = $index;
+                $until = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $from);
+                $index = $until;
+
+                $this->injectArrayAlignmentPlaceholders($tokens, $from + 1, $until - 1);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_DOUBLE_ARROW)) { // no need to analyze for `isBinaryOperator` (always true), nor if part of declare statement (not valid PHP)
+                $tokenContent = sprintf(self::ALIGN_PLACEHOLDER, $this->currentLevel).$token->getContent();
+
+                $nextToken = $tokens[$index + 1];
+                if (!$nextToken->isWhitespace()) {
+                    $tokenContent .= ' ';
+                } elseif ($nextToken->isWhitespace(" \t")) {
+                    $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
+                }
+
+                $tokens[$index] = new Token([T_DOUBLE_ARROW, $tokenContent]);
+
+                continue;
+            }
+
+            if ($token->equals(';')) {
+                ++$this->deepestLevel;
+                ++$this->currentLevel;
+
+                continue;
+            }
+
+            if ($token->equals(',')) {
+                for ($i = $index; $i < $endAt - 1; ++$i) {
+                    if (false !== strpos($tokens[$i - 1]->getContent(), "\n")) {
+                        break;
+                    }
+
+                    if ($tokens[$i + 1]->isGivenKind([T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN])) {
+                        $arrayStartIndex = $tokens[$i + 1]->isGivenKind(T_ARRAY)
+                            ? $tokens->getNextMeaningfulToken($i + 1)
+                            : $i + 1
+                        ;
+                        $blockType = Tokens::detectBlockType($tokens[$arrayStartIndex]);
+                        $arrayEndIndex = $tokens->findBlockEnd($blockType['type'], $arrayStartIndex);
+
+                        if ($tokens->isPartialCodeMultiline($arrayStartIndex, $arrayEndIndex)) {
+                            break;
+                        }
+                    }
+
+                    ++$index;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $from
+     * @param int    $until
+     */
+    private function injectArrayAlignmentPlaceholders(Tokens $tokens, $from, $until)
+    {
+        // Only inject placeholders for multi-line arrays
+        if ($tokens->isPartialCodeMultiline($from, $until)) {
+            ++$this->deepestLevel;
+            ++$this->currentLevel;
+            $this->injectAlignmentPlaceholdersForArrow($tokens, $from, $until);
+            --$this->currentLevel;
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param string $alignStrategy
+     */
+    private function fixWhiteSpaceBeforeOperator(Tokens $tokens, $index, $alignStrategy)
+    {
+        // fix white space after operator is not needed as BinaryOperatorSpacesFixer took care of this (if strategy is _not_ ALIGN)
+        if (!$tokens[$index - 1]->isWhitespace()) {
+            $tokens->insertAt($index, new Token([T_WHITESPACE, ' ']));
+
+            return;
+        }
+
+        if (self::ALIGN_SINGLE_SPACE_MINIMAL !== $alignStrategy || $tokens[$tokens->getPrevNonWhitespace($index - 1)]->isComment()) {
+            return;
+        }
+
+        $content = $tokens[$index - 1]->getContent();
+        if (' ' !== $content && false === strpos($content, "\n")) {
+            $tokens[$index - 1] = new Token([T_WHITESPACE, ' ']);
+        }
+    }
+
+    /**
+     * Look for group of placeholders and provide vertical alignment.
+     *
+     * @param Tokens $tokens
+     * @param string $alignStrategy
+     *
+     * @return string
+     */
+    private function replacePlaceholders(Tokens $tokens, $alignStrategy)
+    {
+        $tmpCode = $tokens->generateCode();
+
+        for ($j = 0; $j <= $this->deepestLevel; ++$j) {
+            $placeholder = sprintf(self::ALIGN_PLACEHOLDER, $j);
+
+            if (false === strpos($tmpCode, $placeholder)) {
+                continue;
+            }
+
+            $lines = explode("\n", $tmpCode);
+            $groups = [];
+            $groupIndex = 0;
+            $groups[$groupIndex] = [];
+
+            foreach ($lines as $index => $line) {
+                if (substr_count($line, $placeholder) > 0) {
+                    $groups[$groupIndex][] = $index;
+                } else {
+                    ++$groupIndex;
+                    $groups[$groupIndex] = [];
+                }
+            }
+
+            foreach ($groups as $group) {
+                if (count($group) < 1) {
+                    continue;
+                }
+
+                if (self::ALIGN !== $alignStrategy) {
+                    // move place holders to match strategy
+                    foreach ($group as $index) {
+                        $currentPosition = strpos(utf8_decode($lines[$index]), $placeholder);
+                        $before = substr($lines[$index], 0, $currentPosition);
+
+                        if (self::ALIGN_SINGLE_SPACE === $alignStrategy) {
+                            if (1 > strlen($before) || ' ' !== substr($before, -1)) { // if last char of before-content is not ' '; add it
+                                $before .= ' ';
+                            }
+                        } elseif (self::ALIGN_SINGLE_SPACE_MINIMAL === $alignStrategy) {
+                            if (1 !== preg_match('/^\h+$/', $before)) { // if indent; do not move, leave to other fixer
+                                $before = rtrim($before).' ';
+                            }
+                        }
+
+                        $lines[$index] = $before.substr($lines[$index], $currentPosition);
+                    }
+                }
+
+                $rightmostSymbol = 0;
+                foreach ($group as $index) {
+                    $rightmostSymbol = max($rightmostSymbol, strpos(utf8_decode($lines[$index]), $placeholder));
+                }
+
+                foreach ($group as $index) {
+                    $line = $lines[$index];
+                    $currentSymbol = strpos(utf8_decode($line), $placeholder);
+                    $delta = abs($rightmostSymbol - $currentSymbol);
+
+                    if ($delta > 0) {
+                        $line = str_replace($placeholder, str_repeat(' ', $delta).$placeholder, $line);
+                        $lines[$index] = $line;
+                    }
+                }
+            }
+
+            $tmpCode = str_replace($placeholder, '', implode("\n", $lines));
+        }
+
+        return $tmpCode;
     }
 }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -55,10 +55,7 @@ final class RuleSet implements RuleSetInterface
         ],
         '@Symfony' => [
             '@PSR2' => true,
-            'binary_operator_spaces' => [
-                'align_double_arrow' => false,
-                'align_equals' => false,
-            ],
+            'binary_operator_spaces' => true,
             'blank_line_after_opening_tag' => true,
             'blank_line_before_statement' => [
                 'statements' => ['return'],

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -175,6 +175,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['combine_consecutive_issets'], $fixers['no_trailing_whitespace']], // tested also in: combine_consecutive_issets,no_trailing_whitespace.test
             [$fixers['combine_consecutive_issets'], $fixers['no_whitespace_in_blank_line']], // tested also in: combine_consecutive_issets,no_whitespace_in_blank_line.test
             [$fixers['combine_consecutive_issets'], $fixers['no_spaces_inside_parenthesis']], // tested also in: combine_consecutive_issets,no_spaces_inside_parenthesis.test
+            [$fixers['strict_comparison'], $fixers['binary_operator_spaces']], // tested also in: strict_comparison,binary_operator_spaces.text
+            [$fixers['standardize_not_equals'], $fixers['binary_operator_spaces']], // tested also in: standardize_not_equals,binary_operator_spaces.test
         ];
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\Operator;
 
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -22,9 +23,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\AbstractAlignFixerHelper
- * @covers \PhpCsFixer\Fixer\Operator\AlignDoubleArrowFixerHelper
- * @covers \PhpCsFixer\Fixer\Operator\AlignEqualsFixerHelper
  * @covers \PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer
  */
 final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
@@ -32,10 +30,351 @@ final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
     /**
      * @param string      $expected
      * @param null|string $input
+     * @param null|array  $configuration
+     *
+     * @dataProvider provideWithTabsCases
+     */
+    public function testWithTabs($expected, $input = null, array $configuration = null)
+    {
+        $this->fixer->configure($configuration);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideWithTabsCases()
+    {
+        return [
+            [
+                "<?php function myFunction() {
+\t\$foo         = 1;
+\t\$looooongVar = 2;
+\t\$middleVar   = 1;
+}",
+                "<?php function myFunction() {
+\t\$foo= \t1;
+\t\$looooongVar\t  = 2;
+\t\$middleVar\t= 1;
+}",
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                "<?php class A{
+public function myFunction() {
+\t \$foo         = 1;
+\t \$looooongVar = 2;
+\t \$middleVar   = 1;
+}
+}",
+                "<?php class A{
+public function myFunction() {
+\t \$foo = 1;
+\t \$looooongVar = 2;
+\t \$middleVar = 1;
+}
+}",
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN]],
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $configuration
+     *
+     * @dataProvider provideTestCases
+     */
+    public function testConfigured($expected, $input = null, array $configuration = null)
+    {
+        $this->fixer->configure($configuration);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestCases()
+    {
+        return [
+            [
+                '<?php
+$this->a
+ = $this->b
+ = 1
+;',
+                                '<?php
+$this->a
+= $this->b
+= 1
+;',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+        $this->newName
+                = $this->path
+                = $this->randomName
+                = $this->remoteFile
+                = $this->tmpContent
+                = null;',
+                '<?php
+        $this->newName
+                =     $this->path
+               =    $this->randomName
+              =   $this->remoteFile
+             =  $this->tmpContent
+            = null;',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+$a//
+     = 1;
+                ',
+                '<?php
+$a//
+     =  1;
+                ',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE]],
+            ],
+            [
+                '<?php
+    $var = [];
+    foreach ([
+                1 => 2,
+                2 => 3,
+            ] as $k => $v) {
+        $var[] = [$i => $bar];
+    }',
+                '<?php
+    $var = [];
+    foreach ([
+                1=> 2,
+                2   =>3,
+            ] as $k => $v) {
+        $var[] = [$i => $bar];
+    }',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a = array(
+                    1 => 2, 4 => 5,
+                    5 => 2, 6 => 5, 7 => 8, 9 => 10, 11 => 1222,
+                );',
+                '<?php $a = array(
+                    1=>2, 4=>5,
+                    5=>2, 6 =>   5, 7=>8, 9=>10, 11=>1222,
+                );',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a = array(1 => 2, 4 => 5);',
+                '<?php $a = array(1=>2, 4  =>  5);',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a = array(1 => 2, 4 => 5 && $b, 5 => 5 && $b, 6 => 5 && $b, 7 => 5 && $b);',
+                '<?php $a = array(1 => 2, 4 => 5&&$b, 5 => 5  &&  $b, 6 => 5&&  $b, 7 => 5  &&$b);',
+                ['operators' => ['&&' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+                    [1 =>   "foo"];
+                    [2    => "foo"];
+                    [3 => "foo"];
+                ',
+                '<?php
+                    [1 =>   "foo"];
+                    [2    =>"foo"];
+                    [3=>"foo"];
+                ',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
+            [
+                '<?php
+                    [1 => "foo"];
+                    [2 => "foo"];
+                    [3 => "foo"];
+                ',
+                '<?php
+                    [1 =>   "foo"];
+                    [2    =>"foo"];
+                    [3=>"foo"];
+                ',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a += 1;',
+                '<?php $a+=1;',
+                ['operators' => ['+=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
+            [
+                '<?php $a += 1;',
+                '<?php $a+=1;',
+                ['operators' => ['+=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a+=1;',
+                null,
+                ['operators' => ['+=' => BinaryOperatorSpacesFixer::ALIGN]],
+            ],
+            [
+                '<?php
+    $ade = $b !==   $a;
+    $b = $b   !==   $a;
+    $c = $b   !== $a;
+                ',
+                '<?php
+    $ade = $b!==   $a;
+    $b = $b!==   $a;
+    $c = $b!==$a;
+                ',
+                ['operators' => ['!==' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
+            [
+                '<?php
+    $aab = $b !== $e;
+    $b = $b   !== $c;
+    $c = $b   !== $d;
+                ',
+                '<?php
+    $aab = $b         !==$e;
+    $b = $b     !==$c;
+    $c = $b             !==$d;
+                ',
+                ['operators' => ['!==' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+    $aaa*= 11;
+    $b  *= 21;
+    $c  *=31;
+
+    $d = $e and $f;
+    $d = $g   or    $h;
+                ',
+                '<?php
+    $aaa*= 11;
+    $b *= 21;
+    $c*=31;
+
+    $d = $e   and    $f;
+    $d = $g   or    $h;
+                ',
+                [
+                    'operators' => [
+                        'and' => BinaryOperatorSpacesFixer::SINGLE_SPACE,
+                        '*=' => BinaryOperatorSpacesFixer::ALIGN,
+                        'or' => null,
+                    ],
+                ],
+            ],
+            [
+                '<?php
+    $abc = $b !== $a;
+    $b = $b   !== $a;
+    $c = $b   !== $a;
+                ',
+                '<?php
+    $abc = $b         !==    $a;
+    $b = $b     !==     $a;
+    $c = $b             !==    $a;
+                ',
+                ['operators' => ['!==' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a = [
+                    1 => 2,
+                    2 => 3,
+                ];',
+                '<?php $a = [
+                    1=>2,
+                    2  =>   3,
+                ];',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+                    [1 => "foo",
+                     2 => "foo"];
+                ',
+                '<?php
+                    [1 =>   "foo",
+                     2   => "foo"];
+                ',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php
+                    [1 => "foo"];
+                    $i += 1;
+                ',
+                '<?php
+                    [1 => "foo"];
+                    $i+= 1;
+                ',
+                ['operators' => ['+=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+            [
+                '<?php $a    =   1   +    2; $b = array(
+                    13 =>3,
+                    4  =>  3,
+                    5=>2,
+                );',
+                null,
+                ['default' => null],
+            ],
+            [
+                '<?php $a = 1 + 2; $b = array(
+                    13 => 3,
+                    4  => 3,
+                    5  => 2,
+                );
+                $a = 12 + 1;
+                $a = 13 + 41;
+                ',
+                '<?php $a    =   1   +    2; $b = array(
+                    13 =>3,
+                    4  =>  3,
+                    5=>2,
+                );
+                $a = 12   +  1;
+                $a = 13+41;
+                ',
+                ['default' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL],
+            ],
+            'do not align with nor touch strings' => [
+                '<?php
+                    \putenv("{$name}= {$value}");
+                $b                     = $c + 1;
+                                    $b = $c - 1;
+                ',
+                '<?php
+                    \putenv("{$name}= {$value}");
+                $b =$c+1;
+                                    $b =$c  -  1;
+                ',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
+            'do not align with declare' => [
+                '<?php
+                    declare(ticks=1);
+                    $a = 1;
+                    $b = 1;
+                ',
+                '<?php
+                    declare(ticks=1);
+                    $a   = 1;
+                    $b              = 1;
+                ',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
      *
      * @dataProvider provideFixCases
      */
-    public function testFix($expected, $input = null)
+    public function testFixDefaults($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
@@ -125,7 +464,6 @@ final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
                 '<?php $a &=
 $b;',
             ],
-
             [
                 '<?php $a
 &= $b;',
@@ -216,6 +554,18 @@ $b;',
                 '<?php [1, 2]   + //   '.'
                 [3, 4];',
             ],
+            [
+                '<?php $a = $b + $c;$a = $b + $c;$a = $b + $c;$a = $b + $c;$a = $b + $c;$a = $b + $c;$a = $b + $c;$a = $b + $c;',
+                '<?php $a=$b+$c;$a=$b+$c;$a=$b+$c;$a=$b+$c;$a=$b+$c;$a=$b+$c;$a=$b+$c;$a=$b+$c;',
+            ],
+            [
+                '<?php
+$c =
+$a
++
+$b;
+',
+            ],
         ];
     }
 
@@ -234,8 +584,8 @@ $b;',
     {
         return [
             [
-                '<?php $a = "c";',
-                '<?php $a="c";',
+                '<?php $a = "c"?>',
+                '<?php $a="c"?>',
             ],
             [
                 '<?php $a = "c";',
@@ -246,9 +596,9 @@ $b;',
                 '<?php $a= "c";',
             ],
             [
-                '<?php $d = $c + $a +     //
+                '<?php $d = $c + $a/**/ +     //
                 $b;',
-                '<?php $d =    $c+$a+     //
+                '<?php $d =    $c+$a/**/+     //
                 $b;',
             ],
             [
@@ -362,24 +712,129 @@ $b;',
         ];
     }
 
-    public function testWrongConfigItem()
+    /**
+     * @group legacy
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true]. Use configuration: ['operators' => ['=>' => 'single_space']] as replacement for ['align_double_arrow' => false].
+     */
+    public function testWrongConfigOldDeprecated()
     {
-        $this->setExpectedExceptionRegExp(
-            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
-            '/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. Defined options are: "align_double_arrow", "align_equals"\.$/'
-        );
-
-        $this->fixer->configure(['foo' => true]);
+        $this->fixer->configure([
+            'align_equals' => true,
+            'align_double_arrow' => false,
+        ]);
     }
 
-    public function testWrongConfigValue()
+    /**
+     * @group legacy
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true].
+     */
+    public function testWrongConfigOldDeprecated2()
+    {
+        $this->fixer->configure([
+            'align_equals' => true,
+            'align_double_arrow' => null,
+        ]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     */
+    public function testWrongConfigOldDeprecated3()
+    {
+        $this->fixer->configure([
+            'align_equals' => null,
+            'align_double_arrow' => true,
+        ]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'single_space']] as replacement for ['align_equals' => false]. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     */
+    public function testWrongConfigOldDeprecated4()
+    {
+        $this->fixer->configure([
+            'align_equals' => false,
+            'align_double_arrow' => true,
+        ]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true]. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     */
+    public function testWrongConfigOldDeprecated5()
+    {
+        $this->fixer->configure([
+            'align_equals' => true,
+            'align_double_arrow' => true,
+        ]);
+
+        // simple test to see if the old config is still used
+        $this->doTest(
+            '<?php
+                $a = array(
+                    1  => 2,
+                    2  => 3,
+                );
+
+                $b   = 1;
+                $c   =  2;
+            ',
+            '<?php
+                $a = array(
+                    1 => 2,
+                    2  => 3,
+                );
+
+                $b = 1;
+                $c   =  2;
+            '
+        );
+    }
+
+    public function testWrongConfigOldAndNewMixed()
     {
         $this->setExpectedExceptionRegExp(
             \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
-            '/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid\. Accepted values are: true, false, null\.$/'
+            '/^\[binary_operator_spaces\] Mixing old configuration with new configuration is not allowed\.$/'
         );
 
-        $this->fixer->configure(['align_double_arrow' => 123]);
+        $this->fixer->configure([
+            'align_double_arrow' => true,
+            'operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN],
+        ]);
+    }
+
+    public function testWrongConfigTypeForOperators()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '/^\[binary_operator_spaces\] Invalid configuration: The option "operators" with value true is expected to be of type "array", but is of type "boolean"\.$/'
+        );
+
+        $this->fixer->configure(['operators' => true]);
+    }
+
+    public function testWrongConfigTypeForOperatorsKey()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '/^\[binary_operator_spaces\] Unexpected "operators" key, expected any of ".*", got "integer#123"\.$/'
+        );
+
+        $this->fixer->configure(['operators' => [123 => 1]]);
+    }
+
+    public function testWrongConfigTypeForOperatorsKeyValue()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '/^\[binary_operator_spaces\] Unexpected value for operator "\+", expected any of ".*", got "string#abc"\.$/'
+        );
+
+        $this->fixer->configure(['operators' => ['+' => 'abc']]);
     }
 
     /**
@@ -787,7 +1242,7 @@ $b;',
      */
     public function testFixAlignEquals($expected, $input = null)
     {
-        $this->fixer->configure(['align_equals' => true]);
+        $this->fixer->configure(['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN]]);
         $this->doTest($expected, $input);
     }
 
@@ -913,7 +1368,7 @@ $b;',
      */
     public function testFixAlignDoubleArrow($expected, $input = null)
     {
-        $this->fixer->configure(['align_double_arrow' => true]);
+        $this->fixer->configure(['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN]]);
         $this->doTest($expected, $input);
     }
 
@@ -940,7 +1395,7 @@ $b;',
                 '<?php
     return new JsonResponse(array(
         "result" => "OK",
-        "html"   => 1, array(
+        "html"   => 1, /**/array(
             "foo"    => "bar",
             "foofoo" => array(
                 "a"  => 1,
@@ -951,7 +1406,7 @@ $b;',
                 '<?php
     return new JsonResponse(array(
         "result" => "OK",
-        "html" => 1, array(
+        "html" => 1, /**/array(
             "foo" => "bar",
             "foofoo" => array(
                 "a" => 1,
@@ -1456,10 +1911,14 @@ $b;',
 
     public function testDoNotTouchEqualsAndArrowByConfig()
     {
-        $this->fixer->configure([
-            'align_equals' => null,
-            'align_double_arrow' => null,
-        ]);
+        $this->fixer->configure(
+            [
+                'operators' => [
+                    '=' => null,
+                    '=>' => null,
+                ],
+            ]
+        );
 
         $this->doTest(
             '<?php
@@ -1480,22 +1939,89 @@ $b;',
     }
 
     /**
-     * @requires PHP 7.1
+     * @requires PHP 7.0
      */
-    public function testAlignArrayDestruction()
+    public function testPHP70Cases()
     {
-        $this->fixer->configure(['align_equals' => true]);
+        $this->fixer->configure(['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE, '??' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]]);
         $this->doTest(
-            '<?php
-                $c = [$d] = $e[1];
-                function A(){}[$a] = $a[$c];
-                $b                 = 1;
-            ',
-            '<?php
-                $c = [$d] = $e[1];
-                function A(){}[$a] = $a[$c];
-                $b = 1;
-            '
+            '<?php declare(strict_types=1);
+$a = 1;
+echo 1 <=> 1;
+echo 1 <=> 2;
+echo 2 <=> 1;
+echo 2 <=> 1;
+
+$a = $a  ?? $b;
+$a = $ab ?? $b;
+$a = $ac ?? $b;
+$a = $ad ?? $b;
+$a = $ae ?? $b;
+',
+            '<?php declare(strict_types=1);
+$a = 1;
+echo 1<=>1;
+echo 1 <=>2;
+echo 2<=> 1;
+echo 2  <=>   1;
+
+$a = $a ?? $b;
+$a = $ab   ?? $b;
+$a = $ac    ?? $b;
+$a = $ad  ?? $b;
+$a = $ae?? $b;
+'
         );
+    }
+
+    /**
+     * @requires PHP 7.1
+     *
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $configuration
+     *
+     * @dataProvider providePHP71Cases
+     */
+    public function testPHP71Cases($expected, $input = null, array $configuration = null)
+    {
+        $this->fixer->configure($configuration);
+        $this->doTest($expected, $input);
+    }
+
+    public function providePHP71Cases()
+    {
+        return [
+            'align array destruction' => [
+                '<?php
+                    $c = [$d] = $e[1];
+                    function A(){}[$a] = $a[$c];
+                    $b                 = 1;
+                ',
+                '<?php
+                    $c = [$d] = $e[1];
+                    function A(){}[$a] = $a[$c];
+                    $b = 1;
+                ',
+                ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN]],
+            ],
+            'align array destruction with assignments' => [
+                '<?php
+                    $d = [
+                        "a" => $a,
+                        "b" => $b,
+                        "c" => $c
+                    ] = $array;
+                ',
+                '<?php
+                    $d = [
+                        "a"=>$a,
+                        "b"   => $b,
+                        "c" =>   $c
+                    ] = $array;
+                ',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
+            ],
+        ];
     }
 }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -712,9 +712,29 @@ $b;
         ];
     }
 
+    public function testWrongConfigItem()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. Defined options are: "align_double_arrow", "align_equals", "default", "operators"\.$/'
+        );
+
+        $this->fixer->configure(['foo' => true]);
+    }
+
+    public function testWrongConfigOldValue()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid\. Accepted values are: true, false, null\.$/'
+        );
+
+        $this->fixer->configure(['align_double_arrow' => 123]);
+    }
+
     /**
      * @group legacy
-     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true]. Use configuration: ['operators' => ['=>' => 'single_space']] as replacement for ['align_double_arrow' => false].
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'align', '=>' => 'single_space']] as replacement for ['align_equals' => true, 'align_double_arrow' => false].
      */
     public function testWrongConfigOldDeprecated()
     {
@@ -726,7 +746,7 @@ $b;
 
     /**
      * @group legacy
-     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true].
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true, 'align_double_arrow' => null].
      */
     public function testWrongConfigOldDeprecated2()
     {
@@ -738,7 +758,7 @@ $b;
 
     /**
      * @group legacy
-     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=>' => 'align']] as replacement for ['align_equals' => null, 'align_double_arrow' => true].
      */
     public function testWrongConfigOldDeprecated3()
     {
@@ -750,7 +770,7 @@ $b;
 
     /**
      * @group legacy
-     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'single_space']] as replacement for ['align_equals' => false]. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'single_space', '=>' => 'align']] as replacement for ['align_equals' => false, 'align_double_arrow' => true].
      */
     public function testWrongConfigOldDeprecated4()
     {
@@ -762,7 +782,7 @@ $b;
 
     /**
      * @group legacy
-     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration: ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true]. Use configuration: ['operators' => ['=>' => 'align']] as replacement for ['align_double_arrow' => true].
+     * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'align', '=>' => 'align']] as replacement for ['align_equals' => true, 'align_double_arrow' => true].
      */
     public function testWrongConfigOldDeprecated5()
     {
@@ -821,7 +841,7 @@ $b;
     {
         $this->setExpectedExceptionRegExp(
             \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
-            '/^\[binary_operator_spaces\] Unexpected "operators" key, expected any of ".*", got "integer#123"\.$/'
+            '/^\[binary_operator_spaces\] Invalid configuration: Unexpected "operators" key, expected any of ".*", got "integer#123"\.$/'
         );
 
         $this->fixer->configure(['operators' => [123 => 1]]);
@@ -831,7 +851,7 @@ $b;
     {
         $this->setExpectedExceptionRegExp(
             \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
-            '/^\[binary_operator_spaces\] Unexpected value for operator "\+", expected any of ".*", got "string#abc"\.$/'
+            '/^\[binary_operator_spaces\] Invalid configuration: Unexpected value for operator "\+", expected any of ".*", got "string#abc"\.$/'
         );
 
         $this->fixer->configure(['operators' => ['+' => 'abc']]);

--- a/tests/Fixtures/Integration/priority/array_syntax,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/array_syntax,binary_operator_spaces.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: array_syntax,binary_operator_spaces.
 --RULESET--
-{"array_syntax": {"syntax":"short"}, "binary_operator_spaces": {"align_equals":false}}
+{"array_syntax": {"syntax":"short"}, "binary_operator_spaces": {"operators":{"=":"single_space"}}}
 --EXPECT--
 <?php
 $a = [];

--- a/tests/Fixtures/Integration/priority/list_syntax,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/list_syntax,binary_operator_spaces.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: list_syntax,binary_operator_spaces.
 --RULESET--
-{"list_syntax": {"syntax":"short"}, "binary_operator_spaces": {"align_equals":false}}
+{"list_syntax": {"syntax":"short"}, "binary_operator_spaces": {"operators":{"=":"single_space"}}}
 --REQUIREMENTS--
 {"php": 70100}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/no_multiline_whitespace_around_double_arrow,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/no_multiline_whitespace_around_double_arrow,binary_operator_spaces.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: no_multiline_whitespace_around_double_arrow,binary_operator_spaces.
 --RULESET--
-{"no_multiline_whitespace_around_double_arrow": true, "binary_operator_spaces": {"align_double_arrow":true}}
+{"no_multiline_whitespace_around_double_arrow": true, "binary_operator_spaces": {"operators":{"=>":"align"}}}
 --EXPECT--
 <?php
 $a = [

--- a/tests/Fixtures/Integration/priority/standardize_not_equals,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/standardize_not_equals,binary_operator_spaces.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: standardize_not_equals,binary_operator_spaces.
+--RULESET--
+{"standardize_not_equals": true, "binary_operator_spaces": {"operators":{"!==":"align"}}}
+--EXPECT--
+<?php
+$a = $b != $c;
+$d = $e != $f;
+
+--INPUT--
+<?php
+$a = $b <> $c;
+$d = $e   <>   $f;

--- a/tests/Fixtures/Integration/priority/strict_comparison,binary_operator_spaces.text
+++ b/tests/Fixtures/Integration/priority/strict_comparison,binary_operator_spaces.text
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: strict_comparison,binary_operator_spaces.text.
+--RULESET--
+{"strict_comparison": true, "binary_operator_spaces": {"operators":{"===":"align"}}}
+--EXPECT--
+<?php
+$a = $b === $c;
+$d = $e === $f;
+
+--INPUT--
+<?php
+$a = $b == $c;
+$d = $e   ==   $f;


### PR DESCRIPTION
closes
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1055
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2355
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2411
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2811

replaces
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1566
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2555

closes part of:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2559

Fixing examples.

Default:
```diff
--- Original
+++ New
@@ @@
<?php
-    $a= 1  + $b^ $d !==  $e or   $f;
+    $a = 1 + $b ^ $d !== $e or $f;
```

Fixing with configuration: `['operators' => ['=' => 'align', 'xor' => NULL]]`.
```diff
--- Original
+++ New
@@ @@
 <?php
 $aa=  1;
-$b=2;
+$b =2;

$c = $d    xor    $e;
-$f    -=  1;
+$f -= 1;
```

Fixing with configuration: `['operators' => ['+=' => 'align_single_space']]`.
```diff
--- Original
+++ New
@@ @@
 <?php
-$a = $b+=$c;
-$d = $ee+=$f;
+$a = $b  += $c;
+$d = $ee += $f;
```

Fixing with configuration: `['operators' => ['===' => 'align_single_space_minimal']]`.
```diff
--- Original
+++ New
@@ @@
 <?php
-$a = $b===$c;
-$d = $f   ===  $g;
-$h = $i===  $j;
+$a = $b === $c;
+$d = $f === $g;
+$h = $i === $j;
```

```
Fixing examples:
 * Example #1. Fixing with the default configuration.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php
   -    $a= 1  + $b^ $d !==  $e or   $f;
   +    $a = 1 + $b ^ $d !== $e or $f;
   ----------- end diff -----------

 * Example #2. Fixing with configuration: ['operators' => ['=' => 'align', 'xor' => null]].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php
    $aa=  1;
   -$b=2;
   +$b =2;

    $c = $d    xor    $e;
   -$f    -=  1;
   +$f -= 1;
   ----------- end diff -----------

 * Example #3. Fixing with configuration: ['operators' => ['+=' => 'align_single_space']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php
   -$a = $b +=$c;
   -$d = $ee+=$f;
   +$a = $b  += $c;
   +$d = $ee += $f;

   -$g = $b     +=$c;
   -$h = $ee+=$f;
   +$g = $b     += $c;
   +$h = $ee    += $f;
   ----------- end diff -----------

 * Example #4. Fixing with configuration: ['operators' => ['===' => 'align_single_space_minimal']].
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php
   -$a = $b===$c;
   -$d = $f   ===  $g;
   -$h = $i===  $j;
   +$a = $b === $c;
   +$d = $f === $g;
   +$h = $i === $j;
   ----------- end diff -----------
```
