### PR TITLE
PhpdocAddMissingParamAnnotationFixer, PhpdocOrderFixer - fix priority issue

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -222,7 +222,7 @@ function f9(string $foo, $bar, $baz) {}',
     public function getPriority()
     {
         // must be run after PhpdocNoAliasTagFixer and before PhpdocAlignFixer
-        return -5;
+        return -1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -89,7 +89,7 @@ final class PhpdocOrderFixer extends AbstractFixer
          * create incorrect annotation grouping while moving the annotations
          * about, we're still ok.
          */
-        return 5;
+        return -2;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -72,6 +72,14 @@ function fnc($foo, $bar) {}'
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        return -3;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isCandidate(Tokens $tokens)
     {
         return $tokens->isTokenKindFound(T_DOC_COMMENT);

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -304,6 +304,7 @@ final class FixerFactoryTest extends \PHPUnit_Framework_TestCase
             array($fixers['phpdoc_no_useless_inheritdoc'], $fixers['phpdoc_inline_tag']), // tested also in: phpdoc_no_useless_inheritdoc,phpdoc_inline_tag.test
             array($fixers['phpdoc_to_comment'], $fixers['phpdoc_no_useless_inheritdoc']), // tested also in: phpdoc_to_comment,phpdoc_no_useless_inheritdoc.test
             array($fixers['declare_strict_types'], $fixers['declare_equal_normalize']), // tested also in: declare_strict_types,declare_equal_normalize.test
+            array($fixers['phpdoc_add_missing_param_annotation'], $fixers['phpdoc_order']), // tested also in: phpdoc_add_missing_param_annotation,phpdoc_order.test
         );
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixtures/Integration/priority/phpdoc_add_missing_param_annotation,phpdoc_order.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_add_missing_param_annotation,phpdoc_order.test
@@ -1,0 +1,18 @@
+--TEST--
+Integration of fixers: phpdoc_add_missing_param_annotation,phpdoc_order.
+--RULESET--
+{"phpdoc_add_missing_param_annotation": true, "phpdoc_order": true}
+--EXPECT--
+<?php
+/**
+ * @param mixed $fo
+ * @return int
+ */
+function foo ($fo) {}
+
+--INPUT--
+<?php
+/**
+ * @return int
+ */
+function foo ($fo) {}


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2602