### PR TITLE
ProcessLinter - compatibility with Symfony 3.3

### DIFF
--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -16,7 +16,7 @@ use PhpCsFixer\FileRemoval;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Handle PHP code linting process.
@@ -125,7 +125,7 @@ final class ProcessLinter implements LinterInterface
             return $this->createProcessForSource(file_get_contents($path));
         }
 
-        $process = new Process($this->prepareCommand($path));
+        $process = $this->prepareProcess($path);
         $process->setTimeout(null);
         $process->start();
 
@@ -154,22 +154,17 @@ final class ProcessLinter implements LinterInterface
     }
 
     /**
-     * Prepare command that will lint a file.
-     *
      * @param string $path
      *
-     * @return string
+     * @return Process
      */
-    private function prepareCommand($path)
+    private function prepareProcess($path)
     {
-        $executable = ProcessUtils::escapeArgument($this->executable);
-
+        $arguments = array('-l', $path);
         if (defined('HHVM_VERSION')) {
-            $executable .= ' --php';
+            array_unshift($arguemtns, '--php');
         }
 
-        $path = ProcessUtils::escapeArgument($path);
-
-        return sprintf('%s -l %s', $executable, $path);
+        return ProcessBuilder::create($arguments)->setPrefix($this->executable)->getProcess();
     }
 }

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -162,7 +162,7 @@ final class ProcessLinter implements LinterInterface
     {
         $arguments = array('-l', $path);
         if (defined('HHVM_VERSION')) {
-            array_unshift($arguemtns, '--php');
+            array_unshift($arguments, '--php');
         }
 
         return ProcessBuilder::create($arguments)->setPrefix($this->executable)->getProcess();

--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -14,7 +14,6 @@ namespace PhpCsFixer\Tests\Linter;
 
 use PhpCsFixer\Linter\ProcessLinter;
 use PhpCsFixer\Test\AccessibleObject;
-use Symfony\Component\Process\ProcessUtils;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -38,13 +37,13 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         }
 
         $this->assertSame(
-            $this->fixEscape('"php" -l "foo.php"'),
-            AccessibleObject::create(new ProcessLinter('php'))->prepareCommand('foo.php')
+            $this->fixEscape('"php" "-l" "foo.php"'),
+            AccessibleObject::create(new ProcessLinter('php'))->prepareProcess('foo.php')->getCommandLine()
         );
 
         $this->assertSame(
-            $this->fixEscape('"C:\Program Files\php\php.exe" -l "foo bar\baz.php"'),
-            AccessibleObject::create(new ProcessLinter('C:\Program Files\php\php.exe'))->prepareCommand('foo bar\baz.php')
+            $this->fixEscape('"C:\Program Files\php\php.exe" "-l" "foo bar\baz.php"'),
+            AccessibleObject::create(new ProcessLinter('C:\Program Files\php\php.exe'))->prepareProcess('foo bar\baz.php')->getCommandLine()
         );
     }
 
@@ -55,8 +54,8 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         }
 
         $this->assertSame(
-            $this->fixEscape('"hhvm" --php -l "foo.php"'),
-            AccessibleObject::create(new ProcessLinter('hhvm'))->prepareCommand('foo.php')
+            $this->fixEscape('"hhvm" "--php" "-l" "foo.php"'),
+            AccessibleObject::create(new ProcessLinter('hhvm'))->prepareProcess('foo.php')->getCommandLine()
         );
     }
 
@@ -85,7 +84,7 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         static $escapeChar = null;
 
         if (null === $escapeChar) {
-            $escapeChar = substr(ProcessUtils::escapeArgument('x'), 0, 1);
+            $escapeChar = substr(escapeshellarg('x'), 0, 1);
         }
 
         if ($usedEscapeChar === $escapeChar) {


### PR DESCRIPTION
Sadly, 3.3 introduced new deprecation (#21474).

One can not operate with `Process` directly to have same code on 3.2 and 3.3 that is not triggering the deprecation on 3.3 (as to avoid triggering deprecation one must to pass array to Process, which is not possible on 3.2). For that, I go behind `ProcessBuilder`, which has same interface between 3.2 and 3.3...