### PR TITLE
NoUnneededControlParenthesesFixer - Remove useless braces after case and default

### DIFF
--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -55,7 +55,7 @@ final class NoUnneededControlParenthesesFixer extends AbstractFixer implements C
      */
     public function isCandidate(Tokens $tokens)
     {
-        $types = [];
+        $types = [[T_DEFAULT]];
 
         foreach (self::$loops as $loop) {
             $types[] = (array) $loop['lookupTokens'];
@@ -122,6 +122,8 @@ yield(2);
 
         foreach ($tokens as $index => $token) {
             if (!$token->equals('(')) {
+                $this->fixCaseDefault($tokens, $index);
+
                 continue;
             }
 
@@ -180,5 +182,42 @@ yield(2);
                 ])
                 ->getOption(),
         ]);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     */
+    private function fixCaseDefault(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index]->isGivenKind([T_CASE, T_DEFAULT])) {
+            return;
+        }
+
+        $ternariesCount = 0;
+        for ($colonIndex = $index + 1; ; ++$colonIndex) {
+            // We have to skip ternary case for colons.
+            if ($tokens[$colonIndex]->equals('?')) {
+                ++$ternariesCount;
+            }
+
+            if ($tokens[$colonIndex]->equalsAny([':', ';'])) {
+                if (0 === $ternariesCount) {
+                    break;
+                }
+
+                --$ternariesCount;
+            }
+        }
+
+        do {
+            $openBrace = $tokens->getNextMeaningfulToken($colonIndex);
+            if (!$tokens[$openBrace]->equals('{')) {
+                return;
+            }
+
+            $tokens->clearTokenAndMergeSurroundingWhitespace($tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openBrace));
+            $tokens->clearTokenAndMergeSurroundingWhitespace($openBrace);
+        } while (true);
     }
 }

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -493,29 +493,19 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         return[
             [
                 '<?php
-
-$c=  1;
-$b = "c";
-$a = 1;
-
 switch($a) {
     case 1 === $a ? true : ${$b} : //
         echo 456;
         break;
-    
+    '.'
 
-    case ${$b}: 
+    case ${$b}: '.'
         echo 123;
         break;
-    
+    '.'
 }
 ',
                 '<?php
-
-$c=  1;
-$b = "c";
-$a = 1;
-
 switch($a) {
     case (1 === $a ? true : ${$b}) : {//
         echo 456;

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -345,33 +345,33 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
                 $a = 5.1;
                 $b = 1.0;
                 switch($a) {
-                    case (int) $a < 1 : {
+                    case (int) $a < 1 : '.'
                         echo "leave alone";
                         break;
-                    }
-                    case $a < 2/* test */: {
+                    '.'
+                    case $a < 2/* test */: '.'
                         echo "fix 1";
                         break;
-                    }
-                    case 3 : {
+                    '.'
+                    case 3 : '.'
                         echo "fix 2";
                         break;
-                    }
+                    '.'
                     case /**//**/ // test
                         4
                         /**///
-                        /**/: {
+                        /**/: '.'
                         echo "fix 3";
                         break;
-                    }
-                    case ((int)$b) + 4.1: {
+                    '.'
+                    case ((int)$b) + 4.1: '.'
                         echo "fix 4";
                         break;
-                    }
-                    case ($b + 1) * 2: {
+                    '.'
+                    case ($b + 1) * 2: '.'
                         echo "leave alone";
                         break;
-                    }
+                    '.'
                 }
                 ',
                 '<?php
@@ -472,6 +472,101 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
             [
                 '<?php
                 $var = clone ($obj1->getSubject() ?? $obj2);
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideSwitchCases
+     */
+    public function testSwitchCases($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideSwitchCases()
+    {
+        return[
+            [
+                '<?php
+
+$c=  1;
+$b = "c";
+$a = 1;
+
+switch($a) {
+    case 1 === $a ? true : ${$b} : //
+        echo 456;
+        break;
+    
+
+    case ${$b}: 
+        echo 123;
+        break;
+    
+}
+',
+                '<?php
+
+$c=  1;
+$b = "c";
+$a = 1;
+
+switch($a) {
+    case (1 === $a ? true : ${$b}) : {//
+        echo 456;
+        break;
+    }
+
+    case ${$b}: {
+        echo 123;
+        break;
+    }
+}
+',
+            ],
+            [
+                '<?php
+                    switch($a) {
+                        case 0; '.'
+                        '.'
+                        case 1 : /**/
+                        '.'
+                        case 2 ;  // a
+                        '.'
+                        default : '.'
+                            $a = function() {};
+                        '.'
+                    }
+                ',
+                '<?php
+                    switch($a) {
+                        case 0; {
+                        }
+                        case 1 : /**/{
+                        }
+                        case 2 ; {{{ // a
+                        }}}
+                        default : {
+                            $a = function() {};
+                        }
+                    }
+                ',
+            ],
+            [
+'<?php switch ($foo): ?>
+<?php case 1:  ?>
+        ...
+<?php  endswitch ?>
+                ',
+'<?php switch ($foo): ?>
+<?php case 1: { ?>
+        ...
+<?php } endswitch ?>
                 ',
             ],
         ];


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2798
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1540

not sure we want to add a configuration option to enable this behavior?

ping @nazarhussain
