### PR TITLE
PhpdocToCommentFixer - Allow phpdoc for language constructs

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -78,10 +79,12 @@ foreach($connections as $key => $sqlite) {
             T_WHILE,
             T_FOR,
         );
+
         static $languageStructures = array(
             T_LIST,
             T_PRINT,
             T_ECHO,
+            CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN,
         );
 
         foreach ($tokens as $index => $token) {
@@ -94,6 +97,7 @@ foreach($connections as $key => $sqlite) {
 
             if (null === $nextToken || $nextToken->equals('}')) {
                 $tokens->overrideAt($index, array(T_COMMENT, '/*'.ltrim($token->getContent(), '/*')));
+
                 continue;
             }
 
@@ -194,7 +198,13 @@ foreach($connections as $key => $sqlite) {
      */
     private function isValidLanguageConstruct(Tokens $tokens, Token $docsToken, $languageConstructIndex)
     {
-        $endIndex = $tokens->getNextTokenOfKind($languageConstructIndex, array(')'));
+        $endKind = $tokens[$languageConstructIndex]->isGivenKind(CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN)
+            ? array(CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE)
+            : ')'
+        ;
+
+        $endIndex = $tokens->getNextTokenOfKind($languageConstructIndex, array($endKind));
+
         $docsContent = $docsToken->getContent();
 
         for ($index = $languageConstructIndex + 1; $index < $endIndex; ++$index) {

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -78,6 +78,11 @@ foreach($connections as $key => $sqlite) {
             T_WHILE,
             T_FOR,
         );
+        static $languageStructures = array(
+            T_LIST,
+            T_PRINT,
+            T_ECHO,
+        );
 
         foreach ($tokens as $index => $token) {
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
@@ -104,7 +109,7 @@ foreach($connections as $key => $sqlite) {
                 continue;
             }
 
-            if ($nextToken->isGivenKind(T_LIST) && $this->isValidList($tokens, $token, $nextIndex)) {
+            if ($nextToken->isGivenKind($languageStructures) && $this->isValidLanguageConstruct($tokens, $token, $nextIndex)) {
                 continue;
             }
 
@@ -179,20 +184,20 @@ foreach($connections as $key => $sqlite) {
     }
 
     /**
-     * Checks variable assignments through `list()` calls for correct docblock usage.
+     * Checks variable assignments through `list()`, `print()` etc. calls for correct docblock usage.
      *
      * @param Tokens $tokens
-     * @param Token  $docsToken docs Token
-     * @param int    $listIndex index of variable Token
+     * @param Token  $docsToken              docs Token
+     * @param int    $languageConstructIndex index of variable Token
      *
      * @return bool
      */
-    private function isValidList(Tokens $tokens, Token $docsToken, $listIndex)
+    private function isValidLanguageConstruct(Tokens $tokens, Token $docsToken, $languageConstructIndex)
     {
-        $endIndex = $tokens->getNextTokenOfKind($listIndex, array(')'));
+        $endIndex = $tokens->getNextTokenOfKind($languageConstructIndex, array(')'));
         $docsContent = $docsToken->getContent();
 
-        for ($index = $listIndex + 1; $index < $endIndex; ++$index) {
+        for ($index = $languageConstructIndex + 1; $index < $endIndex; ++$index) {
             $token = $tokens[$index];
 
             if (

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -552,4 +552,52 @@ trait DocBlocks
             ),
         );
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideCases71
+     * @requires PHP 7.1
+     */
+    public function testFix71($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideCases71()
+    {
+        return array(
+            array(
+                '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** @var int $a */
+[$a] = $b;
+
+/* @var int $c */
+[$a] = $c;
+                ',
+                '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** @var int $a */
+[$a] = $b;
+
+/** @var int $c */
+[$a] = $c;
+                ',
+            ),
+            array(
+                '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/**
+ * @var int $a
+ */
+[$a] = $b;
+                ',
+            ),
+        );
+    }
 }

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -518,6 +518,20 @@ function getNumberFormatter()
 ',
         );
 
+        $cases[] = array(
+            '<?php
+
+class A
+{
+    public function b()
+    {
+        /** @var int $c */
+        print($c = 0);
+    }
+}
+',
+        );
+
         return $cases;
     }
 


### PR DESCRIPTION
closes #2634 
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2636

rebase the work of @ceeram and add supported for short array destructing syntax