### PR TITLE
PhpdocAddMissingParamAnnotationFixer - handle one-line docblocks

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -146,7 +146,14 @@ function f9(string $foo, $bar, $baz) {}',
                 continue;
             }
 
-            if (false !== stripos($token->getContent(), 'inheritdoc')) {
+            $tokenContent = $token->getContent();
+
+            if (false !== stripos($tokenContent, 'inheritdoc')) {
+                continue;
+            }
+
+            // ignore one-line phpdocs like `/** foo */`, as there is no place to put new annotations
+            if (false === strpos($tokenContent, "\n")) {
                 continue;
             }
 
@@ -189,7 +196,7 @@ function f9(string $foo, $bar, $baz) {}',
                 continue;
             }
 
-            $doc = new DocBlock($token->getContent());
+            $doc = new DocBlock($tokenContent);
             $lastParamLine = null;
 
             foreach ($doc->getAnnotationsOfType('param') as $annotation) {

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -241,6 +241,48 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      function f11($caseSensitive) {}
 ',
             ),
+            array(
+                '<?php
+    /** @return string */
+    function hello($string)
+    {
+        return $string;
+    }',
+            ),
+            array(
+                '<?php
+    /** @return string
+     * @param mixed $string
+     */
+    function hello($string)
+    {
+        return $string;
+    }',
+                '<?php
+    /** @return string
+     */
+    function hello($string)
+    {
+        return $string;
+    }',
+            ),
+            array(
+                '<?php
+    /**
+     * @param mixed $string
+     * @return string */
+    function hello($string)
+    {
+        return $string;
+    }',
+                '<?php
+    /**
+     * @return string */
+    function hello($string)
+    {
+        return $string;
+    }',
+            ),
         );
     }
 


### PR DESCRIPTION
reported here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2646#issuecomment-290388670