### PR TITLE
Fix handling of PHPDoc collection types

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -205,10 +205,9 @@ class Annotation
                 throw new \RuntimeException('This tag does not support types.');
             }
 
-            $tagSplit = preg_split('/\s*\@'.$name.'\s*/', $this->lines[0]->getContent(), 2);
-            $spaceSplit = preg_split('/\s/', $tagSplit[1], 2);
+            preg_match('/\@'.$name.'\s+(([^\s|<]+(?:<.*?>)?)(?:\|(?2))*)/', $this->lines[0]->getContent(), $matches);
 
-            $this->typesContent = $spaceSplit[0];
+            $this->typesContent = $matches[1];
         }
 
         return $this->typesContent;

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -241,6 +241,24 @@ final class AnnotationTest extends TestCase
             array(array('false'), array('bool'), '*   @return            false', '*   @return            bool'),
             array(array('RUNTIMEEEEeXCEPTION'), array('Throwable'), "\t@throws\t  \t RUNTIMEEEEeXCEPTION\t\t\t\t\t\t\t\n\n\n", "\t@throws\t  \t Throwable\t\t\t\t\t\t\t\n\n\n"),
             array(array('string'), array('string', 'null'), ' * @method string getString()', ' * @method string|null getString()'),
+            array(
+                array('array<int, string>', 'null'),
+                array('null', 'array<int, string>'),
+                ' * @method array<int, string>|null getStrings()',
+                ' * @method null|array<int, string> getStrings()',
+            ),
+            array(
+                array('array<int, string>', '\ArrayObject<int, string>', 'null'),
+                array('null', 'array<int, string>', '\ArrayObject<int, string>'),
+                ' * @method array<int, string>|\ArrayObject<int, string>|null getStrings()',
+                ' * @method null|array<int, string>|\ArrayObject<int, string> getStrings()',
+            ),
+            array(
+                array('array<int, array<int, string>>', 'null'),
+                array('null', 'array<int, array<int, string>>'),
+                ' * @method array<int, array<int, string>>|null getStrings()',
+                ' * @method null|array<int, array<int, string>> getStrings()',
+            ),
         );
     }
 


### PR DESCRIPTION
Considering this PHPDoc:
```
/**
 * @param array<int, string>|null $foo
 */
```
`Annotation::getTypes()` will return `['array<int,']`. This PR fixes the method to return `['array<int, string>', 'null']` instead.

Not sure if the bug really affects any existing fixer, but it does affect the fixer introduced in #2825.