### PR TITLE
[WIP] AssertTokens Trait

### DIFF
--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\RuleSet;
+use PhpCsFixer\Test\Assert\AssertTokensTrait;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -29,6 +30,8 @@ use Prophecy\Argument;
  */
 abstract class AbstractFixerTestCase extends TestCase
 {
+    use AssertTokensTrait;
+
     /**
      * @var LinterInterface
      */
@@ -185,29 +188,6 @@ abstract class AbstractFixerTestCase extends TestCase
             $this->linter->lintSource($source)->check();
         } catch (\Exception $e) {
             return $e->getMessage()."\n\nSource:\n$source";
-        }
-    }
-
-    private function assertTokens(Tokens $expectedTokens, Tokens $inputTokens)
-    {
-        foreach ($expectedTokens as $index => $expectedToken) {
-            $inputToken = $inputTokens[$index];
-            $option = ['JSON_PRETTY_PRINT'];
-            $this->assertTrue(
-                $expectedToken->equals($inputToken),
-                sprintf("The token at index %d must be:\n%s,\ngot:\n%s.", $index, $expectedToken->toJson($option), $inputToken->toJson($option))
-            );
-        }
-
-        $this->assertSame($expectedTokens->count(), $inputTokens->count(), 'The collection must have the same length than the expected one.');
-
-        $foundTokenKinds = array_keys(AccessibleObject::create($expectedTokens)->foundTokenKinds);
-
-        foreach ($foundTokenKinds as $tokenKind) {
-            $this->assertTrue(
-                $inputTokens->isTokenKindFound($tokenKind),
-                sprintf('The token kind %s must be found in fixed tokens collection.', $tokenKind)
-            );
         }
     }
 

--- a/src/Test/Assert/AssertTokensTrait.php
+++ b/src/Test/Assert/AssertTokensTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Test\Assert;
+
+use PhpCsFixer\Test\AccessibleObject;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+trait AssertTokensTrait
+{
+    private function assertTokens(Tokens $expectedTokens, Tokens $inputTokens)
+    {
+        foreach ($expectedTokens as $index => $expectedToken) {
+            $inputToken = $inputTokens[$index];
+            $option = ['JSON_PRETTY_PRINT'];
+            $this->assertTrue(
+                $expectedToken->equals($inputToken),
+                sprintf("The token at index %d must be:\n%s,\ngot:\n%s.", $index, $expectedToken->toJson($option), $inputToken->toJson($option))
+            );
+        }
+
+        $this->assertSame($expectedTokens->count(), $inputTokens->count(), 'The collection must have the same length than the expected one.');
+
+        $foundTokenKinds = array_keys(AccessibleObject::create($expectedTokens)->foundTokenKinds);
+
+        foreach ($foundTokenKinds as $tokenKind) {
+            $this->assertTrue(
+                $inputTokens->isTokenKindFound($tokenKind),
+                sprintf('The token kind %s must be found in fixed tokens collection.', $tokenKind)
+            );
+        }
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -65,6 +65,7 @@ final class ProjectCodeTest extends TestCase
         \PhpCsFixer\Runner\FileFilterIterator::class,
         \PhpCsFixer\Runner\FileLintingIterator::class,
         \PhpCsFixer\StdinFileInfo::class,
+        \PhpCsFixer\Test\Assert\AssertTokensTrait::class,
         \PhpCsFixer\Test\IntegrationCaseFactory::class,
         \PhpCsFixer\Tokenizer\Transformers::class,
     ];

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Tokenizer;
 
+use PhpCsFixer\Test\Assert\AssertTokensTrait;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class TokensTest extends TestCase
 {
+    use AssertTokensTrait;
+
     public function testReadFromCacheAfterClearing()
     {
         $code = '<?php echo 1;';
@@ -873,7 +876,7 @@ PHP;
         $tokens = Tokens::fromCode($input);
         $tokens->ensureWhitespaceAtIndex($index, $offset, $whiteSpace);
 
-        $this->assertSame($expected, $tokens->generateCode());
+        $this->assertTokens(Tokens::fromCode($expected), $tokens);
     }
 
     public function provideEnsureWhitespaceAtIndexCases()


### PR DESCRIPTION
```
D:\GIT\fork\PHP-CS-Fixer (2.x_assertTokens)
λ vendor\bin\phpunit tests\Tokenizer\TokensTest.php
PHPUnit 5.7.19 by Sebastian Bergmann and contributors.

Testing PhpCsFixer\Tests\Tokenizer\TokensTest
................................................................. 65 / 87 ( 74%)
.........S.....FFF.FFF                                            87 / 87 (100%)

Time: 514 ms, Memory: 4.00MB

There were 6 failures:

1) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #0 ('<?php ', '<?php', 0, 1, ' ')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php ",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 321,
    "name": "T_INLINE_HTML",
    "content": "<?php",
    "isArray": true,
    "changed": false
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

2) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #1 ('<?php\n', '<?php', 0, 1, '\n')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php\n",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 321,
    "name": "T_INLINE_HTML",
    "content": "<?php",
    "isArray": true,
    "changed": false
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

3) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #2 ('<?php  ', '<?php', 0, 1, '     ')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php\t",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 321,
    "name": "T_INLINE_HTML",
    "content": "<?php",
    "isArray": true,
    "changed": false
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

4) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #4 ('<?php\n echo $a;', '<?php\necho $a;', 0, 1, '\n ')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php\n",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php",
    "isArray": true,
    "changed": true
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

5) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #5 ('<?php\necho $a;', '<?php echo $a;', 0, 1, '\n')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php\n",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php",
    "isArray": true,
    "changed": true
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

6) PhpCsFixer\Tests\Tokenizer\TokensTest::testEnsureWhitespaceAtIndex with data set #6 ('<?php  echo $a;', '<?php echo $a;', 0, 1, '    ')
The token at index 0 must be:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php\t",
    "isArray": true,
    "changed": false
},
got:
{
    "id": 379,
    "name": "T_OPEN_TAG",
    "content": "<?php",
    "isArray": true,
    "changed": true
}.
Failed asserting that false is true.

D:\GIT\fork\PHP-CS-Fixer\src\Test\Assert\AssertTokensTrait.php:33
D:\GIT\fork\PHP-CS-Fixer\tests\Tokenizer\TokensTest.php:879

FAILURES!
Tests: 87, Assertions: 369, Failures: 6, Skipped: 1.

```