### PR TITLE
MethodArgumentSpaceFixer - Always remove trailing spaces

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -157,7 +157,10 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         //  1) multiple spaces after comma
         //  2) no space after comma
         if ($nextToken->isWhitespace()) {
-            if ($this->configuration['keep_multiple_spaces_after_comma'] || $this->isCommentLastLineToken($tokens, $index + 2)) {
+            if (
+                ($this->configuration['keep_multiple_spaces_after_comma'] && !preg_match('/\R/', $nextToken->getContent()))
+                || $this->isCommentLastLineToken($tokens, $index + 2)
+            ) {
                 return;
             }
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -250,6 +250,11 @@ EOTXTb
 $a#
 );',
             ),
+            array(
+                "<?php xyz(\$a=10,\n\$b=20);",
+                "<?php xyz(\$a=10,   \n\$b=20);",
+                array('keep_multiple_spaces_after_comma' => true),
+            ),
         );
     }
 


### PR DESCRIPTION
Option `keep_multiple_spaces_after_comma` shoud not apply to trailing spaces IMO.

Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2440#issuecomment-306912730