### PR TITLE
Enhancement: Reference phpunit.xsd from phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="./vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="./vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    syntaxCheck="false"
 >
     <testsuites>
         <testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,6 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
 >
     <testsuites>
         <testsuite>


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` from `phpunit.xml.dist`
* [x] drops an unsupported attribute `syntaxCheck`

💁‍♂️ Helps with validation and auto-completion in IDEs that support it!