### PR TITLE
Fixing code style automagically by pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.php_cs
 /composer.lock
 /phpunit.xml
 /vendor/

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,46 @@
+<?php
+
+$header = <<<'EOF'
+This file is part of PHP CS Fixer.
+
+(c) Fabien Potencier <fabien@symfony.com>
+    Dariusz Rumiński <dariusz.ruminski@gmail.com>
+
+This source file is subject to the MIT license that is bundled
+with this source code in the file LICENSE.
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PHP56Migration' => true,
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'combine_consecutive_unsets' => true,
+        // one should use PHPUnit methods to set up expected exception instead of annotations
+        'general_phpdoc_annotation_remove' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp'],
+        'header_comment' => ['header' => $header],
+        'heredoc_to_nowdoc' => true,
+        'list_syntax' => ['syntax' => 'long'],
+        'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
+        'no_short_echo_tag' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'php_unit_test_class_requires_covers' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_order' => true,
+        'semicolon_after_instruction' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('tests/Fixtures')
+            ->in(__DIR__)
+    )
+;

--- a/build/hooks/pre-commit
+++ b/build/hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+echo "PHP-CS-Fixer pre commit hook start"
+
+ROOT=$(git rev-parse --show-toplevel)
+PHP_CS_FIXER_CONFIG_FILE="$ROOT/.php_cs"
+
+if [ -f $PHP_CS_FIXER_CONFIG_FILE ]; then
+
+    if [ -f $ROOT/php-cs-fixer ]; then
+        # Special case for PHP-CS-Fixer itself.
+        PHP_CS_FIXER="./php-cs-fixer"
+    elif [[ $OSTYPE =~ msys* || $OSTYPE =~ win* ]]; then
+        PHP_CS_FIXER="bin/php-cs-fixer.bat"
+    else
+        PHP_CS_FIXER="bin/php-cs-fixer"
+    fi
+
+    git status --porcelain | grep -e '^[AM]\(.*\).php$' | cut -c 3- | while read line; do
+        $PHP_CS_FIXER fix --config=$PHP_CS_FIXER_CONFIG_FILE --verbose "$line";
+        git add "$line";
+    done
+else
+    echo ""
+    echo "$PHP_CS_FIXER_CONFIG_FILE is missing, automatic code style fixing skipped"
+    echo ""
+fi
+
+echo "PHP-CS-Fixer pre commit hook finish"

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,14 @@
         "psr-4": { "PhpCsFixer\\Tests\\": "tests/" }
     },
     "bin": ["php-cs-fixer"],
+    "scripts": {
+        "post-install-cmd": [
+            "PhpCsFixer\\Composer\\ScriptHandler::enableAutoCSFix"
+        ],
+        "post-update-cmd": [
+            "PhpCsFixer\\Composer\\ScriptHandler::enableAutoCSFix"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.4-dev"

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -12,7 +12,8 @@
 
 namespace PhpCsFixer\Composer;
 
-use Composer\Script\Event;
+// Including it breaks tests.
+//use Composer\Script\Event;
 
 /**
  * @author Dmitry Danilson <patchranger+github@gmail.com>
@@ -24,7 +25,7 @@ class ScriptHandler
      *
      * @param Event $event
      */
-    public static function enableAutoCSFix(Event $event)
+    public static function enableAutoCSFix($event)
     {
         if (file_exists('./.git')) {
             $phpCsFixerPath = file_exists('./bin/php-cs-fixer')

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -14,6 +14,9 @@ namespace PhpCsFixer\Composer;
 
 use Composer\Script\Event;
 
+/**
+ * @author Dmitry Danilson <patchranger+github@gmail.com>
+ */
 class ScriptHandler
 {
     /**

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Composer;
+
+use Composer\Script\Event;
+
+class ScriptHandler
+{
+    /**
+     * Enables automatic code style fixing by pre-commit hook.
+     *
+     * @param Event $event
+     */
+    public static function enableAutoCSFix(Event $event)
+    {
+        if (file_exists('./.git')) {
+            $phpCsFixerPath = file_exists('./bin/php-cs-fixer')
+                ? './vendor/friendsofphp/php-cs-fixer/Symfony/CS'
+                : '.';
+            copy("{$phpCsFixerPath}/build/hooks/pre-commit", './.git/hooks/pre-commit');
+            chmod('./.git/hooks/pre-commit', 0775);
+        }
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -35,10 +35,10 @@ final class ProjectCodeTest extends TestCase
      * @var string[]
      */
     private static $classesWithoutTests = [
+        \PhpCsFixer\Composer\SciptHandler::class,
         \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class,
         \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
         \PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException::class,
-        \PhpCsFixer\Composer\SciptHandler::class,
         \PhpCsFixer\Console\Command\HelpCommand::class,
         \PhpCsFixer\Console\Command\DescribeNameNotFoundException::class,
         \PhpCsFixer\Console\Command\SelfUpdateCommand::class,

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -38,6 +38,7 @@ final class ProjectCodeTest extends TestCase
         \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class,
         \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
         \PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException::class,
+        \PhpCsFixer\Composer\SciptHandler::class,
         \PhpCsFixer\Console\Command\HelpCommand::class,
         \PhpCsFixer\Console\Command\DescribeNameNotFoundException::class,
         \PhpCsFixer\Console\Command\SelfUpdateCommand::class,

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -35,7 +35,6 @@ final class ProjectCodeTest extends TestCase
      * @var string[]
      */
     private static $classesWithoutTests = [
-        \PhpCsFixer\Composer\SciptHandler::class,
         \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class,
         \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
         \PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException::class,

--- a/tests/Composer/ScriptHandlerTest.php
+++ b/tests/Composer/ScriptHandlerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Composer;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Composer\ScriptHandler
+ */
+final class ScriptHandlerTest extends TestCase
+{
+}

--- a/tests/Composer/ScriptHandlerTest.php
+++ b/tests/Composer/ScriptHandlerTest.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\Tests\Composer;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @internal
  *

--- a/tests/Composer/ScriptHandlerTest.php
+++ b/tests/Composer/ScriptHandlerTest.php
@@ -21,4 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class ScriptHandlerTest extends TestCase
 {
+    public function testStub()
+    {
+    }
 }


### PR DESCRIPTION
## What
I've created a command to be placed inside `composer.json`. It is intended to copy bash-script as pre-commit git hook. Pre-commit git hook checks changes introduced by the commit - and automagically fixes them, according to defined code style standarts. In case if code style standarts are not defined (project missing `.php_cs`) - then a simple notification is shown.

## How
In order to get the power of auto-fixing for your project:
- Create `.php_cs` file, defining your code style rules.
- Require `php-cs-fixer` in `composer.json`.
- Run `composer install`.
=> When you try to commit to your project, your commit will be fixed to correspond code style on-the-fly without aborting commit.

The PR is based on similar experience from https://github.com/mautic/mautic/pull/2462 & https://github.com/mautic/mautic/pull/3157 . I've decided to push this functionality forward to incorporating it into `PHP-CS-Fixer` itself in order to make it re-usable by other projects.