### PR TITLE
NoUselessElseFixer - Fix detection of conditional block

### DIFF
--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -282,8 +282,9 @@ final class NoUselessElseFixer extends AbstractFixer
                     return false;
                 }
             } elseif ($token->equals(')')) {
+                $type = Tokens::detectBlockType($token);
                 $index = $tokens->findBlockEnd(
-                    Tokens::detectBlockType($token)['type'],
+                    $type['type'],
                     $index,
                     false
                 );


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2802

I've modified the fixer to skip all `if`, `elseif`, `else` cases if these miss the `{}` body, this means we loose a bunch of opportunities. However these are edge cases and hard to fix.
So lets bug fix first and I've someone want to fix those edges as well than that can be done in another PR.