### PR TITLE
NoUnreachableDefaultArgumentValueFixer - fix typo

### DIFF
--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -59,7 +59,7 @@ function example($foo = "two words", $bar) {}
             null,
             null,
             null,
-            'Modifies the signature of functions; therefor risky when using systems (such as some Symfony components) that rely on those (for example through reflection).'
+            'Modifies the signature of functions; therefore risky when using systems (such as some Symfony components) that rely on those (for example through reflection).'
         );
     }
 


### PR DESCRIPTION
Fixes a typo in the risky description of the `NoUnreachableDefaultArgumentValueFixer`