### PR TITLE
Travis - use stages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ install:
 
 before_test:
     - cd C:\projects\php-cs-fixer
-    - php C:\tools\composer.phar update --no-interaction --no-progress --optimize-autoloader --prefer-stable --no-ansi
+    - php C:\tools\composer.phar update --no-interaction --no-progress --prefer-stable --no-ansi
 
 test_script:
     - cd C:\projects\php-cs-fixer

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,104 +5,112 @@ sudo: false
 git:
     depth: 1
 
-env:
-    global:
-        - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-progress --optimize-autoloader"
-        - TASK_TESTS=1
-        - TASK_TESTS_COVERAGE=0
-        - TASK_CS=1
-        - TASK_SCA=0
-
-matrix:
-    fast_finish: true
-    include:
-        - php: 7.1
-          env: DEPLOY=yes TASK_TESTS_COVERAGE=1
-        - php: nightly
-          env: TASK_SCA=1 COMPOSER_FLAGS="--ignore-platform-reqs" SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_IGNORE_ENV=1
-        - php: 5.6
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        - php: 7.0
-          env: SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1
-
 cache:
     directories:
         - $HOME/.composer
 
-before_install:
-    # check phpdbg
-    - phpdbg --version 2> /dev/null || { echo 'No phpdbg'; export TASK_TESTS_COVERAGE=0; }
+env:
+    global:
+        - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-progress"
+        - COMPOSER_FLAGS=""
 
+before_install:
     # turn off XDebug
     - phpenv config-rm xdebug.ini || return 0
-
-    # validate tasks configuration
-    - if [ $TASK_TESTS == 0 ] && [ $TASK_TESTS_COVERAGE == 1 ]; then travis_terminate 1; fi
-
-    # for building a tag release we don't need to run SCA tools, collect code coverage or self-fix CS
-    - if [ $TRAVIS_TAG ]; then export TASK_SCA=0; fi
-    - if [ $TRAVIS_TAG ]; then export TASK_TESTS_COVERAGE=0; fi
-    - if [ $TRAVIS_TAG ]; then export TASK_CS=0; fi
 
     # Composer: boost installation
     - composer global show -ND 2>&1 | grep "hirak/prestissimo" || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
 
-    # display tasks configuration for a job
-    - set | grep ^TASK | sort
+jobs:
+    include:
+        -
+            stage: Static Code Analysis
+            php: 7.1
+            env: COMPOSER_FLAGS="--no-dev --prefer-stable"
+            install:
+                - travis_retry composer update -d dev-tools $DEFAULT_COMPOSER_FLAGS
+                - composer info -d dev-tools -D | sort
 
-install:
-    - if [ $TASK_SCA == 1 ]; then travis_retry composer global require $DEFAULT_COMPOSER_FLAGS maglnet/composer-require-checker:^0.1.4; fi
-    - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
-    - composer info -D | sort
+                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - composer info -D | sort
+            before_script:
+                - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then COMMIT_RANGE=$TRAVIS_COMMIT_RANGE; else COMMIT_RANGE="HEAD~..HEAD"; fi;
+                - export COMMIT_SCA_FILES=`git diff --name-only --diff-filter=ACMRTUXB $COMMIT_RANGE`
+            script:
+                - ./check_trailing_spaces.sh || travis_terminate 1
+                - if [ -n "$COMMIT_SCA_FILES" ]; then ./dev-tools/vendor/bin/phpmd `echo "$COMMIT_SCA_FILES" | grep -Ev "^(src/Resources|tests/Fixtures)" | xargs | sed 's/ /,/g'` text phpmd.xml || travis_terminate 1; fi
+                - ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file=.composer-require-checker.json
 
-before_script:
-    - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then COMMIT_RANGE=$TRAVIS_COMMIT_RANGE; else COMMIT_RANGE="HEAD~..HEAD"; fi;
-    - if [ $TASK_SCA == 1 ]; then export COMMIT_SCA_FILES=`git diff --name-only --diff-filter=ACMRTUXB $COMMIT_RANGE`; fi
 
-script:
-    - if [ $TASK_SCA == 1 ]; then ./check_trailing_spaces.sh || travis_terminate 1; fi
-    - if [ $TASK_SCA == 1 ] && [ -n "$COMMIT_SCA_FILES" ]; then vendor/bin/phpmd `echo "$COMMIT_SCA_FILES" | grep -Ev "^(src/Resources|tests/Fixtures)" | xargs | sed 's/ /,/g'` text phpmd.xml || travis_terminate 1; fi;
-    - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,native_function_invocation -q; fi
-    - if [ $TASK_SCA == 1 ]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS --no-dev --prefer-stable; fi
-    - if [ $TASK_SCA == 1 ]; then $HOME/.composer/vendor/bin/composer-require-checker check composer.json --config-file=.composer-require-checker.json || travis_terminate 1; fi
-    - if [ $TASK_SCA == 1 ]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS; fi
+        - &STANDARD_TEST_JOB
+            stage: Test
+            php: 7.0
+            install:
+                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - composer info -D | sort
+            script:
+                - vendor/bin/phpunit --verbose || travis_terminate 1
+                - php php-cs-fixer --diff --dry-run -v fix
 
-    - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 0 ]; then vendor/bin/phpunit --verbose; fi
-    - if [ $TASK_TESTS == 1 ] && [ $TASK_TESTS_COVERAGE == 1 ]; then phpdbg -qrr vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml; fi
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 5.6
+            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
-    - if [ $TASK_SCA == 1 ]; then git checkout . -q; fi
+        -
+            <<: *STANDARD_TEST_JOB
+            php: 7.1
+            env: COLLECT_COVERAGE=1
+            before_script:
+                # check phpdbg
+                - phpdbg --version 2> /dev/null || { echo 'No phpdbg'; export COLLECT_COVERAGE=0; }
 
-    - if [ $TASK_CS == 1 ]; then php php-cs-fixer --diff --dry-run -v fix; fi
+                # for building a tag release we don't need to collect code coverage
+                - if [ $TRAVIS_TAG ]; then export COLLECT_COVERAGE=0; fi
+            script:
+                - if [ $COLLECT_COVERAGE == 0 ]; then vendor/bin/phpunit --verbose || travis_terminate 1; fi
+                - if [ $COLLECT_COVERAGE == 1 ]; then phpdbg -qrr vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml || travis_terminate 1; fi
+                - php php-cs-fixer --diff --dry-run -v fix || travis_terminate 1
+                - if [ $COLLECT_COVERAGE == 1 ]; then php vendor/bin/coveralls -v; fi
 
-after_success:
-    - if [ $TASK_TESTS_COVERAGE == 1 ]; then php vendor/bin/coveralls -v; fi
+        -
+            <<: *STANDARD_TEST_JOB
+            php: nightly
+            env: COMPOSER_FLAGS="--ignore-platform-reqs" SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_IGNORE_ENV=1 PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1
+            script:
+                - php php-cs-fixer fix --rules @PHP70Migration:risky,@PHP71Migration,native_function_invocation -q || travis_terminate 1
+                - vendor/bin/phpunit --verbose || travis_terminate 1
+                - git checkout . -q
+                - php php-cs-fixer --diff --dry-run -v fix
 
-before_deploy:
-    # install box2
-    - curl -LSs http://box-project.github.io/box2/installer.php | php
-    - php box.phar --version
+        -
+            stage: Deployment
+            php: 7.1
+            env: COMPOSER_FLAGS="--no-dev --prefer-stable"
+            install: skip
+            script: skip
+            before_deploy:
+                # ensure that deps will work on lowest supported PHP version
+                - composer config platform.php 2> /dev/null || composer config platform.php 5.6.0
 
-    # ensure that deps will work on lowest supported PHP version
-    - composer config platform.php 2> /dev/null || composer config platform.php 5.6.0
+                # require suggested packages
+                - composer require --no-update symfony/polyfill-mbstring
 
-    # require suggested packages
-    - composer require --no-update symfony/polyfill-mbstring
+                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - composer info -D | sort
 
-    # update deps to highest possible for lowest supported PHP version
-    - composer update $DEFAULT_COMPOSER_FLAGS --no-dev --prefer-stable
+                # install box2
+                - curl -LSs http://box-project.github.io/box2/installer.php | php
+                - php box.phar --version
 
-    - composer info -D | sort
-
-    # build phar file
-    - php -d phar.readonly=false box.phar build
-
-deploy:
-    provider: releases
-    api_key:
-        secure: K9NKi7X1OPz898fxtVc1RfWrSI+4hTFFYOik932wTz1jC4dQJ64Khh1LV9frA1+JiDS3+R6TvmQtpzbkX3y4L75UrSnP1ADH5wfMYIVmydG3ZjTMo8SWQWHmRMh3ORAKTMMpjl4Q7EkRkLp6RncKe+FAFPP5mgv55mtIMaE4qUk=
-    file: php-cs-fixer.phar
-    skip_cleanup: true
-    on:
-        repo: FriendsOfPHP/PHP-CS-Fixer
-        tags: true
-        condition: $DEPLOY = yes
+                # build phar file
+                - php -d phar.readonly=false box.phar build
+            deploy:
+                provider: releases
+                api_key:
+                    secure: K9NKi7X1OPz898fxtVc1RfWrSI+4hTFFYOik932wTz1jC4dQJ64Khh1LV9frA1+JiDS3+R6TvmQtpzbkX3y4L75UrSnP1ADH5wfMYIVmydG3ZjTMo8SWQWHmRMh3ORAKTMMpjl4Q7EkRkLp6RncKe+FAFPP5mgv55mtIMaE4qUk=
+                file: php-cs-fixer.phar
+                skip_cleanup: true
+                on:
+                    repo: FriendsOfPHP/PHP-CS-Fixer
+                    tags: true

--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-files_with_trailing_spaces=$(find . -type f -not -path "./.git/*" -not -path "./vendor/*" -not -path "./tests/Fixtures/*" -exec egrep -nH " $" {} \;)
+files_with_trailing_spaces=$(find . -type f -not -path "./.git/*" -not -path "./dev-tools/vendor/*" -not -path "./vendor/*" -not -path "./tests/Fixtures/*" -exec egrep -nH " $" {} \;)
 
 if [[ $files_with_trailing_spaces ]]
 then

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,6 @@
     "require-dev": {
         "johnkary/phpunit-speedtrap": "^1.1",
         "justinrainbow/json-schema": "^5.0",
-        "mi-schi/phpmd-extension": "^4.2",
-        "phpmd/phpmd": "^2.4.3",
         "phpunit/phpunit": "^4.8.35 || ^5.4.3",
         "satooshi/php-coveralls": "^1.0",
         "symfony/phpunit-bridge": "^3.2.2"
@@ -47,6 +45,7 @@
         "hhvm": "*"
     },
     "config": {
+        "optimize-autoloader": true,
         "sort-packages": true
     },
     "autoload": {

--- a/dev-tools/.gitignore
+++ b/dev-tools/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "php": "^7.0"
+    },
+    "require-dev": {
+        "maglnet/composer-require-checker": "^0.1.4",
+        "mi-schi/phpmd-extension": "^4.2",
+        "phpmd/phpmd": "^2.4.3"
+    },
+    "conflict": {
+        "hhvm": "*"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    }
+}

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -18,10 +18,10 @@
 
     <rule ref="rulesets/naming.xml/ConstantNamingConventions" />
 
-    <rule ref="vendor/mi-schi/phpmd-extension/rulesets/cleancode.xml/DataStructureMethods" />
-    <rule ref="vendor/mi-schi/phpmd-extension/rulesets/cleancode.xml/SwitchStatement" />
+    <rule ref="../../../../../mi-schi/phpmd-extension/rulesets/cleancode.xml/DataStructureMethods" />
+    <rule ref="../../../../../mi-schi/phpmd-extension/rulesets/cleancode.xml/SwitchStatement" />
 
-    <rule ref="vendor/mi-schi/phpmd-extension/rulesets/naming.xml/CommentDescription">
+    <rule ref="../../../../../mi-schi/phpmd-extension/rulesets/naming.xml/CommentDescription">
         <properties>
             <property name="percent" value="70" />
         </properties>


### PR DESCRIPTION
Main benefits:
- deployment is done only when whole matrix of previous step is green [using pure matrix without stages, build is executed on each job that matches the conditions (here it was matching for env var set up for one job), but without checking other jobs (so it was possible that 7.1 was green so deployment happen even if 5.6 was red)]
- less conditions (like checking `TASK_*` vars which were local implementation of stages idea)