### PR TITLE
Add VoidReturnFixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
     - composer info -D | sort
 
 script:
-    - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules @PHP70Migration:risky,@PHP71Migration,native_function_invocation -q; fi
+    - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,native_function_invocation -q; fi
     - if [ $TASK_SCA == 1 ]; then ./check_trailing_spaces.sh || travis_terminate 1; fi
 
     - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 0 ]; then vendor/bin/phpunit --verbose; fi

--- a/README.rst
+++ b/README.rst
@@ -1116,8 +1116,8 @@ Choose from the list of available rules:
 * **void_return** [@PHP71Migration:risky]
 
   Add void return type to functions with missing or empty return
-  statements, but priority is given to ``@return`` annotations. Requires PHP
-  >= 7.1.
+  statements, but priority is given to ``@return`` annotations. Requires
+  PHP >= 7.1.
 
   *Risky rule: modifies the signature of functions.*
 

--- a/README.rst
+++ b/README.rst
@@ -299,7 +299,7 @@ Choose from the list of available rules:
   - ``space`` (``'none'``, ``'single'``): spacing to apply around the equal sign;
     defaults to ``'none'``
 
-* **declare_strict_types** [@PHP70Migration:risky]
+* **declare_strict_types** [@PHP70Migration:risky, @PHP71Migration:risky]
 
   Force strict types declaration in all files. Requires PHP >= 7.0.
 
@@ -1112,6 +1112,14 @@ Choose from the list of available rules:
 
   - ``elements`` (``array``): the structural elements to fix (PHP >= 7.1 required
     for ``const``); defaults to ``['property', 'method']``
+
+* **void_return** [@PHP71Migration:risky]
+
+  Add void return type to functions with missing or empty return
+  statements, but priority is given to ``@return`` annotations. Requires PHP
+  >= 7.1.
+
+  *Risky rule: modifies the signature of functions.*
 
 * **whitespace_after_comma_in_array** [@Symfony]
 

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -98,7 +98,7 @@ final class VoidReturnFixer extends AbstractFixer
                 continue;
             }
 
-            if (!$tokens[$startIndex]->equals('{')) {
+            if ($tokens[$startIndex]->equals(';')) {
                 // No function body defined, fallback to PHPDoc.
                 if ($this->hasVoidReturnAnnotation($tokens, $index)) {
                     $this->fixFunctionDefinition($tokens, $startIndex);
@@ -120,7 +120,7 @@ final class VoidReturnFixer extends AbstractFixer
     }
 
     /**
-     * Determine if there is a non-void return annotation in the function's PHPDoc comment.
+     * Determine whether there is a non-void return annotation in the function's PHPDoc comment.
      *
      * @param Tokens $tokens
      * @param int    $index  The index of the function token
@@ -130,8 +130,7 @@ final class VoidReturnFixer extends AbstractFixer
     private function hasReturnAnnotation(Tokens $tokens, $index)
     {
         foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
-            $types = $return->getTypes();
-            if (count($types) > 1 || 'void' !== $types[0]) {
+            if (['void'] !== $return->getTypes()) {
                 return true;
             }
         }
@@ -140,7 +139,7 @@ final class VoidReturnFixer extends AbstractFixer
     }
 
     /**
-     * Determine if there is a void return annotation in the function's PHPDoc comment.
+     * Determine whether there is a void return annotation in the function's PHPDoc comment.
      *
      * @param Tokens $tokens
      * @param int    $index  The index of the function token
@@ -150,8 +149,7 @@ final class VoidReturnFixer extends AbstractFixer
     private function hasVoidReturnAnnotation(Tokens $tokens, $index)
     {
         foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
-            $types = $return->getTypes();
-            if (1 === count($types) && 'void' === $types[0]) {
+            if (['void'] === $return->getTypes()) {
                 return true;
             }
         }
@@ -160,7 +158,7 @@ final class VoidReturnFixer extends AbstractFixer
     }
 
     /**
-     * Determine the function already has a return type hint.
+     * Determine whether the function already has a return type hint.
      *
      * @param Tokens $tokens
      * @param int    $index  The index of the end of the function definition line, EG at { or ;
@@ -176,7 +174,7 @@ final class VoidReturnFixer extends AbstractFixer
     }
 
     /**
-     * Determine if the function has a void return.
+     * Determine whether the function has a void return.
      *
      * @param Tokens $tokens
      * @param int    $startIndex Start of function body
@@ -188,15 +186,16 @@ final class VoidReturnFixer extends AbstractFixer
     {
         for ($i = $startIndex; $i < $endIndex; ++$i) {
             if ($tokens[$i]->isGivenKind(T_YIELD)) {
-                return false; // Do not apply fix as generators cannot return void.
+                return false; // Generators cannot return void.
             }
+
             if (!$tokens[$i]->isGivenKind(T_RETURN)) {
                 continue;
             }
 
             $nextToken = $tokens->getNextMeaningfulToken($i);
             if (!$tokens[$nextToken]->equals(';')) {
-                return false; // Do not apply fix, non-empty return statement found.
+                return false;
             }
         }
 

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\FunctionNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Mark Nielsen
+ */
+final class VoidReturnFixer extends AbstractFixer
+{
+    /**
+     * @internal
+     */
+    const VOID_RETURN_PATTERN = '/@return\s+void(?!\|)/';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Add void return type to functions with missing or empty return statements, but priority is given to `@return` annotations. Requires PHP >= 7.1.',
+            [
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction foo(\$a) {};",
+                    new VersionSpecification(70100)
+                ),
+            ],
+            'Rule is applied only in a PHP 7.1+ environment.',
+            'Modifies the signature of functions.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must run before ReturnTypeDeclarationFixer and PhpdocNoEmptyReturnFixer
+        return 15;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return PHP_VERSION_ID >= 70100 && $tokens->isTokenKindFound(T_FUNCTION);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        // These cause syntax errors.
+        static $blacklistFuncNames = [
+            [T_STRING, '__construct'],
+            [T_STRING, '__destruct'],
+            [T_STRING, '__clone'],
+        ];
+
+        for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $funcName = $tokens->getNextMeaningfulToken($index);
+            if ($tokens[$funcName]->equalsAny($blacklistFuncNames, false)) {
+                continue;
+            }
+
+            $startIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
+
+            if ($this->hasReturnTypeHint($tokens, $startIndex)) {
+                continue;
+            }
+
+            if (!$tokens[$startIndex]->equals('{')) {
+                // No function body defined, fallback to PHPDoc.
+                if ($this->hasVoidReturnAnnotation($tokens, $index)) {
+                    $this->fixFunctionDefinition($tokens, $startIndex);
+                }
+
+                continue;
+            }
+
+            if ($this->hasReturnAnnotation($tokens, $index)) {
+                continue;
+            }
+
+            $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $startIndex);
+
+            if ($this->hasVoidReturn($tokens, $startIndex, $endIndex)) {
+                $this->fixFunctionDefinition($tokens, $startIndex);
+            }
+        }
+    }
+
+    /**
+     * Determine if there is a non-void return annotation in the function's PHPDoc comment.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  The index of the function token
+     *
+     * @return bool
+     */
+    private function hasReturnAnnotation(Tokens $tokens, $index)
+    {
+        foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
+            if (0 === preg_match(self::VOID_RETURN_PATTERN, $return->getContent())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if there is a void return annotation in the function's PHPDoc comment.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  The index of the function token
+     *
+     * @return bool
+     */
+    private function hasVoidReturnAnnotation(Tokens $tokens, $index)
+    {
+        foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
+            if (1 === preg_match(self::VOID_RETURN_PATTERN, $return->getContent())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine the function already has a return type hint.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  The index of the end of the function definition line, EG at { or ;
+     *
+     * @return bool
+     */
+    private function hasReturnTypeHint(Tokens $tokens, $index)
+    {
+        $endFuncIndex = $tokens->getPrevTokenOfKind($index, [')']);
+        $nextIndex = $tokens->getNextMeaningfulToken($endFuncIndex);
+
+        return $tokens[$nextIndex]->equals([CT::T_TYPE_COLON, ':']);
+    }
+
+    /**
+     * Determine if the function has a void return.
+     *
+     * @param Tokens $tokens
+     * @param int    $startIndex Start of function body
+     * @param int    $endIndex   End of function body
+     *
+     * @return bool
+     */
+    private function hasVoidReturn(Tokens $tokens, $startIndex, $endIndex)
+    {
+        for ($i = $startIndex; $i < $endIndex; ++$i) {
+            if ($tokens[$i]->isGivenKind(T_YIELD)) {
+                return false; // Do not apply fix as generators cannot return void.
+            }
+            if (!$tokens[$i]->isGivenKind(T_RETURN)) {
+                continue;
+            }
+
+            $nextToken = $tokens->getNextMeaningfulToken($i);
+            if (!$tokens[$nextToken]->equals(';')) {
+                return false; // Do not apply fix, non-empty return statement found.
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Apply the fix to the function definition.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  The index of the end of the function definition line, EG at { or ;
+     */
+    private function fixFunctionDefinition(Tokens $tokens, $index)
+    {
+        $endFuncIndex = $tokens->getPrevTokenOfKind($index, [')']);
+        $tokens->insertAt($endFuncIndex + 1, [
+            new Token([CT::T_TYPE_COLON, ':']),
+            new Token([T_WHITESPACE, ' ']),
+            new Token([T_STRING, 'void']),
+        ]);
+    }
+
+    /**
+     * Find all the return annotations in the function's PHPDoc comment.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  The index of the function token
+     *
+     * @return Annotation[]
+     */
+    private function findReturnAnnotations(Tokens $tokens, $index)
+    {
+        do {
+            $index = $tokens->getPrevNonWhitespace($index);
+        } while ($tokens[$index]->isGivenKind([
+            T_ABSTRACT,
+            T_FINAL,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_PUBLIC,
+            T_STATIC,
+        ]));
+
+        if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
+            return [];
+        }
+
+        $doc = new DocBlock($tokens[$index]->getContent());
+
+        return $doc->getAnnotationsOfType('return');
+    }
+}

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -28,11 +28,6 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class VoidReturnFixer extends AbstractFixer
 {
     /**
-     * @internal
-     */
-    const VOID_RETURN_PATTERN = '/@return\s+void(?!\|)/';
-
-    /**
      * {@inheritdoc}
      */
     public function getDefinition()
@@ -135,7 +130,8 @@ final class VoidReturnFixer extends AbstractFixer
     private function hasReturnAnnotation(Tokens $tokens, $index)
     {
         foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
-            if (0 === preg_match(self::VOID_RETURN_PATTERN, $return->getContent())) {
+            $types = $return->getTypes();
+            if (count($types) > 1 || 'void' !== $types[0]) {
                 return true;
             }
         }
@@ -154,7 +150,8 @@ final class VoidReturnFixer extends AbstractFixer
     private function hasVoidReturnAnnotation(Tokens $tokens, $index)
     {
         foreach ($this->findReturnAnnotations($tokens, $index) as $return) {
-            if (1 === preg_match(self::VOID_RETURN_PATTERN, $return->getContent())) {
+            $types = $return->getTypes();
+            if (1 === count($types) && 'void' === $types[0]) {
                 return true;
             }
         }

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -45,7 +45,7 @@ final class VoidReturnFixer extends AbstractFixer
                     new VersionSpecification(70100)
                 ),
             ],
-            'Rule is applied only in a PHP 7.1+ environment.',
+            null,
             'Modifies the signature of functions.'
         );
     }
@@ -175,7 +175,7 @@ final class VoidReturnFixer extends AbstractFixer
         $endFuncIndex = $tokens->getPrevTokenOfKind($index, [')']);
         $nextIndex = $tokens->getNextMeaningfulToken($endFuncIndex);
 
-        return $tokens[$nextIndex]->equals([CT::T_TYPE_COLON, ':']);
+        return $tokens[$nextIndex]->isGivenKind(CT::T_TYPE_COLON);
     }
 
     /**

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -193,8 +193,8 @@ final class VoidReturnFixer extends AbstractFixer
                 continue;
             }
 
-            $nextToken = $tokens->getNextMeaningfulToken($i);
-            if (!$tokens[$nextToken]->equals(';')) {
+            $i = $tokens->getNextMeaningfulToken($i);
+            if (!$tokens[$i]->equals(';')) {
                 return false;
             }
         }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -173,6 +173,10 @@ final class RuleSet implements RuleSetInterface
                 'property',
             ],
         ],
+        '@PHP71Migration:risky' => [
+            '@PHP70Migration:risky' => true,
+            'void_return' => true,
+        ],
     ];
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -166,6 +166,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['function_to_constant'], $fixers['no_whitespace_in_blank_line']], // tested also in: function_to_constant,no_whitespace_in_blank_line.test
             [$fixers['list_syntax'], $fixers['binary_operator_spaces']], // tested also in: list_syntax,binary_operator_spaces.test
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']], // tested also in: list_syntax,ternary_operator_spaces.test
+            [$fixers['void_return'], $fixers['return_type_declaration']], // tested also in: void_return,return_type_declaration.test
+            [$fixers['void_return'], $fixers['phpdoc_no_empty_return']], // tested also in: void_return,phpdoc_no_empty_return.test
         ];
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
+
+use PhpCsFixer\Test\AbstractFixerTestCase;
+
+/**
+ * @author Mark Nielsen
+ *
+ * @internal
+ *
+ * @requires PHP 7.1
+ * @covers   \PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer
+ */
+final class VoidReturnFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            ['<?php class Test { public function __construct() {} }'],
+            ['<?php class Test { public function __destruct() {} }'],
+            ['<?php class Test { public function __clone() {} }'],
+            ['<?php function foo($param) { return $param; }'],
+            ['<?php function foo($param) { return null; }'],
+            ['<?php function foo($param) { yield; }'],
+            ['<?php function foo($param) { yield $param; }'],
+            ['<?php function foo($param): Void {}'],
+            ['<?php interface Test { public function foo($param); }'],
+            ['<?php function foo($param) { return function($a) use ($param): string {}; }'],
+            ['<?php abstract class Test { abstract public function foo($param); }'],
+            ['<?php
+                /**
+                 * @return array
+                 */
+                function foo($param) {}
+            '],
+            [
+                '<?php function foo($param): void { return; }',
+                '<?php function foo($param) { return; }',
+            ],
+            [
+                '<?php function foo($param): void {}',
+                '<?php function foo($param) {}',
+            ],
+            [
+                '<?php class Test { public function foo($param): void { return; } }',
+                '<?php class Test { public function foo($param) { return; } }',
+            ],
+            [
+                '<?php class Test { public function foo($param): void {} }',
+                '<?php class Test { public function foo($param) {} }',
+            ],
+            [
+                '<?php trait Test { public function foo($param): void { return; } }',
+                '<?php trait Test { public function foo($param) { return; } }',
+            ],
+            [
+                '<?php trait Test { public function foo($param): void {} }',
+                '<?php trait Test { public function foo($param) {} }',
+            ],
+            [
+                '<?php usort([], function ($a, $b): void {});',
+                '<?php usort([], function ($a, $b) {});',
+            ],
+            [
+                '<?php $param = 1; usort([], function ($a, $b) use ($param): void {});',
+                '<?php $param = 1; usort([], function ($a, $b) use ($param) {});',
+            ],
+            [
+                '<?php function foo($param) { return function($a) use ($param): void {}; }',
+                '<?php function foo($param) { return function($a) use ($param) {}; }',
+            ],
+            [
+                '<?php function foo($param): void { usort([], function ($a, $b) use ($param): void {}); }',
+                '<?php function foo($param) { usort([], function ($a, $b) use ($param) {}); }',
+            ],
+            [
+                '<?php function foo() { return usort([], new class { public function __invoke($a, $b): void {} }); }',
+                '<?php function foo() { return usort([], new class { public function __invoke($a, $b) {} }); }',
+            ],
+            [
+                '<?php function foo(): void { usort([], new class { public function __invoke($a, $b): void {} }); }',
+                '<?php function foo() { usort([], new class { public function __invoke($a, $b) {} }); }',
+            ],
+            [
+                '<?php
+                /**
+                 * @return void
+                 */
+                function foo($param): void {}',
+
+                '<?php
+                /**
+                 * @return void
+                 */
+                function foo($param) {}',
+            ],
+            [
+                '<?php
+                interface Test {
+                    /**
+                     * @return void
+                     */
+                    public function foo($param): void;
+                }',
+
+                '<?php
+                interface Test {
+                    /**
+                     * @return void
+                     */
+                    public function foo($param);
+                }',
+            ],
+            [
+                '<?php
+                abstract class Test {
+                    /**
+                     * @return void
+                     */
+                    abstract private function foo($param): void;
+                }',
+
+                '<?php
+                abstract class Test {
+                    /**
+                     * @return void
+                     */
+                    abstract private function foo($param);
+                }',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -55,6 +55,20 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
                  */
                 function foo($param) {}
             '],
+            ['<?php
+                /**
+                 * @return void|array
+                 */
+                function foo($param) {}
+            '],
+            ['<?php
+                interface Test {
+                    /**
+                     * @return array
+                     */
+                    public function foo($param);
+                }
+            '],
             [
                 '<?php function foo($param): void { return; }',
                 '<?php function foo($param) { return; }',

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -56,12 +56,6 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
                 function foo($param) {}
             '],
             ['<?php
-                /**
-                 * @return void|array
-                 */
-                function foo($param) {}
-            '],
-            ['<?php
                 interface Test {
                     /**
                      * @return array

--- a/tests/Fixtures/Integration/priority/void_return,phpdoc_no_empty_return.test
+++ b/tests/Fixtures/Integration/priority/void_return,phpdoc_no_empty_return.test
@@ -1,0 +1,22 @@
+--TEST--
+Integration of fixers: void_return,phpdoc_no_empty_return.
+--RULESET--
+{"void_return": true, "phpdoc_no_empty_return": true}
+--REQUIREMENTS--
+{"php": 70100}
+--EXPECT--
+<?php
+interface Test {
+    /**
+     */
+    public function foo(): void;
+}
+
+--INPUT--
+<?php
+interface Test {
+    /**
+     * @return void
+     */
+    public function foo();
+}

--- a/tests/Fixtures/Integration/priority/void_return,return_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/void_return,return_type_declaration.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: void_return,return_type_declaration.
+--RULESET--
+{"void_return": true, "return_type_declaration": {"space_before":"one"}}
+--REQUIREMENTS--
+{"php": 70100}
+--EXPECT--
+<?php
+function test() : void {}
+
+--INPUT--
+<?php
+function test() {}


### PR DESCRIPTION
Hello, first time contributor here!

This fixer adds the PHP7.1 void return type on functions that have no return statements or all the return statements are empty.

For reviewers, I'd like to call out the following:
* Please ensure `getDefinition` looks right.
* `applyFix` could likely be optimized by not using a `foreach` and instead jumping over function body definitions when a function is skipped.  Let me know if this should be done.
* In `fixFunctionDefinition`, I'm unsure if `new Token([T_STRING, 'void']),` is correct.

I ran this fixer on one of my personal projects and it worked well, except that it applies the fix to methods that implement interfaces, abstract classes, etc that belong to 3rd party vendors.  This doesn't seem to break tests, but also doesn't seem 100% correct.  Unsure if there is a better way to fix this or because it's not 100% correct, then this fixer shouldn't be included.  Maybe this is a fixer that you just run occasionally instead of all the time?  Anyways, feedback on this is welcome.

Cheers and thanks!