### PR TITLE
Add DoctrineAnnotationArrayAssignmentFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,6 +312,35 @@ Choose from the list of available rules:
 
   *Risky rule: risky when the function ``dirname()`` is overridden.*
 
+* **doctrine_annotation_array_assignment**
+
+  Doctrine annotations must use configured operator for assignment in
+  arrays.
+
+  Configuration options:
+
+  - ``ignored_tags`` (``array``): list of tags that must not be treated as Doctrine
+    Annotations; defaults to ``['abstract', 'access', 'code', 'deprec',
+    'encode', 'exception', 'final', 'ingroup', 'inheritdoc', 'inheritDoc',
+    'magic', 'name', 'toc', 'tutorial', 'private', 'static', 'staticvar',
+    'staticVar', 'throw', 'api', 'author', 'category', 'copyright',
+    'deprecated', 'example', 'filesource', 'global', 'ignore', 'internal',
+    'license', 'link', 'method', 'package', 'param', 'property',
+    'property-read', 'property-write', 'return', 'see', 'since', 'source',
+    'subpackage', 'throws', 'todo', 'TODO', 'usedBy', 'uses', 'var',
+    'version', 'after', 'afterClass', 'backupGlobals',
+    'backupStaticAttributes', 'before', 'beforeClass',
+    'codeCoverageIgnore', 'codeCoverageIgnoreStart',
+    'codeCoverageIgnoreEnd', 'covers', 'coversDefaultClass',
+    'coversNothing', 'dataProvider', 'depends', 'expectedException',
+    'expectedExceptionCode', 'expectedExceptionMessage',
+    'expectedExceptionMessageRegExp', 'group', 'large', 'medium',
+    'preserveGlobalState', 'requires', 'runTestsInSeparateProcesses',
+    'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses',
+    'SuppressWarnings', 'noinspection', 'package_version', 'enduml',
+    'startuml', 'fix', 'FIXME', 'fixme', 'override']``
+  - ``operator`` (``':'``, ``'='``): the operator to use; defaults to ``'='``
+
 * **doctrine_annotation_braces**
 
   Doctrine annotations without arguments must use the configured syntax.

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\DoctrineAnnotation;
+
+use Doctrine\Common\Annotations\DocLexer;
+use PhpCsFixer\AbstractDoctrineAnnotationFixer;
+use PhpCsFixer\Doctrine\Annotation\Tokens;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+
+/**
+ * Forces the configured operator for assignment in arrays in Doctrine Annotations.
+ */
+final class DoctrineAnnotationArrayAssignmentFixer extends AbstractDoctrineAnnotationFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Doctrine annotations must use configured operator for assignment in arrays.',
+            [
+                new CodeSample(
+                    "<?php\n/**\n * @Foo({bar : \"baz\"})\n */\nclass Bar {}",
+                    ['operator' => '=']
+                ),
+                new CodeSample(
+                    "<?php\n/**\n * @Foo({bar = \"baz\"})\n */\nclass Bar {}",
+                    ['operator' => ':']
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        $options = parent::createConfigurationDefinition()->getOptions();
+
+        $operator = new FixerOptionBuilder('operator', 'The operator to use.');
+        $options[] = $operator
+            ->setAllowedValues(['=', ':'])
+            ->setDefault('=')
+            ->getOption()
+        ;
+
+        return new FixerConfigurationResolver($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function fixAnnotations(Tokens $tokens)
+    {
+        $scopes = [];
+        foreach ($tokens as $index => $token) {
+            if ($token->isType(DocLexer::T_OPEN_PARENTHESIS)) {
+                $scopes[] = 'annotation';
+                continue;
+            }
+
+            if ($token->isType(DocLexer::T_OPEN_CURLY_BRACES)) {
+                $scopes[] = 'array';
+                continue;
+            }
+
+            if ($token->isType([DocLexer::T_CLOSE_PARENTHESIS, DocLexer::T_CLOSE_CURLY_BRACES])) {
+                array_pop($scopes);
+                continue;
+            }
+
+            if ('array' === end($scopes) && $token->isType([DocLexer::T_EQUALS, DocLexer::T_COLON])) {
+                $token->setContent($this->configuration['operator']);
+            }
+        }
+    }
+}

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\DoctrineAnnotation;
+
+use PhpCsFixer\Tests\AbstractDoctrineAnnotationFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\AbstractDoctrineAnnotationFixer
+ * @covers \PhpCsFixer\Fixer\DoctrineAnnotation\DoctrineAnnotationArrayAssignmentFixer
+ */
+final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineAnnotationFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider getFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider getFixCases
+     */
+    public function testFixWithEqual($expected, $input = null)
+    {
+        $this->fixer->configure(['operator' => '=']);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function getFixCases()
+    {
+        return $this->createTestCases([
+            ['
+/**
+ * @Foo
+ */'],
+            ['
+/**
+ * @Foo()
+ */'],
+            ['
+/**
+ * @Foo(bar="baz")
+ */'],
+            [
+                '
+/**
+ * @Foo(bar="baz")
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo({bar="baz"})
+ */',
+                '
+/**
+ * @Foo({bar:"baz"})
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo({bar="baz"})
+ */',
+                '
+/**
+ * @Foo({bar:"baz"})
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo({bar = "baz"})
+ */',
+                '
+/**
+ * @Foo({bar : "baz"})
+ */',
+            ],
+            ['
+/**
+ * See {@link http://help Help} or {@see BarClass} for details.
+ */'],
+        ]);
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider getFixWithColonCases
+     */
+    public function testFixWithColon($expected, $input = null)
+    {
+        $this->fixer->configure(['operator' => ':']);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function getFixWithColonCases()
+    {
+        return $this->createTestCases([
+            ['
+/**
+ * @Foo
+ */'],
+            ['
+/**
+ * @Foo()
+ */'],
+            ['
+/**
+ * @Foo(bar:"baz")
+ */'],
+            [
+                '
+/**
+ * @Foo(bar:"baz")
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo({bar:"baz"})
+ */',
+                '
+/**
+ * @Foo({bar="baz"})
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo({bar : "baz"})
+ */',
+                '
+/**
+ * @Foo({bar = "baz"})
+ */',
+            ],
+            [
+                '
+/**
+ * @Foo(foo="bar", {bar:"baz"})
+ */',
+                '
+/**
+ * @Foo(foo="bar", {bar="baz"})
+ */',
+            ],
+            ['
+/**
+ * See {@link http://help Help} or {@see BarClass} for details.
+ */'],
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    public function getInvalidConfigurationCases()
+    {
+        return array_merge(parent::getInvalidConfigurationCases(), [
+            [['operator' => 'foo']],
+            [[
+                'operator' => 'foo',
+                'ignored_tags' => [],
+            ]],
+        ]);
+    }
+}


### PR DESCRIPTION
In Doctrine Annotations, you can use `=` or `:` in arrays. This fixer forces the usage of the configured operator:

```diff
 /**
- * @Foo(foo="bar", {bar:"baz"})
+ * @Foo(foo="bar", {bar="baz"})
  */
```