### PR TITLE
[WIP] First attempt at solving double indent issue #2650

### DIFF
--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -58,6 +58,8 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens as $index => $token) {
+            $indent = $this->whitespacesConfig->getIndent();
+
             if ($token->isComment()) {
                 $content = preg_replace('/^(?:(?<! ) {1,3})?\t/m', '\1    ', $token->getContent(), -1, $count);
 
@@ -67,7 +69,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
                 }
 
                 // change indent to expected one
-                $content = preg_replace('/^    /m', $this->whitespacesConfig->getIndent(), $content);
+                $content = preg_replace('/^    /m', $indent, $content);
 
                 $tokens[$index]->setContent($content);
                 continue;
@@ -75,10 +77,10 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
 
             if ($token->isWhitespace()) {
                 // normalize mixed indent
-                $content = preg_replace('/(?:(?<! ) {1,3})?\t/', '    ', $token->getContent());
+                $content = preg_replace('/'.$indent.'|(?:(?<! ) {1,3})?\t/', '    ', $token->getContent());
 
                 // change indent to expected one
-                $content = str_replace('    ', $this->whitespacesConfig->getIndent(), $content);
+                $content = str_replace('    ', $indent, $content);
 
                 $tokens[$index]->setContent($content);
             }

--- a/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+++ b/tests/Fixer/Whitespace/IndentationTypeFixerTest.php
@@ -270,4 +270,58 @@ final class IndentationTypeFixerTest extends AbstractFixerTestCase
 
         return $cases;
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideDoubleSpaceCases
+     */
+    public function testDoubleSpace($expected, $input = null)
+    {
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('  '));
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideDoubleSpaceCases()
+    {
+        return array(
+            array(
+                '<?php
+    echo ALPHA;',
+                "<?php
+\t\techo ALPHA;",
+            ),
+            array(
+                '<?php
+  /**
+   * Test that tabs in docblocks are converted to spaces.
+   *
+   * @test
+   *
+   * @return
+   */',
+                "<?php
+\t/**
+\t * Test that tabs in docblocks are converted to spaces.
+\t *
+\t * @test
+\t *
+\t * @return
+\t */",
+            ),
+            // Issue #2650
+            array(
+                '<?php
+switch($myvar) {
+  case 1:
+    echo "Got case 1";
+    break;
+  default:
+    echo "Got default case";
+}',
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Issue: #2650

This is an interesting one, because we can't match just double spaces, because that would break files with four spaces for indentation. I decided to go with the whitespace config value, but I don't think this is a good idea because if a user wanted to change from double space to tabs or four spaces, it wouldn't pick it up correctly.

One solution that could work making indentation_type configurable, and allowing the user to pass in the "from" indentation (e.g. if a user wanted to convert from 2 spaces to 4 spaces: `indentation_type => ['from' => '  ']],` or something like that. Is that a good route to go down? This option would also work for 8 space or more indent (😱)

Thoughts & feedback would be greatly appreciated