### PR TITLE
PHPUnit: upgrade to 5.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "johnkary/phpunit-speedtrap": "^1.0.1",
         "justinrainbow/json-schema": "^5.0",
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3",
+        "phpunit/phpunit": "^5.4.3",
         "satooshi/php-coveralls": "^1.0",
         "symfony/phpunit-bridge": "^3.2.2"
     },

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -64,7 +64,7 @@ final class CacheTest extends TestCase
 
     public function testSetThrowsInvalidArgumentExceptionIfValueIsNotAnInteger()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $signature = $this->getSignatureDouble();
 
@@ -107,7 +107,7 @@ final class CacheTest extends TestCase
 
     public function testFromJsonThrowsInvalidArgumentExceptionIfJsonIsInvalid()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $json = '{"foo';
 
@@ -121,7 +121,7 @@ final class CacheTest extends TestCase
      */
     public function testFromJsonThrowsInvalidArgumentExceptionIfJsonIsMissingKey(array $data)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $json = json_encode($data);
 

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -105,7 +105,7 @@ final class FileHandlerTest extends TestCase
         $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
         $this->expectExceptionMessageRegExp(sprintf(
             '#^Failed to write file "%s"(, ".*")?.#',
-            preg_quote($file)
+            preg_quote($file, '#')
         ));
 
         $cache = new Cache(new Signature(

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -102,7 +102,8 @@ final class FileHandlerTest extends TestCase
     {
         $file = __DIR__.'/non-existent-directory/.php_cs.cache';
 
-        $this->setExpectedExceptionRegExp('Symfony\Component\Filesystem\Exception\IOException', sprintf(
+        $this->expectException('Symfony\Component\Filesystem\Exception\IOException');
+        $this->expectExceptionMessageRegExp(sprintf(
             '#^Failed to write file "%s"(, ".*")?.#',
             preg_quote($file)
         ));

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -71,7 +71,7 @@ final class ConfigTest extends TestCase
 
     public function testConfigRulesUsingInvalidJson()
     {
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
 
         $config = new Config();
         $configResolver = new ConfigurationResolver(

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -176,9 +176,9 @@ final class ConfigTest extends TestCase
 
     public function testRegisterCustomFixersWithInvalidArgument()
     {
-        $this->setExpectedExceptionRegExp(
-            'InvalidArgumentException',
-            '/^Argument must be an array or a Traversable, got "\w+"\.$/'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Argument must be an array or a Traversable, got "\w+"\.$/'
         );
 
         $config = new Config();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -176,10 +176,8 @@ final class ConfigTest extends TestCase
 
     public function testRegisterCustomFixersWithInvalidArgument()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('/^Argument must be an array or a Traversable, got "\w+"\.$/'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Argument must be an array or a Traversable, got "\w+"\.$/');
 
         $config = new Config();
         $config->registerCustomFixers('foo');

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -138,7 +138,8 @@ EOT;
 
         $commandTester = new CommandTester($command);
 
-        $this->setExpectedExceptionRegExp('RuntimeException', '/^Not enough arguments( \(missing: "name"\))?\.$/');
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessageRegExp('/^Not enough arguments( \(missing: "name"\))?\.$/');
         $commandTester->execute(array(
             'command' => $command->getName(),
         ));

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -121,7 +121,8 @@ EOT;
 
         $commandTester = new CommandTester($command);
 
-        $this->setExpectedException('InvalidArgumentException', 'Rule Foo/bar not found.');
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Rule Foo/bar not found.');
         $commandTester->execute(array(
             'command' => $command->getName(),
             'name' => 'Foo/bar',

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -46,10 +46,8 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testSetOptionWithUndefinedOption()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessageRegExp('/^Unknown option name: "foo"\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^Unknown option name: "foo"\.$/');
 
         new ConfigurationResolver(
             $this->config,
@@ -187,10 +185,8 @@ final class ConfigurationResolverTest extends TestCase
             ''
         );
 
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessage('The progress type "foo" is not defined, supported are "none", "run-in", "estimating".'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage('The progress type "foo" is not defined, supported are "none", "run-in", "estimating".');
 
         $resolver->getProgress();
     }
@@ -292,10 +288,8 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithInvalidFile()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessageRegExp('#^The config file: ".+[\/\\\]Fixtures[\/\\\]ConfigurationResolverConfigFile[\/\\\]case_5[\/\\\]\.php_cs.dist" does not return a "PhpCsFixer\\\ConfigInterface" instance\. Got: "string"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('#^The config file: ".+[\/\\\]Fixtures[\/\\\]ConfigurationResolverConfigFile[\/\\\]case_5[\/\\\]\.php_cs.dist" does not return a "PhpCsFixer\\\ConfigInterface" instance\. Got: "string"\.$#');
 
         $dirBase = $this->getFixtureDir();
 
@@ -310,10 +304,8 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithInvalidFormat()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are json, junit, txt, xml.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are json, junit, txt, xml.$/');
 
         $dirBase = $this->getFixtureDir();
 
@@ -328,10 +320,8 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithPathArrayWithoutConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessageRegExp('/^For multiple paths config parameter is required.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^For multiple paths config parameter is required.$/');
 
         $dirBase = $this->getFixtureDir();
 
@@ -908,10 +898,8 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveRulesWithUnknownRules()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
-        $this->expectExceptionMessage('The rules contain unknown fixers (bar).'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage('The rules contain unknown fixers (bar).');
 
         $resolver = new ConfigurationResolver(
             $this->config,

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -187,9 +187,9 @@ final class ConfigurationResolverTest extends TestCase
             ''
         );
 
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            'The progress type "foo" is not defined, supported are "none", "run-in", "estimating".'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage('The progress type "foo" is not defined, supported are "none", "run-in", "estimating".'
         );
 
         $resolver->getProgress();
@@ -475,7 +475,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveIntersectionOfPaths($expected, $configFinder, array $path, $pathMode, $config = null)
     {
         if ($expected instanceof \Exception) {
-            $this->setExpectedException(get_class($expected));
+            $this->expectException(get_class($expected));
         }
 
         if (null !== $configFinder) {
@@ -908,9 +908,9 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveRulesWithUnknownRules()
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            'The rules contain unknown fixers (bar).'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage('The rules contain unknown fixers (bar).'
         );
 
         $resolver = new ConfigurationResolver(

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -46,9 +46,9 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testSetOptionWithUndefinedOption()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            '/^Unknown option name: "foo"\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^Unknown option name: "foo"\.$/'
         );
 
         new ConfigurationResolver(
@@ -292,9 +292,9 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithInvalidFile()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            '#^The config file: ".+[\/\\\]Fixtures[\/\\\]ConfigurationResolverConfigFile[\/\\\]case_5[\/\\\]\.php_cs.dist" does not return a "PhpCsFixer\\\ConfigInterface" instance\. Got: "string"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('#^The config file: ".+[\/\\\]Fixtures[\/\\\]ConfigurationResolverConfigFile[\/\\\]case_5[\/\\\]\.php_cs.dist" does not return a "PhpCsFixer\\\ConfigInterface" instance\. Got: "string"\.$#'
         );
 
         $dirBase = $this->getFixtureDir();
@@ -310,9 +310,9 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithInvalidFormat()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            '/^The format "xls" is not defined, supported are json, junit, txt, xml.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are json, junit, txt, xml.$/'
         );
 
         $dirBase = $this->getFixtureDir();
@@ -328,9 +328,9 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testResolveConfigFileChooseFileWithPathArrayWithoutConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-            '/^For multiple paths config parameter is required.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessageRegExp('/^For multiple paths config parameter is required.$/'
         );
 
         $dirBase = $this->getFixtureDir();

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -246,9 +246,9 @@ final class AnnotationTest extends TestCase
 
     public function testGetTypesOnBadTag()
     {
-        $this->setExpectedException(
-            'RuntimeException',
-            'This tag does not support types'
+        $this->expectException(
+            'RuntimeException');
+        $this->expectExceptionMessage('This tag does not support types'
         );
 
         $tag = new Annotation(array(new Line(' * @deprecated since 1.2')));
@@ -258,9 +258,9 @@ final class AnnotationTest extends TestCase
 
     public function testSetTypesOnBadTag()
     {
-        $this->setExpectedException(
-            'RuntimeException',
-            'This tag does not support types'
+        $this->expectException(
+            'RuntimeException');
+        $this->expectExceptionMessage('This tag does not support types'
         );
 
         $tag = new Annotation(array(new Line(' * @author Chuck Norris')));

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -246,10 +246,8 @@ final class AnnotationTest extends TestCase
 
     public function testGetTypesOnBadTag()
     {
-        $this->expectException(
-            'RuntimeException');
-        $this->expectExceptionMessage('This tag does not support types'
-        );
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('This tag does not support types');
 
         $tag = new Annotation(array(new Line(' * @deprecated since 1.2')));
 
@@ -258,10 +256,8 @@ final class AnnotationTest extends TestCase
 
     public function testSetTypesOnBadTag()
     {
-        $this->expectException(
-            'RuntimeException');
-        $this->expectExceptionMessage('This tag does not support types'
-        );
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('This tag does not support types');
 
         $tag = new Annotation(array(new Line(' * @author Chuck Norris')));
 

--- a/tests/DocBlock/TagTest.php
+++ b/tests/DocBlock/TagTest.php
@@ -39,7 +39,8 @@ final class TagTest extends TestCase
         $this->assertSame($expected, $tag->getName());
 
         if ('other' === $expected) {
-            $this->setExpectedException('RuntimeException', 'Cannot set name on unknown tag');
+            $this->expectException('RuntimeException');
+            $this->expectExceptionMessage('Cannot set name on unknown tag');
         }
 
         $tag->setName($new);

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -24,9 +24,9 @@ final class FinderTest extends TestCase
 {
     public function testThatDefaultFinderDoesNotSpecifyAnyDirectory()
     {
-        $this->setExpectedExceptionRegExp(
-            'LogicException',
-            '/^You must call (?:the in\(\) method)|(?:one of in\(\) or append\(\)) methods before iterating over a Finder\.$/'
+        $this->expectException(
+            'LogicException');
+        $this->expectExceptionMessageRegExp('/^You must call (?:the in\(\) method)|(?:one of in\(\) or append\(\)) methods before iterating over a Finder\.$/'
         );
 
         $finder = Finder::create();

--- a/tests/FinderTest.php
+++ b/tests/FinderTest.php
@@ -24,8 +24,7 @@ final class FinderTest extends TestCase
 {
     public function testThatDefaultFinderDoesNotSpecifyAnyDirectory()
     {
-        $this->expectException(
-            'LogicException');
+        $this->expectException('LogicException');
         $this->expectExceptionMessageRegExp('/^You must call (?:the in\(\) method)|(?:one of in\(\) or append\(\)) methods before iterating over a Finder\.$/'
         );
 

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -299,10 +299,8 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
      */
     public function testWrongConfig($wrongConfig, $expectedMessage)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp($expectedMessage
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp($expectedMessage);
 
         $this->fixer->configure($wrongConfig);
     }

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -299,9 +299,9 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
      */
     public function testWrongConfig($wrongConfig, $expectedMessage)
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            $expectedMessage
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp($expectedMessage
         );
 
         $this->fixer->configure($wrongConfig);

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -26,9 +26,9 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 {
     public function testConfigureCheckSearchFunction()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[random_api_migration\] Invalid configuration: Function "is_null" is not handled by the fixer.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Function "is_null" is not handled by the fixer.$#'
         );
 
         $this->fixer->configure(array('replacements' => array('is_null' => 'random_int')));
@@ -36,9 +36,9 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 
     public function testConfigureCheckReplacementType()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[random_api_migration\] Invalid configuration: Replacement for function "rand" must be a string, "NULL" given.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Replacement for function "rand" must be a string, "NULL" given.$#'
         );
 
         $this->fixer->configure(array('replacements' => array('rand' => null)));

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -26,20 +26,16 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
 {
     public function testConfigureCheckSearchFunction()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Function "is_null" is not handled by the fixer.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Function "is_null" is not handled by the fixer.$#');
 
         $this->fixer->configure(array('replacements' => array('is_null' => 'random_int')));
     }
 
     public function testConfigureCheckReplacementType()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Replacement for function "rand" must be a string, "NULL" given.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[random_api_migration\] Invalid configuration: Replacement for function "rand" must be a string, "NULL" given.$#');
 
         $this->fixer->configure(array('replacements' => array('rand' => null)));
     }

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -27,9 +27,9 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfiguration()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[array_syntax\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "syntax"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[array_syntax\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "syntax"\.$#'
         );
 
         $this->fixer->configure(array('a' => 1));

--- a/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+++ b/tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
@@ -27,10 +27,8 @@ final class ArraySyntaxFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfiguration()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[array_syntax\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "syntax"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[array_syntax\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "syntax"\.$#');
 
         $this->fixer->configure(array('a' => 1));
     }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -28,9 +28,9 @@ final class BracesFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationClassyConstructs()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[braces\] Invalid configuration: The option "position_after_functions_and_oop_constructs" with value "neither" is invalid\. Accepted values are: "next", "same"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[braces\] Invalid configuration: The option "position_after_functions_and_oop_constructs" with value "neither" is invalid\. Accepted values are: "next", "same"\.$#'
         );
 
         $this->fixer->configure(array('position_after_functions_and_oop_constructs' => 'neither'));

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -28,10 +28,8 @@ final class BracesFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationClassyConstructs()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[braces\] Invalid configuration: The option "position_after_functions_and_oop_constructs" with value "neither" is invalid\. Accepted values are: "next", "same"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[braces\] Invalid configuration: The option "position_after_functions_and_oop_constructs" with value "neither" is invalid\. Accepted values are: "next", "same"\.$#');
 
         $this->fixer->configure(array('position_after_functions_and_oop_constructs' => 'neither'));
     }

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -137,10 +137,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationKey()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "multiLineExtendsEachSingleLine", "singleItemSingleLine", "singleLine"\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "multiLineExtendsEachSingleLine", "singleItemSingleLine", "singleLine"\.$/');
 
         $fixer = new ClassDefinitionFixer();
         $fixer->configure(array('a' => false));
@@ -148,10 +146,8 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationValueType()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "singleLine" with value "z" is expected to be of type "bool", but is of type "string"\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "singleLine" with value "z" is expected to be of type "bool", but is of type "string"\.$/');
 
         $fixer = new ClassDefinitionFixer();
         $fixer->configure(array('singleLine' => 'z'));

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -137,9 +137,9 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationKey()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[class_definition\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "multiLineExtendsEachSingleLine", "singleItemSingleLine", "singleLine"\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "multiLineExtendsEachSingleLine", "singleItemSingleLine", "singleLine"\.$/'
         );
 
         $fixer = new ClassDefinitionFixer();
@@ -148,9 +148,9 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationValueType()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[class_definition\] Invalid configuration: The option "singleLine" with value "z" is expected to be of type "bool", but is of type "string"\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[class_definition\] Invalid configuration: The option "singleLine" with value "z" is expected to be of type "bool", but is of type "string"\.$/'
         );
 
         $fixer = new ClassDefinitionFixer();

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -616,9 +616,9 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[ordered_class_elements\] Invalid configuration: The option "order" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[ordered_class_elements\] Invalid configuration: The option "order" .*\.$/'
         );
 
         $this->fixer->configure(array('order' => array('foo')));

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -616,10 +616,8 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[ordered_class_elements\] Invalid configuration: The option "order" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[ordered_class_elements\] Invalid configuration: The option "order" .*\.$/');
 
         $this->fixer->configure(array('order' => array('foo')));
     }

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -709,9 +709,9 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[single_class_element_per_statement\] Invalid configuration: The option "elements" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[single_class_element_per_statement\] Invalid configuration: The option "elements" .*\.$/'
         );
 
         $this->fixer->configure(array('elements' => array('foo')));

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -709,10 +709,8 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[single_class_element_per_statement\] Invalid configuration: The option "elements" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[single_class_element_per_statement\] Invalid configuration: The option "elements" .*\.$/');
 
         $this->fixer->configure(array('elements' => array('foo')));
     }

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -433,9 +433,9 @@ EOF;
 
     public function testInvalidConfigurationType()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
         );
 
         $this->fixer->configure(array('elements' => array(null)));
@@ -443,9 +443,9 @@ EOF;
 
     public function testInvalidConfigurationValue()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
         );
 
         $this->fixer->configure(array('elements' => array('_unknown_')));
@@ -457,9 +457,9 @@ EOF;
             $this->markTestSkipped('PHP version to high.');
         }
 
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[visibility_required\] Invalid configuration: "const" option can only be enabled with PHP 7\.1\+\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: "const" option can only be enabled with PHP 7\.1\+\.$/'
         );
 
         $this->fixer->configure(array('elements' => array('const')));

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -433,20 +433,16 @@ EOF;
 
     public function testInvalidConfigurationType()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/');
 
         $this->fixer->configure(array('elements' => array(null)));
     }
 
     public function testInvalidConfigurationValue()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/');
 
         $this->fixer->configure(array('elements' => array('_unknown_')));
     }
@@ -457,10 +453,8 @@ EOF;
             $this->markTestSkipped('PHP version to high.');
         }
 
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: "const" option can only be enabled with PHP 7\.1\+\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: "const" option can only be enabled with PHP 7\.1\+\.$/');
 
         $this->fixer->configure(array('elements' => array('const')));
     }

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -329,10 +329,8 @@ echo \'x\';',
      */
     public function testLegacyMisconfiguration()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[header_comment] Missing required configuration: The required option "header" is missing.'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[header_comment] Missing required configuration: The required option "header" is missing.');
 
         $this->fixer->configure(null);
     }
@@ -345,10 +343,8 @@ echo \'x\';',
      */
     public function testMisconfiguration($configuration, $exceptionMessage)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[header_comment] '.$exceptionMessage
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[header_comment] '.$exceptionMessage);
 
         $this->fixer->configure($configuration);
     }

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -329,9 +329,9 @@ echo \'x\';',
      */
     public function testLegacyMisconfiguration()
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[header_comment] Missing required configuration: The required option "header" is missing.'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[header_comment] Missing required configuration: The required option "header" is missing.'
         );
 
         $this->fixer->configure(null);
@@ -345,9 +345,9 @@ echo \'x\';',
      */
     public function testMisconfiguration($configuration, $exceptionMessage)
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[header_comment] '.$exceptionMessage
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[header_comment] '.$exceptionMessage
         );
 
         $this->fixer->configure($configuration);
@@ -518,7 +518,7 @@ declare(strict_types=1)?>',
 
     public function testWithoutConfiguration()
     {
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException');
+        $this->expectException('PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException');
 
         $this->doTest('<?php echo 1;');
     }

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -28,9 +28,9 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationClosureFunctionSpacing()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[function_declaration\] Invalid configuration: The option "closure_function_spacing" with value "neither" is invalid\. Accepted values are: "none", "one"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_declaration\] Invalid configuration: The option "closure_function_spacing" with value "neither" is invalid\. Accepted values are: "none", "one"\.$#'
         );
 
         $this->fixer->configure(array('closure_function_spacing' => 'neither'));

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -28,10 +28,8 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigurationClosureFunctionSpacing()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[function_declaration\] Invalid configuration: The option "closure_function_spacing" with value "neither" is invalid\. Accepted values are: "none", "one"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_declaration\] Invalid configuration: The option "closure_function_spacing" with value "neither" is invalid\. Accepted values are: "none", "one"\.$#');
 
         $this->fixer->configure(array('closure_function_spacing' => 'neither'));
     }

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -27,7 +27,8 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     {
         $key = 'foo';
 
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage(sprintf(
             '[native_function_invocation] Invalid configuration: The option "%s" does not exist.',
             $key
         ));
@@ -44,7 +45,8 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
      */
     public function testConfigureRejectsInvalidConfigurationElement($element)
     {
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage(sprintf(
             'Each element must be a non-empty, trimmed string, got "%s" instead.',
             \is_object($element) ? \get_class($element) : \gettype($element)
         ));

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -26,10 +26,8 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfiguration()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[return_type_declaration\] Invalid configuration: The option "s" does not exist. (Known|Defined) options are: "space_before".$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[return_type_declaration\] Invalid configuration: The option "s" does not exist. (Known|Defined) options are: "space_before".$#');
 
         $this->fixer->configure(array('s' => 9000));
     }

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -26,9 +26,9 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfiguration()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[return_type_declaration\] Invalid configuration: The option "s" does not exist. (Known|Defined) options are: "space_before".$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[return_type_declaration\] Invalid configuration: The option "s" does not exist. (Known|Defined) options are: "space_before".$#'
         );
 
         $this->fixer->configure(array('s' => 9000));

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -790,9 +790,9 @@ use Foo\Bor\{
 
     public function testInvalidOrderTypesSize()
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[ordered_imports] Invalid configuration: Missing sort type "function".'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "function".'
         );
 
         $this->fixer->configure(array(
@@ -803,9 +803,9 @@ use Foo\Bor\{
 
     public function testInvalidOrderType()
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[ordered_imports] Invalid configuration: Missing sort type "class".'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "class".'
         );
 
         $this->fixer->configure(array(
@@ -822,9 +822,9 @@ use Foo\Bor\{
      */
     public function testInvalidSortAlgorithm($configuration, $expectedValue)
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            sprintf(
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage(sprintf(
                 '[ordered_imports] Invalid configuration: The option "sortAlgorithm" with value %s is invalid. Accepted values are: "alpha", "length".',
                 $expectedValue
             )

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -790,10 +790,8 @@ use Foo\Bor\{
 
     public function testInvalidOrderTypesSize()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "function".'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "function".');
 
         $this->fixer->configure(array(
             'sortAlgorithm' => OrderedImportsFixer::SORT_ALPHA,
@@ -803,10 +801,8 @@ use Foo\Bor\{
 
     public function testInvalidOrderType()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "class".'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[ordered_imports] Invalid configuration: Missing sort type "class".');
 
         $this->fixer->configure(array(
             'sortAlgorithm' => OrderedImportsFixer::SORT_ALPHA,
@@ -822,13 +818,11 @@ use Foo\Bor\{
      */
     public function testInvalidSortAlgorithm($configuration, $expectedValue)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
         $this->expectExceptionMessage(sprintf(
-                '[ordered_imports] Invalid configuration: The option "sortAlgorithm" with value %s is invalid. Accepted values are: "alpha", "length".',
-                $expectedValue
-            )
-        );
+            '[ordered_imports] Invalid configuration: The option "sortAlgorithm" with value %s is invalid. Accepted values are: "alpha", "length".',
+            $expectedValue
+        ));
 
         $this->fixer->configure($configuration);
     }

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -113,9 +113,9 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
      */
     public function testInvalidConfig(array $config, $expectedMessage)
     {
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage)
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage(sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage)
         );
 
         $this->fixer->configure($config);

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -113,10 +113,8 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
      */
     public function testInvalidConfig(array $config, $expectedMessage)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage(sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage)
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage(sprintf('[declare_equal_normalize] Invalid configuration: %s', $expectedMessage));
 
         $this->fixer->configure($config);
     }

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -136,9 +136,9 @@ $a =
      */
     public function testInvalidConfigurationKeys(array $config)
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[function_to_constant\] Invalid configuration: The option "functions" with value array is invalid\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "functions" with value array is invalid\.$#'
         );
 
         $this->fixer->configure($config);
@@ -155,9 +155,9 @@ $a =
 
     public function testInvalidConfigurationValue()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[function_to_constant\] Invalid configuration: The option "0" does not exist\. (Defined|Known) options are: "functions"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "0" does not exist\. (Defined|Known) options are: "functions"\.$#'
         );
 
         $this->fixer->configure(array('pi123'));

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -136,10 +136,8 @@ $a =
      */
     public function testInvalidConfigurationKeys(array $config)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "functions" with value array is invalid\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "functions" with value array is invalid\.$#');
 
         $this->fixer->configure($config);
     }
@@ -155,10 +153,8 @@ $a =
 
     public function testInvalidConfigurationValue()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "0" does not exist\. (Defined|Known) options are: "functions"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "0" does not exist\. (Defined|Known) options are: "functions"\.$#');
 
         $this->fixer->configure(array('pi123'));
     }

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -28,10 +28,8 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     {
         $fixer = new IsNullFixer();
 
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "yoda" does not exist.'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "yoda" does not exist.');
         $fixer->configure(array('yoda' => true));
     }
 
@@ -39,10 +37,8 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     {
         $fixer = new IsNullFixer();
 
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "use_yoda_style" with value -1 is expected to be of type "bool", but is of type "integer".'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "use_yoda_style" with value -1 is expected to be of type "bool", but is of type "integer".');
         $fixer->configure(array('use_yoda_style' => -1));
     }
 

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -28,9 +28,9 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     {
         $fixer = new IsNullFixer();
 
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[is_null] Invalid configuration: The option "yoda" does not exist.'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "yoda" does not exist.'
         );
         $fixer->configure(array('yoda' => true));
     }
@@ -39,9 +39,9 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     {
         $fixer = new IsNullFixer();
 
-        $this->setExpectedException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '[is_null] Invalid configuration: The option "use_yoda_style" with value -1 is expected to be of type "bool", but is of type "integer".'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessage('[is_null] Invalid configuration: The option "use_yoda_style" with value -1 is expected to be of type "bool", but is of type "integer".'
         );
         $fixer->configure(array('use_yoda_style' => -1));
     }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -350,20 +350,16 @@ $b;',
 
     public function testWrongConfigItem()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. (Known|Defined) options are: "align_double_arrow", "align_equals"\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. (Known|Defined) options are: "align_double_arrow", "align_equals"\.$/');
 
         $this->fixer->configure(array('foo' => true));
     }
 
     public function testWrongConfigValue()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid. Accepted values are: true, false, null\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid. Accepted values are: true, false, null\.$/');
 
         $this->fixer->configure(array('align_double_arrow' => 123));
     }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -350,9 +350,9 @@ $b;',
 
     public function testWrongConfigItem()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. (Known|Defined) options are: "align_double_arrow", "align_equals"\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "foo" does not exist\. (Known|Defined) options are: "align_double_arrow", "align_equals"\.$/'
         );
 
         $this->fixer->configure(array('foo' => true));
@@ -360,9 +360,9 @@ $b;',
 
     public function testWrongConfigValue()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid. Accepted values are: true, false, null\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[binary_operator_spaces\] Invalid configuration: The option "align_double_arrow" with value 123 is invalid. Accepted values are: true, false, null\.$/'
         );
 
         $this->fixer->configure(array('align_double_arrow' => 123));

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -26,9 +26,9 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfigMissingKey()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[concat_space\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "spacing"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "spacing"\.$#'
         );
 
         $this->fixer->configure(array('a' => 1));
@@ -36,9 +36,9 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigValue()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[concat_space\] Invalid configuration: The option "spacing" with value "tabs" is invalid\. Accepted values are: "one", "none"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "spacing" with value "tabs" is invalid\. Accepted values are: "one", "none"\.$#'
         );
 
         $this->fixer->configure(array('spacing' => 'tabs'));

--- a/tests/Fixer/Operator/ConcatSpaceFixerTest.php
+++ b/tests/Fixer/Operator/ConcatSpaceFixerTest.php
@@ -26,20 +26,16 @@ final class ConcatSpaceFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfigMissingKey()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "spacing"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "a" does not exist\. (Known|Defined) options are: "spacing"\.$#');
 
         $this->fixer->configure(array('a' => 1));
     }
 
     public function testInvalidConfigValue()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "spacing" with value "tabs" is invalid\. Accepted values are: "one", "none"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[concat_space\] Invalid configuration: The option "spacing" with value "tabs" is invalid\. Accepted values are: "one", "none"\.$#');
 
         $this->fixer->configure(array('spacing' => 'tabs'));
     }

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -128,10 +128,8 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[php_unit_construct\] Invalid configuration: The option "assertions" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_construct\] Invalid configuration: The option "assertions" .*\.$/');
 
         $this->fixer->configure(array('assertions' => array('__TEST__')));
     }

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -128,9 +128,9 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[php_unit_construct\] Invalid configuration: The option "assertions" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_construct\] Invalid configuration: The option "assertions" .*\.$/'
         );
 
         $this->fixer->configure(array('assertions' => array('__TEST__')));

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -268,9 +268,9 @@ $a#
 
     public function testInvalidConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[php_unit_dedicate_assert\] Invalid configuration: The option "functions" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_dedicate_assert\] Invalid configuration: The option "functions" .*\.$/'
         );
 
         $this->fixer->configure(array('functions' => array('_unknown_')));

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -268,10 +268,8 @@ $a#
 
     public function testInvalidConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[php_unit_dedicate_assert\] Invalid configuration: The option "functions" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_dedicate_assert\] Invalid configuration: The option "functions" .*\.$/');
 
         $this->fixer->configure(array('functions' => array('_unknown_')));
     }

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -100,10 +100,8 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[php_unit_strict\] Invalid configuration: The option "assertions" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_strict\] Invalid configuration: The option "assertions" .*\.$/');
 
         $this->fixer->configure(array('assertions' => array('__TEST__')));
     }

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -100,9 +100,9 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[php_unit_strict\] Invalid configuration: The option "assertions" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[php_unit_strict\] Invalid configuration: The option "assertions" .*\.$/'
         );
 
         $this->fixer->configure(array('assertions' => array('__TEST__')));

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -29,7 +29,8 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     {
         $key = 'foo';
 
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage(sprintf(
             '[phpdoc_add_missing_param_annotation] Invalid configuration: The option "%s" does not exist.',
             $key
         ));
@@ -46,7 +47,8 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      */
     public function testConfigureRejectsInvalidConfigurationValue($value)
     {
-        $this->setExpectedException('PhpCsFixer\ConfigurationException\InvalidConfigurationException', sprintf(
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidConfigurationException');
+        $this->expectExceptionMessage(sprintf(
             'expected to be of type "bool", but is of type "%s".',
             is_object($value) ? get_class($value) : gettype($value)
         ));

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -27,40 +27,32 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfigCase1()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace must be a string\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace must be a string\.$#');
 
         $this->fixer->configure(array('replacements' => array(1 => 'abc')));
     }
 
     public function testInvalidConfigCase2()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace to from "a" must be a string\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace to from "a" must be a string\.$#');
 
         $this->fixer->configure(array('replacements' => array('a' => null)));
     }
 
     public function testInvalidConfigCase3()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag "see" cannot be replaced by invalid tag "link\*\/"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag "see" cannot be replaced by invalid tag "link\*\/"\.$#');
 
         $this->fixer->configure(array('replacements' => array('see' => 'link*/')));
     }
 
     public function testInvalidConfigCase4()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "link" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "link" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#');
 
         $this->fixer->configure(array('replacements' => array(
             'link' => 'see',
@@ -71,10 +63,8 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase5()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "b" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "b" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#');
 
         $this->fixer->configure(array('replacements' => array(
             'b' => 'see',
@@ -85,10 +75,8 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase6()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "see" to tag "link", as the tag "link" is configured to be replaced to "b"\.$#'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "see" to tag "link", as the tag "link" is configured to be replaced to "b"\.$#');
 
         $this->fixer->configure(array('replacements' => array(
             'see' => 'link',

--- a/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
@@ -27,9 +27,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 {
     public function testInvalidConfigCase1()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace must be a string\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace must be a string\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array(1 => 'abc')));
@@ -37,9 +37,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase2()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace to from "a" must be a string\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag to replace to from "a" must be a string\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array('a' => null)));
@@ -47,9 +47,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase3()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag "see" cannot be replaced by invalid tag "link\*\/"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Tag "see" cannot be replaced by invalid tag "link\*\/"\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array('see' => 'link*/')));
@@ -57,9 +57,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase4()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "link" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "link" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array(
@@ -71,9 +71,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase5()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "b" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "b" to tag "see", as the tag "see" is configured to be replaced to "link"\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array(
@@ -85,9 +85,9 @@ final class PhpdocNoAliasTagFixerTest extends AbstractFixerTestCase
 
     public function testInvalidConfigCase6()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "see" to tag "link", as the tag "link" is configured to be replaced to "b"\.$#'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('#^\[phpdoc_no_alias_tag\] Invalid configuration: Cannot change tag "see" to tag "link", as the tag "link" is configured to be replaced to "b"\.$#'
         );
 
         $this->fixer->configure(array('replacements' => array(

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -183,10 +183,8 @@ class F
      */
     public function testInvalidConfiguration(array $configuration, $message)
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp(sprintf('/^\[phpdoc_return_self_reference\] %s$/', preg_quote($message, '/'))
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp(sprintf('/^\[phpdoc_return_self_reference\] %s$/', preg_quote($message, '/')));
 
         $this->fixer->configure($configuration);
     }

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -183,9 +183,9 @@ class F
      */
     public function testInvalidConfiguration(array $configuration, $message)
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            sprintf('/^\[phpdoc_return_self_reference\] %s$/', preg_quote($message, '/'))
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp(sprintf('/^\[phpdoc_return_self_reference\] %s$/', preg_quote($message, '/'))
         );
 
         $this->fixer->configure($configuration);

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -445,10 +445,8 @@ EOF
 
     public function testWrongConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[no_extra_consecutive_blank_lines\] Invalid configuration: The option "tokens" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[no_extra_consecutive_blank_lines\] Invalid configuration: The option "tokens" .*\.$/');
 
         $this->fixer->configure(array('tokens' => array('__TEST__')));
     }

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -445,9 +445,9 @@ EOF
 
     public function testWrongConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[no_extra_consecutive_blank_lines\] Invalid configuration: The option "tokens" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[no_extra_consecutive_blank_lines\] Invalid configuration: The option "tokens" .*\.$/'
         );
 
         $this->fixer->configure(array('tokens' => array('__TEST__')));

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -366,10 +366,8 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->expectException(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
-        $this->expectExceptionMessageRegExp('/^\[no_spaces_around_offset\] Invalid configuration: The option "positions" .*\.$/'
-        );
+        $this->expectException('PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[no_spaces_around_offset\] Invalid configuration: The option "positions" .*\.$/');
 
         $this->fixer->configure(array('positions' => array('foo')));
     }

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -366,9 +366,9 @@ EOT
 
     public function testWrongConfig()
     {
-        $this->setExpectedExceptionRegExp(
-            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException',
-            '/^\[no_spaces_around_offset\] Invalid configuration: The option "positions" .*\.$/'
+        $this->expectException(
+            'PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException');
+        $this->expectExceptionMessageRegExp('/^\[no_spaces_around_offset\] Invalid configuration: The option "positions" .*\.$/'
         );
 
         $this->fixer->configure(array('positions' => array('foo')));

--- a/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
@@ -25,7 +25,8 @@ final class FixerConfigurationResolverRootlessTest extends TestCase
 {
     public function testMapRootConfigurationTo()
     {
-        $this->setExpectedException('LogicException', 'The "bar" option is not defined.');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The "bar" option is not defined.');
 
         $configuration = new FixerConfigurationResolverRootless('bar', array(
             new FixerOption('foo', 'Bar.'),

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -27,14 +27,16 @@ final class FixerConfigurationResolverTest extends TestCase
 {
     public function testWithoutOptions()
     {
-        $this->setExpectedException('LogicException', 'Options cannot be empty.');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Options cannot be empty.');
 
         $configuration = new FixerConfigurationResolver(array());
     }
 
     public function testWithDuplicatesOptions()
     {
-        $this->setExpectedException('LogicException', 'The "foo" option is defined multiple times.');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('The "foo" option is defined multiple times.');
 
         $configuration = new FixerConfigurationResolver(array(
             new FixerOption('foo', 'Bar-1.'),
@@ -70,7 +72,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('foo', 'Bar.'),
         ));
 
-        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
         $configuration->resolve(array());
     }
 
@@ -97,7 +99,7 @@ final class FixerConfigurationResolverTest extends TestCase
             $configuration->resolve(array('foo' => 1))
         );
 
-        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->assertSame(
             array('foo' => 1),
             $configuration->resolve(array('foo' => '1'))
@@ -115,7 +117,7 @@ final class FixerConfigurationResolverTest extends TestCase
             $configuration->resolve(array('foo' => true))
         );
 
-        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
         $this->assertSame(
             array('foo' => 1),
             $configuration->resolve(array('foo' => 1))
@@ -128,7 +130,7 @@ final class FixerConfigurationResolverTest extends TestCase
             new FixerOption('bar', 'Bar.'),
         ));
 
-        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException');
         $configuration->resolve(array('foo' => 'foooo'));
     }
 

--- a/tests/FixerConfiguration/FixerOptionTest.php
+++ b/tests/FixerConfiguration/FixerOptionTest.php
@@ -53,7 +53,8 @@ final class FixerOptionTest extends TestCase
     {
         $option = new FixerOption('foo', 'Bar.');
 
-        $this->setExpectedException('LogicException', 'No default value defined.');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('No default value defined.');
         $option->getDefault();
     }
 
@@ -99,7 +100,8 @@ final class FixerOptionTest extends TestCase
 
     public function testRequiredWithDefaultValue()
     {
-        $this->setExpectedException('LogicException', 'Required options cannot have a default value.');
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('Required options cannot have a default value.');
 
         new FixerOption('foo', 'Bar.', true, false);
     }

--- a/tests/FixerDefinition/VersionSpecificationTest.php
+++ b/tests/FixerDefinition/VersionSpecificationTest.php
@@ -26,7 +26,7 @@ final class VersionSpecificationTest extends TestCase
 {
     public function testConstructorRequiresEitherMinimumOrMaximum()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         new VersionSpecification();
     }
@@ -38,7 +38,7 @@ final class VersionSpecificationTest extends TestCase
      */
     public function testConstructorRejectsInvalidMinimum($minimum)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         new VersionSpecification($minimum);
     }
@@ -50,7 +50,7 @@ final class VersionSpecificationTest extends TestCase
      */
     public function testConstructorRejectsInvalidMaximum($maximum)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         new VersionSpecification(
             PHP_VERSION_ID,
@@ -76,7 +76,7 @@ final class VersionSpecificationTest extends TestCase
 
     public function testConstructorRejectsMaximumLessThanMinimum()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         new VersionSpecification(
             PHP_VERSION_ID,

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -121,10 +121,8 @@ final class FixerFactoryTest extends TestCase
      */
     public function testRegisterFixerWithOccupiedName()
     {
-        $this->expectException(
-            'UnexpectedValueException');
-        $this->expectExceptionMessage('Fixer named "non_unique_name" is already registered.'
-        );
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Fixer named "non_unique_name" is already registered.');
 
         $factory = new FixerFactory();
 
@@ -159,10 +157,8 @@ final class FixerFactoryTest extends TestCase
      */
     public function testUseRuleSetWithNonExistingRule()
     {
-        $this->expectException(
-            'UnexpectedValueException');
-        $this->expectExceptionMessage('Rule "non_existing_rule" does not exist.'
-        );
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Rule "non_existing_rule" does not exist.');
 
         $factory = FixerFactory::create()
             ->registerBuiltInFixers()
@@ -211,10 +207,8 @@ final class FixerFactoryTest extends TestCase
      */
     public function testConflictingFixers(RuleSet $ruleSet)
     {
-        $this->expectException(
-            'UnexpectedValueException');
-        $this->expectExceptionMessageRegExp('#^Rule contains conflicting fixers:\n#'
-        );
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessageRegExp('#^Rule contains conflicting fixers:\n#');
 
         FixerFactory::create()->registerBuiltInFixers()->useRuleSet($ruleSet);
     }

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -211,9 +211,9 @@ final class FixerFactoryTest extends TestCase
      */
     public function testConflictingFixers(RuleSet $ruleSet)
     {
-        $this->setExpectedExceptionRegExp(
-            'UnexpectedValueException',
-            '#^Rule contains conflicting fixers:\n#'
+        $this->expectException(
+            'UnexpectedValueException');
+        $this->expectExceptionMessageRegExp('#^Rule contains conflicting fixers:\n#'
         );
 
         FixerFactory::create()->registerBuiltInFixers()->useRuleSet($ruleSet);

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -121,9 +121,9 @@ final class FixerFactoryTest extends TestCase
      */
     public function testRegisterFixerWithOccupiedName()
     {
-        $this->setExpectedException(
-            'UnexpectedValueException',
-            'Fixer named "non_unique_name" is already registered.'
+        $this->expectException(
+            'UnexpectedValueException');
+        $this->expectExceptionMessage('Fixer named "non_unique_name" is already registered.'
         );
 
         $factory = new FixerFactory();
@@ -159,9 +159,9 @@ final class FixerFactoryTest extends TestCase
      */
     public function testUseRuleSetWithNonExistingRule()
     {
-        $this->setExpectedException(
-            'UnexpectedValueException',
-            'Rule "non_existing_rule" does not exist.'
+        $this->expectException(
+            'UnexpectedValueException');
+        $this->expectExceptionMessage('Rule "non_existing_rule" does not exist.'
         );
 
         $factory = FixerFactory::create()

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -88,9 +88,9 @@ final class ReporterFactoryTest extends TestCase
 
     public function testRegisterReportWithOccupiedFormat()
     {
-        $this->setExpectedException(
-            'UnexpectedValueException',
-            'Reporter for format "non_unique_name" is already registered.'
+        $this->expectException(
+            'UnexpectedValueException');
+        $this->expectExceptionMessage('Reporter for format "non_unique_name" is already registered.'
         );
 
         $factory = new ReporterFactory();
@@ -103,9 +103,9 @@ final class ReporterFactoryTest extends TestCase
 
     public function testGetNonRegisteredReport()
     {
-        $this->setExpectedException(
-            'UnexpectedValueException',
-            'Reporter for format "non_registered_format" is not registered.'
+        $this->expectException(
+            'UnexpectedValueException');
+        $this->expectExceptionMessage('Reporter for format "non_registered_format" is not registered.'
         );
 
         $builder = new ReporterFactory();

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -88,10 +88,8 @@ final class ReporterFactoryTest extends TestCase
 
     public function testRegisterReportWithOccupiedFormat()
     {
-        $this->expectException(
-            'UnexpectedValueException');
-        $this->expectExceptionMessage('Reporter for format "non_unique_name" is already registered.'
-        );
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Reporter for format "non_unique_name" is already registered.');
 
         $factory = new ReporterFactory();
 
@@ -103,10 +101,8 @@ final class ReporterFactoryTest extends TestCase
 
     public function testGetNonRegisteredReport()
     {
-        $this->expectException(
-            'UnexpectedValueException');
-        $this->expectExceptionMessage('Reporter for format "non_registered_format" is not registered.'
-        );
+        $this->expectException('UnexpectedValueException');
+        $this->expectExceptionMessage('Reporter for format "non_registered_format" is not registered.');
 
         $builder = new ReporterFactory();
 

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -69,9 +69,9 @@ final class RuleSetTest extends TestCase
 
     public function testResolveRulesWithInvalidSet()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Set "@foo" does not exist.'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessage('Set "@foo" does not exist.'
         );
 
         RuleSet::create(array(
@@ -81,9 +81,9 @@ final class RuleSetTest extends TestCase
 
     public function testResolveRulesWithMissingRuleValue()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Missing value for "braces" rule/set.'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessage('Missing value for "braces" rule/set.'
         );
 
         RuleSet::create(array(

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -69,10 +69,8 @@ final class RuleSetTest extends TestCase
 
     public function testResolveRulesWithInvalidSet()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessage('Set "@foo" does not exist.'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Set "@foo" does not exist.');
 
         RuleSet::create(array(
             '@foo' => true,
@@ -81,10 +79,8 @@ final class RuleSetTest extends TestCase
 
     public function testResolveRulesWithMissingRuleValue()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessage('Missing value for "braces" rule/set.'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Missing value for "braces" rule/set.');
 
         RuleSet::create(array(
             'braces',
@@ -287,10 +283,8 @@ final class RuleSetTest extends TestCase
 
     public function testInvalidConfigNestedSets()
     {
-        $this->expectException(
-            '\UnexpectedValueException');
-        $this->expectExceptionMessageRegExp('#^Nested rule set "@PSR1" configuration must be a boolean\.$#'
-        );
+        $this->expectException('\UnexpectedValueException');
+        $this->expectExceptionMessageRegExp('#^Nested rule set "@PSR1" configuration must be a boolean\.$#');
 
         new RuleSet(
             array('@PSR1' => array('@PSR2' => 'no'))
@@ -453,10 +447,8 @@ final class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet();
 
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('#^Rule "_not_exists" is not in the set\.$#'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('#^Rule "_not_exists" is not in the set\.$#');
 
         $ruleSet->getRuleConfiguration('_not_exists');
     }

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -287,9 +287,9 @@ final class RuleSetTest extends TestCase
 
     public function testInvalidConfigNestedSets()
     {
-        $this->setExpectedExceptionRegExp(
-            '\UnexpectedValueException',
-            '#^Nested rule set "@PSR1" configuration must be a boolean\.$#'
+        $this->expectException(
+            '\UnexpectedValueException');
+        $this->expectExceptionMessageRegExp('#^Nested rule set "@PSR1" configuration must be a boolean\.$#'
         );
 
         new RuleSet(
@@ -453,9 +453,9 @@ final class RuleSetTest extends TestCase
     {
         $ruleSet = new RuleSet();
 
-        $this->setExpectedExceptionRegExp(
-            'InvalidArgumentException',
-            '#^Rule "_not_exists" is not in the set\.$#'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('#^Rule "_not_exists" is not in the set\.$#'
         );
 
         $ruleSet->getRuleConfiguration('_not_exists');

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -286,7 +286,9 @@ final class TokenTest extends TestCase
      */
     public function testCreatingToken($prototype, $expectedId, $expectedContent, $expectedIsArray, $expectedExceptionClass = null)
     {
-        $this->expectException($expectedExceptionClass);
+        if ($expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+        }
 
         $token = new Token($prototype);
         $this->assertSame($expectedId, $token->getId());

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -286,7 +286,7 @@ final class TokenTest extends TestCase
      */
     public function testCreatingToken($prototype, $expectedId, $expectedContent, $expectedIsArray, $expectedExceptionClass = null)
     {
-        $this->setExpectedException($expectedExceptionClass);
+        $this->expectException($expectedExceptionClass);
 
         $token = new Token($prototype);
         $this->assertSame($expectedId, $token->getId());

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -746,7 +746,7 @@ $b;',
      */
     public function testIsMultiLineArrayException($source, $tokenIndex)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -284,9 +284,9 @@ final class TokensTest extends TestCase
      */
     public function testFindSequenceException($message, array $sequence)
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            $message
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessage($message
         );
 
         $tokens = Tokens::fromCode('<?php $x = 1;');
@@ -773,7 +773,7 @@ PHP;
             $this->markTestSkipped('Skip tests for PHP compiler when running on non HHVM compiler.');
         }
 
-        $this->setExpectedException('ParseError');
+        $this->expectException('ParseError');
         Tokens::fromCode('<?php# this will cause T_HH_ERROR');
     }
 

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -745,9 +745,9 @@ PHP;
 
     public function testFindBlockEndInvalidType()
     {
-        $this->setExpectedExceptionRegExp(
-            'InvalidArgumentException',
-            '/^Invalid param type: -1\.$/'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Invalid param type: -1\.$/'
         );
 
         Tokens::clearCache();
@@ -757,9 +757,9 @@ PHP;
 
     public function testFindBlockEndInvalidStart()
     {
-        $this->setExpectedExceptionRegExp(
-            'InvalidArgumentException',
-            '/^Invalid param \$startIndex - not a proper block start\.$/'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Invalid param \$startIndex - not a proper block start\.$/'
         );
 
         Tokens::clearCache();

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -284,10 +284,8 @@ final class TokensTest extends TestCase
      */
     public function testFindSequenceException($message, array $sequence)
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessage($message
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage($message);
 
         $tokens = Tokens::fromCode('<?php $x = 1;');
         $tokens->findSequence($sequence);
@@ -745,10 +743,8 @@ PHP;
 
     public function testFindBlockEndInvalidType()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('/^Invalid param type: -1\.$/'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Invalid param type: -1\.$/');
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');
@@ -757,10 +753,8 @@ PHP;
 
     public function testFindBlockEndInvalidStart()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessageRegExp('/^Invalid param \$startIndex - not a proper block start\.$/'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessageRegExp('/^Invalid param \$startIndex - not a proper block start\.$/');
 
         Tokens::clearCache();
         $tokens = Tokens::fromCode('<?php ');

--- a/tests/ToolInfoTest.php
+++ b/tests/ToolInfoTest.php
@@ -41,7 +41,7 @@ final class ToolInfoTest extends TestCase
 
     public function testGetComposerVersionThrowsExceptionIfOutsideComposerScope()
     {
-        $this->setExpectedException('LogicException');
+        $this->expectException('LogicException');
 
         ToolInfo::getComposerVersion();
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -150,10 +150,8 @@ final class UtilsTest extends TestCase
 
     public function testCalculateTrailingWhitespaceIndentFail()
     {
-        $this->expectException(
-            'InvalidArgumentException');
-        $this->expectExceptionMessage('The given token must be whitespace, got "T_STRING".'
-        );
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The given token must be whitespace, got "T_STRING".');
 
         $token = new Token(array(T_STRING, 'foo'));
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -150,9 +150,9 @@ final class UtilsTest extends TestCase
 
     public function testCalculateTrailingWhitespaceIndentFail()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'The given token must be whitespace, got "T_STRING".'
+        $this->expectException(
+            'InvalidArgumentException');
+        $this->expectExceptionMessage('The given token must be whitespace, got "T_STRING".'
         );
 
         $token = new Token(array(T_STRING, 'foo'));

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -34,7 +34,8 @@ final class WhitespacesFixerConfigTest extends TestCase
     public function testCases($indent, $lineEnding, $exceptionRegExp = null)
     {
         if (null !== $exceptionRegExp) {
-            $this->setExpectedExceptionRegExp('InvalidArgumentException', $exceptionRegExp);
+            $this->expectException('InvalidArgumentException');
+            $this->expectExceptionMessageRegExp($exceptionRegExp);
         }
 
         $config = new WhitespacesFixerConfig($indent, $lineEnding);


### PR DESCRIPTION
With this PR, we are not using anything deprecated on PHPUnit 5.4 and lower

sadly, cannot go to 2.2 line as PHPUnit 5+ requires PHP 5.6+