### PR TITLE
Apply fully multiline rules to the codebase

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -58,8 +58,8 @@ final class Cache implements CacheInterface
         if (!is_int($hash)) {
             throw new \InvalidArgumentException(sprintf(
                 'Value needs to be an integer, got "%s".',
-                is_object($hash) ? get_class($hash) : gettype($hash))
-            );
+                is_object($hash) ? get_class($hash) : gettype($hash)
+            ));
         }
 
         $this->hashes[$file] = $hash;

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -106,7 +106,9 @@ final class DescribeCommand extends Command
 
             throw new \InvalidArgumentException(sprintf(
                 '%s %s not found.%s',
-                ucfirst($e->getType()), $name, null === $alternative ? '' : ' Did you mean "'.$alternative.'"?'
+                ucfirst($e->getType()),
+                $name,
+                null === $alternative ? '' : ' Did you mean "'.$alternative.'"?'
             ));
         }
     }

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -43,7 +43,8 @@ final class SelfUpdateCommand extends Command
                 ]
             )
             ->setDescription('Update php-cs-fixer.phar to the latest stable version.')
-            ->setHelp(<<<'EOT'
+            ->setHelp(
+                <<<'EOT'
 The <info>%command.name%</info> command replace your php-cs-fixer.phar by the
 latest version released on:
 <comment>https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases</comment>

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -30,15 +30,13 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
     {
         return new FixerDefinition(
             'Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator.',
-            [new CodeSample(
-'<?php
+            [new CodeSample('<?php
     $a = intval($b);
     $a = floatval($b);
     $a = doubleval($b);
     $a = strval ($b);
     $a = boolval($b);
-'),
-            ],
+    ')],
             null,
             'Risky if any of the functions `intval`, `floatval`, `doubleval`, `strval` or `boolval` are overridden.'
         );

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -73,7 +73,8 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         foreach ($tokens as $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
                 $token->setContent(preg_replace(
-                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m', '$1\\\\$2',
+                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m',
+                    '$1\\\\$2',
                     $token->getContent()
                 ));
             }

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -32,8 +32,8 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
     {
         return new FixerDefinition(
             'Code MUST use configured indentation type.',
-            [new CodeSample("<?php\n\nif (true) {\n\techo 'Hello!';\n}"),
-        ]);
+            [new CodeSample("<?php\n\nif (true) {\n\techo 'Hello!';\n}")]
+        );
     }
 
     /**

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -38,8 +38,7 @@ final class NoSpacesInsideParenthesisFixer extends AbstractFixer
                 new CodeSample('<?php
 function foo( $bar, $baz )
 {
-}'
-                ),
+}'),
             ]
         );
     }

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -128,14 +128,16 @@ final class IntegrationCase
         if (!is_string($name)) {
             throw new \InvalidArgumentException(sprintf(
                 'Requirement key must be a string, got "%s".',
-                is_object($name) ? get_class($name) : gettype($name).'#'.$name));
+                is_object($name) ? get_class($name) : gettype($name).'#'.$name
+            ));
         }
 
         if (!array_key_exists($name, $this->requirements)) {
             throw new \InvalidArgumentException(sprintf(
                 'Unknown requirement key "%s", expected any of "%s".',
-                $name, implode('","', array_keys($this->requirements)))
-            );
+                $name,
+                implode('","', array_keys($this->requirements))
+            ));
         }
 
         return $this->requirements[$name];

--- a/src/Test/IntegrationCaseFactory.php
+++ b/src/Test/IntegrationCaseFactory.php
@@ -93,15 +93,15 @@ final class IntegrationCaseFactory
         if (!is_string($parsed['indent'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected string value for "indent", got "%s".',
-                is_object($parsed['indent']) ? get_class($parsed['indent']) : gettype($parsed['indent']).'#'.$parsed['indent'])
-            );
+                is_object($parsed['indent']) ? get_class($parsed['indent']) : gettype($parsed['indent']).'#'.$parsed['indent']
+            ));
         }
 
         if (!is_string($parsed['lineEnding'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected string value for "lineEnding", got "%s".',
-                is_object($parsed['lineEnding']) ? get_class($parsed['lineEnding']) : gettype($parsed['lineEnding']).'#'.$parsed['lineEnding'])
-            );
+                is_object($parsed['lineEnding']) ? get_class($parsed['lineEnding']) : gettype($parsed['lineEnding']).'#'.$parsed['lineEnding']
+            ));
         }
 
         return $parsed;
@@ -124,15 +124,15 @@ final class IntegrationCaseFactory
         if (!is_int($parsed['php'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected int value like 50509 for "php", got "%s".',
-                is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php'])
-            );
+                is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php']
+            ));
         }
 
         if (!is_bool($parsed['hhvm'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected bool value for "hhvm", got "%s".',
-                is_object($parsed['hhvm']) ? get_class($parsed['hhvm']) : gettype($parsed['hhvm']).'#'.$parsed['hhvm'])
-            );
+                is_object($parsed['hhvm']) ? get_class($parsed['hhvm']) : gettype($parsed['hhvm']).'#'.$parsed['hhvm']
+            ));
         }
 
         return $parsed;
@@ -166,8 +166,8 @@ final class IntegrationCaseFactory
         if (!is_bool($parsed['checkPriority'])) {
             throw new \InvalidArgumentException(sprintf(
                 'Expected bool value for "checkPriority", got "%s".',
-                is_object($parsed['checkPriority']) ? get_class($parsed['checkPriority']) : gettype($parsed['checkPriority']).'#'.$parsed['checkPriority'])
-            );
+                is_object($parsed['checkPriority']) ? get_class($parsed['checkPriority']) : gettype($parsed['checkPriority']).'#'.$parsed['checkPriority']
+            ));
         }
 
         return $parsed;

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -713,7 +713,9 @@ $a = new class implements
 {}
 
 %s /**/ B //
-/**/\n{}", $classy, $classy
+/**/\n{}",
+                    $classy,
+                    $classy
                 ),
                 sprintf(
                     '<?php
@@ -722,22 +724,28 @@ $a = new class implements
 {}
 
 %s/**/B //
-/**/ {}', $classy, $classy
+/**/ {}',
+                    $classy,
+                    $classy
                 ),
             ],
             [
-                sprintf('<?php
+              sprintf(
+                '<?php
 namespace {
     %s IndentedNameSpacedClass
 {
     }
-}', $classy
+}',
+                    $classy
                 ),
-                sprintf('<?php
+                sprintf(
+                    '<?php
 namespace {
     %s IndentedNameSpacedClass    {
     }
-}', $classy
+}',
+                    $classy
                 ),
             ],
         ];

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -134,7 +134,8 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                 '<?php function xyz(
                     $a=10,      //comment1
                     $b=20,      //comment2
-                    $c=30) {
+                    $c=30
+                ) {
                 }',
             ],
             'must keep align comments (2)' => [
@@ -181,12 +182,15 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                 '<?php function xyz(
                     $a=10,
                     $b=20,
-                    $c=30) {
+                    $c=30
+                ) {
                 }',
-                '<?php function xyz(
+                '<?php
+                function xyz(
                     $a=10 ,
                     $b=20,
-                    $c=30) {
+                    $c=30
+                ) {
                 }',
             ],
             'multi line testing method call' => [

--- a/tests/Report/TextReporterTest.php
+++ b/tests/Report/TextReporterTest.php
@@ -63,7 +63,10 @@ TEXT;
 
     public function testGenerateSimple()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
 
 TEXT
@@ -90,7 +93,10 @@ TEXT
 
     public function testGenerateWithDiff()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
       ---------- begin diff ----------
 this text is a diff ;)
@@ -122,7 +128,10 @@ TEXT
 
     public function testGenerateWithAppliedFixers()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php (some_fixer_name_here)
 
 TEXT
@@ -149,7 +158,10 @@ TEXT
 
     public function testGenerateWithTimeAndMemory()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php
 
 Fixed all files in 1.234 seconds, 2.500 MB memory used
@@ -178,7 +190,10 @@ TEXT
 
     public function testGenerateComplexWithDecoratedOutput()
     {
-        $expectedReport = str_replace("\n", PHP_EOL, <<<'TEXT'
+        $expectedReport = str_replace(
+            "\n",
+            PHP_EOL,
+            <<<'TEXT'
    1) someFile.php (<comment>some_fixer_name_here</comment>)
 <comment>      ---------- begin diff ----------</comment>
 this text is a diff ;)

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -258,7 +258,8 @@ final class RuleSetTest extends TestCase
             $fixerNames,
             sprintf(
                 'Set should only contain %s fixers, got: \'%s\'.',
-                $safe ? 'safe' : 'risky', implode('\', \'', $fixerNames)
+                $safe ? 'safe' : 'risky',
+                implode('\', \'', $fixerNames)
             )
         );
     }


### PR DESCRIPTION
From http://www.php-fig.org/psr/psr-2/ :
Argument lists MAY be split across multiple lines, where each subsequent
line is indented once. When doing so, the first item in the list MUST be
on the next line, and there MUST be only one argument per line.