### PR TITLE
AbstractFixer: use applyFix instead of fix

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -61,7 +61,7 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
         }
     }
 
-    public function fix(\SplFileInfo $file, Tokens $tokens)
+    final public function fix(\SplFileInfo $file, Tokens $tokens)
     {
         if (0 < $tokens->count() && $this->isCandidate($tokens) && $this->supports($file)) {
             $this->applyFix($file, $tokens);


### PR DESCRIPTION
Stated that:
1. `AbstractFixer` is `@internal`
1. `applyFix` is mandatory
1. Tests pass
1. https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.2.0/doc/COOKBOOK-FIXERS.md#step-1---creating-files

`fix` should be final