### PR TITLE
DescribeCommandTest - fix test execution on decorated console

### DIFF
--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -158,10 +158,15 @@ EOT;
         $command = $application->find('describe');
 
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array(
-            'command' => $command->getName(),
-            'name' => 'Foo/bar',
-        ));
+        $commandTester->execute(
+            array(
+                'command' => $command->getName(),
+                'name' => 'Foo/bar',
+            ),
+            array(
+                'decorated' => false,
+            )
+        );
 
         return $commandTester;
     }


### PR DESCRIPTION
Under Windows, dunno if happens on Unix as well.
On non-decorated console original test works, on decorated - it doesn't.