### PR TITLE
FixCommand - fix diff optional value handling

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -133,7 +133,7 @@ final class FixCommand extends Command
                 'using-cache' => $input->getOption('using-cache'),
                 'cache-file' => $input->getOption('cache-file'),
                 'format' => $input->getOption('format'),
-                'diff' => $input->getOption('diff'),
+                'diff' => $input->hasParameterOption('--diff') ? $input->getOption('diff') : null,
                 'stop-on-violation' => $input->getOption('stop-on-violation'),
                 'verbosity' => $verbosity,
                 'show-progress' => $input->getOption('show-progress'),


### PR DESCRIPTION
regression fix for #2554:
```php
new InputOption('diff', '', InputOption::VALUE_OPTIONAL, 'Also produce diff for each file.', 'sbd'),
```
that means:
- 'diff' option may or may not be passed
- when it's passed, value for it is optional
- 'sbd' is default value of `diff` option regardless it is passed or not (!!!)

I guess assumption during creating 2254 was that `sbd` would be only a value for `diff` if one would pass `--diff` (without value). Apparently, it is a value even if one would not pass that option at all, leading to generate diff even without using `--diff` option.

ref https://github.com/symfony/symfony/issues/11572