### PR TITLE
Fix UPGRADE.md table syntax so it works in GitHub

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -50,7 +50,7 @@ Exit codes
 Exit codes for `fix` command have been changed and are build using the following bit flags:
 
 | 1.x bit | 2.0 bit | Description                                                 | Note                                                             |
-| ------- | ------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| -------:| -------:| ----------------------------------------------------------- | ---------------------------------------------------------------- |
 | 0       | 0       | OK                                                          |                                                                  |
 | 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags |
 |         | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode                       |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,8 +22,8 @@ CLI options
 
 1.x             | 2.0             | Description                                                               | Note
 --------------- | --------------- | ------------------------------------------------------------------------- | ----
-                | --allow-risky   | Are risky fixers allowed                                                  |
-                | --cache-file    | The path to the cache file                                                | option was added
+&nbsp;          | --allow-risky   | Are risky fixers allowed                                                  |
+&nbsp;          | --cache-file    | The path to the cache file                                                | option was added
 --config        |                 | Config class codename                                                     | option was removed
 --config-file   | --config        | The path to a .php_cs file                                                | option was renamed
 --diff          | --diff          | Show diff                                                                 |
@@ -31,9 +31,9 @@ CLI options
 --fixers        |                 | Coding standard fixers                                                    | option was removed, see --rules
 --format        | --format        | Choose format                                                             |
 --level         |                 | Coding standard level                                                     | option was removed, see --rules
-                | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added
-                | --rules         | Rules to be used                                                          | option was added
-                | --using-cache   | Does cache should be used                                                 | option was added
+&nbsp;          | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added
+&nbsp;          | --rules         | Rules to be used                                                          | option was added
+&nbsp;          | --using-cache   | Does cache should be used                                                 | option was added
 
 
 CLI argument
@@ -53,11 +53,11 @@ Exit codes for `fix` command have been changed and are build using the following
 -------:| -------:| ----------------------------------------------------------- | ----
 0       | 0       | OK                                                          |
 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags
-        | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode
-        | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode
+&nbsp;  | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode
+&nbsp;  | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode
 16      | 16      | Configuration error of the application                      |
 32      | 32      | Configuration error of a Fixer                              |
-        | 64      | Exception within the application                            | flag was added
+&nbsp;  | 64      | Exception within the application                            | flag was added
 
 Namespace
 ---------

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,20 +20,20 @@ Finally, the caching mechanism is enabled by default.
 CLI options
 -----------
 
-1.x             | 2.0             | Description                                                               | Note
---------------- | --------------- | ------------------------------------------------------------------------- | ----
-&nbsp;          | --allow-risky   | Are risky fixers allowed                                                  |
-&nbsp;          | --cache-file    | The path to the cache file                                                | option was added
---config        |                 | Config class codename                                                     | option was removed
---config-file   | --config        | The path to a .php_cs file                                                | option was renamed
---diff          | --diff          | Show diff                                                                 |
---dry-run       | --dry-run       | Run in dry-run mode                                                       |
---fixers        |                 | Coding standard fixers                                                    | option was removed, see --rules
---format        | --format        | Choose format                                                             |
---level         |                 | Coding standard level                                                     | option was removed, see --rules
-&nbsp;          | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added
-&nbsp;          | --rules         | Rules to be used                                                          | option was added
-&nbsp;          | --using-cache   | Does cache should be used                                                 | option was added
+| 1.x             | 2.0             | Description                                                               | Note
+| --------------- | --------------- | ------------------------------------------------------------------------- | ----
+|                 | --allow-risky   | Are risky fixers allowed                                                  |
+|                 | --cache-file    | The path to the cache file                                                | option was added
+| --config        |                 | Config class codename                                                     | option was removed
+| --config-file   | --config        | The path to a .php_cs file                                                | option was renamed
+| --diff          | --diff          | Show diff                                                                 |
+| --dry-run       | --dry-run       | Run in dry-run mode                                                       |
+| --fixers        |                 | Coding standard fixers                                                    | option was removed, see --rules
+| --format        | --format        | Choose format                                                             |
+| --level         |                 | Coding standard level                                                     | option was removed, see --rules
+|                 | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added
+|                 | --rules         | Rules to be used                                                          | option was added
+|                 | --using-cache   | Does cache should be used                                                 | option was added
 
 
 CLI argument
@@ -49,15 +49,15 @@ Exit codes
 
 Exit codes for `fix` command have been changed and are build using the following bit flags:
 
-1.x bit | 2.0 bit | Description                                                 | Note
--------:| -------:| ----------------------------------------------------------- | ----
-0       | 0       | OK                                                          |
-1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags
-&nbsp;  | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode
-&nbsp;  | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode
-16      | 16      | Configuration error of the application                      |
-32      | 32      | Configuration error of a Fixer                              |
-&nbsp;  | 64      | Exception within the application                            | flag was added
+| 1.x bit | 2.0 bit | Description                                                 | Note
+| -------:| -------:| ----------------------------------------------------------- | ----
+| 0       | 0       | OK                                                          |
+| 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags
+|         | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode
+|         | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode
+| 16      | 16      | Configuration error of the application                      |
+| 32      | 32      | Configuration error of a Fixer                              |
+|         | 64      | Exception within the application                            | flag was added
 
 Namespace
 ---------

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -49,8 +49,8 @@ Exit codes
 
 Exit codes for `fix` command have been changed and are build using the following bit flags:
 
-| 1.x bit | 2.0 bit | Description                                                 | Note
-| -------:| -------:| ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| 1.x bit | 2.0 bit | Description                                                 | Note                                                             |
+| ------- | ------- | ----------------------------------------------------------- | ---------------------------------------------------------------- |
 | 0       | 0       | OK                                                          |                                                                  |
 | 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags |
 |         | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode                       |

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,20 +20,20 @@ Finally, the caching mechanism is enabled by default.
 CLI options
 -----------
 
-| 1.x             | 2.0             | Description                                                               | Note
-| --------------- | --------------- | ------------------------------------------------------------------------- | ----
-|                 | --allow-risky   | Are risky fixers allowed                                                  |
-|                 | --cache-file    | The path to the cache file                                                | option was added
-| --config        |                 | Config class codename                                                     | option was removed
-| --config-file   | --config        | The path to a .php_cs file                                                | option was renamed
-| --diff          | --diff          | Show diff                                                                 |
-| --dry-run       | --dry-run       | Run in dry-run mode                                                       |
-| --fixers        |                 | Coding standard fixers                                                    | option was removed, see --rules
-| --format        | --format        | Choose format                                                             |
-| --level         |                 | Coding standard level                                                     | option was removed, see --rules
-|                 | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added
-|                 | --rules         | Rules to be used                                                          | option was added
-|                 | --using-cache   | Does cache should be used                                                 | option was added
+| 1.x             | 2.0             | Description                                                                    | Note                            |
+| --------------- | --------------- | ------------------------------------------------------------------------------ | ------------------------------- |
+|                 | --allow-risky   | Are risky fixers allowed                                                       |                                 |
+|                 | --cache-file    | The path to the cache file                                                     | option was added                |
+| --config        |                 | Config class codename                                                          | option was removed              |
+| --config-file   | --config        | The path to a .php_cs file                                                     | option was renamed              |
+| --diff          | --diff          | Show diff                                                                      |                                 |
+| --dry-run       | --dry-run       | Run in dry-run mode                                                            |                                 |
+| --fixers        |                 | Coding standard fixers                                                         | option was removed, see --rules |
+| --format        | --format        | Choose format                                                                  |                                 |
+| --level         |                 | Coding standard level                                                          | option was removed, see --rules |
+|                 | --path-mode     | Should the finder from config be<br/>overridden or intersected with `path` arg | option was added                |
+|                 | --rules         | Rules to be used                                                               | option was added                |
+|                 | --using-cache   | Does cache should be used                                                      | option was added                |
 
 
 CLI argument
@@ -50,14 +50,14 @@ Exit codes
 Exit codes for `fix` command have been changed and are build using the following bit flags:
 
 | 1.x bit | 2.0 bit | Description                                                 | Note
-| -------:| -------:| ----------------------------------------------------------- | ----
-| 0       | 0       | OK                                                          |
-| 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags
-|         | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode
-|         | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode
-| 16      | 16      | Configuration error of the application                      |
-| 32      | 32      | Configuration error of a Fixer                              |
-|         | 64      | Exception within the application                            | flag was added
+| -------:| -------:| ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| 0       | 0       | OK                                                          |                                                                  |
+| 1       | 1       | General error (or PHP/HHVM minimal requirement not matched) | no longer used for other states, never combined with other flags |
+|         | 4       | Some files have invalid syntax                              | flag was added, works only in dry-run mode                       |
+|         | 8       | Some files need fixing                                      | flag was added, works only in dry-run mode                       |
+| 16      | 16      | Configuration error of the application                      |                                                                  |
+| 32      | 32      | Configuration error of a Fixer                              |                                                                  |
+|         | 64      | Exception within the application                            | flag was added                                                   |
 
 Namespace
 ---------


### PR DESCRIPTION
GitHub doesn't like when you miss out the starting pipe and have an empty cell first