### PR TITLE
SemicolonAfterInstructionFixer - Handle alternative syntax

### DIFF
--- a/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+++ b/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
@@ -34,7 +34,7 @@ final class SemicolonAfterInstructionFixer extends AbstractFixer
             }
 
             $prev = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$prev]->equalsAny(array(';', '}', array(T_OPEN_TAG)))) {
+            if ($tokens[$prev]->equalsAny(array(';', '}', ':', array(T_OPEN_TAG)))) {
                 continue;
             }
 

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -58,6 +58,22 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
             array('<?php ?>'),
             array('<?php if($a){}'),
             array('<?php while($a > $b){}'),
+            array(
+'<?php if ($a == 5): ?>
+A is equal to 5
+<?php endif; ?>
+<?php switch ($foo): ?>
+<?php case 1: ?>
+...
+<?php endswitch; ?>',
+'<?php if ($a == 5): ?>
+A is equal to 5
+<?php endif; ?>
+<?php switch ($foo): ?>
+<?php case 1: ?>
+...
+<?php endswitch ?>',
+                ),
         );
     }
 


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2638