### PR TITLE
DoctrineAnnotationIndentationFixer - add option to indent mixed lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -367,6 +367,8 @@ Choose from the list of available rules:
     'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses',
     'SuppressWarnings', 'noinspection', 'package_version', 'enduml',
     'startuml', 'fix', 'FIXME', 'fixme', 'override']``
+  - ``indent_mixed_lines`` (``bool``): whether to indent lines that have content
+    before closing parenthesis; defaults to ``false``
 
 * **doctrine_annotation_spaces**
 

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
@@ -15,6 +15,8 @@ namespace PhpCsFixer\Fixer\DoctrineAnnotation;
 use Doctrine\Common\Annotations\DocLexer;
 use PhpCsFixer\AbstractDoctrineAnnotationFixer;
 use PhpCsFixer\Doctrine\Annotation\Tokens;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 
@@ -29,8 +31,28 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
             'Doctrine annotations must be indented with four spaces.',
             [
                 new CodeSample("<?php\n/**\n *  @Foo(\n *   foo=\"foo\"\n *  )\n */\nclass Bar {}"),
+                new CodeSample(
+                    "<?php\n/**\n *  @Foo({@Bar,\n *   @Baz})\n */\nclass Bar {}",
+                    ['indent_mixed_lines' => true]
+                ),
             ]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver(array_merge(
+            parent::createConfigurationDefinition()->getOptions(),
+            [
+                (new FixerOptionBuilder('indent_mixed_lines', 'Whether to indent lines that have content before closing parenthesis.'))
+                    ->setAllowedTypes(['bool'])
+                    ->setDefault(false)
+                    ->getOption(),
+            ]
+        ));
     }
 
     /**
@@ -66,18 +88,23 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
 
             $currentLineDelta = $this->getLineBracesDelta($tokens, $index);
 
+            $extraIndentLevel = 0;
             if ($previousLineBracesDelta > 0) {
                 ++$indentLevel;
             }
             if ($currentLineDelta < 0) {
                 --$indentLevel;
+
+                if ($this->configuration['indent_mixed_lines'] && $this->isClosingLineWithMeaningfulContent($tokens, $index)) {
+                    $extraIndentLevel = 1;
+                }
             }
 
             $previousLineBracesDelta = $currentLineDelta;
 
             $token->setContent(preg_replace(
                 '/(\n( +\*)?) *$/',
-                '$1'.str_repeat(' ', 4 * $indentLevel + 1),
+                '$1'.str_repeat(' ', 4 * ($indentLevel + $extraIndentLevel) + 1),
                 $token->getContent()
             ));
         }
@@ -110,6 +137,30 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
         }
 
         return $lineBracesDelta;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isClosingLineWithMeaningfulContent(Tokens $tokens, $index)
+    {
+        while (isset($tokens[++$index])) {
+            $token = $tokens[$index];
+            if ($token->isType(DocLexer::T_NONE)) {
+                if (false !== strpos($token->getContent(), "\n")) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            return !$token->isType([DocLexer::T_CLOSE_PARENTHESIS, DocLexer::T_CLOSE_CURLY_BRACES]);
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -34,6 +34,20 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
     }
 
     /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider getFixCases
+     */
+    public function testFixWithUnindentedMixedLines($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'indent_mixed_lines' => false,
+        ]);
+        $this->doTest($expected, $input);
+    }
+
+    /**
      * @return array
      */
     public function getFixCases()
@@ -172,6 +186,313 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  * )
  *
  * @param mixed description with a single " character.
+ */'],
+            ['
+/**
+ * @Foo(@Bar,
+ * @Baz)
+ * @Qux
+ */', '
+/**
+ *  @Foo(@Bar,
+ *   @Baz)
+ *    @Qux
+ */'],
+            ['
+/**
+ * @Foo({"bar",
+ * "baz"})
+ * @Qux
+ */', '
+/**
+ *  @Foo({"bar",
+ *   "baz"})
+ *    @Qux
+ */'],
+            ['
+/**
+ * // PHPDocumentor 1
+ *     @abstract
+ *     @access
+ *     @code
+ *     @deprec
+ *     @encode
+ *     @exception
+ *     @final
+ *     @ingroup
+ *     @inheritdoc
+ *     @inheritDoc
+ *     @magic
+ *     @name
+ *     @toc
+ *     @tutorial
+ *     @private
+ *     @static
+ *     @staticvar
+ *     @staticVar
+ *     @throw
+ *
+ * // PHPDocumentor 2
+ *     @api
+ *     @author
+ *     @category
+ *     @copyright
+ *     @deprecated
+ *     @example
+ *     @filesource
+ *     @global
+ *     @ignore
+ *     @internal
+ *     @license
+ *     @link
+ *     @method
+ *     @package
+ *     @param
+ *     @property
+ *     @property-read
+ *     @property-write
+ *     @return
+ *     @see
+ *     @since
+ *     @source
+ *     @subpackage
+ *     @throws
+ *     @todo
+ *     @TODO
+ *     @usedBy
+ *     @uses
+ *     @var
+ *     @version
+ *
+ * // PHPUnit
+ *     @after
+ *     @afterClass
+ *     @backupGlobals
+ *     @backupStaticAttributes
+ *     @before
+ *     @beforeClass
+ *     @codeCoverageIgnore
+ *     @codeCoverageIgnoreStart
+ *     @codeCoverageIgnoreEnd
+ *     @covers
+ *     @coversDefaultClass
+ *     @coversNothing
+ *     @dataProvider
+ *     @depends
+ *     @expectedException
+ *     @expectedExceptionCode
+ *     @expectedExceptionMessage
+ *     @expectedExceptionMessageRegExp
+ *     @group
+ *     @large
+ *     @medium
+ *     @preserveGlobalState
+ *     @requires
+ *     @runTestsInSeparateProcesses
+ *     @runInSeparateProcess
+ *     @small
+ *     @test
+ *     @testdox
+ *     @ticket
+ *     @uses
+ *
+ * // PHPCheckStyle
+ *     @SuppressWarnings
+ *
+ * // PHPStorm
+ *     @noinspection
+ *
+ * // PEAR
+ *     @package_version
+ *
+ * // PlantUML
+ *     @enduml
+ *     @startuml
+ *
+ * // other
+ *     @fix
+ *     @FIXME
+ *     @fixme
+ *     @override
+ */'],
+        ]);
+    }
+
+    /**
+     * @param string      $expected
+     * @param string|null $input
+     *
+     * @dataProvider getFixWithIndentedMixedLinesCases
+     */
+    public function testFixWithIndentedMixedLines($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'indent_mixed_lines' => true,
+        ]);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function getFixWithIndentedMixedLinesCases()
+    {
+        return $this->createTestCases([
+            ['
+/**
+ * Foo.
+ *
+ * @author John Doe
+ *
+ * @Foo
+ * @Bar
+ */', '
+/**
+ * Foo.
+ *
+ * @author John Doe
+ *
+ *    @Foo
+ *  @Bar
+ */'],
+            ['
+/**
+ * @Foo(
+ *     foo="foo"
+ * )
+ */', '
+/**
+ *     @Foo(
+ * foo="foo"
+ *     )
+ */'],
+            ['
+/**
+ * @Foo(foo="foo", bar={
+ *     "foo": 1,
+ *     "foobar": 2,
+ *     "foobarbaz": 3
+ * })
+ */', '
+/**
+ * @Foo(foo="foo", bar={
+ *        "foo": 1,
+ *     "foobar": 2,
+ *  "foobarbaz": 3
+ * })
+ */'],
+            ['
+/**
+ * @Foo(@Bar({
+ *     "FOO": 1,
+ *     "BAR": 2,
+ *     "BAZ": 3
+ * }))
+ */', '
+/**
+ * @Foo(@Bar({
+ *   "FOO": 1,
+ *   "BAR": 2,
+ *   "BAZ": 3
+ * }))
+ */'],
+            ['
+/**
+ * @Foo(
+ *     @Bar({
+ *         "FOO": 1,
+ *         "BAR": 2,
+ *         "BAZ": 3
+ *     })
+ * )
+ */', '
+/**
+ * @Foo(
+ *  @Bar({
+ *   "FOO": 1,
+ *   "BAR": 2,
+ *   "BAZ": 3
+ *  })
+ * )
+ */'],
+            ['
+/**
+ * @Foo(
+ *   @Bar(
+ *  "baz"
+ * )
+ */'],
+            ['
+/**
+ *  Foo(
+ *      Bar()
+ *      "baz"
+ *  )
+ */'],
+            ['
+/**
+ * @Foo(  @Bar(
+ *     "baz"
+ * ) )
+ */', '
+/**
+ * @Foo(  @Bar(
+ *  "baz"
+ * ) )
+ */'],
+            ['
+/**
+ * @Foo(x={
+ *     @Bar
+ * })
+ * @Foo\z
+ */', '
+/**
+ * @Foo(x={
+ * @Bar
+ * })
+ * @Foo\z
+ */'],
+            ['
+/**
+ * Description with a single " character.
+ *
+ * @Foo(
+ *     "string "" with inner quote"
+ * )
+ *
+ * @param mixed description with a single " character.
+ */', '
+/**
+ * Description with a single " character.
+ *
+ * @Foo(
+ *  "string "" with inner quote"
+ * )
+ *
+ * @param mixed description with a single " character.
+ */'],
+            ['
+/**
+ * @Foo(@Bar,
+ *     @Baz)
+ * @Qux
+ */', '
+/**
+ *  @Foo(@Bar,
+ *   @Baz)
+ *    @Qux
+ */'],
+            ['
+/**
+ * @Foo({"bar",
+ *     "baz"})
+ * @Qux
+ */', '
+/**
+ *  @Foo({"bar",
+ *   "baz"})
+ *    @Qux
  */'],
             ['
 /**


### PR DESCRIPTION
Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2682#issuecomment-294216905

The current behavior of the fixer is to unindent lines that close elements:

```diff
 /**
- *  @Foo(@Bar,
- *   @Baz)
+ * @Foo(@Bar,
+ * @Baz)
  */
```

This new option allows to indent these lines as well:

```diff
 /**
- *  @Foo(@Bar,
- *   @Baz)
+ * @Foo(@Bar,
+ *     @Baz)
  */
```

/cc @edhgoose 