### PR TITLE
Add PhpdocTypesOrderFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -38,6 +38,7 @@ return PhpCsFixer\Config::create()
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
+        'phpdoc_types_order' => true,
         'semicolon_after_instruction' => true,
         'single_line_comment_style' => true,
         'strict_comparison' => true,

--- a/README.rst
+++ b/README.rst
@@ -1041,7 +1041,7 @@ Choose from the list of available rules:
     position of ``null`` (overrides ``sort_algorithm``); defaults to
     ``'always_first'``
   - ``sort_algorithm`` (``'alpha'``, ``'none'``): the sorting algorithm to apply;
-    defaults to ``'none'``
+    defaults to ``'alpha'``
 
 * **phpdoc_var_without_name** [@Symfony]
 

--- a/README.rst
+++ b/README.rst
@@ -1037,8 +1037,9 @@ Choose from the list of available rules:
 
   Configuration options:
 
-  - ``null_position`` (``'always_first'``, ``'always_last'``, ``'default'``): forces the
-    position of ``null``; defaults to ``'always_first'``
+  - ``null_adjustment`` (``'always_first'``, ``'always_last'``, ``'none'``): forces the
+    position of ``null`` (overrides ``sort_algorithm``); defaults to
+    ``'always_first'``
   - ``sort_algorithm`` (``'alpha'``, ``'none'``): the sorting algorithm to apply;
     defaults to ``'none'``
 

--- a/README.rst
+++ b/README.rst
@@ -1031,6 +1031,17 @@ Choose from the list of available rules:
 
   The correct case must be used for standard PHP types in phpdoc.
 
+* **phpdoc_types_order**
+
+  Sorts PHPDoc types.
+
+  Configuration options:
+
+  - ``null_position`` (``'always_first'``, ``'always_last'``, ``'default'``): forces the
+    position of ``null``; defaults to ``'always_first'``
+  - ``sort_algorithm`` (``'alpha'``, ``'none'``): the sorting algorithm to apply;
+    defaults to ``'none'``
+
 * **phpdoc_var_without_name** [@Symfony]
 
   @var and @type annotations should not contain the variable name.

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|\Traversable|string[]
+     * @return iterable|string[]|\Traversable
      */
     public function getFinder();
 
@@ -107,7 +107,7 @@ interface ConfigInterface
      *
      * Name of custom fixer should follow `VendorName/rule_name` convention.
      *
-     * @param iterable|\Traversable|FixerInterface[] $fixers
+     * @param FixerInterface[]|iterable|\Traversable $fixers
      */
     public function registerCustomFixers($fixers);
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param iterable|\Traversable|string[] $finder
+     * @param iterable|string[]|\Traversable $finder
      *
      * @return self
      */

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -315,7 +315,7 @@ class Example
      * @param Tokens $tokens
      * @param int    $index
      *
-     * @return string|array type or array of type and name
+     * @return array|string type or array of type and name
      */
     private function detectElementType(Tokens $tokens, $index)
     {

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -174,7 +174,7 @@ class Sample
      * @param Tokens $tokens Tokens collection
      * @param int    $index  token index
      *
-     * @return array<string, Token|null> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array<string, null|Token> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
      */
     private function grabAttribsBeforeMethodToken(Tokens $tokens, $index)
     {
@@ -207,7 +207,7 @@ class Sample
      *
      * @param Tokens                    $tokens      Tokens collection
      * @param int                       $memberIndex token index
-     * @param array<string, Token|null> $attribs     map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @param array<string, null|Token> $attribs     map of grabbed attributes, key is attribute name and value is array of index and clone of Token
      */
     private function overrideAttribs(Tokens $tokens, $memberIndex, array $attribs)
     {
@@ -242,7 +242,7 @@ class Sample
      * @param Tokens $tokens Tokens collection
      * @param int    $index  token index
      *
-     * @return array<string, Token|null> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array<string, null|Token> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
      */
     private function grabAttribsBeforePropertyToken(Tokens $tokens, $index)
     {
@@ -270,10 +270,10 @@ class Sample
      *
      * @param Tokens                    $tokens          Tokens collection
      * @param int                       $index           token index
-     * @param array<int, string|null>   $tokenAttribsMap token to attribute name map
-     * @param array<string, Token|null> $attribs         array of token attributes
+     * @param array<int, null|string>   $tokenAttribsMap token to attribute name map
+     * @param array<string, null|Token> $attribs         array of token attributes
      *
-     * @return array<string, Token|null> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
+     * @return array<string, null|Token> map of grabbed attributes, key is attribute name and value is array of index and clone of Token
      */
     private function grabAttribsBeforeToken(Tokens $tokens, $index, array $tokenAttribsMap, array $attribs)
     {

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -120,7 +120,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
     }
 
     /**
-     * @return array<string|array>
+     * @return array<array|string>
      */
     private function getBraceAfterVariableKinds()
     {

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -220,7 +220,7 @@ $className = Baz::class;
     }
 
     /**
-     * @param string|false $classImport
+     * @param false|string $classImport
      * @param string       $classString
      *
      * @return string

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -124,7 +124,7 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
      * @param Tokens $tokens
      * @param int    $index
      *
-     * @return int[]|int
+     * @return int|int[]
      */
     private function getPreviousUnsetCall(Tokens $tokens, $index)
     {

--- a/src/Fixer/ListNotation/ListSyntaxFixer.php
+++ b/src/Fixer/ListNotation/ListSyntaxFixer.php
@@ -34,7 +34,7 @@ final class ListSyntaxFixer extends AbstractFixer implements ConfigurationDefini
     /**
      * Use 'syntax' => 'long'|'short'.
      *
-     * @param array<string, string>|null $configuration
+     * @param null|array<string, string> $configuration
      *
      * @throws InvalidFixerConfigurationException
      */

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -281,7 +281,7 @@ $this->assertTrue(is_nan($a));
 
     /**
      * @param Tokens    $tokens
-     * @param int|false $callNSIndex
+     * @param false|int $callNSIndex
      * @param int       $callIndex
      * @param int       $openIndex
      * @param int       $closeIndex

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -94,7 +94,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('sort_algorithm', 'The sorting algorithm to apply.'))
                 ->setAllowedValues(['alpha', 'none'])
-                ->setDefault('none')
+                ->setDefault('alpha')
                 ->getOption(),
             (new FixerOptionBuilder('null_adjustment', 'Forces the position of `null` (overrides `sort_algorithm`).'))
                 ->setAllowedValues(['always_first', 'always_last', 'none'])

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Phpdoc;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
+
+final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Sorts PHPDoc types.',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * @param string|null $bar
+ */'
+                ),
+                new CodeSample(
+                    '<?php
+/**
+ * @param null|string $bar
+ */',
+                    ['null_position' => 'always_last']
+                ),
+                new CodeSample(
+                    '<?php
+/**
+ * @param null|string|int|\Foo $bar
+ */',
+                    ['sort_algorithm' => 'alpha']
+                ),
+                new CodeSample(
+                    '<?php
+/**
+ * @param null|string|int|\Foo $bar
+ */',
+                    [
+                        'sort_algorithm' => 'alpha',
+                        'null_position' => 'always_last',
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+/**
+ * @param null|string|int|\Foo $bar
+ */',
+                    [
+                        'sort_algorithm' => 'alpha',
+                        'null_position' => 'default',
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('sort_algorithm', 'The sorting algorithm to apply.'))
+                ->setAllowedValues(['alpha', 'none'])
+                ->setDefault('none')
+                ->getOption(),
+            (new FixerOptionBuilder('null_position', 'Forces the position of `null`.'))
+                ->setAllowedValues(['always_first', 'always_last', 'default'])
+                ->setDefault('always_first')
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType(Annotation::getTagsWithTypes());
+
+            if (!count($annotations)) {
+                continue;
+            }
+
+            foreach ($annotations as $annotation) {
+                $types = $annotation->getTypes();
+
+                // fix main types
+                $annotation->setTypes($this->sortTypes($types));
+
+                // fix @method parameters types
+                $line = $doc->getLine($annotation->getStart());
+                $line->setContent(preg_replace_callback('/(@method\s+.+?\s+\w+\()(.*)\)/', function (array $matches) {
+                    $sorted = preg_replace_callback('/((?:^|,)\s*)([^\s]+)/', function (array $matches) {
+                        return $matches[1].$this->sortJoinedTypes($matches[2]);
+                    }, $matches[2]);
+
+                    return $matches[1].$sorted.')';
+                }, $line->getContent()));
+            }
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+        }
+    }
+
+    /**
+     * @param string[] $types
+     *
+     * @return string[]
+     */
+    private function sortTypes(array $types)
+    {
+        foreach ($types as $index => $type) {
+            $types[$index] = preg_replace_callback('/^([^<]+)<(?:(.+?)(,\s*))?(.*)>$/', function (array $matches) {
+                return $matches[1].'<'.$this->sortJoinedTypes($matches[2]).$matches[3].$this->sortJoinedTypes($matches[4]).'>';
+            }, $type);
+        }
+
+        if ('alpha' === $this->configuration['sort_algorithm']) {
+            $types = Utils::stableSort(
+                $types,
+                function ($type) { return $type; },
+                function ($typeA, $typeB) {
+                    $regexp = '/^\\??\\\?/';
+
+                    return strcasecmp(
+                        preg_replace($regexp, '', $typeA),
+                        preg_replace($regexp, '', $typeB)
+                    );
+                }
+            );
+        }
+
+        if ('default' !== $this->configuration['null_position']) {
+            $nulls = [];
+            foreach ($types as $index => $type) {
+                if (preg_match('/^\\\?null$/i', $type)) {
+                    $nulls[$index] = $type;
+                    unset($types[$index]);
+                }
+            }
+
+            if (count($nulls)) {
+                if ('always_last' === $this->configuration['null_position']) {
+                    array_push($types, ...$nulls);
+                } else {
+                    array_unshift($types, ...$nulls);
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param string $types
+     *
+     * @return string
+     */
+    private function sortJoinedTypes($types)
+    {
+        $types = array_filter(
+            preg_split('/([^|<]+(?:<.*>)?)/', $types, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
+            function ($value) {
+                return '|' !== $value;
+            }
+        );
+
+        return implode('|', $this->sortTypes($types));
+    }
+}

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -45,7 +45,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
 /**
  * @param null|string $bar
  */',
-                    ['null_position' => 'always_last']
+                    ['null_adjustment' => 'always_last']
                 ),
                 new CodeSample(
                     '<?php
@@ -61,7 +61,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
  */',
                     [
                         'sort_algorithm' => 'alpha',
-                        'null_position' => 'always_last',
+                        'null_adjustment' => 'always_last',
                     ]
                 ),
                 new CodeSample(
@@ -71,7 +71,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
  */',
                     [
                         'sort_algorithm' => 'alpha',
-                        'null_position' => 'default',
+                        'null_adjustment' => 'none',
                     ]
                 ),
             ]
@@ -96,8 +96,8 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
                 ->setAllowedValues(['alpha', 'none'])
                 ->setDefault('none')
                 ->getOption(),
-            (new FixerOptionBuilder('null_position', 'Forces the position of `null`.'))
-                ->setAllowedValues(['always_first', 'always_last', 'default'])
+            (new FixerOptionBuilder('null_adjustment', 'Forces the position of `null` (overrides `sort_algorithm`).'))
+                ->setAllowedValues(['always_first', 'always_last', 'none'])
                 ->setDefault('always_first')
                 ->getOption(),
         ]);
@@ -166,7 +166,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
             );
         }
 
-        if ('default' !== $this->configuration['null_position']) {
+        if ('none' !== $this->configuration['null_adjustment']) {
             $nulls = [];
             foreach ($types as $index => $type) {
                 if (preg_match('/^\\\?null$/i', $type)) {
@@ -176,7 +176,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
             }
 
             if (count($nulls)) {
-                if ('always_last' === $this->configuration['null_position']) {
+                if ('always_last' === $this->configuration['null_adjustment']) {
                     array_push($types, ...$nulls);
                 } else {
                     array_unshift($types, ...$nulls);

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -223,17 +223,15 @@ final class FixerFactory
         // Schwartzian transform is used to improve the efficiency and avoid
         // `usort(): Array was modified by the user comparison function` warning for mocked objects.
 
-        $data = array_map(function (FixerInterface $fixer) {
-            return [$fixer, $fixer->getPriority()];
-        }, $this->fixers);
-
-        usort($data, function (array $a, array $b) {
-            return Utils::cmpInt($b[1], $a[1]);
-        });
-
-        $this->fixers = array_map(function (array $item) {
-            return $item[0];
-        }, $data);
+        $this->fixers = Utils::stableSort(
+            $this->fixers,
+            function (FixerInterface $fixer) {
+                return $fixer->getPriority();
+            },
+            function ($a, $b) {
+                return Utils::cmpInt($b, $a);
+            }
+        );
 
         return $this;
     }

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -51,7 +51,7 @@ class Token
     private $changed = false;
 
     /**
-     * @param string|array $token token prototype
+     * @param array|string $token token prototype
      */
     public function __construct($token)
     {
@@ -129,7 +129,7 @@ class Token
      *
      * If tokens are arrays, then only keys defined in parameter token are checked.
      *
-     * @param Token|array|string $other         token or it's prototype
+     * @param array|string|Token $other         token or it's prototype
      * @param bool               $caseSensitive perform a case sensitive comparison
      *
      * @return bool
@@ -188,7 +188,7 @@ class Token
     /**
      * A helper method used to find out whether or not a certain input token has to be case-sensitively matched.
      *
-     * @param bool|array<int, bool> $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     * @param array<int, bool>|bool $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
      *                                             the ones used in $others. If any is missing, the default case-sensitive
      *                                             comparison is used
      * @param int                   $key           the key of the token that has to be looked up
@@ -205,7 +205,7 @@ class Token
     }
 
     /**
-     * @return string|array token prototype
+     * @return array|string token prototype
      */
     public function getPrototype()
     {
@@ -456,7 +456,7 @@ class Token
      *
      * If called on Token inside Tokens collection please use `Tokens::overrideAt` instead.
      *
-     * @param Token|array|string $other token prototype
+     * @param array|string|Token $other token prototype
      *
      * @deprecated since 2.4
      */

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -68,7 +68,7 @@ class Tokens extends \SplFixedArray
      * was ever seen inside the collection (but may not be part of it any longer).
      * The key is token kind and the value is always true.
      *
-     * @var array<string|int, int>
+     * @var array<int|string, int>
      */
     private $foundTokenKinds = [];
 
@@ -474,7 +474,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * @param int|array $possibleKind kind or array of kind
+     * @param array|int $possibleKind kind or array of kind
      * @param int       $start        optional offset
      * @param null|int  $end          optional limit
      *
@@ -776,7 +776,7 @@ class Tokens extends \SplFixedArray
      * @param array                 $sequence      an array of tokens (kinds) (same format used by getNextTokenOfKind)
      * @param int                   $start         start index, defaulting to the start of the file
      * @param int                   $end           end index, defaulting to the end of the file
-     * @param bool|array<int, bool> $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
+     * @param array<int, bool>|bool $caseSensitive global case sensitiveness or an array of booleans, whose keys should match
      *                                             the ones used in $others. If any is missing, the default case-sensitive
      *                                             comparison is used
      *
@@ -874,7 +874,7 @@ class Tokens extends \SplFixedArray
      * Insert instances of Token inside collection.
      *
      * @param int                  $index start inserting index
-     * @param Tokens|Token[]|Token $items instances of Token to insert
+     * @param Token|Token[]|Tokens $items instances of Token to insert
      */
     public function insertAt($index, $items)
     {
@@ -945,7 +945,7 @@ class Tokens extends \SplFixedArray
      * Override token at given index and register it.
      *
      * @param int                $index
-     * @param Token|array|string $token token prototype
+     * @param array|string|Token $token token prototype
      *
      * @deprecated since 2.4, use offsetSet instead
      */
@@ -963,7 +963,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int            $indexStart start overriding index
      * @param int            $indexEnd   end overriding index
-     * @param Tokens|Token[] $items      tokens to insert
+     * @param Token[]|Tokens $items      tokens to insert
      */
     public function overrideRange($indexStart, $indexEnd, $items)
     {
@@ -1313,7 +1313,7 @@ class Tokens extends \SplFixedArray
     /**
      * Register token as found.
      *
-     * @param Token|array|string $token token prototype
+     * @param array|string|Token $token token prototype
      */
     private function registerFoundToken($token)
     {
@@ -1329,7 +1329,7 @@ class Tokens extends \SplFixedArray
     /**
      * Register token as found.
      *
-     * @param Token|array|string $token token prototype
+     * @param array|string|Token $token token prototype
      */
     private function unregisterFoundToken($token)
     {
@@ -1343,7 +1343,7 @@ class Tokens extends \SplFixedArray
     }
 
     /**
-     * @param Token|array|string $token token prototype
+     * @param array|string|Token $token token prototype
      *
      * @return int|string
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -128,9 +128,9 @@ final class Utils
     }
 
     /**
-     * Sorts the given values using a Schwartzian transform and a custom
-     * comparison function. Order of equal elements is maintained. Only
-     * supports integer keys.
+     * Perform stable sorting using provided comparison function.
+     *
+     * Stability is ensured by using Schwartzian transform.
      *
      * @param mixed[]  $elements
      * @param callable $getComparedValue a callable that takes a single element and returns the value to compare

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -126,4 +126,36 @@ final class Utils
 
         return ltrim($str, "\n");
     }
+
+    /**
+     * Sorts the given values using a Schwartzian transform and a custom
+     * comparison function. Order of equal elements is maintained. Only
+     * supports integer keys.
+     *
+     * @param mixed[]  $elements
+     * @param callable $getComparedValue a callable that takes a single element and returns the value to compare
+     * @param callable $compareValues    a callable that compares two values
+     *
+     * @return mixed[]
+     */
+    public static function stableSort(array $elements, callable $getComparedValue, callable $compareValues)
+    {
+        array_walk($elements, function (&$element, $index) use ($getComparedValue) {
+            $element = [$element, $index, $getComparedValue($element)];
+        });
+
+        usort($elements, function ($a, $b) use ($compareValues) {
+            $comparison = $compareValues($a[2], $b[2]);
+
+            if (0 !== $comparison) {
+                return $comparison;
+            }
+
+            return self::cmpInt($a[1], $b[1]);
+        });
+
+        return array_map(function (array $item) {
+            return $item[0];
+        }, $elements);
+    }
 }

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -986,7 +986,7 @@ final class ConfigurationResolverTest extends TestCase
 
     /**
      * @param string      $expected
-     * @param string|bool $differConfig
+     * @param bool|string $differConfig
      *
      * @dataProvider provideDifferCases
      */

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
@@ -24,7 +24,7 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
 {
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixCases
      */
@@ -35,7 +35,7 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixCases
      */
@@ -108,7 +108,7 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixWithColonCases
      */

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -35,7 +35,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixCases
      */
@@ -320,7 +320,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixWithIndentedMixedLinesCases
      */

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -137,6 +137,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
                 '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
                 '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
             ],
+            [
+                '<?php /** @var null|Foo[]|Foo|Foo\Bar|Foo_Bar */',
+                '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
+            ],
         ];
     }
 
@@ -251,6 +255,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
                 '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
                 '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
             ],
+            [
+                '<?php /** @var Foo[]|Foo|Foo\Bar|Foo_Bar|null */',
+                '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
+            ],
         ];
     }
 
@@ -361,6 +369,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
                 '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
                 '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
             ],
+            [
+                '<?php /** @var Foo|Foo[]|Foo\Bar|Foo_Bar|null */',
+                '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
+            ],
         ];
     }
 
@@ -468,6 +480,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
                 '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+            ],
+            [
+                '<?php /** @var null|Foo|Foo[]|Foo\Bar|Foo_Bar */',
+                '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
             ],
         ];
     }
@@ -578,6 +594,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
                 '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+            ],
+            [
+                '<?php /** @var Foo|Foo[]|Foo\Bar|Foo_Bar|null */',
+                '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
             ],
         ];
     }

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -25,7 +25,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixCases
+     * @dataProvider getFixWithAlphaAlgorithmAndNullAlwaysFirstCases
      */
     public function testFix($expected, $input = null)
     {
@@ -148,7 +148,10 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
      */
     public function testFixWithNullLast($expected, $input = null)
     {
-        $this->fixer->configure(['null_adjustment' => 'always_last']);
+        $this->fixer->configure([
+            'sort_algorithm' => 'none',
+            'null_adjustment' => 'always_last',
+        ]);
 
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -1,0 +1,581 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Phpdoc;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Phpdoc\PhpdocTypesOrderFixer
+ */
+final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixCases
+     */
+    public function testFixWithNullFirst($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'none',
+            'null_position' => 'always_first',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function getFixCases()
+    {
+        return [
+            [
+                '<?php /** @var null|string */',
+                '<?php /** @var string|null */',
+            ],
+            [
+                '<?php /** @param null|string $foo */',
+                '<?php /** @param string|null $foo */',
+            ],
+            [
+                '<?php /** @property null|string $foo */',
+                '<?php /** @property string|null $foo */',
+            ],
+            [
+                '<?php /** @property-read null|string $foo */',
+                '<?php /** @property-read string|null $foo */',
+            ],
+            [
+                '<?php /** @property-write null|string $foo */',
+                '<?php /** @property-write string|null $foo */',
+            ],
+            [
+                '<?php /** @method null|string foo(null|int $foo, null|string $bar) */',
+                '<?php /** @method string|null foo(int|null $foo, string|null $bar) */',
+            ],
+            [
+                '<?php /** @return null|string */',
+                '<?php /** @return string|null */',
+            ],
+            [
+                '<?php /** @var null|string[]|resource|false|object|Foo|Bar\Baz|bool[]|string|array|int */',
+                '<?php /** @var string[]|resource|false|object|null|Foo|Bar\Baz|bool[]|string|array|int */',
+            ],
+            [
+                '<?php /** @var null|array<int, string> Foo */',
+                '<?php /** @var array<int, string>|null Foo */',
+            ],
+            [
+                '<?php /** @var null|array<int, array<string>> Foo */',
+                '<?php /** @var array<int, array<string>>|null Foo */',
+            ],
+            [
+                '<?php /** @var NULL|string */',
+                '<?php /** @var string|NULL */',
+            ],
+            [
+                '<?php /** @var Foo|?Bar */',
+            ],
+            [
+                '<?php /** @var ?Foo|Bar */',
+            ],
+            [
+                '<?php /** @var array<null|string> */',
+                '<?php /** @var array<string|null> */',
+            ],
+            [
+                '<?php /** @var array<int, null|string> */',
+                '<?php /** @var array<int, string|null> */',
+            ],
+            [
+                '<?php /** @var array<int,     array<null|int|string>> */',
+                '<?php /** @var array<int,     array<int|string|null>> */',
+            ],
+            [
+                '<?php /** @var null|null */',
+            ],
+            [
+                '<?php /** @var null|\null */',
+            ],
+            [
+                '<?php /** @var \null|null */',
+            ],
+            [
+                '<?php /** @var \null|\null */',
+            ],
+            [
+                '<?php /** @var \null|int */',
+                '<?php /** @var int|\null */',
+            ],
+            [
+                '<?php /** @var array<\null|int> */',
+                '<?php /** @var array<int|\null> */',
+            ],
+            [
+                '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+                '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixWithNullLastCases
+     */
+    public function testFixWithNullLast($expected, $input = null)
+    {
+        $this->fixer->configure(['null_position' => 'always_last']);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function getFixWithNullLastCases()
+    {
+        return [
+            [
+                '<?php /** @var string|null */',
+                '<?php /** @var null|string */',
+            ],
+            [
+                '<?php /** @param string|null $foo */',
+                '<?php /** @param null|string $foo */',
+            ],
+            [
+                '<?php /** @property string|null $foo */',
+                '<?php /** @property null|string $foo */',
+            ],
+            [
+                '<?php /** @property-read string|null $foo */',
+                '<?php /** @property-read null|string $foo */',
+            ],
+            [
+                '<?php /** @property-write string|null $foo */',
+                '<?php /** @property-write null|string $foo */',
+            ],
+            [
+                '<?php /** @method string|null foo(int|null $foo, string|null $bar) */',
+                '<?php /** @method null|string foo(null|int $foo, null|string $bar) */',
+            ],
+            [
+                '<?php /** @return string|null */',
+                '<?php /** @return null|string */',
+            ],
+            [
+                '<?php /** @var string[]|resource|false|object|Foo|Bar\Baz|bool[]|string|array|int|null */',
+                '<?php /** @var string[]|resource|false|object|null|Foo|Bar\Baz|bool[]|string|array|int */',
+            ],
+            [
+                '<?php /** @var array<int, string>|null Foo */',
+                '<?php /** @var null|array<int, string> Foo */',
+            ],
+            [
+                '<?php /** @var array<int, array<string>>|null Foo */',
+                '<?php /** @var null|array<int, array<string>> Foo */',
+            ],
+            [
+                '<?php /** @var string|NULL */',
+                '<?php /** @var NULL|string */',
+            ],
+            [
+                '<?php /** @var Foo|?Bar */',
+            ],
+            [
+                '<?php /** @var ?Foo|Bar */',
+            ],
+            [
+                '<?php /** @var Foo|?\Bar */',
+            ],
+            [
+                '<?php /** @var ?\Foo|Bar */',
+            ],
+            [
+                '<?php /** @var array<string|null> */',
+                '<?php /** @var array<null|string> */',
+            ],
+            [
+                '<?php /** @var array<int, string|null> */',
+                '<?php /** @var array<int, null|string> */',
+            ],
+            [
+                '<?php /** @var array<int,     array<int|string|null>> */',
+                '<?php /** @var array<int,     array<null|int|string>> */',
+            ],
+            [
+                '<?php /** @var null|null */',
+            ],
+            [
+                '<?php /** @var null|\null */',
+            ],
+            [
+                '<?php /** @var \null|null */',
+            ],
+            [
+                '<?php /** @var \null|\null */',
+            ],
+            [
+                '<?php /** @var int|\null */',
+                '<?php /** @var \null|int */',
+            ],
+            [
+                '<?php /** @var array<int|\null> */',
+                '<?php /** @var array<\null|int> */',
+            ],
+            [
+                '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+                '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixWithAlphaAlgorithmCases
+     */
+    public function testFixWithAlphaAlgorithm($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'alpha',
+            'null_position' => 'default',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function getFixWithAlphaAlgorithmCases()
+    {
+        return [
+            [
+                '<?php /** @var int|null|string */',
+                '<?php /** @var string|int|null */',
+            ],
+            [
+                '<?php /** @param Bar|\Foo */',
+                '<?php /** @param \Foo|Bar */',
+            ],
+            [
+                '<?php /** @property-read \Bar|Foo */',
+                '<?php /** @property-read Foo|\Bar */',
+            ],
+            [
+                '<?php /** @property-write bar|Foo */',
+                '<?php /** @property-write Foo|bar */',
+            ],
+            [
+                '<?php /** @return Bar|foo */',
+                '<?php /** @return foo|Bar */',
+            ],
+            [
+                '<?php /** @method \Bar|Foo foo(\Bar|Foo $foo, \Bar|Foo $bar) */',
+                '<?php /** @method Foo|\Bar foo(Foo|\Bar $foo, Foo|\Bar $bar) */',
+            ],
+            [
+                '<?php /** @var array|Bar\Baz|bool[]|false|Foo|int|null|object|resource|string|string[] */',
+                '<?php /** @var string[]|resource|false|object|null|Foo|Bar\Baz|bool[]|string|array|int */',
+            ],
+            [
+                '<?php /** @var array<int, string>|null Foo */',
+                '<?php /** @var null|array<int, string> Foo */',
+            ],
+            [
+                '<?php /** @var array<int, array<string>>|null Foo */',
+                '<?php /** @var null|array<int, array<string>> Foo */',
+            ],
+            [
+                '<?php /** @var ?Bar|Foo */',
+                '<?php /** @var Foo|?Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?Foo */',
+                '<?php /** @var ?Foo|Bar */',
+            ],
+            [
+                '<?php /** @var ?\Bar|Foo */',
+                '<?php /** @var Foo|?\Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?\Foo */',
+                '<?php /** @var ?\Foo|Bar */',
+            ],
+            [
+                '<?php /** @var array<null|string> */',
+                '<?php /** @var array<string|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string, null|string> */',
+                '<?php /** @var array<string|int, string|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string,     array<int|string, null|string>> */',
+                '<?php /** @var array<string|int,     array<string|int, string|null>> */',
+            ],
+            [
+                '<?php /** @var null|null */',
+            ],
+            [
+                '<?php /** @var null|\null */',
+            ],
+            [
+                '<?php /** @var \null|null */',
+            ],
+            [
+                '<?php /** @var \null|\null */',
+            ],
+            [
+                '<?php /** @var int|\null|string */',
+                '<?php /** @var string|\null|int */',
+            ],
+            [
+                '<?php /** @var array<int|\null|string> */',
+                '<?php /** @var array<string|\null|int> */',
+            ],
+            [
+                '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+                '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixWithAlphaAlgorithmAndNullAlwaysFirstCases
+     */
+    public function testFixWithAlphaAlgorithmAndNullAlwaysFirst($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'alpha',
+            'null_position' => 'always_first',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function getFixWithAlphaAlgorithmAndNullAlwaysFirstCases()
+    {
+        return [
+            [
+                '<?php /** @var null|int|string */',
+                '<?php /** @var string|int|null */',
+            ],
+            [
+                '<?php /** @param Bar|\Foo */',
+                '<?php /** @param \Foo|Bar */',
+            ],
+            [
+                '<?php /** @property-read \Bar|Foo */',
+                '<?php /** @property-read Foo|\Bar */',
+            ],
+            [
+                '<?php /** @property-write bar|Foo */',
+                '<?php /** @property-write Foo|bar */',
+            ],
+            [
+                '<?php /** @return Bar|foo */',
+                '<?php /** @return foo|Bar */',
+            ],
+            [
+                '<?php /** @method \Bar|Foo foo(\Bar|Foo $foo, \Bar|Foo $bar) */',
+                '<?php /** @method Foo|\Bar foo(Foo|\Bar $foo, Foo|\Bar $bar) */',
+            ],
+            [
+                '<?php /** @var null|array|Bar\Baz|bool[]|false|Foo|int|object|resource|string|string[] */',
+                '<?php /** @var string[]|resource|false|object|null|Foo|Bar\Baz|bool[]|string|array|int */',
+            ],
+            [
+                '<?php /** @var null|array<int, string> Foo */',
+            ],
+            [
+                '<?php /** @var null|array<int, array<string>> Foo */',
+            ],
+            [
+                '<?php /** @var NULL|int|string */',
+                '<?php /** @var string|int|NULL */',
+            ],
+            [
+                '<?php /** @var ?Bar|Foo */',
+                '<?php /** @var Foo|?Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?Foo */',
+                '<?php /** @var ?Foo|Bar */',
+            ],
+            [
+                '<?php /** @var ?\Bar|Foo */',
+                '<?php /** @var Foo|?\Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?\Foo */',
+                '<?php /** @var ?\Foo|Bar */',
+            ],
+            [
+                '<?php /** @var array<null|int|string> */',
+                '<?php /** @var array<string|int|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string, null|int|string> */',
+                '<?php /** @var array<string|int, string|int|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string,     array<int|string, null|int|string>> */',
+                '<?php /** @var array<string|int,     array<string|int, string|int|null>> */',
+            ],
+            [
+                '<?php /** @var null|null */',
+            ],
+            [
+                '<?php /** @var null|\null */',
+            ],
+            [
+                '<?php /** @var \null|null */',
+            ],
+            [
+                '<?php /** @var \null|\null */',
+            ],
+            [
+                '<?php /** @var array<\null|int|string> */',
+                '<?php /** @var array<string|\null|int> */',
+            ],
+            [
+                '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+                '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider getFixWithAlphaAlgorithmAndNullAlwaysLastCases
+     */
+    public function testFixWithAlphaAlgorithmAndNullAlwaysLast($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => 'alpha',
+            'null_position' => 'always_last',
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function getFixWithAlphaAlgorithmAndNullAlwaysLastCases()
+    {
+        return [
+            [
+                '<?php /** @var int|string|null */',
+                '<?php /** @var string|int|null */',
+            ],
+            [
+                '<?php /** @param Bar|\Foo */',
+                '<?php /** @param \Foo|Bar */',
+            ],
+            [
+                '<?php /** @property-read \Bar|Foo */',
+                '<?php /** @property-read Foo|\Bar */',
+            ],
+            [
+                '<?php /** @property-write bar|Foo */',
+                '<?php /** @property-write Foo|bar */',
+            ],
+            [
+                '<?php /** @return Bar|foo */',
+                '<?php /** @return foo|Bar */',
+            ],
+            [
+                '<?php /** @method \Bar|Foo foo(\Bar|Foo $foo, \Bar|Foo $bar) */',
+                '<?php /** @method Foo|\Bar foo(Foo|\Bar $foo, Foo|\Bar $bar) */',
+            ],
+            [
+                '<?php /** @var array|Bar\Baz|bool[]|false|Foo|int|object|resource|string|string[]|null */',
+                '<?php /** @var string[]|resource|false|object|null|Foo|Bar\Baz|bool[]|string|array|int */',
+            ],
+            [
+                '<?php /** @var array<int, string>|null Foo */',
+                '<?php /** @var null|array<int, string> Foo */',
+            ],
+            [
+                '<?php /** @var array<int, array<string>>|null Foo */',
+                '<?php /** @var null|array<int, array<string>> Foo */',
+            ],
+            [
+                '<?php /** @var int|string|NULL */',
+                '<?php /** @var string|int|NULL */',
+            ],
+            [
+                '<?php /** @var ?Bar|Foo */',
+                '<?php /** @var Foo|?Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?Foo */',
+                '<?php /** @var ?Foo|Bar */',
+            ],
+            [
+                '<?php /** @var ?\Bar|Foo */',
+                '<?php /** @var Foo|?\Bar */',
+            ],
+            [
+                '<?php /** @var Bar|?\Foo */',
+                '<?php /** @var ?\Foo|Bar */',
+            ],
+            [
+                '<?php /** @var array<int|string|null> */',
+                '<?php /** @var array<string|int|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string, int|string|null> */',
+                '<?php /** @var array<string|int, string|int|null> */',
+            ],
+            [
+                '<?php /** @var array<int|string,     array<int|string, int|string|null>> */',
+                '<?php /** @var array<string|int,     array<string|int, string|int|null>> */',
+            ],
+            [
+                '<?php /** @var null|null */',
+            ],
+            [
+                '<?php /** @var null|\null */',
+            ],
+            [
+                '<?php /** @var \null|null */',
+            ],
+            [
+                '<?php /** @var \null|\null */',
+            ],
+            [
+                '<?php /** @var array<int|string|\null> */',
+                '<?php /** @var array<string|\null|int> */',
+            ],
+            [
+                '<?php /** @var array<int, array<int, array<int, array<int, array<OutputInterface|null>>>>> */',
+                '<?php /** @var array<int, array<int, array<int, array<int, array<null|OutputInterface>>>>> */',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -42,7 +42,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([
             'sort_algorithm' => 'none',
-            'null_position' => 'always_first',
+            'null_adjustment' => 'always_first',
         ]);
 
         $this->doTest($expected, $input);
@@ -148,7 +148,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
      */
     public function testFixWithNullLast($expected, $input = null)
     {
-        $this->fixer->configure(['null_position' => 'always_last']);
+        $this->fixer->configure(['null_adjustment' => 'always_last']);
 
         $this->doTest($expected, $input);
     }
@@ -261,7 +261,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([
             'sort_algorithm' => 'alpha',
-            'null_position' => 'default',
+            'null_adjustment' => 'none',
         ]);
 
         $this->doTest($expected, $input);
@@ -371,7 +371,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([
             'sort_algorithm' => 'alpha',
-            'null_position' => 'always_first',
+            'null_adjustment' => 'always_first',
         ]);
 
         $this->doTest($expected, $input);
@@ -479,7 +479,7 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([
             'sort_algorithm' => 'alpha',
-            'null_position' => 'always_last',
+            'null_adjustment' => 'always_last',
         ]);
 
         $this->doTest($expected, $input);

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -73,7 +73,7 @@ final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
      * @dataProvider providerFixWithBreak
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithBreak($expected, $input = null)
     {
@@ -169,7 +169,7 @@ while (true) {
      * @dataProvider providerFixWithContinue
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithContinue($expected, $input = null)
     {
@@ -267,7 +267,7 @@ while (true) {
      * @dataProvider providerFixWithDeclare
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithDeclare($expected, $input = null)
     {
@@ -310,7 +310,7 @@ declare(ticks=1);',
      * @dataProvider providerFixWithDo
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithDo($expected, $input = null)
     {
@@ -350,7 +350,7 @@ do {
      * @dataProvider providerFixWithFor
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithFor($expected, $input = null)
     {
@@ -382,7 +382,7 @@ do {
      * @dataProvider providerFixWithIf
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithIf($expected, $input = null)
     {
@@ -397,7 +397,7 @@ do {
      * @dataProvider providerFixWithForEach
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithForEach($expected, $input = null)
     {
@@ -462,7 +462,7 @@ if ($foo) { }',
      * @dataProvider providerFixWithInclude
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithInclude($expected, $input = null)
     {
@@ -499,7 +499,7 @@ include "foo.php";',
      * @dataProvider providerFixWithIncludeOnce
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithIncludeOnce($expected, $input = null)
     {
@@ -536,7 +536,7 @@ include_once "foo.php";',
      * @dataProvider providerFixWithRequire
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithRequire($expected, $input = null)
     {
@@ -573,7 +573,7 @@ require "foo.php";',
      * @dataProvider providerFixWithRequireOnce
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithRequireOnce($expected, $input = null)
     {
@@ -610,7 +610,7 @@ require_once "foo.php";',
      * @dataProvider providerFixWithReturn
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithReturn($expected, $input = null)
     {
@@ -769,7 +769,7 @@ function foo()
      * @dataProvider providerFixWithSwitch
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithSwitch($expected, $input = null)
     {
@@ -815,7 +815,7 @@ switch ($foo) {
      * @dataProvider providerFixWithThrow
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithThrow($expected, $input = null)
     {
@@ -858,7 +858,7 @@ if (false) {
      * @dataProvider providerFixWithTry
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithTry($expected, $input = null)
     {
@@ -907,7 +907,7 @@ try {
      * @dataProvider providerFixWithWhile
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithWhile($expected, $input = null)
     {
@@ -970,7 +970,7 @@ do {
      *
      * @param string[]    $statements
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function testFixWithMultipleConfigStatements(array $statements, $expected, $input = null)
     {

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -321,7 +321,7 @@ final class TokenTest extends TestCase
     /**
      * @param Token              $token
      * @param string             $equals
-     * @param Token|array|string $other
+     * @param array|string|Token $other
      * @param bool               $caseSensitive
      *
      * @dataProvider provideEquals
@@ -408,7 +408,7 @@ final class TokenTest extends TestCase
 
     /**
      * @param bool       $isKeyCaseSensitive
-     * @param bool|array $caseSensitive
+     * @param array|bool $caseSensitive
      * @param int        $key
      *
      * @dataProvider provideIsKeyCaseSensitive

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -51,7 +51,7 @@ final class TokensTest extends TestCase
      * @param Token[]    $sequence
      * @param int        $start
      * @param null|int   $end
-     * @param bool|array $caseSensitive
+     * @param array|bool $caseSensitive
      *
      * @dataProvider provideFindSequence
      */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -125,7 +125,7 @@ final class UtilsTest extends TestCase
 
     /**
      * @param string       $spaces
-     * @param string|array $input  token prototype
+     * @param array|string $input  token prototype
      *
      * @dataProvider provideCalculateTrailingWhitespaceIndentCases
      */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -159,4 +159,49 @@ final class UtilsTest extends TestCase
 
         Utils::calculateTrailingWhitespaceIndent($token);
     }
+
+    /**
+     * @dataProvider getStableSortCases
+     */
+    public function testStableSort(
+        array $expected,
+        array $elements,
+        callable $getComparableValueCallback,
+        callable $compareValuesCallback
+    ) {
+        $this->assertSame(
+            $expected,
+            Utils::stableSort($elements, $getComparableValueCallback, $compareValuesCallback)
+        );
+    }
+
+    public function getStableSortCases()
+    {
+        return [
+            [
+                ['a', 'b', 'c', 'd', 'e'],
+                ['b', 'd', 'e', 'a', 'c'],
+                function ($element) { return $element; },
+                'strcmp',
+            ],
+            [
+                ['b', 'd', 'e', 'a', 'c'],
+                ['b', 'd', 'e', 'a', 'c'],
+                function ($element) { return 'foo'; },
+                'strcmp',
+            ],
+            [
+                ['b', 'd', 'e', 'a', 'c'],
+                ['b', 'd', 'e', 'a', 'c'],
+                function ($element) { return $element; },
+                function ($a, $b) { return 0; },
+            ],
+            [
+                ['bar1', 'baz1', 'foo1', 'bar2', 'baz2', 'foo2'],
+                ['foo1', 'foo2', 'bar1', 'bar2', 'baz1', 'baz2'],
+                function ($element) { return preg_replace('/([a-z]+)(\d+)/', '$2$1', $element); },
+                'strcmp',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
A new fixer that sorts the types in PHPDoc annotations like `@param`. For now, it only moves `null` to the first position:
```diff
 /**
- * @return string|null
+ * @return null|string
  */
```
An option allows to move it to the last position instead:
```diff
 /**
- * @return null|string
+ * @return string|null
  */
```