### PR TITLE
NoExtraConsecutiveBlankLinesFixer - Fix single indent characters not working

### DIFF
--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -441,7 +441,7 @@ class Foo
             $ending = $this->whitespacesConfig->getLineEnding();
 
             $pos = strrpos($content, "\n");
-            if ($pos + 2 < strlen($content)) { // preserve indenting where possible
+            if ($pos + 2 <= strlen($content)) { // preserve indenting where possible
                 $this->tokens[$i]->setContent($ending.substr($content, $pos + 1));
             } else {
                 $this->tokens[$i]->setContent($ending);

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -942,6 +942,11 @@ class Foo
                 "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
                 "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
             ),
+            array(
+                array('tokens' => array('square_brace_block')),
+                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\t1,\r\n2];",
+                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n\t1,\r\n2];",
+            ),
         );
     }
 


### PR DESCRIPTION
Would change indenting with a single character like tab or a single space from this:

```php
<?php

$a = [
[TAB]'a',
[TAB]'b',
];
```

to this

```php
<?php

$ = [
'a',
[TAB]'b',
];
```