### PR TITLE
HeaderCommentFixer - fix handling blank lines

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -298,6 +298,11 @@ echo 1;
                 } else {
                     $tokens->insertAt($headerIndex + 1, new Token(array(T_WHITESPACE, $missing)));
                 }
+            } elseif ($lineBreakCount > 2) {
+                // remove extra line endings
+                if ($tokens[$headerIndex + 1]->isWhitespace()) {
+                    $tokens[$headerIndex + 1]->setContent($lineEnding.$lineEnding);
+                }
             }
         }
 

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -266,22 +266,43 @@ echo \'bar\';',
                 '<?php echo \'bar\';',
             ),
             array(
-                array('header' => 'Toe'),
+                array('header' => 'x'),
                 '<?php
 
 /*
- * Toe
+ * x
  */
 
-echo \'bar\';',
+echo \'a\';',
                 '<?php
 
 /*
- * Tic
- * Tac
+ * y
+ * z
  */
 
-echo \'bar\';',
+echo \'a\';',
+            ),
+            array(
+                array('header' => "a\na"),
+                '<?php
+
+/*
+ * a
+ * a
+ */
+
+echo \'x\';',
+                '<?php
+
+
+/*
+ * b
+ * c
+ */
+
+
+echo \'x\';',
             ),
         );
     }

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -265,6 +265,24 @@ echo 1;',
 echo \'bar\';',
                 '<?php echo \'bar\';',
             ),
+            array(
+                array('header' => 'Toe'),
+                '<?php
+
+/*
+ * Toe
+ */
+
+echo \'bar\';',
+                '<?php
+
+/*
+ * Tic
+ * Tac
+ */
+
+echo \'bar\';',
+            ),
         );
     }
 


### PR DESCRIPTION
Try to resolve issue #2730.
Remove every extra line endings after the header_comment.