### PR TITLE
NonPrintableCharacterFixer - Add option to replace with escape sequences

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -772,12 +772,17 @@ Choose from the list of available rules:
 
   Remove trailing whitespace at the end of blank lines.
 
-* **non_printable_character** [@Symfony:risky]
+* **non_printable_character** [@Symfony:risky, @PHP70Migration, @PHP71Migration]
 
   Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other
   invisible unicode symbols.
 
   *Risky rule: risky when strings contain intended invisible characters.*
+
+  Configuration options:
+
+  - ``use_escape_sequences_in_strings`` (``bool``): whether characters should be
+    replaced with escape sequences in strings; defaults to ``false``
 
 * **normalize_index_brace** [@Symfony]
 

--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -13,17 +13,24 @@
 namespace PhpCsFixer\Fixer\Basic;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * Removes Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.
  *
  * @author Ivan Boprzenkov <ivan.borzenkov@gmail.com>
  */
-final class NonPrintableCharacterFixer extends AbstractFixer
+final class NonPrintableCharacterFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
     private $symbolsReplace;
 
@@ -40,12 +47,13 @@ final class NonPrintableCharacterFixer extends AbstractFixer
     public function __construct()
     {
         parent::__construct();
+
         $this->symbolsReplace = [
-            pack('CCC', 0xe2, 0x80, 0x8b) => '', // ZWSP
-            pack('CCC', 0xe2, 0x80, 0x87) => ' ', // FIGURE SPACE
-            pack('CCC', 0xe2, 0x80, 0xaf) => ' ', // NBSP
-            pack('CCC', 0xe2, 0x81, 0xa0) => '', // WORD JOINER
-            pack('CC', 0xc2, 0xa0) => ' ', // NO-BREAK SPACE
+            pack('H*', 'e2808b') => ['', '200b'], // ZWSP U+200B
+            pack('H*', 'e28087') => [' ', '2007'], // FIGURE SPACE U+2007
+            pack('H*', 'e280af') => [' ', '202f'], // NBSP U+202F
+            pack('H*', 'e281a0') => ['', '2060'], // WORD JOINER U+2060
+            pack('H*', 'c2a0') => [' ', 'a0'], // NO-BREAK SPACE U+A0
         ];
     }
 
@@ -58,10 +66,12 @@ final class NonPrintableCharacterFixer extends AbstractFixer
             'Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.',
             [
                 new CodeSample(
-'<?php
-
-echo "'.pack('CCC', 0xe2, 0x80, 0x8b).'Hello'.pack('CCC', 0xe2, 0x80, 0x87).'World'.pack('CC', 0xc2, 0xa0).'!";
-'
+                    '<?php echo "'.pack('H*', 'e2808b').'Hello'.pack('H*', 'e28087').'World'.pack('H*', 'c2a0').'!";'
+                ),
+                new VersionSpecificCodeSample(
+                    '<?php echo "'.pack('H*', 'e2808b').'Hello'.pack('H*', 'e28087').'World'.pack('H*', 'c2a0').'!";',
+                    new VersionSpecification(70000),
+                    ['use_escape_sequences_in_strings' => true]
                 ),
             ],
             null,
@@ -88,11 +98,72 @@ echo "'.pack('CCC', 0xe2, 0x80, 0x8b).'Hello'.pack('CCC', 0xe2, 0x80, 0x87).'Wor
     /**
      * {@inheritdoc}
      */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('use_escape_sequences_in_strings', 'Whether characters should be replaced with escape sequences in strings.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false) // @TODO change to true in 3.0
+                ->setNormalizer(function (Options $options, $value) {
+                    if (PHP_VERSION_ID < 70000 && $value) {
+                        throw new InvalidOptionsException('Escape sequences require PHP 7.0+.');
+                    }
+
+                    return $value;
+                })
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        $replacements = [];
+        $escapeSequences = [];
+        foreach ($this->symbolsReplace as $character => list($replacement, $codepoint)) {
+            $replacements[$character] = $replacement;
+            $escapeSequences[$character] = '\u{'.$codepoint.'}';
+        }
+
         foreach ($tokens as $index => $token) {
-            if (in_array($token->getId(), self::$tokens, true)) {
-                $tokens[$index] = new Token([$token->getId(), strtr($token->getContent(), $this->symbolsReplace)]);
+            $content = $token->getContent();
+
+            if (
+                $this->configuration['use_escape_sequences_in_strings']
+                && $token->isGivenKind([T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE])
+            ) {
+                if (!preg_match('/'.implode('|', array_keys($escapeSequences)).'/', $content)) {
+                    continue;
+                }
+
+                $previousToken = $tokens[$index - 1];
+                $stringTypeChanged = false;
+
+                if ($previousToken->isGivenKind(T_START_HEREDOC)) {
+                    $previousTokenContent = $previousToken->getContent();
+
+                    if (false !== strpos($previousTokenContent, '\'')) {
+                        $tokens[$index - 1] = new Token([T_START_HEREDOC, str_replace('\'', '', $previousTokenContent)]);
+                        $stringTypeChanged = true;
+                    }
+                } elseif ("'" === $content[0]) {
+                    $content = preg_replace('/^\'(.*)\'$/', '"$1"', $content);
+                    $stringTypeChanged = true;
+                }
+
+                if ($stringTypeChanged) {
+                    $content = preg_replace('/([\\\\$])/', '\\\\$1', $content);
+                }
+
+                $tokens[$index] = new Token([$token->getId(), strtr($content, $escapeSequences)]);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(self::$tokens)) {
+                $tokens[$index] = new Token([$token->getId(), strtr($content, $replacements)]);
             }
         }
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -157,6 +157,9 @@ final class RuleSet implements RuleSetInterface
         ],
         '@PHP70Migration' => [
             '@PHP56Migration' => true,
+            'non_printable_character' => [
+                'use_escape_sequences_in_strings' => true,
+            ],
             'random_api_migration' => [
                 'mt_rand' => 'random_int',
                 'rand' => 'random_int',


### PR DESCRIPTION
Using this option makes the fixer non-risky by replacing characters with `\u{...}` escape sequences instead of removing them.

I also replaced `pack('CCC', x, y, z)` with `pack('H*', 'xyz')` because I find the later easier to read, is it ok?