### PR TITLE
Tokens::ensureWhitespaceAtIndex - clean up comment check, add check for T_OPEN

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -325,14 +325,8 @@ class Tokens extends \SplFixedArray
     public function ensureWhitespaceAtIndex($index, $indexOffset, $whitespace)
     {
         $removeLastCommentLine = function (Token $token, $indexOffset) {
-            // because comments tokens are greedy and may consume single \n if we are putting whitespace after it let trim that \n
-            if (1 === $indexOffset && $token->isComment()) {
-                $token->setContent(preg_replace(
-                    "#\r\n$|\n$#",
-                    '',
-                    $token->getContent(),
-                    1
-                ));
+            if (1 === $indexOffset && $token->isGivenKind(T_OPEN_TAG)) {
+                $token->setContent(rtrim($token->getContent()));
             }
         };
 

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -869,6 +869,85 @@ PHP;
     }
 
     /**
+     * @param string $expected   valid PHP code
+     * @param string $input      valid PHP code
+     * @param int    $index      token index
+     * @param int    $offset
+     * @param string $whiteSpace white space
+     *
+     * @dataProvider provideEnsureWhitespaceAtIndexCases
+     */
+    public function testEnsureWhitespaceAtIndex($expected, $input, $index, $offset, $whiteSpace)
+    {
+        $tokens = Tokens::fromCode($input);
+        $tokens->ensureWhitespaceAtIndex($index, $offset, $whiteSpace);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+
+    public function provideEnsureWhitespaceAtIndexCases()
+    {
+        return array(
+            array(
+                '<?php ',
+                '<?php',
+                0,
+                1,
+                ' ',
+            ),
+            array(
+                "<?php\n",
+                '<?php',
+                0,
+                1,
+                "\n",
+            ),
+            array(
+                "<?php\t",
+                '<?php',
+                0,
+                1,
+                "\t",
+            ),
+            array(
+                '<?php
+//
+ echo $a;',
+                '<?php
+//
+echo $a;',
+                2,
+                1,
+                "\n ",
+            ),
+            array(
+                '<?php
+ echo $a;',
+                '<?php
+echo $a;',
+                0,
+                1,
+                "\n ",
+            ),
+            array(
+                '<?php
+echo $a;',
+                '<?php echo $a;',
+                0,
+                1,
+                "\n",
+            ),
+            array(
+                "<?php\techo \$a;",
+                '<?php echo $a;',
+                0,
+                1,
+                "\t",
+            ),
+        );
+    }
+
+    /**
      * @param null|Token[] $expected
      * @param null|Token[] $input
      */


### PR DESCRIPTION
The current logic assumes comment tokens can have a trailing line break, however the transformers make sure this is never the case anymore.
Second change is that an T_OPEN tag can still have a trailing line break (i.e. not transformed to own whitespace token).
I theory this is also true for close tags, but inserting an white space token after a close tag is not valid in the first place.