### PR TITLE
ToolInfo - use static dir check for composer discovery

### DIFF
--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -23,7 +23,6 @@ use PhpCsFixer\Console\Application;
  */
 final class ToolInfo
 {
-    const COMPOSER_INSTALLED_FILE = '/../../composer/installed.json';
     const COMPOSER_PACKAGE_NAME = 'friendsofphp/php-cs-fixer';
 
     public static function getComposerVersion()
@@ -35,7 +34,7 @@ final class ToolInfo
         }
 
         if (null === $result) {
-            $composerInstalled = json_decode(file_get_contents(self::getScriptDir().self::COMPOSER_INSTALLED_FILE), true);
+            $composerInstalled = json_decode(file_get_contents(self::getComposerInstalledFile()), true);
 
             foreach ($composerInstalled as $package) {
                 if (self::COMPOSER_PACKAGE_NAME === $package['name']) {
@@ -73,33 +72,14 @@ final class ToolInfo
         static $result;
 
         if (null === $result) {
-            $result = !self::isInstalledAsPhar() && file_exists(self::getScriptDir().self::COMPOSER_INSTALLED_FILE);
+            $result = !self::isInstalledAsPhar() && file_exists(self::getComposerInstalledFile());
         }
 
         return $result;
     }
 
-    private static function getScriptDir()
+    private static function getComposerInstalledFile()
     {
-        static $result;
-
-        if (null === $result) {
-            $script = $_SERVER['SCRIPT_NAME'];
-
-            if (is_link($script)) {
-                $linkTarget = readlink($script);
-
-                // If the link target is relative to the link
-                if (false === realpath($linkTarget)) {
-                    $linkTarget = dirname($script).'/'.$linkTarget;
-                }
-
-                $script = $linkTarget;
-            }
-
-            $result = dirname($script);
-        }
-
-        return $result;
+        return __DIR__.'/../../../composer/installed.json';
     }
 }

--- a/tests/ToolInfoTest.php
+++ b/tests/ToolInfoTest.php
@@ -30,4 +30,16 @@ final class ToolInfoTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse(ToolInfo::isInstalledAsPhar());
     }
+
+    public function testIsInstalledByComposer()
+    {
+        $this->assertFalse(ToolInfo::isInstalledByComposer());
+    }
+
+    public function testGetComposerVersionThrowsExceptionIfOutsideComposerScope()
+    {
+        $this->setExpectedException('LogicException');
+
+        ToolInfo::getComposerVersion();
+    }
 }


### PR DESCRIPTION
In a Composer installation `php-cs-fixer` binary is present in
* `vendor/friendsofphp/php-cs-fixer/php-cs-fixer`
* `vendor/bin/php-cs-fixer` (symlink)

but someone may want to re-symlink the symlink in a custom/private bin dir.
If so, the script currently fails to detect whether is installed through composer or not.

This is due to the `$_SERVER['SCRIPT_NAME']` variable, that could vary a lot.
But composer installations can have only 2 result path, so just check them statically.