### PR TITLE
Tokenizer - fix edge cases with empty code, registered found tokens and code hash

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -135,15 +135,15 @@ class Tokens extends \SplFixedArray
             foreach ($array as $key => $val) {
                 $tokens[$key] = $val;
             }
+        } else {
+            $index = 0;
 
-            return $tokens;
+            foreach ($array as $val) {
+                $tokens[$index++] = $val;
+            }
         }
 
-        $index = 0;
-
-        foreach ($array as $val) {
-            $tokens[$index++] = $val;
-        }
+        $tokens->generateCode(); // regenerate code to calculate code hash
 
         return $tokens;
     }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -69,7 +69,7 @@ class Tokens extends \SplFixedArray
      *
      * @var bool[]
      */
-    private $foundTokenKinds;
+    private $foundTokenKinds = array();
 
     /**
      * Clone tokens collection.

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -803,11 +803,12 @@ PHP;
     {
         $code = '<?php echo 1;';
 
-        $tokens = Tokens::fromCode($code);
-        $this->assertTrue($tokens->isTokenKindFound(T_OPEN_TAG));
+        $tokens1 = Tokens::fromCode($code);
+        $tokens2 = Tokens::fromArray($tokens1->toArray());
 
-        $tokens2 = Tokens::fromArray($tokens->toArray());
+        $this->assertTrue($tokens1->isTokenKindFound(T_OPEN_TAG));
         $this->assertTrue($tokens2->isTokenKindFound(T_OPEN_TAG));
+        $this->assertSame($tokens1->getCodeHash(), $tokens2->getCodeHash());
     }
 
     public function testFromArrayEmpty()

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -776,6 +776,65 @@ PHP;
         Tokens::fromCode('<?php# this will cause T_HH_ERROR');
     }
 
+    public function testEmptyTokens()
+    {
+        $code = '';
+        $tokens = Tokens::fromCode($code);
+
+        $this->assertCount(0, $tokens);
+        $this->assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+    }
+
+    public function testEmptyTokensMultiple()
+    {
+        $code = '';
+
+        $tokens = Tokens::fromCode($code);
+        $tokens->insertAt(0, new Token(array(T_WHITESPACE, ' ')));
+        $this->assertCount(1, $tokens);
+        $this->assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+
+        $tokens2 = Tokens::fromCode($code);
+        $this->assertCount(0, $tokens2);
+        $this->assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+    }
+
+    public function testFromArray()
+    {
+        $code = '<?php echo 1;';
+
+        $tokens = Tokens::fromCode($code);
+        $this->assertTrue($tokens->isTokenKindFound(T_OPEN_TAG));
+
+        $tokens2 = Tokens::fromArray($tokens->toArray());
+        $this->assertTrue($tokens2->isTokenKindFound(T_OPEN_TAG));
+    }
+
+    public function testFromArrayEmpty()
+    {
+        $tokens = Tokens::fromArray(array());
+        $this->assertFalse($tokens->isTokenKindFound(T_OPEN_TAG));
+    }
+
+    public function testClone()
+    {
+        $code = '<?php echo 1;';
+        $tokens = Tokens::fromCode($code);
+
+        $tokensClone = clone $tokens;
+
+        $this->assertTrue($tokens->isTokenKindFound(T_OPEN_TAG));
+        $this->assertTrue($tokensClone->isTokenKindFound(T_OPEN_TAG));
+
+        $count = count($tokens);
+        $this->assertCount($count, $tokensClone);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $this->assertTrue($tokens[$i]->equals($tokensClone[$i]));
+            $this->assertNotSame($tokens[$i], $tokensClone[$i]);
+        }
+    }
+
     /**
      * @param int    $expectedIndex
      * @param string $source


### PR DESCRIPTION
Currently both the `Tokens` class and some `Fixers` depend on behavior of the `FileFilterIterator` to filter out empty files and by that empty strings.
This breaks the possibility to use the `Tokens` and `Fixers` outside of this context.