### PR TITLE
Configuration resolvement - Do not fix the same path multiple times.

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -100,7 +100,7 @@ final class ConfigTest extends TestCase
             )
         );
         $this->assertStringMatchesFormat(
-            sprintf('%%ALoaded config custom_config_test from "%s".%%A', $customConfigFile),
+            sprintf('%%ALoaded config custom_config_test from "%s".%%A', realpath($customConfigFile)),
             $commandTester->getDisplay(true)
         );
     }


### PR DESCRIPTION
Detect if the same path has been passed multiple times, either by passing the same value multiple times are using a mix of absolute and relative paths.

We can deal with https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2490 here as well.
There are two calls to make on the PR and than it can be finished.
