### PR TITLE
Fixing example and description for GeneralPhpdocAnnotationRemoveFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -454,8 +454,8 @@ Choose from the list of available rules:
 
   Configuration options:
 
-  - ``annotations`` (``array``): list of annotations to remove, e.g.
-    ``["@author"]``; defaults to ``[]``
+  - ``annotations`` (``array``): list of annotations to remove, e.g. ``["author"]``;
+    defaults to ``[]``
 
 * **hash_to_slash_comment** [@Symfony]
 

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -101,7 +101,7 @@ function foo() {}',
      */
     protected function createConfigurationDefinition()
     {
-        $annotations = new FixerOptionBuilder('annotations', 'List of annotations to remove, e.g. `["@author"]`.');
+        $annotations = new FixerOptionBuilder('annotations', 'List of annotations to remove, e.g. `["author"]`.');
         $annotations = $annotations
             ->setAllowedTypes(array('array'))
             ->setDefault(array())


### PR DESCRIPTION
The working version is [without](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/.php_cs.dist#L22) "@" sign.