### PR TITLE
Drop HHVM support

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,6 +1,6 @@
 {
     "symbol-whitelist" : [
-        "HHVM_VERSION_ID", "T_HH_ERROR",
+        "HHVM_VERSION_ID",
         "PHPUnit\\Framework\\TestCase", "Prophecy\\Argument",
         "GeckoPackages\\PHPUnit\\Constraints\\SameStringsConstraint",
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_script:
 
 script:
     - if [ $TASK_SCA == 1 ]; then ./check_trailing_spaces.sh || travis_terminate 1; fi
-    - if [ $TASK_SCA == 1 ] && [ -n "$COMMIT_SCA_FILES" ]; then vendor/bin/phpmd `echo $COMMIT_SCA_FILES | sed 's/ /,/g'` text phpmd.xml --exclude src/Resources,tests/Fixtures || travis_terminate 1; fi;
+    - if [ $TASK_SCA == 1 ] && [ -n "$COMMIT_SCA_FILES" ]; then vendor/bin/phpmd `echo "$COMMIT_SCA_FILES" | grep -Ev "^(src/Resources|tests/Fixtures)" | xargs | sed 's/ /,/g'` text phpmd.xml || travis_terminate 1; fi;
     - if [ $TASK_SCA == 1 ]; then php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,native_function_invocation -q; fi
     - if [ $TASK_SCA == 1 ]; then travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS --no-dev --prefer-stable; fi
     - if [ $TASK_SCA == 1 ]; then $HOME/.composer/vendor/bin/composer-require-checker check composer.json --config-file=.composer-require-checker.json || travis_terminate 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,6 @@ matrix:
         - php: 5.6
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 7.0
-        # Use the newer stack for HHVM as HHVM does not support Precise anymore since a long time and so Precise has an outdated version
-        - php: hhvm
-          env: SKIP_LINT_TEST_CASES=1
-          sudo: required
-          dist: trusty
-          group: edge
 
 cache:
     directories:

--- a/README.rst
+++ b/README.rst
@@ -1257,7 +1257,7 @@ Exit codes
 Exit code is build using following bit flags:
 
 *  0 OK.
-*  1 General error (or PHP/HHVM minimal requirement not matched).
+*  1 General error (or PHP minimal requirement not matched).
 *  4 Some files have invalid syntax (only in dry-run mode).
 *  8 Some files need fixing (only in dry-run mode).
 * 16 Configuration error of the application.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
     },
     "conflict": {
-        "hhvm": "<3.18"
+        "hhvm": "*"
     },
     "config": {
         "sort-packages": true

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -17,14 +17,12 @@
  */
 
 if (defined('HHVM_VERSION_ID')) {
-    if (HHVM_VERSION_ID < 31800) {
-        fwrite(STDERR, "HHVM needs to be a minimum version of HHVM 3.18.0.\n");
+    fwrite(STDERR, "HHVM is not supported.\n");
 
-        if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
-            fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");
-        } else {
-            exit(1);
-        }
+    if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
+        fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");
+    } else {
+        exit(1);
     }
 } elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50600 || PHP_VERSION_ID >= 70200) {
     fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.1.*.\n");

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -238,7 +238,7 @@ Exit codes
 Exit code is build using following bit flags:
 
 *  0 OK.
-*  1 General error (or PHP/HHVM minimal requirement not matched).
+*  1 General error (or PHP minimal requirement not matched).
 *  4 Some files have invalid syntax (only in dry-run mode).
 *  8 Some files need fixing (only in dry-run mode).
 * 16 Configuration error of the application.

--- a/src/Fixer/Alias/NoMixedEchoPrintFixer.php
+++ b/src/Fixer/Alias/NoMixedEchoPrintFixer.php
@@ -121,19 +121,6 @@ final class NoMixedEchoPrintFixer extends AbstractFixer implements Configuration
      */
     private function fixEchoToPrint(Tokens $tokens, $index)
     {
-        /*
-         * HHVM parses '<?=' as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
-         *
-         * @see https://github.com/facebook/hhvm/issues/4809
-         * @see https://github.com/facebook/hhvm/issues/7161
-         */
-        if (
-            defined('HHVM_VERSION')
-            && 0 === strpos($tokens[$index]->getContent(), '<?=')
-        ) {
-            return;
-        }
-
         $nextTokenIndex = $tokens->getNextMeaningfulToken($index);
         $endTokenIndex = $tokens->getNextTokenOfKind($index, [';', [T_CLOSE_TAG]]);
         $canBeConverted = true;

--- a/src/Fixer/PhpTag/NoShortEchoTagFixer.php
+++ b/src/Fixer/PhpTag/NoShortEchoTagFixer.php
@@ -39,17 +39,7 @@ final class NoShortEchoTagFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_OPEN_TAG_WITH_ECHO)
-        /*
-         * HHVM parses '<?=' as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
-         *
-         * @see https://github.com/facebook/hhvm/issues/4809
-         * @see https://github.com/facebook/hhvm/issues/7161
-         */
-        || (
-            defined('HHVM_VERSION')
-            && $tokens->isTokenKindFound(T_ECHO)
-        );
+        return $tokens->isTokenKindFound(T_OPEN_TAG_WITH_ECHO);
     }
 
     /**
@@ -57,24 +47,12 @@ final class NoShortEchoTagFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $isHhvm = defined('HHVM_VERSION');
         $i = count($tokens);
 
         while ($i--) {
             $token = $tokens[$i];
 
-            if (
-                !$token->isGivenKind(T_OPEN_TAG_WITH_ECHO)
-                && !(
-                    /*
-                     * HHVM parses '<?=' as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
-                     *
-                     * @see https://github.com/facebook/hhvm/issues/4809
-                     * @see https://github.com/facebook/hhvm/issues/7161
-                     */
-                    $isHhvm && $token->equals([T_ECHO, '<?='])
-                )
-            ) {
+            if (!$token->isGivenKind(T_OPEN_TAG_WITH_ECHO)) {
                 continue;
             }
 

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -158,14 +158,10 @@ final class ProcessLinter implements LinterInterface
      */
     private function prepareCommand($path)
     {
-        $executable = ProcessUtils::escapeArgument($this->executable);
-
-        if (defined('HHVM_VERSION')) {
-            $executable .= ' --php';
-        }
-
-        $path = ProcessUtils::escapeArgument($path);
-
-        return sprintf('%s -l %s', $executable, $path);
+        return sprintf(
+            '%s -l %s',
+            ProcessUtils::escapeArgument($this->executable),
+            ProcessUtils::escapeArgument($path)
+        );
     }
 }

--- a/src/Resources/phar-stub.php
+++ b/src/Resources/phar-stub.php
@@ -12,14 +12,12 @@
  */
 
 if (defined('HHVM_VERSION_ID')) {
-    if (HHVM_VERSION_ID < 31800) {
-        fwrite(STDERR, "HHVM needs to be a minimum version of HHVM 3.18.0.\n");
+    fwrite(STDERR, "HHVM is not supported.\n");
 
-        if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
-            fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");
-        } else {
-            exit(1);
-        }
+    if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
+        fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");
+    } else {
+        exit(1);
     }
 } elseif (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50600 || PHP_VERSION_ID >= 70200) {
     fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.1.*.\n");

--- a/src/Test/AbstractIntegrationTestCase.php
+++ b/src/Test/AbstractIntegrationTestCase.php
@@ -48,7 +48,7 @@ use Symfony\Component\Finder\Finder;
  * --SETTINGS--*
  * {"key": "value"} # optional extension point for custom IntegrationTestCase class
  * --REQUIREMENTS--*
- * {"php": 50600**, "hhvm": false***}
+ * {"php": 50600**}
  * --EXPECT--
  * Expected code after fixing
  * --INPUT--*
@@ -56,7 +56,6 @@ use Symfony\Component\Finder\Finder;
  *
  *   * Section or any line in it may be omitted.
  *  ** PHP minimum version. Default to current running php version (no effect).
- * *** HHVM compliant flag. Default to true. Set to false to skip test under HHVM.
  *
  * @author SpacePossum
  */
@@ -171,10 +170,6 @@ abstract class AbstractIntegrationTestCase extends TestCase
      */
     protected function doTest(IntegrationCase $case)
     {
-        if (defined('HHVM_VERSION') && false === $case->getRequirement('hhvm')) {
-            $this->markTestSkipped('HHVM is not supported.');
-        }
-
         if (PHP_VERSION_ID < $case->getRequirement('php')) {
             $this->markTestSkipped(sprintf('PHP %d (or later) is required for "%s", current "%d".', $case->getRequirement('php'), $case->getFileName(), PHP_VERSION_ID));
         }

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -40,7 +40,7 @@ final class IntegrationCase
     private $inputCode;
 
     /**
-     * Env requirements (possible keys: php, hhvm).
+     * Env requirements (possible keys: php).
      *
      * @var array
      */

--- a/src/Test/IntegrationCaseFactory.php
+++ b/src/Test/IntegrationCaseFactory.php
@@ -117,7 +117,6 @@ final class IntegrationCaseFactory
     private function determineRequirements($config)
     {
         $parsed = $this->parseJson($config, [
-            'hhvm' => true,
             'php' => PHP_VERSION_ID,
         ]);
 
@@ -125,13 +124,6 @@ final class IntegrationCaseFactory
             throw new \InvalidArgumentException(sprintf(
                 'Expected int value like 50509 for "php", got "%s".',
                 is_object($parsed['php']) ? get_class($parsed['php']) : gettype($parsed['php']).'#'.$parsed['php'])
-            );
-        }
-
-        if (!is_bool($parsed['hhvm'])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Expected bool value for "hhvm", got "%s".',
-                is_object($parsed['hhvm']) ? get_class($parsed['hhvm']) : gettype($parsed['hhvm']).'#'.$parsed['hhvm'])
             );
         }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -967,10 +967,6 @@ class Tokens extends \SplFixedArray
             $this->registerFoundToken($token);
         }
 
-        if (defined('T_HH_ERROR') && $this->isTokenKindFound(T_HH_ERROR)) {
-            throw new \ParseError('Parsing error, encountered "T_HH_ERROR".');
-        }
-
         $this->rewind();
         $this->changeCodeHash(self::calculateCodeHash($code));
         $this->changed = true;
@@ -1077,20 +1073,8 @@ class Tokens extends \SplFixedArray
             return false;
         }
 
-        $isHhvm = defined('HHVM_VERSION');
         for ($index = 1; $index < $size; ++$index) {
-            if (
-                $this[$index]->isGivenKind([T_INLINE_HTML, T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO])
-                || (
-                    /*
-                     * HHVM parses '<?=' as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
-                     *
-                     * @see https://github.com/facebook/hhvm/issues/4809
-                     * @see https://github.com/facebook/hhvm/issues/7161
-                     */
-                    $isHhvm && $this[$index]->equals([T_ECHO, '<?='])
-                )
-            ) {
+            if ($this[$index]->isGivenKind([T_INLINE_HTML, T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO])) {
                 return false;
             }
         }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -95,12 +95,6 @@ final class ProjectCodeTest extends TestCase
      */
     public function testThatSrcClassesNotAbuseInterfaces($className)
     {
-        // HHVM knows better which interfaces you implements
-        // https://github.com/facebook/hhvm/issues/5890
-        if (defined('HHVM_VERSION') && interface_exists('Stringish')) {
-            $this->markTestSkipped('Skipped as HHVM violate inheritance tree with `Stringish` interface.');
-        }
-
         $rc = new \ReflectionClass($className);
 
         $doc = false !== $rc->getDocComment()

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -724,10 +724,7 @@ else?><?php echo 5;',
                     ';
         $cases[] = [[2, 25], $source, 27];
         $cases[] = [[27, 40], $source, 42];
-        if (!defined('HHVM_VERSION')) {
-            // HHVM 3.6.x tokenizes in a different way
-            $cases[] = [[59, 72], $source, 74];
-        }
+        $cases[] = [[59, 72], $source, 74];
 
         return $cases;
     }

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -494,39 +494,24 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
      */
     public function testCasesWithShortOpenTag($expected, $input = null)
     {
+        if (!ini_get('short_open_tag')) {
+            $this->markTestSkipped('No short tag tests possible.');
+        }
         $this->doTest($expected, $input);
     }
 
     public function provideCasesWithShortOpenTag()
     {
-        $cases = [];
-        /*
-         * short_open_tag setting is ignored by HHVM
-         * @see https://github.com/facebook/hhvm/issues/4758
-         */
-        if (ini_get('short_open_tag') || defined('HHVM_VERSION')) {
-            $cases[] =
-                [
-                    '<? ',
-                    '<? ;',
-                ];
-        }
-
-        // HHVM parses '<?=' as T_ECHO instead of T_OPEN_TAG_WITH_ECHO
-        // test the fixer doesn't break anything
-        if (ini_get('short_open_tag') && !defined('HHVM_VERSION')) {
-            $cases[] =
-                [
-                    '<?= ',
-                    '<?= ;',
-                ];
-        }
-
-        if (count($cases) < 1) {
-            $this->markTestSkipped('No short tag tests possible.');
-        }
-
-        return $cases;
+        return [
+            [
+                '<? ',
+                '<? ;',
+            ],
+            [
+                '<?= ',
+                '<?= ;',
+            ],
+        ];
     }
 
     /**

--- a/tests/Fixtures/Integration/priority/no_mixed_echo_print,no_short_echo_tag.test
+++ b/tests/Fixtures/Integration/priority/no_mixed_echo_print,no_short_echo_tag.test
@@ -2,8 +2,6 @@
 Integration of fixers: no_mixed_echo_print,no_short_echo_tag.
 --RULESET--
 {"no_mixed_echo_print": {"use":"print"}, "no_short_echo_tag": true}
---REQUIREMENTS--
-{"hhvm": false}
 --EXPECT--
 <div><?php print "test" ?></div>
 

--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -31,12 +31,8 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         $this->assertTrue($this->createLinter()->isAsync());
     }
 
-    public function testPrepareCommandOnPhp()
+    public function testPrepareCommand()
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Skip tests for PHP compiler when running on HHVM compiler.');
-        }
-
         $this->assertSame(
             $this->fixEscape('"php" -l "foo.php"'),
             AccessibleObject::create(new ProcessLinter('php'))->prepareCommand('foo.php')
@@ -45,18 +41,6 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         $this->assertSame(
             $this->fixEscape('"C:\Program Files\php\php.exe" -l "foo bar\baz.php"'),
             AccessibleObject::create(new ProcessLinter('C:\Program Files\php\php.exe'))->prepareCommand('foo bar\baz.php')
-        );
-    }
-
-    public function testPrepareCommandOnHhvm()
-    {
-        if (!defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Skip tests for HHVM compiler when running on PHP compiler.');
-        }
-
-        $this->assertSame(
-            $this->fixEscape('"hhvm" --php -l "foo.php"'),
-            AccessibleObject::create(new ProcessLinter('hhvm'))->prepareCommand('foo.php')
         );
     }
 

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -380,12 +380,7 @@ PHP;
      */
     public function testShortOpenTagMonolithicPhpDetection($source, $monolithic)
     {
-        /*
-         * short_open_tag setting is ignored by HHVM
-         * @see https://github.com/facebook/hhvm/issues/4758
-         */
-        if (!ini_get('short_open_tag') && !defined('HHVM_VERSION')) {
-            // Short open tag is parsed as T_INLINE_HTML
+        if (!ini_get('short_open_tag')) {
             $monolithic = false;
         }
 
@@ -761,16 +756,6 @@ PHP;
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');
         $tokens->findBlockEnd(Tokens::BLOCK_TYPE_DYNAMIC_VAR_BRACE, 0);
-    }
-
-    public function testParsingWithHHError()
-    {
-        if (!defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Skip tests for PHP compiler when running on non HHVM compiler.');
-        }
-
-        $this->setExpectedException(\ParseError::class);
-        Tokens::fromCode('<?php# this will cause T_HH_ERROR');
     }
 
     public function testEmptyTokens()


### PR DESCRIPTION
1. HHVM don't care about php incompatibilities we raised for years.

2. https://seld.be/notes/php-versions-stats-2017-1-edition
> HHVM usage is not included above in the graph it is at 0.36% 