### PR TITLE
PHPUnit: Use all the columns

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
     backupStaticAttributes="false"
     bootstrap="./vendor/autoload.php"
     colors="true"
+    columns="max"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"


### PR DESCRIPTION
This PR

* [x] allows using all the columns, all the columns

Follows #2828.

💁‍♂️ For reference, see https://github.com/sebastianbergmann/phpunit/pull/2518 (this is missing from the schema in older versions).

### Before

```
$ vendor/bin/phpunit

PHPUnit v2.2.4-19-ga8976647 by Sebastian Bergmann and contributors.

Testing
.............................................................   61 / 8305 (  0%)
.............................................................  122 / 8305 (  1%)
.............................................................  183 / 8305 (  2%)
.............................................................  244 / 8305 (  2%)
.............................................................  305 / 8305 (  3%)
.............................................................  366 / 8305 (  4%)
.............................................................  427 / 8305 (  5%)
```

### After

```
$ vendor/bin/phpunit

PHPUnit v2.2.4-20-gc4ca8ba2 by Sebastian Bergmann and contributors.

Testing
.............................................................................................................................................................................................  189 / 8305 (  2%)
.............................................................................................................................................................................................  378 / 8305 (  4%)
.............................................................................................................................................................................................  567 / 8305 (  6%)
.............................................................................................................................................................................................  756 / 8305 (  9%)
```