### PR TITLE
Finder - Remove `*.twig` as default

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -28,7 +28,6 @@ class Finder extends BaseFinder
             ->files()
             ->name('*.php')
             ->name('*.phpt')
-            ->name('*.twig')
             ->ignoreDotFiles(true)
             ->ignoreVCS(true)
             ->exclude('vendor')


### PR DESCRIPTION
Twig files do not (or should) not contain PHP code. Therefore it does not make sense to me why we should try to fix those by default.