### PR TITLE
Travis - Improve trailing spaces detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
 
 script:
     - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules declare_strict_types,native_function_invocation -q; fi
-    - if [ $TASK_SCA == 1 ]; then files_with_trailing_spaces=`find . -type f -not -path "./.git/*" -not -path "./vendor/*" -not -path "./tests/Fixtures/*" -exec egrep -nH " $" {} \;` && [[ $files_with_trailing_spaces ]] && echo $files_with_trailing_spaces && travis_terminate 1 || echo "No trailing spaces detected."; fi
+    - if [ $TASK_SCA == 1 ]; then ./check_trailing_spaces.sh || travis_terminate 1; fi
 
     - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 0 ]; then vendor/bin/phpunit --verbose; fi
     - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 1 ]; then phpdbg -qrr vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
  * Make changes.
  * If you are adding functionality or fixing a bug - add a test!
  * Fix project itself: `php php-cs-fixer fix`.
+ * Make sure there is no trailing spaces in code: `./check_trailing_spaces.sh`.
  * Regenerate readme: `php php-cs-fixer readme > README.rst`. Do not modify `README.rst` manually!
  * Check if tests pass: `phpunit` [(4.x or 5.x)](https://phpunit.de/manual/current/en/installation.html)
 

--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+files_with_trailing_spaces=$(find . -type f -not -path "./.git/*" -not -path "./vendor/*" -not -path "./tests/Fixtures/*" -exec egrep -nH " $" {} \;)
+
+if [[ $files_with_trailing_spaces ]]
+then
+    echo -e "\e[97;41mTrailing spaces detected:\e[0m"
+    e=$(printf '\033')
+    echo "${files_with_trailing_spaces}" | sed -E "s/^\.\/([^:]+):([0-9]+):(.*[^ ])( +)$/${e}[0;31m - in ${e}[0;33m\1${e}[0;31m at line ${e}[0;33m\2\n   ${e}[0;31m>${e}[0m \3${e}[41m\4${e}[0m/"
+
+    exit 1
+fi
+
+echo -e "\e[0;32mNo trailing spaces detected.\e[0m"


### PR DESCRIPTION
Current output on Travis for detected trailing spaces is not very helpful, this PR:
* improves this output to be more helpful;
* extracts the detection into an executable file so one can run it *before* submitting a PR and waiting for Travis to run the check.
* adds a note about this file in CONTRIBUTING.md.

See Travis builds [with](https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/217751873#L298) and [without](https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/217750986#L300) detected trailing spaces.