### PR TITLE
Add LogicalOperatorsFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -39,6 +39,7 @@ $config = PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],
+        'logical_operators' => true,
         'method_argument_space' => ['ensure_fully_multiline' => true],
         'method_chaining_indentation' => true,
         'multiline_comment_opening_closing' => true,

--- a/README.rst
+++ b/README.rst
@@ -721,6 +721,12 @@ Choose from the list of available rules:
   - ``syntax`` (``'long'``, ``'short'``): whether to use the ``long`` or ``short`` ``list``
     syntax; defaults to ``'long'``
 
+* **logical_operators**
+
+  Use ``&&`` and ``||`` logical operators instead of ``and`` and ``or``.
+
+  *Risky rule: risky, because you must double-check if using and/or with lower precedence was intentional.*
+
 * **lowercase_cast** [@Symfony]
 
   Cast should be written in lower case.

--- a/src/Fixer/Operator/LogicalOperatorsFixer.php
+++ b/src/Fixer/Operator/LogicalOperatorsFixer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Operator;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ */
+final class LogicalOperatorsFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Use `&&` and `||` logical operators instead of `and` and `or`.',
+            [
+                new CodeSample(
+'<?php
+
+if ($a == "foo" and ($b == "bar" or $c == "baz")) {
+}
+'
+                ),
+            ],
+            null,
+            'Risky, because you must double-check if using and/or with lower precedence was intentional.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound([T_LOGICAL_AND, T_LOGICAL_OR]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_LOGICAL_AND)) {
+                $tokens[$index] = new Token([T_BOOLEAN_AND, '&&']);
+            } elseif ($token->isGivenKind(T_LOGICAL_OR)) {
+                $tokens[$index] = new Token([T_BOOLEAN_OR, '||']);
+            }
+        }
+    }
+}

--- a/tests/Fixer/Operator/LogicalOperatorsFixerTest.php
+++ b/tests/Fixer/Operator/LogicalOperatorsFixerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Operator;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Operator\LogicalOperatorsFixer
+ */
+final class LogicalOperatorsFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param string $expected
+     * @param string $input
+     */
+    public function testFix($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php if ($a == "foo" && $b == "bar") {}',
+                '<?php if ($a == "foo" and $b == "bar") {}',
+            ],
+            [
+                '<?php if ($a == "foo" || $b == "bar") {}',
+                '<?php if ($a == "foo" or $b == "bar") {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" and ($b == "bar" or $c == "baz")) {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" and ($b == "bar" || $c == "baz")) {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" && ($b == "bar" or $c == "baz")) {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" AND ($b == "bar" OR $c == "baz")) {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" and ($b == "bar" OR $c == "baz")) {}',
+            ],
+            [
+                '<?php if ($a == "foo" && ($b == "bar" || $c == "baz")) {}',
+                '<?php if ($a == "foo" AND ($b == "bar" or $c == "baz")) {}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1212

This fixer adds the ability to ~~toggle between using keywords for logical operators - `and` and `or`, and using symbols - `&&` and `||`~~ convert logical operators using keywords `and`, `or` to their counterparts with higher precedence `&&`, `||`.

~~The fixer is configurable so you can choose either one. The default is using characters - `&&`, `||`.!~

As discussed in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1212, the fixer is risky. ~~It also doesn't try to add parenthesis around conditions when converting from not using keywords to using keywords (which have lower precedence than the assignment operation).~~ People using it need to double check if there was a case where using keywords would have produced different logic and it was intentional.

---

This is my first fixer and my first dive into PHP CS Fixer. Please try to review it thoroughly and provide feedback. Thank you!