### PR TITLE
Remove needlessly strict PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || >=7.0 <7.2",
+        "php": ">=5.6",
         "doctrine/annotations": "^1.2",
         "ext-tokenizer": "*",
         "sebastian/diff": "^1.4",


### PR DESCRIPTION
There's no reason to restrict the upper version of PHP, this only makes testing on newer PHP versions harder, see e.g. https://travis-ci.org/amphp/amp/jobs/225272947#L854.