### PR TITLE
Fix: Use phpunit/phpunit:^5.4.3 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "justinrainbow/json-schema": "^5.0",
         "mi-schi/phpmd-extension": "^4.2",
         "phpmd/phpmd": "^2.4.3",
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3",
+        "phpunit/phpunit": "^5.4.3",
         "satooshi/php-coveralls": "^1.0",
         "symfony/phpunit-bridge": "^3.2.2"
     },


### PR DESCRIPTION
This PR

* [x] requires `phpunit/phpunit:^5.4.3` only

Follows https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2828#discussion_r120751017.