### PR TITLE
Add PhpUnitTestClassRequiresCoversFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -30,6 +30,7 @@ return PhpCsFixer\Config::create()
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'php_unit_strict' => true,
+        'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
         'semicolon_after_instruction' => true,

--- a/README.rst
+++ b/README.rst
@@ -820,6 +820,10 @@ Choose from the list of available rules:
     ``['assertAttributeEquals', 'assertAttributeNotEquals', 'assertEquals',
     'assertNotEquals']``
 
+* **php_unit_test_class_requires_covers**
+
+  PHPUnit test class requires any of ``covers*`` annotation.
+
 * **phpdoc_add_missing_param_annotation**
 
   Phpdoc should contain @param for all params.

--- a/README.rst
+++ b/README.rst
@@ -822,7 +822,8 @@ Choose from the list of available rules:
 
 * **php_unit_test_class_requires_covers**
 
-  PHPUnit test class requires any of ``covers*`` annotation.
+  Adds a default ``@coversNothing`` annotation to PHPUnit test classes that
+  have no ``@covers*`` annotation.
 
 * **phpdoc_add_missing_param_annotation**
 

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -79,7 +79,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
                 ? (
                     false !== strpos($tokens[$index - 1]->getContent(), "\n")
-                    ? preg_replace('/^.*\v*/', '', $tokens[$index - 1]->getContent())
+                    ? preg_replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
                     : $tokens[$index - 1]->getContent()
                 )
                 : '';

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -24,8 +24,6 @@ use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
- *
- * @tofo Before revealing feature let wait for https://github.com/sebastianbergmann/phpunit/pull/2560
  */
 final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
 {

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -74,7 +74,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             }
 
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            $index = $tokens[$prevIndex]->isGivenKind(array(T_FINAL, T_ABSTRACT)) ? $prevIndex : $index;
+            $index = $tokens[$prevIndex]->isGivenKind(T_FINAL) ? $prevIndex : $index;
 
             $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
                 ? (

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @tofo Before revealing feature let wait for https://github.com/sebastianbergmann/phpunit/pull/2560
+ */
+final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'PHPUnit test class requires any of `covers*` annotation.',
+            array(
+                new CodeSample(
+'<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSomeTest()
+    {
+        $this->assertSame(a(), b());
+    }
+}
+'
+                ),
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $phpUnitIndicator = new PhpUnitIndicator();
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            if (!$phpUnitIndicator->isPhpUnitClass($tokens, $index)) {
+                continue;
+            }
+
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            $index = $tokens[$prevIndex]->isGivenKind(array(T_FINAL, T_ABSTRACT)) ? $prevIndex : $index;
+
+            $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
+                ? (
+                    false !== strpos($tokens[$index - 1]->getContent(), "\n")
+                    ? preg_replace('/^.*\v*/', '', $tokens[$index - 1]->getContent())
+                    : $tokens[$index - 1]->getContent()
+                )
+                : '';
+
+            $prevIndex = $tokens->getPrevNonWhitespace($index);
+            $doc = null;
+            $docIndex = null;
+
+            if ($tokens[$prevIndex]->isGivenKind(T_DOC_COMMENT)) {
+                $docIndex = $prevIndex;
+                $docContent = $tokens[$docIndex]->getContent();
+
+                // ignore one-line phpdocs like `/** foo */`, as there is no place to put new annotations
+                if (false === strpos($docContent, "\n")) {
+                    continue;
+                }
+
+                $doc = new DocBlock($docContent);
+
+                // skip if already has annotation
+                if (!empty($doc->getAnnotationsOfType(array(
+                    'covers',
+                    'coversDefaultClass',
+                    'coversNothing',
+                )))) {
+                    continue;
+                }
+            } else {
+                $docIndex = $index;
+                $tokens->insertAt($docIndex, array(
+                    new Token(array(T_DOC_COMMENT, sprintf('/**%s%s */', $this->whitespacesConfig->getLineEnding(), $indent))),
+                    new Token(array(T_WHITESPACE, sprintf('%s%s', $this->whitespacesConfig->getLineEnding(), $indent))),
+                ));
+
+                if (!$tokens[$docIndex - 1]->isGivenKind(T_WHITESPACE)) {
+                    $extraNewLines = $this->whitespacesConfig->getLineEnding();
+
+                    if (!$tokens[$docIndex - 1]->isGivenKind(T_OPEN_TAG)) {
+                        $extraNewLines .= $this->whitespacesConfig->getLineEnding();
+                    }
+
+                    $tokens->insertAt($docIndex, array(
+                        new Token(array(T_WHITESPACE, $extraNewLines.$indent)),
+                    ));
+                    ++$docIndex;
+                }
+
+                $doc = new DocBlock($tokens[$docIndex]->getContent());
+            }
+
+            $lines = $doc->getLines();
+            array_splice(
+                $lines,
+                count($lines) - 1,
+                0,
+                array(
+                    new Line(sprintf(
+                        '%s * @coversNothing%s',
+                        $indent,
+                        $this->whitespacesConfig->getLineEnding()
+                    )),
+                )
+            );
+
+            $tokens[$docIndex]->setContent(implode('', $lines));
+        }
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -34,7 +34,7 @@ final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer implements
     {
         return new FixerDefinition(
             'Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.',
-            array(
+            [
                 new CodeSample(
 '<?php
 final class MyTest extends \PHPUnit_Framework_TestCase
@@ -46,7 +46,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 }
 '
                 ),
-            )
+            ]
         );
     }
 
@@ -97,19 +97,19 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 $doc = new DocBlock($docContent);
 
                 // skip if already has annotation
-                if (!empty($doc->getAnnotationsOfType(array(
+                if (!empty($doc->getAnnotationsOfType([
                     'covers',
                     'coversDefaultClass',
                     'coversNothing',
-                )))) {
+                ]))) {
                     continue;
                 }
             } else {
                 $docIndex = $index;
-                $tokens->insertAt($docIndex, array(
-                    new Token(array(T_DOC_COMMENT, sprintf('/**%s%s */', $this->whitespacesConfig->getLineEnding(), $indent))),
-                    new Token(array(T_WHITESPACE, sprintf('%s%s', $this->whitespacesConfig->getLineEnding(), $indent))),
-                ));
+                $tokens->insertAt($docIndex, [
+                    new Token([T_DOC_COMMENT, sprintf('/**%s%s */', $this->whitespacesConfig->getLineEnding(), $indent)]),
+                    new Token([T_WHITESPACE, sprintf('%s%s', $this->whitespacesConfig->getLineEnding(), $indent)]),
+                ]);
 
                 if (!$tokens[$docIndex - 1]->isGivenKind(T_WHITESPACE)) {
                     $extraNewLines = $this->whitespacesConfig->getLineEnding();
@@ -118,9 +118,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                         $extraNewLines .= $this->whitespacesConfig->getLineEnding();
                     }
 
-                    $tokens->insertAt($docIndex, array(
-                        new Token(array(T_WHITESPACE, $extraNewLines.$indent)),
-                    ));
+                    $tokens->insertAt($docIndex, [
+                        new Token([T_WHITESPACE, $extraNewLines.$indent]),
+                    ]);
                     ++$docIndex;
                 }
 
@@ -132,13 +132,13 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 $lines,
                 count($lines) - 1,
                 0,
-                array(
+                [
                     new Line(sprintf(
                         '%s * @coversNothing%s',
                         $indent,
                         $this->whitespacesConfig->getLineEnding()
                     )),
-                )
+                ]
             );
 
             $tokens[$docIndex]->setContent(implode('', $lines));

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -77,11 +77,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $index = $tokens[$prevIndex]->isGivenKind(T_FINAL) ? $prevIndex : $index;
 
             $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
-                ? (
-                    false !== strpos($tokens[$index - 1]->getContent(), "\n")
-                    ? preg_replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
-                    : $tokens[$index - 1]->getContent()
-                )
+                ? preg_replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
                 : '';
 
             $prevIndex = $tokens->getPrevNonWhitespace($index);

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -64,6 +64,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $phpUnitIndicator = new PhpUnitIndicator();
+
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
             if (!$tokens[$index]->isGivenKind(T_CLASS)) {
                 continue;

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -33,7 +33,7 @@ final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer implements
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPUnit test class requires any of `covers*` annotation.',
+            'Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.',
             array(
                 new CodeSample(
 '<?php

--- a/src/Indicator/PhpUnitIndicator.php
+++ b/src/Indicator/PhpUnitIndicator.php
@@ -36,7 +36,7 @@ final class PhpUnitIndicator
             return true;
         }
 
-        $braceIndex = $tokens->getNextTokenOfKind($index, array('{'));
+        $braceIndex = $tokens->getNextTokenOfKind($index, ['{']);
         $maybeParentSubNameToken = $tokens[$tokens->getPrevMeaningfulToken($braceIndex)];
 
         if (

--- a/src/Indicator/PhpUnitIndicator.php
+++ b/src/Indicator/PhpUnitIndicator.php
@@ -21,6 +21,10 @@ final class PhpUnitIndicator
 {
     public function isPhpUnitClass(Tokens $tokens, $index)
     {
+        if (!$tokens[$index]->isGivenKind(T_CLASS)) {
+            throw new \LogicException(sprintf('No T_CLASS at given index %d, got %s.', $index, $tokens[$index]->getName()));
+        }
+
         $prevIndex = $tokens->getPrevMeaningfulToken($index);
 
         if ($tokens[$prevIndex]->isGivenKind(T_ABSTRACT)) {

--- a/src/Indicator/PhpUnitIndicator.php
+++ b/src/Indicator/PhpUnitIndicator.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Indicator;
+
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ */
+final class PhpUnitIndicator
+{
+    public function isPhpUnitClass(Tokens $tokens, $index)
+    {
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
+        if ($tokens[$prevIndex]->isGivenKind(T_ABSTRACT)) {
+            return false;
+        }
+
+        $classNameIndex = $tokens->getNextMeaningfulToken($index);
+        if (0 !== preg_match('/(?:Test|TestCase)$/', $tokens[$classNameIndex]->getContent())) {
+            return true;
+        }
+
+        $braceIndex = $tokens->getNextTokenOfKind($index, array('{'));
+        $maybeParentSubNameToken = $tokens[$tokens->getPrevMeaningfulToken($braceIndex)];
+
+        if (
+            $maybeParentSubNameToken->isGivenKind(T_STRING) &&
+            0 !== preg_match('/(?:Test|TestCase)$/', $maybeParentSubNameToken->getContent())
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -54,6 +54,7 @@ final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
         \PhpCsFixer\Fixer\Operator\AlignDoubleArrowFixerHelper::class,
         \PhpCsFixer\Fixer\Operator\AlignEqualsFixerHelper::class,
         \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer::class,
+        \PhpCsFixer\Indicator\PhpUnitIndicator::class,
         \PhpCsFixer\Linter\LintingException::class,
         \PhpCsFixer\Linter\ProcessLintingResult::class,
         \PhpCsFixer\Linter\TokenizerLintingResult::class,

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -37,11 +37,6 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
     public function provideFixCases()
     {
         return array(
-            'abstract test class' => array(
-                '<?php
-                    abstract class FooTest extends \PHPUnit_Framework_TestCase {}
-                ',
-            ),
             'already with annotation: @covers' => array(
                 '<?php
                     /**
@@ -54,14 +49,6 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                 '<?php
                     /**
                      * @coversDefaultClass
-                     */
-                    class FooTest extends \PHPUnit_Framework_TestCase {}
-                ',
-            ),
-            'already with annotation: @coversNothing' => array(
-                '<?php
-                    /**
-                     * @coversNothing
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
@@ -79,30 +66,22 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
             ),
-            'without docblock #2' => array(
+            'without docblock #2 (class is final)' => array(
                 '<?php
 
                     /**
                      * @coversNothing
                      */
-                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
                 '<?php
 
-                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
             ),
-            'without docblock #3 (class is final)' => array(
+            'without docblock #2 (class is abstract)' => array(
                 '<?php
-
-                    /**
-                     * @coversNothing
-                     */
-                    final class FooTest extends \PHPUnit_Framework_TestCase {}
-                ',
-                '<?php
-
-                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                    abstract class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
             ),
             'with docblock but annotation is missing' => array(

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitTestClassRequiresCoversFixer
+ */
+final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            'abstract test class' => array(
+                '<?php
+                    abstract class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'already with annotation: @covers' => array(
+                '<?php
+                    /**
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'already with annotation: @coversDefaultClass' => array(
+                '<?php
+                    /**
+                     * @coversDefaultClass
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'already with annotation: @coversNothing' => array(
+                '<?php
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'without docblock #1' => array(
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'without docblock #2' => array(
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'without docblock #3 (class is final)' => array(
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'with docblock but annotation is missing' => array(
+                '<?php
+
+                    /**
+                     * Description.
+                     *
+                     * @since v2.2
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /**
+                     * Description.
+                     *
+                     * @since v2.2
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'with one-line docblock but annotation is missing' => array(
+                '<?php
+
+                    /** Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'with 2-lines docblock but annotation is missing #1' => array(
+                '<?php
+
+                    /** Description.
+                     * @coversNothing
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /** Description.
+                     */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'with 2-lines docblock but annotation is missing #2' => array(
+                '<?php
+
+                    /**
+                     * @coversNothing
+                     * Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+
+                    /**
+                     * Description. */
+                    final class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'with comment instead of docblock' => array(
+                '<?php
+                    /*
+                     * @covers Foo
+                     */
+                    /**
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+                    /*
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ),
+            'not a test class' => array(
+                '<?php
+
+                    class Foo {}
+                ',
+            ),
+            'multiple classes in one file' => array(
+                '<?php /** */
+
+                    use \PHPUnit\Framework\TestCase;
+
+                    /**
+                     * Foo
+                     * @coversNothing
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+
+                    class Bar {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz1 extends PHPUnit_Framework_TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz2 extends \PHPUnit_Framework_TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz3 extends \PHPUnit\Framework\TestCase {}
+
+                    /**
+                     * @coversNothing
+                     */
+                    class Baz4 extends TestCase {}
+                ',
+                '<?php /** */
+
+                    use \PHPUnit\Framework\TestCase;
+
+                    /**
+                     * Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+
+                    class Bar {}
+
+                    class Baz1 extends PHPUnit_Framework_TestCase {}
+
+                    class Baz2 extends \PHPUnit_Framework_TestCase {}
+
+                    class Baz3 extends \PHPUnit\Framework\TestCase {}
+
+                    class Baz4 extends TestCase {}
+                ',
+            ),
+        );
+    }
+}

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -36,24 +36,24 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
 
     public function provideFixCases()
     {
-        return array(
-            'already with annotation: @covers' => array(
+        return [
+            'already with annotation: @covers' => [
                 '<?php
                     /**
                      * @covers Foo
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'already with annotation: @coversDefaultClass' => array(
+            ],
+            'already with annotation: @coversDefaultClass' => [
                 '<?php
                     /**
                      * @coversDefaultClass
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'without docblock #1' => array(
+            ],
+            'without docblock #1' => [
                 '<?php
 
                     /**
@@ -65,8 +65,8 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
 
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'without docblock #2 (class is final)' => array(
+            ],
+            'without docblock #2 (class is final)' => [
                 '<?php
 
                     /**
@@ -78,13 +78,13 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
 
                     final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'without docblock #2 (class is abstract)' => array(
+            ],
+            'without docblock #2 (class is abstract)' => [
                 '<?php
                     abstract class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'with docblock but annotation is missing' => array(
+            ],
+            'with docblock but annotation is missing' => [
                 '<?php
 
                     /**
@@ -104,15 +104,15 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                      */
                     final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'with one-line docblock but annotation is missing' => array(
+            ],
+            'with one-line docblock but annotation is missing' => [
                 '<?php
 
                     /** Description. */
                     final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'with 2-lines docblock but annotation is missing #1' => array(
+            ],
+            'with 2-lines docblock but annotation is missing #1' => [
                 '<?php
 
                     /** Description.
@@ -126,8 +126,8 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                      */
                     final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'with 2-lines docblock but annotation is missing #2' => array(
+            ],
+            'with 2-lines docblock but annotation is missing #2' => [
                 '<?php
 
                     /**
@@ -141,8 +141,8 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                      * Description. */
                     final class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'with comment instead of docblock' => array(
+            ],
+            'with comment instead of docblock' => [
                 '<?php
                     /*
                      * @covers Foo
@@ -158,14 +158,14 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
-            ),
-            'not a test class' => array(
+            ],
+            'not a test class' => [
                 '<?php
 
                     class Foo {}
                 ',
-            ),
-            'multiple classes in one file' => array(
+            ],
+            'multiple classes in one file' => [
                 '<?php /** */
 
                     use \PHPUnit\Framework\TestCase;
@@ -217,7 +217,7 @@ final class PhpUnitTestClassRequiresCoversFixerTest extends AbstractFixerTestCas
 
                     class Baz4 extends TestCase {}
                 ',
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @author SpacePossum
  *
  * @internal
+ *
+ * @coversNothing
  */
 final class TextDiffTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
I originally used slightly modified version to add `@covers \Foo` annotations, but it wasn't generic enough to work for all cases. Here, generic version to ensure that any of those annotation is present