### PR TITLE
PhpdocAlignFixer - make fixer configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -845,8 +845,12 @@ Choose from the list of available rules:
 
 * **phpdoc_align** [@Symfony]
 
-  All items of the @param, @throws, @return, @var, and @type phpdoc tags
-  must be aligned vertically.
+  All items of the given phpdoc tags must be aligned vertically.
+
+  Configuration options:
+
+  - ``tags`` (``array``): the tags that should be aligned; defaults to ``['param',
+    'return', 'throws', 'type', 'var']``
 
 * **phpdoc_annotation_without_dot** [@Symfony]
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -13,7 +13,11 @@
 namespace PhpCsFixer\Fixer\Phpdoc;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerConfiguration\FixerOptionValidatorGenerator;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -26,24 +30,44 @@ use PhpCsFixer\Utils;
  * @author Graham Campbell <graham@alt-three.com>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
+final class PhpdocAlignFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface, WhitespacesAwareFixerInterface
 {
     private $regex;
     private $regexCommentLine;
 
-    public function __construct()
+    private static $alignableTags = [
+        'param',
+        'property',
+        'return',
+        'throws',
+        'type',
+        'var',
+    ];
+
+    private static $tagsWithName = [
+        'param',
+        'property',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
     {
-        parent::__construct();
+        parent::configure($configuration);
+
+        $tagsWithNameToAlign = array_intersect($this->configuration['tags'], self::$tagsWithName);
+        $tagsWithoutNameToAlign = array_diff($this->configuration['tags'], $tagsWithNameToAlign);
 
         $indent = '(?P<indent>(?: {2}|\t)*)';
         // e.g. @param <hint> <$var>
-        $paramTag = '(?P<tag>param)\s+(?P<hint>[^$]+?)\s+(?P<var>(?:&|\.{3})?\$[^\s]+)';
+        $tagsWithName = '(?P<tag>'.implode('|', $tagsWithNameToAlign).')\s+(?P<hint>[^$]+?)\s+(?P<var>(?:&|\.{3})?\$[^\s]+)';
         // e.g. @return <hint>
-        $otherTags = '(?P<tag2>return|throws|var|type)\s+(?P<hint2>[^\s]+?)';
+        $tagsWithoutName = '(?P<tag2>'.implode('|', $tagsWithoutNameToAlign).')\s+(?P<hint2>[^\s]+?)';
         // optional <desc>
         $desc = '(?:\s+(?P<desc>\V*))';
 
-        $this->regex = '/^'.$indent.' \* @(?:'.$paramTag.'|'.$otherTags.')'.$desc.'\s*$/u';
+        $this->regex = '/^'.$indent.' \* @(?:'.$tagsWithName.'|'.$tagsWithoutName.')'.$desc.'\s*$/u';
         $this->regexCommentLine = '/^'.$indent.' \*(?! @)(?:\s+(?P<desc>\V+))(?<!\*\/)$/u';
     }
 
@@ -53,7 +77,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
     public function getDefinition()
     {
         return new FixerDefinition(
-            'All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically.',
+            'All items of the given phpdoc tags must be aligned vertically.',
             [new CodeSample('<?php
 /**
  * @param  EngineInterface $templating
@@ -99,6 +123,32 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
                 $tokens[$index]->setContent($this->fixDocBlock($token->getContent()));
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        $generator = new FixerOptionValidatorGenerator();
+
+        $tags = new FixerOptionBuilder('tags', 'The tags that should be aligned.');
+        $tags
+            ->setAllowedTypes(['array'])
+            ->setAllowedValues([
+                $generator->allowedValueIsSubsetOf(self::$alignableTags),
+            ])
+            // By default, all tags apart from @property will be aligned for backwards compatibility
+            ->setDefault([
+                'param',
+                'return',
+                'throws',
+                'type',
+                'var',
+            ])
+        ;
+
+        return new FixerConfigurationResolver([$tags->getOption()]);
     }
 
     /**
@@ -168,7 +218,10 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
                     $line =
                         $item['indent']
                         .' *  '
-                        .str_repeat(' ', $tagMax + $hintMax + $varMax + ('param' === $currTag ? 3 : 2))
+                        .str_repeat(
+                            ' ',
+                            $tagMax + $hintMax + $varMax + (in_array($currTag, self::$tagsWithName, true) ? 3 : 2)
+                        )
                         .$item['desc']
                         .$lineEnding;
 

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -24,6 +24,8 @@ final class PhpdocAlignFixerTest extends AbstractFixerTestCase
 {
     public function testFix()
     {
+        $this->fixer->configure(['tags' => ['param']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -53,17 +55,21 @@ EOF;
 
     public function testFixMultiLineDesc()
     {
+        $this->fixer->configure(['tags' => ['param', 'property']]);
+
         $expected = <<<'EOF'
 <?php
     /**
-     * @param EngineInterface $templating
-     * @param string          $format
-     * @param int             $code       An HTTP response status code
-     *                                    See constants
-     * @param bool            $debug
-     * @param bool            $debug      See constants
-     *                                    See constants
-     * @param mixed           &$reference A parameter passed by reference
+     * @param    EngineInterface $templating
+     * @param    string          $format
+     * @param    int             $code       An HTTP response status code
+     *                                       See constants
+     * @param    bool            $debug
+     * @param    bool            $debug      See constants
+     *                                       See constants
+     * @param    mixed           &$reference A parameter passed by reference
+     * @property mixed           $foo        A foo
+     *                                       See constants
      */
 
 EOF;
@@ -79,6 +85,8 @@ EOF;
      * @param    bool         $debug See constants
      * See constants
      * @param  mixed    &$reference     A parameter passed by reference
+     * @property   mixed   $foo     A foo
+     *                               See constants
      */
 
 EOF;
@@ -88,6 +96,8 @@ EOF;
 
     public function testFixMultiLineDescWithThrows()
     {
+        $this->fixer->configure(['tags' => ['param', 'return', 'throws']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -133,6 +143,8 @@ EOF;
 
     public function testFixWithReturnAndThrows()
     {
+        $this->fixer->configure(['tags' => ['param', 'throws', 'return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -164,6 +176,8 @@ EOF;
      */
     public function testFixThreeParamsWithReturn()
     {
+        $this->fixer->configure(['tags' => ['param', 'return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -191,6 +205,8 @@ EOF;
 
     public function testFixOnlyReturn()
     {
+        $this->fixer->configure(['tags' => ['return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -212,6 +228,8 @@ EOF;
 
     public function testReturnWithDollarThis()
     {
+        $this->fixer->configure(['tags' => ['param', 'return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -235,6 +253,8 @@ EOF;
 
     public function testCustomAnnotationsStayUntouched()
     {
+        $this->fixer->configure(['tags' => ['return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -258,6 +278,8 @@ EOF;
 
     public function testCustomAnnotationsStayUntouched2()
     {
+        $this->fixer->configure(['tags' => ['var']]);
+
         $expected = <<<'EOF'
 <?php
 
@@ -280,6 +302,8 @@ EOF;
 
     public function testFixWithVar()
     {
+        $this->fixer->configure(['tags' => ['var']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -301,6 +325,8 @@ EOF;
 
     public function testFixWithType()
     {
+        $this->fixer->configure(['tags' => ['type']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -322,6 +348,8 @@ EOF;
 
     public function testFixWithVarAndDescription()
     {
+        $this->fixer->configure(['tags' => ['var']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -347,6 +375,8 @@ EOF;
 
     public function testFixWithVarAndInlineDescription()
     {
+        $this->fixer->configure(['tags' => ['var']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -368,6 +398,8 @@ EOF;
 
     public function testFixWithTypeAndInlineDescription()
     {
+        $this->fixer->configure(['tags' => ['type']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -389,12 +421,16 @@ EOF;
 
     public function testRetainsNewLineCharacters()
     {
+        $this->fixer->configure(['tags' => ['param']]);
+
         // when we're not modifying a docblock, then line endings shouldn't change
         $this->doTest("<?php\r    /**\r     * @param Example Hello there!\r     */\r");
     }
 
     public function testMalformedDocBlock()
     {
+        $this->fixer->configure(['tags' => ['return']]);
+
         $input = <<<'EOF'
 <?php
     /**
@@ -408,6 +444,8 @@ EOF;
 
     public function testDifferentIndentation()
     {
+        $this->fixer->configure(['tags' => ['param', 'return']]);
+
         $expected = <<<'EOF'
 <?php
 /**
@@ -446,13 +484,15 @@ EOF;
     }
 
     /**
+     * @param array       $config
      * @param string      $expected
      * @param null|string $input
      *
      * @dataProvider provideMessyWhitespacesCases
      */
-    public function testMessyWhitespaces($expected, $input = null)
+    public function testMessyWhitespaces(array $config, $expected, $input = null)
     {
+        $this->fixer->configure($config);
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
 
         $this->doTest($expected, $input);
@@ -462,10 +502,12 @@ EOF;
     {
         return [
             [
+                ['tags' => ['type']],
                 "<?php\r\n\t/**\r\n\t * @type Type This is a variable.\r\n\t */",
                 "<?php\r\n\t/**\r\n\t * @type   Type   This is a variable.\r\n\t */",
             ],
             [
+                ['tags' => ['param', 'return']],
                 "<?php\r\n/**\r\n * @param int    \$limit\r\n * @param string \$more\r\n *\r\n * @return array\r\n */",
                 "<?php\r\n/**\r\n * @param   int       \$limit\r\n * @param   string       \$more\r\n *\r\n * @return array\r\n */",
             ],
@@ -474,6 +516,8 @@ EOF;
 
     public function testCanFixBadFormatted()
     {
+        $this->fixer->configure(['tags' => ['var']]);
+
         $expected = "<?php\n    /**\n     * @var Foo */\n";
 
         $this->doTest($expected);
@@ -481,6 +525,8 @@ EOF;
 
     public function testFixUnicode()
     {
+        $this->fixer->configure(['tags' => ['param', 'return']]);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -522,15 +568,97 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    public function testDoesNotAlignPropertyByDefault()
+    {
+        $expected = <<<'EOF'
+<?php
     /**
+     * @param  int       $foobar Description
+     * @return int
+     * @throws Exception
+     * @var    FooBar
+     * @type   BarFoo
+     * @property     string    $foo   Hello World
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param    int   $foobar   Description
+     * @return  int
+     * @throws Exception
+     * @var       FooBar
+     * @type      BarFoo
+     * @property     string    $foo   Hello World
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testAlignsProperty()
+    {
+        $this->fixer->configure(['tags' => ['param', 'property', 'return', 'throws', 'type', 'var']]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param    int       $foobar Description
+     * @return   int
+     * @throws   Exception
+     * @var      FooBar
+     * @type     BarFoo
+     * @property string    $foo    Hello World
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param    int   $foobar   Description
+     * @return  int
+     * @throws Exception
+     * @var       FooBar
+     * @type      BarFoo
+     * @property     string    $foo   Hello World
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testDoesNotAlignWithEmptyConfig()
+    {
+        $this->fixer->configure(['tags' => []]);
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param    int   $foobar   Description
+     * @return  int
+     * @throws Exception
+     * @var       FooBar
+     * @type      BarFoo
+     * @property     string    $foo   Hello World
+     */
+EOF;
+
+        $this->doTest($input);
+    }
+
+    /**
+     * @param array  $config
      * @param string $expected
      * @param string $input
      *
      *
      * @dataProvider provideVariadicCases
      */
-    public function testVariadicParams($expected, $input)
+    public function testVariadicParams(array $config, $expected, $input)
     {
+        $this->fixer->configure($config);
+
         $this->doTest($expected, $input);
     }
 
@@ -538,6 +666,7 @@ EOF;
     {
         return [
             [
+                ['tags' => ['param']],
                 '<?php
 final class Sample
 {
@@ -565,7 +694,8 @@ final class Sample
 }
 ',
             ],
-                        [
+            [
+                ['tags' => ['param']],
                 '<?php
 final class Sample
 {


### PR DESCRIPTION
Leaves `@property` out by default for backwards compatibility.

Addresses #1492