### PR TITLE
Improve process output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,18 @@ Risky rule is a rule, which could change code behaviour. By default no risky rul
 
 The ``--stop-on-violation`` flag stops execution upon first file that needs to be fixed.
 
+The ``--show-progress`` option allows you to choose the way process progress is rendered:
+
+* ``none``: disables progress output;
+* ``run-in``: simple single-line progress output;
+* ``evaluating``: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects.
+
+If the option is not provided, it defaults to ``run-in`` unless a config file that disables output is used, in which case it defaults to ``none``. This option has no effect if the verbosity of the command is less than ``verbose``.
+
+.. code-block:: bash
+
+    $ php php-cs-fixer.phar fix --verbose --show-progress=evaluating
+
 The command can also read from standard input, in which case it won't
 automatically fix anything:
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/annotations": "^1.2",
         "ext-tokenizer": "*",
         "sebastian/diff": "^1.1",
-        "symfony/console": "^2.3 || ^3.0",
+        "symfony/console": "^2.4 || ^3.0",
         "symfony/event-dispatcher": "^2.1 || ^3.0",
         "symfony/filesystem": "^2.4 || ^3.0",
         "symfony/finder": "^2.2 || ^3.0",

--- a/src/Console/Command/CommandHelp.php
+++ b/src/Console/Command/CommandHelp.php
@@ -87,6 +87,16 @@ Risky rule is a rule, which could change code behaviour. By default no risky rul
 
 The <comment>--stop-on-violation</comment> flag stops execution upon first file that needs to be fixed.
 
+The <comment>--show-progress</comment> option allows you to choose the way process progress is rendered:
+
+* <comment>none</comment>: disables progress output;
+* <comment>run-in</comment>: simple single-line progress output;
+* <comment>evaluating</comment>: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects.
+
+If the option is not provided, it defaults to <comment>run-in</comment> unless a config file that disables output is used, in which case it defaults to <comment>none</comment>. This option has no effect if the verbosity of the command is less than <comment>verbose</comment>.
+
+    <info>$ php %command.full_name% --verbose --show-progress=evaluating</info>
+
 The command can also read from standard input, in which case it won't
 automatically fix anything:
 

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -103,6 +103,7 @@ final class FixCommand extends Command
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file.'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
                     new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
+                    new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, run-in, or estimating).'),
                 )
             )
             ->setDescription('Fixes a directory or a file.')
@@ -135,6 +136,7 @@ final class FixCommand extends Command
                 'diff' => $input->getOption('diff'),
                 'stop-on-violation' => $input->getOption('stop-on-violation'),
                 'verbosity' => $verbosity,
+                'show-progress' => $input->getOption('show-progress'),
             ),
             getcwd()
         );
@@ -169,12 +171,23 @@ final class FixCommand extends Command
             }
         }
 
-        $showProgress = $resolver->getProgress();
+        $progressType = $resolver->getProgress();
+        $finder = $resolver->getFinder();
+
+        if ('none' === $progressType || null === $stdErr) {
+            $progressOutput = new NullOutput();
+        } elseif ('run-in' === $progressType) {
+            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, null);
+        } else {
+            $finder = new \ArrayIterator(iterator_to_array($finder));
+            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, count($finder));
+        }
+
         $runner = new Runner(
-            $resolver->getFinder(),
+            $finder,
             $resolver->getFixers(),
             $resolver->getDiffer(),
-            $showProgress ? $this->eventDispatcher : null,
+            'none' !== $progressType ? $this->eventDispatcher : null,
             $this->errorsManager,
             $resolver->getLinter(),
             $resolver->isDryRun(),
@@ -182,11 +195,6 @@ final class FixCommand extends Command
             $resolver->getDirectory(),
             $resolver->shouldStopOnViolation()
         );
-
-        $progressOutput = $showProgress && $stdErr
-            ? new ProcessOutput($stdErr, $this->eventDispatcher)
-            : new NullOutput()
-        ;
 
         $this->stopwatch->start('fixFiles');
         $changed = $runner->fix();

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -52,11 +52,40 @@ final class ProcessOutput implements ProcessOutputInterface
      */
     private $output;
 
-    public function __construct(OutputInterface $output, EventDispatcher $dispatcher)
+    /**
+     * @var int
+     */
+    private $files;
+
+    /**
+     * @var int
+     */
+    private $processedFiles = 0;
+
+    /**
+     * @var int
+     */
+    private $symbolsPerLine;
+
+    /**
+     * @param OutputInterface $output
+     * @param EventDispatcher $dispatcher
+     * @param int|null        $nbFiles
+     */
+    public function __construct(OutputInterface $output, EventDispatcher $dispatcher, $nbFiles)
     {
         $this->output = $output;
         $this->eventDispatcher = $dispatcher;
         $this->eventDispatcher->addListener(FixerFileProcessedEvent::NAME, array($this, 'onFixerFileProcessed'));
+
+        if (null !== $nbFiles) {
+            $this->files = $nbFiles;
+
+            //   80               (lines max length)
+            // - total length x 2 (e.g. "  1 / 123" => 6 digits and padding spaces)
+            // - 11               (extra spaces, parentheses and percentage characters, e.g. " x / x (100%)")
+            $this->symbolsPerLine = 80 - strlen((string) $this->files) * 2 - 11;
+        }
     }
 
     public function __destruct()
@@ -68,6 +97,26 @@ final class ProcessOutput implements ProcessOutputInterface
     {
         $status = self::$eventStatusMap[$event->getStatus()];
         $this->output->write($this->output->isDecorated() ? sprintf($status['format'], $status['symbol']) : $status['symbol']);
+
+        if (null !== $this->files) {
+            ++$this->processedFiles;
+            $symbolsOnCurrentLine = $this->processedFiles % $this->symbolsPerLine;
+            $isLast = $this->processedFiles === $this->files;
+
+            if (0 === $symbolsOnCurrentLine || $isLast) {
+                $this->output->write(sprintf(
+                    '%s %'.strlen((string) $this->files).'d / %d (%3d%%)',
+                    $isLast && 0 !== $symbolsOnCurrentLine ? str_repeat(' ', $this->symbolsPerLine - $symbolsOnCurrentLine) : '',
+                    $this->processedFiles,
+                    $this->files,
+                    round($this->processedFiles / $this->files * 100)
+                ));
+
+                if (!$isLast) {
+                    $this->output->writeln('');
+                }
+            }
+        }
     }
 
     public function printLegend()

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -53,7 +53,7 @@ final class ProcessOutput implements ProcessOutputInterface
     private $output;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $files;
 
@@ -63,7 +63,7 @@ final class ProcessOutput implements ProcessOutputInterface
     private $processedFiles = 0;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $symbolsPerLine;
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -42,7 +42,6 @@ final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
         'PhpCsFixer\Console\Command\ReadmeCommand',
         'PhpCsFixer\Console\Command\SelfUpdateCommand',
         'PhpCsFixer\Console\Output\NullOutput',
-        'PhpCsFixer\Console\Output\ProcessOutput',
         'PhpCsFixer\Differ\DiffConsoleFormatter',
         'PhpCsFixer\Differ\NullDiffer',
         'PhpCsFixer\Differ\SebastianBergmannDiffer',

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -69,10 +69,6 @@ EOT;
 
     public function testExecuteStatusCode()
     {
-        if (!method_exists('Symfony\Component\Console\Tester\CommandTester', 'getStatusCode')) {
-            $this->markTestSkipped('Symfony 2.4+ required.');
-        }
-
         $this->assertSame(0, $this->execute()->getStatusCode());
     }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -68,7 +68,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ''
         );
 
-        $this->assertFalse($resolver->getProgress());
+        $this->assertSame('none', $resolver->getProgress());
     }
 
     public function testResolveProgressWithPositiveConfigAndNegativeOption()
@@ -84,7 +84,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ''
         );
 
-        $this->assertFalse($resolver->getProgress());
+        $this->assertSame('none', $resolver->getProgress());
     }
 
     public function testResolveProgressWithNegativeConfigAndPositiveOption()
@@ -100,7 +100,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ''
         );
 
-        $this->assertTrue($resolver->getProgress());
+        $this->assertSame('run-in', $resolver->getProgress());
     }
 
     public function testResolveProgressWithNegativeConfigAndNegativeOption()
@@ -116,7 +116,80 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
             ''
         );
 
-        $this->assertFalse($resolver->getProgress());
+        $this->assertSame('none', $resolver->getProgress());
+    }
+
+    /**
+     * @param string $progressType
+     *
+     * @dataProvider getProgressTypeCases
+     */
+    public function testResolveProgressWithPositiveConfigAndExplicitProgress($progressType)
+    {
+        $this->config->setHideProgress(true);
+
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array(
+                'format' => 'txt',
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+                'show-progress' => $progressType,
+            ),
+            ''
+        );
+
+        $this->assertSame($progressType, $resolver->getProgress());
+    }
+
+    /**
+     * @param string $progressType
+     *
+     * @dataProvider getProgressTypeCases
+     */
+    public function testResolveProgressWithNegativeConfigAndExplicitProgress($progressType)
+    {
+        $this->config->setHideProgress(false);
+
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array(
+                'format' => 'txt',
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+                'show-progress' => $progressType,
+            ),
+            ''
+        );
+
+        $this->assertSame($progressType, $resolver->getProgress());
+    }
+
+    public function getProgressTypeCases()
+    {
+        return array(
+            array('none'),
+            array('run-in'),
+            array('estimating'),
+        );
+    }
+
+    public function testResolveProgressWithInvalidExplicitProgress()
+    {
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array(
+                'format' => 'txt',
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+                'show-progress' => 'foo',
+            ),
+            ''
+        );
+
+        $this->setExpectedException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            'The progress type "foo" is not defined, supported are "none", "run-in", "estimating".'
+        );
+
+        $resolver->getProgress();
     }
 
     public function testResolveConfigFileDefault()
@@ -915,7 +988,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
 
         $options = $definition->getOptions();
         $this->assertSame(
-            array('path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation'),
+            array('path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress'),
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Output;
+
+use PhpCsFixer\Console\Output\ProcessOutput;
+use PhpCsFixer\FixerFileProcessedEvent;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @internal
+ */
+final class ProcessOutputTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param array  $statuses
+     * @param string $expectedOutput
+     *
+     * @dataProvider getProcessProgressOutputCases
+     */
+    public function testProcessProgressOutput(array $statuses, $expectedOutput)
+    {
+        $processOutput = new ProcessOutput(
+            $output = new BufferedOutput(),
+            $this->prophesize('Symfony\Component\EventDispatcher\EventDispatcher')->reveal(),
+            null
+        );
+
+        $this->foreachStatus($statuses, function ($status) use ($processOutput) {
+            $processOutput->onFixerFileProcessed(new FixerFileProcessedEvent($status));
+        });
+
+        $this->assertSame($expectedOutput, $output->fetch());
+    }
+
+    public function getProcessProgressOutputCases()
+    {
+        return array(
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 4),
+                ),
+                '....',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES),
+                    array(FixerFileProcessedEvent::STATUS_FIXED),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 4),
+                ),
+                '.F....',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 65),
+                ),
+                '.................................................................',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 81),
+                ),
+                '.................................................................................',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 19),
+                    array(FixerFileProcessedEvent::STATUS_EXCEPTION),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 6),
+                    array(FixerFileProcessedEvent::STATUS_LINT),
+                    array(FixerFileProcessedEvent::STATUS_FIXED, 3),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 67),
+                    array(FixerFileProcessedEvent::STATUS_SKIPPED),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 66),
+                    array(FixerFileProcessedEvent::STATUS_INVALID),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES),
+                    array(FixerFileProcessedEvent::STATUS_INVALID),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 40),
+                    array(FixerFileProcessedEvent::STATUS_UNKNOWN),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 32),
+                ),
+                '...................E......EFFF...................................................................S..................................................................I.I........................................?................................',
+            ),
+        );
+    }
+
+    /**
+     * @param array  $statuses
+     * @param string $expectedOutput
+     *
+     * @dataProvider getProcessProgressOutputWithNumbersCases
+     */
+    public function testProcessProgressOutputWithNumbers(array $statuses, $expectedOutput)
+    {
+        $nbFiles = 0;
+        $this->foreachStatus($statuses, function ($status) use (&$nbFiles) {
+            ++$nbFiles;
+        });
+
+        $processOutput = new ProcessOutput(
+            $output = new BufferedOutput(),
+            $this->prophesize('Symfony\Component\EventDispatcher\EventDispatcher')->reveal(),
+            $nbFiles
+        );
+
+        $this->foreachStatus($statuses, function ($status) use ($processOutput) {
+            $processOutput->onFixerFileProcessed(new FixerFileProcessedEvent($status));
+        });
+
+        $this->assertSame($expectedOutput, $output->fetch());
+    }
+
+    public function getProcessProgressOutputWithNumbersCases()
+    {
+        return array(
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 4),
+                ),
+                '....                                                                4 / 4 (100%)',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES),
+                    array(FixerFileProcessedEvent::STATUS_FIXED),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 4),
+                ),
+                '.F....                                                              6 / 6 (100%)',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 65),
+                ),
+                '................................................................. 65 / 65 (100%)',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 66),
+                ),
+                "................................................................. 65 / 66 ( 98%)\n".
+                '.                                                                 66 / 66 (100%)',
+            ),
+            array(
+                array(
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 19),
+                    array(FixerFileProcessedEvent::STATUS_EXCEPTION),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 6),
+                    array(FixerFileProcessedEvent::STATUS_LINT),
+                    array(FixerFileProcessedEvent::STATUS_FIXED, 3),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 50),
+                    array(FixerFileProcessedEvent::STATUS_SKIPPED),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 49),
+                    array(FixerFileProcessedEvent::STATUS_INVALID),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES),
+                    array(FixerFileProcessedEvent::STATUS_INVALID),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 40),
+                    array(FixerFileProcessedEvent::STATUS_UNKNOWN),
+                    array(FixerFileProcessedEvent::STATUS_NO_CHANGES, 15),
+                ),
+                "...................E......EFFF.................................  63 / 189 ( 33%)\n".
+                ".................S............................................. 126 / 189 ( 67%)\n".
+                '....I.I........................................?............... 189 / 189 (100%)',
+            ),
+        );
+    }
+
+    private function foreachStatus(array $statuses, \Closure $action)
+    {
+        foreach ($statuses as $status) {
+            $multiplier = isset($status[1]) ? $status[1] : 1;
+            $status = $status[0];
+
+            for ($i = 0; $i < $multiplier; ++$i) {
+                $action($status);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the process output to look like PHPUnit's one:
* limits line length to 80 characters;
* displays the progression percentage before each newline so you know whether you have time to get a coffee 😉;

![Output](https://cloud.githubusercontent.com/assets/1736542/23835879/40c9cae4-076f-11e7-8d0f-3831d1222e54.png)
