### PR TITLE
AppVeyor - Cache Composer Installation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ cache:
     - '%APPDATA%\Composer'
     - '%LOCALAPPDATA%\Composer'
     - C:\tools\php -> .appveyor.yml
+    - C:\tools\composer.phar -> .appveyor.yml
 
 init:
     - SET PATH=C:\tools\php;%PATH%
@@ -27,14 +28,14 @@ install:
     - echo extension_dir=ext >> php.ini
     - echo extension=php_curl.dll >> php.ini
     - echo extension=php_openssl.dll >> php.ini
+    - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/download/1.4.1/composer.phar)
     - cd C:\projects\php-cs-fixer
-    - appveyor DownloadFile https://getcomposer.org/composer.phar
     - git config --global github.accesstoken 5e7538aa415005c606ea68de2bbbade0409b4b8c
-    - php composer.phar global show -ND 2>1 | findstr "hirak/prestissimo" || php composer.phar global require hirak/prestissimo
+    - php C:\tools\composer.phar global show -ND 2>1 | findstr "hirak/prestissimo" || php C:\tools\composer.phar global require hirak/prestissimo
 
 before_test:
     - cd C:\projects\php-cs-fixer
-    - php composer.phar update --no-interaction --no-progress --optimize-autoloader --prefer-stable --no-ansi
+    - php C:\tools\composer.phar update --no-interaction --no-progress --optimize-autoloader --prefer-stable --no-ansi
 
 test_script:
     - cd C:\projects\php-cs-fixer


### PR DESCRIPTION
Some AppVeyor builds fail because of an SSL error while downloading Composer ([example](https://ci.appveyor.com/project/keradus/php-cs-fixer/build/dev-5425/job/r4i4i6dou35rb2or)). Caching Composer installation should prevent this issue.