### PR TITLE
Move null to first position in PHPDoc types

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -32,7 +32,7 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
 {
     /**
-     * @var array<string, mixed>|null
+     * @var null|array<string, mixed>
      */
     protected $configuration;
 
@@ -42,7 +42,7 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
     protected $whitespacesConfig;
 
     /**
-     * @var FixerConfigurationResolverInterface|null
+     * @var null|FixerConfigurationResolverInterface
      */
     private $configurationDefinition;
 

--- a/src/AbstractFunctionReferenceFixer.php
+++ b/src/AbstractFunctionReferenceFixer.php
@@ -53,9 +53,9 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
      * @param string   $functionNameToSearch
      * @param Tokens   $tokens
      * @param int      $start
-     * @param int|null $end
+     * @param null|int $end
      *
-     * @return int[]|null returns $functionName, $openParenthesis, $closeParenthesis packed into array
+     * @return null|int[] returns $functionName, $openParenthesis, $closeParenthesis packed into array
      */
     protected function find($functionNameToSearch, Tokens $tokens, $start = 0, $end = null)
     {

--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -59,7 +59,7 @@ final class FileCacheManager implements CacheManagerInterface
      * @param FileHandlerInterface    $handler
      * @param SignatureInterface      $signature
      * @param bool                    $isDryRun
-     * @param DirectoryInterface|null $cacheDirectory
+     * @param null|DirectoryInterface $cacheDirectory
      */
     public function __construct(
         FileHandlerInterface $handler,

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -23,7 +23,7 @@ interface ConfigInterface
     /**
      * Returns the path to the cache file.
      *
-     * @return string|null Returns null if not using cache
+     * @return null|string Returns null if not using cache
      */
     public function getCacheFile();
 
@@ -75,7 +75,7 @@ interface ConfigInterface
     /**
      * Get configured PHP executable, if any.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getPhpExecutable();
 
@@ -158,7 +158,7 @@ interface ConfigInterface
     /**
      * Set PHP executable.
      *
-     * @param string|null $phpExecutable
+     * @param null|string $phpExecutable
      *
      * @return self
      */

--- a/src/ConfigurationException/InvalidConfigurationException.php
+++ b/src/ConfigurationException/InvalidConfigurationException.php
@@ -25,8 +25,8 @@ class InvalidConfigurationException extends \InvalidArgumentException
 {
     /**
      * @param string          $message
-     * @param int|null        $code
-     * @param \Exception|null $previous
+     * @param null|int        $code
+     * @param null|\Exception $previous
      */
     public function __construct($message, $code = null, \Exception $previous = null)
     {

--- a/src/ConfigurationException/InvalidFixerConfigurationException.php
+++ b/src/ConfigurationException/InvalidFixerConfigurationException.php
@@ -26,7 +26,7 @@ class InvalidFixerConfigurationException extends InvalidConfigurationException
     /**
      * @param string          $fixerName
      * @param string          $message
-     * @param \Exception|null $previous
+     * @param null|\Exception $previous
      */
     public function __construct($fixerName, $message, \Exception $previous = null)
     {

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -56,7 +56,7 @@ final class DescribeCommand extends Command
     private $fixers;
 
     /**
-     * @param FixerFactory|null $fixerFactory
+     * @param null|FixerFactory $fixerFactory
      */
     public function __construct(FixerFactory $fixerFactory = null)
     {

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -299,7 +299,7 @@ EOF
      *
      * @param FixerOptionInterface $option
      *
-     * @return array|null
+     * @return null|array
      */
     public static function getDisplayableAllowedValues(FixerOptionInterface $option)
     {
@@ -380,7 +380,7 @@ EOF
     }
 
     /**
-     * @return string|null
+     * @return null|string
      */
     private static function getChangeLogFile()
     {

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -140,7 +140,7 @@ EOT
     }
 
     /**
-     * @return string|null
+     * @return null|string
      */
     private function getLatestTag()
     {

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -155,7 +155,7 @@ final class ConfigurationResolver
     }
 
     /**
-     * @return string|null
+     * @return null|string
      */
     public function getCacheFile()
     {

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -53,7 +53,7 @@ final class ProcessOutput implements ProcessOutputInterface
     private $output;
 
     /**
-     * @var int|null
+     * @var null|int
      */
     private $files;
 
@@ -63,14 +63,14 @@ final class ProcessOutput implements ProcessOutputInterface
     private $processedFiles = 0;
 
     /**
-     * @var int|null
+     * @var null|int
      */
     private $symbolsPerLine;
 
     /**
      * @param OutputInterface $output
      * @param EventDispatcher $dispatcher
-     * @param int|null        $nbFiles
+     * @param null|int        $nbFiles
      */
     public function __construct(OutputInterface $output, EventDispatcher $dispatcher, $nbFiles)
     {

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -60,14 +60,14 @@ class Annotation
     /**
      * The associated tag.
      *
-     * @var Tag|null
+     * @var null|Tag
      */
     private $tag;
 
     /**
      * The cached types content.
      *
-     * @var string|null
+     * @var null|string
      */
     private $typesContent;
 

--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -33,7 +33,7 @@ class DocBlock
     /**
      * The array of annotations.
      *
-     * @var Annotation[]|null
+     * @var null|Annotation[]
      */
     private $annotations;
 
@@ -74,7 +74,7 @@ class DocBlock
      *
      * @param int $pos
      *
-     * @return Line|null
+     * @return null|Line
      */
     public function getLine($pos)
     {
@@ -117,7 +117,7 @@ class DocBlock
      *
      * @param int $pos
      *
-     * @return Annotation|null
+     * @return null|Annotation
      */
     public function getAnnotation($pos)
     {

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -41,7 +41,7 @@ class Tag
     /**
      * The cached tag name.
      *
-     * @var string|null
+     * @var null|string
      */
     private $name;
 

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -134,7 +134,7 @@ final class Tokens extends \SplFixedArray
      *
      * @param int $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNextMeaningfulToken($index)
     {
@@ -146,7 +146,7 @@ final class Tokens extends \SplFixedArray
      *
      * @param int $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getPreviousMeaningfulToken($index)
     {
@@ -159,7 +159,7 @@ final class Tokens extends \SplFixedArray
      * @param string|string[] $type
      * @param int             $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNextTokenOfType($type, $index)
     {
@@ -172,7 +172,7 @@ final class Tokens extends \SplFixedArray
      * @param string|string[] $type
      * @param int             $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getPreviousTokenOfType($type, $index)
     {
@@ -184,7 +184,7 @@ final class Tokens extends \SplFixedArray
      *
      * @param int $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getAnnotationEnd($index)
     {
@@ -228,7 +228,7 @@ final class Tokens extends \SplFixedArray
      *
      * @param int $index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getArrayEnd($index)
     {
@@ -333,7 +333,7 @@ final class Tokens extends \SplFixedArray
      * @param int $index
      * @param int $direction
      *
-     * @return int|null
+     * @return null|int
      */
     private function getMeaningfulTokenSibling($index, $direction)
     {
@@ -357,7 +357,7 @@ final class Tokens extends \SplFixedArray
      * @param string|string[] $type
      * @param int             $direction
      *
-     * @return int|null
+     * @return null|int
      */
     private function getTokenOfTypeSibling($index, $type, $direction)
     {

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -47,14 +47,14 @@ final class Error
     private $filePath;
 
     /**
-     * @var \Throwable|null
+     * @var null|\Throwable
      */
     private $source;
 
     /**
      * @param int             $type
      * @param string          $filePath
-     * @param \Throwable|null $source
+     * @param null|\Throwable $source
      */
     public function __construct($type, $filePath, $source = null)
     {
@@ -72,7 +72,7 @@ final class Error
     }
 
     /**
-     * @return \Throwable|null
+     * @return null|\Throwable
      */
     public function getSource()
     {

--- a/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+++ b/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
@@ -333,7 +333,7 @@ class Foo
      * @param int    $startIndex the search start index
      * @param int    $endIndex   the search end index
      *
-     * @return array|null An associative array, if a match is found:
+     * @return null|array An associative array, if a match is found:
      *
      *     - nameIndex (int): The index of the function/method name.
      *     - startIndex (int): The index of the function/method start.

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -211,7 +211,7 @@ echo 1;
      * @param Tokens $tokens
      * @param int    $headerNewIndex
      *
-     * @return int|null
+     * @return null|int
      */
     private function findHeaderCommentCurrentIndex(Tokens $tokens, $headerNewIndex)
     {

--- a/src/Fixer/ConfigurableFixerInterface.php
+++ b/src/Fixer/ConfigurableFixerInterface.php
@@ -34,7 +34,7 @@ interface ConfigurableFixerInterface extends FixerInterface
      * eg `php_unit_strict` fixer allows to configure which methods should be fixed.
      * Finally, some fixers need configuration to work, eg `header_comment`.
      *
-     * @param array|null $configuration configuration depends on Fixer
+     * @param null|array $configuration configuration depends on Fixer
      *
      * @throws InvalidFixerConfigurationException
      */

--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -113,7 +113,7 @@ function example($foo = "two words", $bar) {}
      * @param int    $startIndex
      * @param int    $endIndex
      *
-     * @return int|null
+     * @return null|int
      */
     private function getLastNonDefaultArgumentIndex(Tokens $tokens, $startIndex, $endIndex)
     {

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -143,7 +143,7 @@ $this->assertNotSame(null, $d);
      * @param int    $index
      * @param string $method
      *
-     * @return int|null
+     * @return null|int
      */
     private function fixAssertNegative(Tokens $tokens, $index, $method)
     {
@@ -161,7 +161,7 @@ $this->assertNotSame(null, $d);
      * @param int    $index
      * @param string $method
      *
-     * @return int|null
+     * @return null|int
      */
     private function fixAssertPositive(Tokens $tokens, $index, $method)
     {
@@ -180,7 +180,7 @@ $this->assertNotSame(null, $d);
      * @param int                   $index
      * @param string                $method
      *
-     * @return int|null
+     * @return null|int
      */
     private function fixAssert(array $map, Tokens $tokens, $index, $method)
     {

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -217,7 +217,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
      * @param string $line
      * @param bool   $matchCommentOnly
      *
-     * @return string[]|null
+     * @return null|string[]
      */
     private function getMatches($line, $matchCommentOnly = false)
     {

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -81,7 +81,7 @@ function foo () {}
      *
      * @param Line[] $lines
      *
-     * @return int|null
+     * @return null|int
      */
     private function findShortDescriptionEnd(array $lines)
     {

--- a/src/FixerConfiguration/FixerOption.php
+++ b/src/FixerConfiguration/FixerOption.php
@@ -45,7 +45,7 @@ final class FixerOption implements FixerOptionInterface
     private $allowedValues;
 
     /**
-     * @var \Closure|null
+     * @var null|\Closure
      */
     private $normalizer;
 
@@ -54,9 +54,9 @@ final class FixerOption implements FixerOptionInterface
      * @param string        $description
      * @param bool          $isRequired
      * @param mixed         $default
-     * @param string[]|null $allowedTypes
-     * @param array|null    $allowedValues
-     * @param \Closure|null $normalizer
+     * @param null|string[] $allowedTypes
+     * @param null|array    $allowedValues
+     * @param null|\Closure $normalizer
      */
     public function __construct(
         $name,

--- a/src/FixerConfiguration/FixerOptionBuilder.php
+++ b/src/FixerConfiguration/FixerOptionBuilder.php
@@ -45,7 +45,7 @@ final class FixerOptionBuilder
     private $allowedValues;
 
     /**
-     * @var \Closure|null
+     * @var null|\Closure
      */
     private $normalizer;
 

--- a/src/FixerConfiguration/FixerOptionInterface.php
+++ b/src/FixerConfiguration/FixerOptionInterface.php
@@ -47,7 +47,7 @@ interface FixerOptionInterface
     public function getAllowedValues();
 
     /**
-     * @return \Closure|null
+     * @return null|\Closure
      */
     public function getNormalizer();
 }

--- a/src/FixerDefinition/VersionSpecification.php
+++ b/src/FixerDefinition/VersionSpecification.php
@@ -18,18 +18,18 @@ namespace PhpCsFixer\FixerDefinition;
 final class VersionSpecification implements VersionSpecificationInterface
 {
     /**
-     * @var int|null
+     * @var null|int
      */
     private $minimum;
 
     /**
-     * @var int|null
+     * @var null|int
      */
     private $maximum;
 
     /**
-     * @param int|null $minimum
-     * @param int|null $maximum
+     * @param null|int $minimum
+     * @param null|int $maximum
      *
      * @throws \InvalidArgumentException
      */

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -253,7 +253,7 @@ final class FixerFactory
     /**
      * @param FixerInterface $fixer
      *
-     * @return string[]|null
+     * @return null|string[]
      */
     private function getFixersConflicts(FixerInterface $fixer)
     {

--- a/src/Linter/Linter.php
+++ b/src/Linter/Linter.php
@@ -27,7 +27,7 @@ final class Linter implements LinterInterface
     private $sublinter;
 
     /**
-     * @param string|null $executable PHP executable, null for autodetection
+     * @param null|string $executable PHP executable, null for autodetection
      */
     public function __construct($executable = null)
     {

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -30,7 +30,7 @@ final class ProcessLinter implements LinterInterface
     /**
      * Temporary file for code linting.
      *
-     * @var string|null
+     * @var null|string
      */
     private $temporaryFile;
 
@@ -49,7 +49,7 @@ final class ProcessLinter implements LinterInterface
     private $fileRemoval;
 
     /**
-     * @param string|null $executable PHP executable, null for autodetection
+     * @param null|string $executable PHP executable, null for autodetection
      */
     public function __construct($executable = null)
     {

--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -20,12 +20,12 @@ namespace PhpCsFixer\Linter;
 final class TokenizerLintingResult implements LintingResultInterface
 {
     /**
-     * @var \ParseError|null
+     * @var null|\ParseError
      */
     private $error;
 
     /**
-     * @param \ParseError|null $error
+     * @param null|\ParseError $error
      */
     public function __construct(\ParseError $error = null)
     {

--- a/src/RuleSetInterface.php
+++ b/src/RuleSetInterface.php
@@ -30,7 +30,7 @@ interface RuleSetInterface
      *
      * @param string $rule name of rule
      *
-     * @return array|null
+     * @return null|array
      */
     public function getRuleConfiguration($rule);
 

--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 final class FileFilterIterator extends \FilterIterator
 {
     /**
-     * @var EventDispatcher|null
+     * @var null|EventDispatcher
      */
     private $eventDispatcher;
 

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -45,7 +45,7 @@ final class Runner
     private $directory;
 
     /**
-     * @var EventDispatcher|null
+     * @var null|EventDispatcher
      */
     private $eventDispatcher;
 

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -109,8 +109,8 @@ abstract class AbstractFixerTestCase extends TestCase
      * not test anything.
      *
      * @param string            $expected The expected fixer output
-     * @param string|null       $input    The fixer input, or null if it should intentionally be equal to the output
-     * @param \SplFileInfo|null $file     The file to fix, or null if unneeded
+     * @param null|string       $input    The fixer input, or null if it should intentionally be equal to the output
+     * @param null|\SplFileInfo $file     The file to fix, or null if unneeded
      */
     protected function doTest($expected, $input = null, \SplFileInfo $file = null)
     {
@@ -177,7 +177,7 @@ abstract class AbstractFixerTestCase extends TestCase
     /**
      * @param string $source
      *
-     * @return string|null
+     * @return null|string
      */
     protected function lintSource($source)
     {

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -35,7 +35,7 @@ final class IntegrationCase
     private $fileName;
 
     /**
-     * @var string|null
+     * @var null|string
      */
     private $inputCode;
 
@@ -71,7 +71,7 @@ final class IntegrationCase
      * @param array       $config
      * @param RuleSet     $ruleset
      * @param string      $expectedCode
-     * @param string|null $inputCode
+     * @param null|string $inputCode
      */
     public function __construct(
         $fileName,

--- a/src/Test/IntegrationCaseFactory.php
+++ b/src/Test/IntegrationCaseFactory.php
@@ -174,7 +174,7 @@ final class IntegrationCaseFactory
     }
 
     /**
-     * @param string|null $code
+     * @param null|string $code
      * @param SplFileInfo $file
      *
      * @return string
@@ -191,10 +191,10 @@ final class IntegrationCaseFactory
     }
 
     /**
-     * @param string|null $code
+     * @param null|string $code
      * @param SplFileInfo $file
      *
-     * @return string|null
+     * @return null|string
      */
     private function determineInputCode($code, SplFileInfo $file)
     {
@@ -202,11 +202,11 @@ final class IntegrationCaseFactory
     }
 
     /**
-     * @param string|null $code
+     * @param null|string $code
      * @param SplFileInfo $file
      * @param string      $suffix
      *
-     * @return string|null
+     * @return null|string
      */
     private function determineCode($code, SplFileInfo $file, $suffix)
     {
@@ -221,8 +221,8 @@ final class IntegrationCaseFactory
     }
 
     /**
-     * @param string|null $encoded
-     * @param array|null  $template
+     * @param null|string $encoded
+     * @param null|array  $template
      *
      * @return array
      */

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -32,7 +32,7 @@ class Token
     /**
      * ID of token prototype, if available.
      *
-     * @var int|null
+     * @var null|int
      */
     private $id;
 
@@ -238,7 +238,7 @@ class Token
      *
      * It shall be used only for getting the internal id of token, not for checking it against excepted value.
      *
-     * @return int|null
+     * @return null|int
      */
     public function getId()
     {
@@ -512,7 +512,7 @@ class Token
     }
 
     /**
-     * @param string[]|null $options JSON encode option
+     * @param null|string[] $options JSON encode option
      *
      * @return string
      */

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -85,7 +85,7 @@ class Tokens extends \SplFixedArray
     /**
      * Clear cache - one position or all of them.
      *
-     * @param string|null $key position to clear, when null clear all
+     * @param null|string $key position to clear, when null clear all
      */
     public static function clearCache($key = null)
     {
@@ -439,7 +439,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int|array $possibleKind kind or array of kind
      * @param int       $start        optional offset
-     * @param int|null  $end          optional limit
+     * @param null|int  $end          optional limit
      *
      * @return array array of tokens of given kinds or assoc array of arrays
      */
@@ -517,7 +517,7 @@ class Tokens extends \SplFixedArray
      * @param int         $index       token index
      * @param null|string $whitespaces whitespaces characters for Token::isWhitespace
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNextNonWhitespace($index, $whitespaces = null)
     {
@@ -533,7 +533,7 @@ class Tokens extends \SplFixedArray
      * @param array $tokens        possible tokens
      * @param bool  $caseSensitive perform a case sensitive comparison
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNextTokenOfKind($index, array $tokens = array(), $caseSensitive = true)
     {
@@ -547,7 +547,7 @@ class Tokens extends \SplFixedArray
      * @param int         $direction   direction for looking, +1 or -1
      * @param null|string $whitespaces whitespaces characters for Token::isWhitespace
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNonWhitespaceSibling($index, $direction, $whitespaces = null)
     {
@@ -574,7 +574,7 @@ class Tokens extends \SplFixedArray
      * @param int         $index       token index
      * @param null|string $whitespaces whitespaces characters for Token::isWhitespace
      *
-     * @return int|null
+     * @return null|int
      */
     public function getPrevNonWhitespace($index, $whitespaces = null)
     {
@@ -589,7 +589,7 @@ class Tokens extends \SplFixedArray
      * @param array $tokens        possible tokens
      * @param bool  $caseSensitive perform a case sensitive comparison
      *
-     * @return int|null
+     * @return null|int
      */
     public function getPrevTokenOfKind($index, array $tokens = array(), $caseSensitive = true)
     {
@@ -604,7 +604,7 @@ class Tokens extends \SplFixedArray
      * @param array $tokens        possible tokens
      * @param bool  $caseSensitive perform a case sensitive comparison
      *
-     * @return int|null
+     * @return null|int
      */
     public function getTokenOfKindSibling($index, $direction, array $tokens = array(), $caseSensitive = true)
     {
@@ -630,7 +630,7 @@ class Tokens extends \SplFixedArray
      * @param int   $direction direction for looking, +1 or -1
      * @param array $tokens    possible tokens
      *
-     * @return int|null
+     * @return null|int
      */
     public function getTokenNotOfKindSibling($index, $direction, array $tokens = array())
     {
@@ -659,7 +659,7 @@ class Tokens extends \SplFixedArray
      * @param int $index     token index
      * @param int $direction direction for looking, +1 or -1
      *
-     * @return int|null
+     * @return null|int
      */
     public function getMeaningfulTokenSibling($index, $direction)
     {
@@ -676,7 +676,7 @@ class Tokens extends \SplFixedArray
      * @param int $index     token index
      * @param int $direction direction for looking, +1 or -1
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNonEmptySibling($index, $direction)
     {
@@ -698,7 +698,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int $index token index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getNextMeaningfulToken($index)
     {
@@ -710,7 +710,7 @@ class Tokens extends \SplFixedArray
      *
      * @param int $index token index
      *
-     * @return int|null
+     * @return null|int
      */
     public function getPrevMeaningfulToken($index)
     {
@@ -727,7 +727,7 @@ class Tokens extends \SplFixedArray
      *                                  the ones used in $others. If any is missing, the default case-sensitive
      *                                  comparison is used
      *
-     * @return array|null an array containing the tokens matching the sequence elements, indexed by their position
+     * @return null|array an array containing the tokens matching the sequence elements, indexed by their position
      */
     public function findSequence(array $sequence, $start = 0, $end = null, $caseSensitive = true)
     {

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -695,7 +695,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param bool             $expected
      * @param bool             $configValue
-     * @param bool|string|null $passed
+     * @param null|bool|string $passed
      *
      * @dataProvider getResolveBooleanOptions
      */
@@ -800,7 +800,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param bool             $expected
      * @param bool             $configValue
-     * @param bool|string|null $passed
+     * @param null|bool|string $passed
      *
      * @dataProvider getResolveBooleanOptions
      */

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -24,7 +24,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
 {
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixWithBracesCases
      */
@@ -266,7 +266,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixWithoutBracesCases
      */

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -24,7 +24,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
 {
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixCases
      */

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -24,7 +24,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 {
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAllCases
      */
@@ -43,7 +43,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAllCases
      */
@@ -323,7 +323,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundParenthesesOnlyCases
      */
@@ -347,7 +347,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundParenthesesOnlyCases
      */
@@ -578,7 +578,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundCommasOnlyCases
      */
@@ -602,7 +602,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundCommasOnlyCases
      */
@@ -856,7 +856,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundArgumentAssignmentsOnlyCases
      */
@@ -880,7 +880,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundArgumentAssignmentsOnlyCases
      */
@@ -1126,7 +1126,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundArrayAssignmentsOnlyCases
      */
@@ -1150,7 +1150,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider getFixAroundArrayAssignmentsOnlyCases
      */

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1535,7 +1535,7 @@ EOF
 
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider provide70CasesByLength
      * @requires PHP 7.0
@@ -1593,7 +1593,7 @@ use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
      * @requires PHP 7.0
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      */
     public function test70TypesOrderAndLength($expected, $input = null)
     {
@@ -1652,7 +1652,7 @@ use function some\f\{fn_c, fn_d, fn_e};
      * @requires PHP 7.0
      *
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      * @param string[]    $importOrder
      */
     public function test70TypesOrderAndAlphabet($expected, $input = null, array $importOrder = null)

--- a/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
@@ -25,7 +25,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
 {
     /**
      * @param string      $expected
-     * @param string|null $input
+     * @param null|string $input
      *
      * @dataProvider provideDoFixCases
      */

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -25,7 +25,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
 {
     /**
      * @param string      $expected PHP code
-     * @param string|null $input    PHP code
+     * @param null|string $input    PHP code
      *
      * @group legacy
      * @dataProvider provideDefaultConfigurationTestCases
@@ -39,7 +39,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
 
     /**
      * @param string      $expected PHP code
-     * @param string|null $input    PHP code
+     * @param null|string $input    PHP code
      *
      * @dataProvider provideDefaultConfigurationTestCases
      */
@@ -71,7 +71,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
 
     /**
      * @param string      $expected      PHP code
-     * @param string|null $input         PHP code
+     * @param null|string $input         PHP code
      * @param array       $configuration
      *
      * @group legacy
@@ -86,7 +86,7 @@ final class PhpdocReturnSelfReferenceFixerTest extends AbstractFixerTestCase
 
     /**
      * @param string      $expected      PHP code
-     * @param string|null $input         PHP code
+     * @param null|string $input         PHP code
      * @param array       $configuration
      *
      * @dataProvider provideTestCases

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -47,7 +47,7 @@ final class TokensTest extends TestCase
      * @param null|array $expected
      * @param Token[]    $sequence
      * @param int        $start
-     * @param int|null   $end
+     * @param null|int   $end
      * @param bool|array $caseSensitive
      *
      * @dataProvider provideFindSequence


### PR DESCRIPTION
Applies fixes with the `phpdoc_types_order` rule introduced in #2825.