### PR TITLE
Deprecate other than "yes" or "no" for input options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 A combination of ``--dry-run`` and ``--diff`` will
 display a summary of proposed fixes, leaving your files unchanged.
 
-The ``--allow-risky`` option (pass `yes` or `no`) allows you to set whether risky rules may run. Default value is taken from config file.
+The ``--allow-risky`` option (pass ``yes`` or ``no``) allows you to set whether risky rules may run. Default value is taken from config file.
 Risky rule is a rule, which could change code behaviour. By default no risky rules are run.
 
 The ``--stop-on-violation`` flag stops execution upon first file that needs to be fixed.
@@ -1180,7 +1180,7 @@ experimental.
         ->setLineEnding("\r\n")
     ;
 
-By using ``--using-cache`` option with `yes` or `no` you can set if the caching
+By using ``--using-cache`` option with ``yes`` or ``no`` you can set if the caching
 mechanism should be used.
 
 Caching

--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 A combination of ``--dry-run`` and ``--diff`` will
 display a summary of proposed fixes, leaving your files unchanged.
 
-The ``--allow-risky`` option allows you to set whether risky rules may run. Default value is taken from config file.
+The ``--allow-risky`` option (pass `yes` or `no`) allows you to set whether risky rules may run. Default value is taken from config file.
 Risky rule is a rule, which could change code behaviour. By default no risky rules are run.
 
 The ``--stop-on-violation`` flag stops execution upon first file that needs to be fixed.
@@ -1180,7 +1180,7 @@ experimental.
         ->setLineEnding("\r\n")
     ;
 
-By using ``--using-cache`` option with yes or no you can set if the caching
+By using ``--using-cache`` option with `yes` or `no` you can set if the caching
 mechanism should be used.
 
 Caching

--- a/src/Console/Command/CommandHelp.php
+++ b/src/Console/Command/CommandHelp.php
@@ -82,7 +82,7 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
 display a summary of proposed fixes, leaving your files unchanged.
 
-The <comment>--allow-risky</comment> option allows you to set whether risky rules may run. Default value is taken from config file.
+The <comment>--allow-risky</comment> option (pass `yes` or `no`) allows you to set whether risky rules may run. Default value is taken from config file.
 Risky rule is a rule, which could change code behaviour. By default no risky rules are run.
 
 The <comment>--stop-on-violation</comment> flag stops execution upon first file that needs to be fixed.
@@ -180,7 +180,7 @@ experimental.
 
     ?>
 
-By using ``--using-cache`` option with yes or no you can set if the caching
+By using ``--using-cache`` option with `yes` or `no` you can set if the caching
 mechanism should be used.
 
 Caching

--- a/src/Console/Command/CommandHelp.php
+++ b/src/Console/Command/CommandHelp.php
@@ -82,7 +82,7 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 A combination of <comment>--dry-run</comment> and <comment>--diff</comment> will
 display a summary of proposed fixes, leaving your files unchanged.
 
-The <comment>--allow-risky</comment> option (pass `yes` or `no`) allows you to set whether risky rules may run. Default value is taken from config file.
+The <comment>--allow-risky</comment> option (pass ``yes`` or ``no``) allows you to set whether risky rules may run. Default value is taken from config file.
 Risky rule is a rule, which could change code behaviour. By default no risky rules are run.
 
 The <comment>--stop-on-violation</comment> flag stops execution upon first file that needs to be fixed.
@@ -180,7 +180,7 @@ experimental.
 
     ?>
 
-By using ``--using-cache`` option with `yes` or `no` you can set if the caching
+By using ``--using-cache`` option with ``yes`` or ``no`` you can set if the caching
 mechanism should be used.
 
 Caching

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -423,10 +423,10 @@ final class ConfigurationResolver
     public function getRiskyAllowed()
     {
         if (null === $this->allowRisky) {
-            if (null !== $this->options['allow-risky']) {
-                $this->allowRisky = 'yes' === $this->options['allow-risky'];
-            } else {
+            if (null === $this->options['allow-risky']) {
                 $this->allowRisky = $this->getConfig()->getRiskyAllowed();
+            } else {
+                $this->allowRisky = $this->resolveOptionBooleanValue('allow-risky');
             }
         }
 
@@ -452,7 +452,7 @@ final class ConfigurationResolver
             if (null === $this->options['using-cache']) {
                 $this->usingCache = $this->getConfig()->getUsingCache();
             } else {
-                $this->usingCache = 'yes' === $this->options['using-cache'];
+                $this->usingCache = $this->resolveOptionBooleanValue('using-cache');
             }
         }
 
@@ -783,5 +783,40 @@ final class ConfigurationResolver
         }
 
         $this->options[$name] = $value;
+    }
+
+    /**
+     * @param string $optionName
+     *
+     * @return bool
+     */
+    private function resolveOptionBooleanValue($optionName)
+    {
+        $value = $this->options[$optionName];
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (!is_string($value)) {
+            throw new InvalidConfigurationException(sprintf('Expected boolean or string value for option "%s".', $optionName));
+        }
+
+        if ('yes' === $value) {
+            return true;
+        }
+
+        if ('no' === $value) {
+            return false;
+        }
+
+        @trigger_error(
+            sprintf(
+                'Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".',
+                $optionName, $value
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return false;
     }
 }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -810,10 +810,7 @@ final class ConfigurationResolver
         }
 
         @trigger_error(
-            sprintf(
-                'Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".',
-                $optionName, $value
-            ),
+            sprintf('Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".', $optionName, $value),
             E_USER_DEPRECATED
         );
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1004,7 +1004,7 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
      * @group legacy
      * @expectedDeprecation Expected "yes" or "no" for option "allow-risky", other values are deprecated and support will be removed in 3.0. Got "yes please", this implicitly set the option to "false".
      */
-    public function testFixme()
+    public function testDeprecationOfPassingOtherThanNoOrYes()
     {
         $resolver = new ConfigurationResolver(
             $this->config,

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -691,56 +691,24 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($resolver->isDryRun());
     }
 
-    public function testResolveUsingCacheWithPositiveConfigAndPositiveOption()
+    /**
+     * @param bool             $expected
+     * @param bool             $configValue
+     * @param bool|string|null $passed
+     *
+     * @dataProvider getResolveBooleanOptions
+     */
+    public function testResolveUsingCacheWithConfigOption($expected, $configValue, $passed)
     {
-        $this->config->setUsingCache(true);
+        $this->config->setUsingCache($configValue);
 
         $resolver = new ConfigurationResolver(
             $this->config,
-            array('using-cache' => 'yes'),
+            array('using-cache' => $passed),
             ''
         );
 
-        $this->assertTrue($resolver->getUsingCache());
-    }
-
-    public function testResolveUsingCacheWithPositiveConfigAndNegativeOption()
-    {
-        $this->config->setUsingCache(true);
-
-        $resolver = new ConfigurationResolver(
-            $this->config,
-            array('using-cache' => 'no'),
-            ''
-        );
-
-        $this->assertFalse($resolver->getUsingCache());
-    }
-
-    public function testResolveUsingCacheWithNegativeConfigAndPositiveOption()
-    {
-        $this->config->setUsingCache(false);
-
-        $resolver = new ConfigurationResolver(
-            $this->config,
-            array('using-cache' => 'yes'),
-            ''
-        );
-
-        $this->assertTrue($resolver->getUsingCache());
-    }
-
-    public function testResolveUsingCacheWithNegativeConfigAndNegativeOption()
-    {
-        $this->config->setUsingCache(false);
-
-        $resolver = new ConfigurationResolver(
-            $this->config,
-            array('using-cache' => 'no'),
-            ''
-        );
-
-        $this->assertFalse($resolver->getUsingCache());
+        $this->assertSame($expected, $resolver->getUsingCache());
     }
 
     public function testResolveUsingCacheWithPositiveConfigAndNoOption()
@@ -828,30 +796,24 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($optionCacheFile, $resolver->getCacheFile());
     }
 
-    public function testResolveAllowRiskyWithPositiveConfigAndPositiveOption()
+    /**
+     * @param bool             $expected
+     * @param bool             $configValue
+     * @param bool|string|null $passed
+     *
+     * @dataProvider getResolveBooleanOptions
+     */
+    public function testResolveAllowRiskyWithConfigOption($expected, $configValue, $passed)
     {
-        $this->config->setRiskyAllowed(true);
+        $this->config->setRiskyAllowed($configValue);
 
         $resolver = new ConfigurationResolver(
             $this->config,
-            array('allow-risky' => 'yes'),
+            array('allow-risky' => $passed),
             ''
         );
 
-        $this->assertTrue($resolver->getRiskyAllowed());
-    }
-
-    public function testResolveAllowRiskyWithPositiveConfigAndNegativeOption()
-    {
-        $this->config->setRiskyAllowed(true);
-
-        $resolver = new ConfigurationResolver(
-            $this->config,
-            array('allow-risky' => 'no'),
-            ''
-        );
-
-        $this->assertFalse($resolver->getRiskyAllowed());
+        $this->assertSame($expected, $resolver->getRiskyAllowed());
     }
 
     public function testResolveAllowRiskyWithNegativeConfigAndPositiveOption()
@@ -1036,6 +998,37 @@ final class ConfigurationResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($resolver->getUsingCache());
         $this->assertNull($resolver->getCacheFile());
         $this->assertSame('xml', $resolver->getReporter()->getFormat());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Expected "yes" or "no" for option "allow-risky", other values are deprecated and support will be removed in 3.0. Got "yes please", this implicitly set the option to "false".
+     */
+    public function testFixme()
+    {
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array('allow-risky' => 'yes please'),
+            ''
+        );
+
+        $this->assertFalse($resolver->getRiskyAllowed());
+    }
+
+    public function getResolveBooleanOptions()
+    {
+        return array(
+            array(true, true, 'yes'),
+            array(true, true, true),
+            array(true, false, 'yes'),
+            array(true, false, true),
+            array(false, true, 'no'),
+            array(false, true, false),
+            array(false, false, 'no'),
+            array(false, false, false),
+            array(true, true, null),
+            array(false, false, null),
+        );
     }
 
     private function assertSameRules(array $expected, array $actual, $message = '')


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2585

Deprecate values other than "yes" and "no" for `--allow-risky` and `--using-cache`.