### PR TITLE
Fix describe command with PSR-0 fixer

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -225,7 +225,13 @@ final class DescribeCommand extends Command
                 $old = $codeSample->getCode();
                 $tokens = Tokens::fromCode($old);
                 if ($fixer instanceof ConfigurableFixerInterface) {
-                    $fixer->configure($codeSample->getConfiguration());
+                    $configuration = $codeSample->getConfiguration();
+
+                    if (null === $configuration) {
+                        $configuration = array();
+                    }
+
+                    $fixer->configure($configuration);
                 }
 
                 $file = $codeSample instanceof FileSpecificCodeSampleInterface

--- a/src/Fixer/Basic/Psr0Fixer.php
+++ b/src/Fixer/Basic/Psr0Fixer.php
@@ -41,7 +41,8 @@ final class Psr0Fixer extends AbstractPsrAutoloadingFixer implements Configurati
 namespace PhpCsFixer\FIXER\Basic;
 class InvalidName {}
 ',
-                    new \SplFileInfo(__FILE__)
+                    new \SplFileInfo(__FILE__),
+                    array('dir' => realpath(__DIR__.'/../..'))
                 ),
                 new FileSpecificCodeSample(
                     '<?php

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\AutoReview;
+
+use PhpCsFixer\Console\Application;
+use PhpCsFixer\Console\Command\DescribeCommand;
+use PhpCsFixer\FixerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ * @group auto-review
+ */
+final class DescribeCommandTest extends TestCase
+{
+    /**
+     * @dataProvider provideDescribeCommandCases
+     *
+     * @param FixerFactory $factory
+     * @param string       $fixerName
+     */
+    public function testDescribeCommand(FixerFactory $factory, $fixerName)
+    {
+        $command = new DescribeCommand($factory);
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'name' => $fixerName,
+        ));
+
+        $this->assertSame(0, $commandTester->getStatusCode());
+    }
+
+    public function provideDescribeCommandCases()
+    {
+        $factory = new FixerFactory();
+        $factory->registerBuiltInFixers();
+
+        $cases = array();
+
+        foreach ($factory->getFixers() as $fixer) {
+            $cases[] = array($factory, $fixer->getName());
+        }
+
+        return $cases;
+    }
+}

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -175,7 +175,7 @@ EOT;
         ));
 
         $things = false;
-        $fixer->configure(null)->will(function () use (&$things) {
+        $fixer->configure(array())->will(function () use (&$things) {
             $things = false;
         });
         $fixer->configure(array('things' => true))->will(function () use (&$things) {


### PR DESCRIPTION
Fixes #2761.

Also adds a test that runs the `describe` command with all fixers and checks that the exit code is `0`.