### PR TITLE
SemicolonAfterInstructionFixer - Fix case where block ends with an opening curly brace

### DIFF
--- a/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+++ b/src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
@@ -53,7 +53,7 @@ final class SemicolonAfterInstructionFixer extends AbstractFixer
             }
 
             $prev = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$prev]->equalsAny(array(';', '}', ':', array(T_OPEN_TAG)))) {
+            if ($tokens[$prev]->equalsAny(array(';', '{', '}', ':', array(T_OPEN_TAG)))) {
                 continue;
             }
 

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -73,7 +73,12 @@ A is equal to 5
 <?php case 1: ?>
 ...
 <?php endswitch ?>',
-                ),
+            ),
+            array(
+'<?php if ($a == 5) { ?>
+A is equal to 5
+<?php } ?>',
+            ),
         );
     }
 


### PR DESCRIPTION
`<?php if ($x) { ?>` was turned into `<?php if ($x) {; ?>`