### PR TITLE
composer: prepare for new PHPUnit, drop 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "gecko-packages/gecko-php-unit": "^2.0",
         "johnkary/phpunit-speedtrap": "^1.1",
         "justinrainbow/json-schema": "^5.0",
-        "phpunit/phpunit": "^4.8.35 || ^5.4",
+        "phpunit/phpunit": "^5.4",
         "satooshi/php-coveralls": "^1.0",
         "symfony/phpunit-bridge": "^3.2.2"
     },


### PR DESCRIPTION
PHPUnit 4.x is not supported anymore and [was aimed for PHP 5.3, 5.4 and 5.5](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-4.8.0#requirements)

With bump to PHP 5.6, I think we could slowly move to PHPUnit 6.0 starting with this.