### PR TITLE
Fix rule sets overwriting rules defined independently

### DIFF
--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -273,7 +273,7 @@ final class RuleSet implements RuleSetInterface
         $rules = $this->set;
 
         $resolveRulesRecursively = function ($ruleSet, $parentValue) use (&$resolveRulesRecursively) {
-            $parsedRules = [];
+            $parsedRules = array();
 
             foreach ($ruleSet as $name => $value) {
                 $value = $parentValue ? $value : false;


### PR DESCRIPTION
Fixing the issue described in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2543 and https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2680.
Rewritten the resolveSet() method to be more concise by using recursion.