### PR TITLE
Add Behat annotation to ignored annotations for Doctrine fixers

### DIFF
--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -177,7 +177,7 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
                 'BeforeScenario',
                 'AfterScenario',
                 'BeforeStep',
-                'AfterStep'
+                'AfterStep',
 
                  // PHPCheckStyle
                  'SuppressWarnings',

--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -165,6 +165,20 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
                  'ticket',
                  'uses',
 
+                // Behat
+                'Given',
+                'When',
+                'Then',
+                'Transform',
+                'BeforeSuite',
+                'AfterSuite',
+                'BeforeFeature',
+                'AfterFeature',
+                'BeforeScenario',
+                'AfterScenario',
+                'BeforeStep',
+                'AfterStep'
+
                  // PHPCheckStyle
                  'SuppressWarnings',
 


### PR DESCRIPTION
This avoids breaking the Behat annotation when fixing Doctrine annotations