### PR TITLE
AbstractDoctrineAnnotationFixerTestCase - split fixers test cases

### DIFF
--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -45,17 +45,35 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
     }
 
     /**
-     * {@inheritdoc}
+     * @param array<array<string>> $commentCases
+     *
+     * @return array
      */
-    protected function doTest($expected, $input = null, \SplFileInfo $file = null)
+    protected function createTestCases(array $commentCases)
     {
-        parent::doTest($this->withClassDocBlock($expected), $this->withClassDocBlock($input), $file);
+        $cases = array();
+        foreach ($commentCases as $commentCase) {
+            $cases[] = array(
+                $this->withClassDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? $this->withClassDocBlock($commentCase[1]) : null,
+            );
 
-        parent::doTest($this->withPropertyDocBlock($expected), $this->withPropertyDocBlock($input), $file);
+            $cases[] = array(
+                $this->withPropertyDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? $this->withPropertyDocBlock($commentCase[1]) : null,
+            );
 
-        parent::doTest($this->withMethodDocBlock($expected), $this->withMethodDocBlock($input), $file);
+            $cases[] = array(
+                $this->withMethodDocBlock($commentCase[0]),
+                isset($commentCase[1]) ? $this->withMethodDocBlock($commentCase[1]) : null,
+            );
 
-        parent::doTest($this->withWrongElementDocBlock($expected), null, $file);
+            $cases[] = array(
+                $this->withWrongElementDocBlock($commentCase[0]),
+            );
+        }
+
+        return $cases;
     }
 
     /**
@@ -121,17 +139,15 @@ $foo = bar();', $comment, false);
     }
 
     /**
-     * @param string      $php
-     * @param string|null $comment
-     * @param bool        $indent
+     * @param string $php
+     * @param string $comment
+     * @param bool   $indent
      *
-     * @return string|null
+     * @return string
      */
     private function with($php, $comment, $indent)
     {
-        if (null === $comment) {
-            return null;
-        }
+        $comment = trim($comment);
 
         if ($indent) {
             $comment = str_replace("\n", "\n    ", $comment);

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -39,7 +39,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixWithBracesCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo()
@@ -261,7 +261,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  * @override
  * @todo: foo
  */'),
-        );
+        ));
     }
 
     /**
@@ -283,7 +283,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixWithoutBracesCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * Foo.
@@ -522,7 +522,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  * @override()
  * @todo: foo()
  */'),
-        );
+        ));
     }
 
     /**

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -38,7 +38,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
      */
     public function getFixCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * Foo.
@@ -266,6 +266,6 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  *     @fixme
  *     @override
  */'),
-        );
+        ));
     }
 }

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -46,7 +46,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixAllCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo
@@ -302,7 +302,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 /**
  * @Transform /^(\d+)$/
  */'),
-        );
+        ));
     }
 
     /**
@@ -334,7 +334,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixAroundParenthesesOnlyCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo
@@ -541,7 +541,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  * @fixme ( foo,bar  =  "baz" )
  * @override
  */'),
-        );
+        ));
     }
 
     /**
@@ -573,7 +573,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixAroundCommasOnlyCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo
@@ -803,7 +803,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  * @fixme ( foo,bar  =  "baz" )
  * @override
  */'),
-        );
+        ));
     }
 
     /**
@@ -835,7 +835,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixAroundArgumentAssignmentsOnlyCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo (foo="foo", bar="bar")
@@ -1057,7 +1057,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  * @fixme ( foo,bar  =  "baz" )
  * @override
  */'),
-        );
+        ));
     }
 
     /**
@@ -1089,7 +1089,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function getFixAroundArrayAssignmentsOnlyCases()
     {
-        return array(
+        return $this->createTestCases(array(
             array('
 /**
  * @Foo (foo="foo", bar="bar")
@@ -1291,7 +1291,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  * @fixme ( foo,bar  =  "baz" )
  * @override
  */'),
-        );
+        ));
     }
 
     /**


### PR DESCRIPTION
Currently, each Doctrine Annotation fixers test runs with a DocBlock comment applied to four elements successively: a class, a method, a property and an element that is not supposed to have a DocBlock, like a regular variable.

This patch makes the test data providers return the comments already applied to those elements as actual separate test cases. This means there are four times more test cases now but all are faster than before so they should not be detected as too slow with #2727.