### PR TITLE
Add estimating-max progress output type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,8 @@ The ``--show-progress`` option allows you to choose the way process progress is 
 
 * ``none``: disables progress output;
 * ``run-in``: simple single-line progress output;
-* ``estimating``: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects.
+* ``estimating``: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects;
+* ``estimating-max``: same as ``estimating`` but using all terminal columns instead of default 80.
 
 If the option is not provided, it defaults to ``run-in`` unless a config file that disables output is used, in which case it defaults to ``none``. This option has no effect if the verbosity of the command is less than ``verbose``.
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/annotations": "^1.2",
         "gecko-packages/gecko-php-unit": "^2.0",
         "sebastian/diff": "^1.4",
-        "symfony/console": "^3.0",
+        "symfony/console": "^3.2",
         "symfony/event-dispatcher": "^3.0",
         "symfony/filesystem": "^3.0",
         "symfony/finder": "^3.0",

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Stopwatch\Stopwatch;
 
@@ -105,7 +106,7 @@ final class FixCommand extends Command
                     new InputOption('diff', '', InputOption::VALUE_NONE, 'Also produce diff for each file.'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
                     new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
-                    new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, run-in, or estimating).'),
+                    new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, run-in, estimating or estimating-max).'),
                 ]
             )
             ->setDescription('Fixes a directory or a file.')
@@ -178,10 +179,15 @@ final class FixCommand extends Command
         if ('none' === $progressType || null === $stdErr) {
             $progressOutput = new NullOutput();
         } elseif ('run-in' === $progressType) {
-            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, null);
+            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, null, null);
         } else {
             $finder = new \ArrayIterator(iterator_to_array($finder));
-            $progressOutput = new ProcessOutput($stdErr, $this->eventDispatcher, count($finder));
+            $progressOutput = new ProcessOutput(
+                $stdErr,
+                $this->eventDispatcher,
+                'estimating-max' === $progressType ? $this->getMaxColumns() : null,
+                count($finder)
+            );
         }
 
         $runner = new Runner(
@@ -274,5 +280,15 @@ final class FixCommand extends Command
         }
 
         return $exitStatus;
+    }
+
+    private function getMaxColumns()
+    {
+        // Terminal was introduced in symfony/console 3.2
+        if (!class_exists(Terminal::class)) {
+            return $this->getApplication()->getTerminalDimensions()[0];
+        }
+
+        return (new Terminal())->getWidth();
     }
 }

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -185,7 +185,7 @@ final class FixCommand extends Command
             $progressOutput = new ProcessOutput(
                 $stdErr,
                 $this->eventDispatcher,
-                'estimating-max' === $progressType ? $this->getMaxColumns() : null,
+                'estimating-max' === $progressType ? (new Terminal())->getWidth() : null,
                 count($finder)
             );
         }
@@ -280,15 +280,5 @@ final class FixCommand extends Command
         }
 
         return $exitStatus;
-    }
-
-    private function getMaxColumns()
-    {
-        // Terminal was introduced in symfony/console 3.2
-        if (!class_exists(Terminal::class)) {
-            return $this->getApplication()->getTerminalDimensions()[0];
-        }
-
-        return (new Terminal())->getWidth();
     }
 }

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -176,6 +176,7 @@ final class FixCommand extends Command
         $progressType = $resolver->getProgress();
         $finder = $resolver->getFinder();
 
+        // @TODO remove `run-in` and `estimating` in 3.0
         if ('none' === $progressType || null === $stdErr) {
             $progressOutput = new NullOutput();
         } elseif ('run-in' === $progressType) {

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -98,7 +98,8 @@ The <comment>--show-progress</comment> option allows you to choose the way proce
 
 * <comment>none</comment>: disables progress output;
 * <comment>run-in</comment>: simple single-line progress output;
-* <comment>estimating</comment>: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects.
+* <comment>estimating</comment>: multiline progress output with number of files and percentage on each line. Note that with this option, the files list is evaluated before processing to get the total number of files and then kept in memory to avoid using the file iterator twice. This has an impact on memory usage so using this option is not recommended on very large projects;
+* <comment>estimating-max</comment>: same as <comment>estimating</comment> but using all terminal columns instead of default 80.
 
 If the option is not provided, it defaults to <comment>run-in</comment> unless a config file that disables output is used, in which case it defaults to <comment>none</comment>. This option has no effect if the verbosity of the command is less than <comment>verbose</comment>.
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -380,7 +380,7 @@ final class ConfigurationResolver
         if (null === $this->progress) {
             if (OutputInterface::VERBOSITY_VERBOSE <= $this->options['verbosity'] && 'txt' === $this->getFormat()) {
                 $progressType = $this->options['show-progress'];
-                $progressTypes = ['none', 'run-in', 'estimating'];
+                $progressTypes = ['none', 'run-in', 'estimating', 'estimating-max'];
 
                 if (null === $progressType) {
                     $progressType = $this->getConfig()->getHideProgress() ? 'none' : 'run-in';

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -66,21 +66,23 @@ final class ProcessOutput implements ProcessOutputInterface
     /**
      * @param OutputInterface $output
      * @param EventDispatcher $dispatcher
+     * @param null|int        $width
      * @param null|int        $nbFiles
      */
-    public function __construct(OutputInterface $output, EventDispatcher $dispatcher, $nbFiles)
+    public function __construct(OutputInterface $output, EventDispatcher $dispatcher, $width, $nbFiles)
     {
         $this->output = $output;
         $this->eventDispatcher = $dispatcher;
         $this->eventDispatcher->addListener(FixerFileProcessedEvent::NAME, [$this, 'onFixerFileProcessed']);
+        $this->symbolsPerLine = $width;
 
         if (null !== $nbFiles) {
             $this->files = $nbFiles;
 
-            //   80               (lines max length)
+            //   max number of characters per line
             // - total length x 2 (e.g. "  1 / 123" => 6 digits and padding spaces)
             // - 11               (extra spaces, parentheses and percentage characters, e.g. " x / x (100%)")
-            $this->symbolsPerLine = 80 - strlen((string) $this->files) * 2 - 11;
+            $this->symbolsPerLine = max(1, ($width ?: 80) - strlen((string) $this->files) * 2 - 11);
         }
     }
 
@@ -91,11 +93,21 @@ final class ProcessOutput implements ProcessOutputInterface
 
     public function onFixerFileProcessed(FixerFileProcessedEvent $event)
     {
+        if (
+            null === $this->files
+            && null !== $this->symbolsPerLine
+            && 0 === $this->processedFiles % $this->symbolsPerLine
+            && 0 !== $this->processedFiles
+        ) {
+            $this->output->writeln('');
+        }
+
         $status = self::$eventStatusMap[$event->getStatus()];
         $this->output->write($this->output->isDecorated() ? sprintf($status['format'], $status['symbol']) : $status['symbol']);
 
+        ++$this->processedFiles;
+
         if (null !== $this->files) {
-            ++$this->processedFiles;
             $symbolsOnCurrentLine = $this->processedFiles % $this->symbolsPerLine;
             $isLast = $this->processedFiles === $this->files;
 

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -64,6 +64,8 @@ final class ProcessOutput implements ProcessOutputInterface
     private $symbolsPerLine;
 
     /**
+     * @TODO make all parameters mandatory (`null` not allowed) in 3.0
+     *
      * @param OutputInterface $output
      * @param EventDispatcher $dispatcher
      * @param null|int        $width

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\Config;
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Finder;
@@ -89,8 +90,11 @@ final class ConfigTest extends TestCase
     public function testCustomConfig()
     {
         $customConfigFile = __DIR__.'/Fixtures/.php_cs_custom.php';
-        $command = new FixCommand();
-        $commandTester = new CommandTester($command);
+
+        $application = new Application();
+        $application->add(new FixCommand());
+
+        $commandTester = new CommandTester($application->find('fix'));
         $commandTester->execute(
             [
                 'path' => [$customConfigFile],

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -172,6 +172,7 @@ final class ConfigurationResolverTest extends TestCase
             ['none'],
             ['run-in'],
             ['estimating'],
+            ['estimating-max'],
         ];
     }
 
@@ -189,7 +190,7 @@ final class ConfigurationResolverTest extends TestCase
 
         $this->setExpectedException(
             \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class,
-            'The progress type "foo" is not defined, supported are "none", "run-in", "estimating".'
+            'The progress type "foo" is not defined, supported are "none", "run-in", "estimating", "estimating-max".'
         );
 
         $resolver->getProgress();

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -25,16 +25,18 @@ use Symfony\Component\Console\Output\BufferedOutput;
 final class ProcessOutputTest extends TestCase
 {
     /**
-     * @param array  $statuses
-     * @param string $expectedOutput
+     * @param array    $statuses
+     * @param string   $expectedOutput
+     * @param null|int $width
      *
      * @dataProvider getProcessProgressOutputCases
      */
-    public function testProcessProgressOutput(array $statuses, $expectedOutput)
+    public function testProcessProgressOutput(array $statuses, $expectedOutput, $width = null)
     {
         $processOutput = new ProcessOutput(
             $output = new BufferedOutput(),
             $this->prophesize(\Symfony\Component\EventDispatcher\EventDispatcher::class)->reveal(),
+            $width,
             null
         );
 
@@ -53,6 +55,13 @@ final class ProcessOutputTest extends TestCase
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 4],
                 ],
                 '....',
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 4],
+                ],
+                '....',
+                80,
             ],
             [
                 [
@@ -76,6 +85,30 @@ final class ProcessOutputTest extends TestCase
             ],
             [
                 [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 81],
+                ],
+                '................................................................................'.PHP_EOL.
+                '.',
+                80,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 81],
+                ],
+                '........................................'.PHP_EOL.
+                '........................................'.PHP_EOL.
+                '.',
+                40,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 81],
+                ],
+                '.................................................................................',
+                100,
+            ],
+            [
+                [
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
                     [FixerFileProcessedEvent::STATUS_EXCEPTION],
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
@@ -93,16 +126,60 @@ final class ProcessOutputTest extends TestCase
                 ],
                 '...................E......EFFF...................................................................S..................................................................I.I........................................?................................',
             ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
+                    [FixerFileProcessedEvent::STATUS_EXCEPTION],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
+                    [FixerFileProcessedEvent::STATUS_LINT],
+                    [FixerFileProcessedEvent::STATUS_FIXED, 3],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 67],
+                    [FixerFileProcessedEvent::STATUS_SKIPPED],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 66],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 40],
+                    [FixerFileProcessedEvent::STATUS_UNKNOWN],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 32],
+                ],
+                '...................E......EFFF..................................................'.PHP_EOL.
+                '.................S..............................................................'.PHP_EOL.
+                '....I.I........................................?................................',
+                80,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
+                    [FixerFileProcessedEvent::STATUS_EXCEPTION],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
+                    [FixerFileProcessedEvent::STATUS_LINT],
+                    [FixerFileProcessedEvent::STATUS_FIXED, 3],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 67],
+                    [FixerFileProcessedEvent::STATUS_SKIPPED],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 66],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 40],
+                    [FixerFileProcessedEvent::STATUS_UNKNOWN],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 32],
+                ],
+                '...................E......EFFF...................................................................S......................'.PHP_EOL.
+                '............................................I.I........................................?................................',
+                120,
+            ],
         ];
     }
 
     /**
-     * @param array  $statuses
-     * @param string $expectedOutput
+     * @param array    $statuses
+     * @param string   $expectedOutput
+     * @param null|int $width
      *
      * @dataProvider getProcessProgressOutputWithNumbersCases
      */
-    public function testProcessProgressOutputWithNumbers(array $statuses, $expectedOutput)
+    public function testProcessProgressOutputWithNumbers(array $statuses, $expectedOutput, $width = null)
     {
         $nbFiles = 0;
         $this->foreachStatus($statuses, function ($status) use (&$nbFiles) {
@@ -112,6 +189,7 @@ final class ProcessOutputTest extends TestCase
         $processOutput = new ProcessOutput(
             $output = new BufferedOutput(),
             $this->prophesize(\Symfony\Component\EventDispatcher\EventDispatcher::class)->reveal(),
+            $width,
             $nbFiles
         );
 
@@ -130,6 +208,13 @@ final class ProcessOutputTest extends TestCase
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 4],
                 ],
                 '....                                                                4 / 4 (100%)',
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 4],
+                ],
+                '....                                                                4 / 4 (100%)',
+                80,
             ],
             [
                 [
@@ -154,6 +239,30 @@ final class ProcessOutputTest extends TestCase
             ],
             [
                 [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 66],
+                ],
+                '................................................................. 65 / 66 ( 98%)'.PHP_EOL.
+                '.                                                                 66 / 66 (100%)',
+                80,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 66],
+                ],
+                '......................... 25 / 66 ( 38%)'.PHP_EOL.
+                '......................... 50 / 66 ( 76%)'.PHP_EOL.
+                '................          66 / 66 (100%)',
+                40,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 66],
+                ],
+                '..................................................................                    66 / 66 (100%)',
+                100,
+            ],
+            [
+                [
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
                     [FixerFileProcessedEvent::STATUS_EXCEPTION],
                     [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
@@ -172,6 +281,49 @@ final class ProcessOutputTest extends TestCase
                 '...................E......EFFF.................................  63 / 189 ( 33%)'.PHP_EOL.
                 '.................S............................................. 126 / 189 ( 67%)'.PHP_EOL.
                 '....I.I........................................?............... 189 / 189 (100%)',
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
+                    [FixerFileProcessedEvent::STATUS_EXCEPTION],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
+                    [FixerFileProcessedEvent::STATUS_LINT],
+                    [FixerFileProcessedEvent::STATUS_FIXED, 3],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 50],
+                    [FixerFileProcessedEvent::STATUS_SKIPPED],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 49],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 40],
+                    [FixerFileProcessedEvent::STATUS_UNKNOWN],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 15],
+                ],
+                '...................E......EFFF.................................  63 / 189 ( 33%)'.PHP_EOL.
+                '.................S............................................. 126 / 189 ( 67%)'.PHP_EOL.
+                '....I.I........................................?............... 189 / 189 (100%)',
+                80,
+            ],
+            [
+                [
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 19],
+                    [FixerFileProcessedEvent::STATUS_EXCEPTION],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 6],
+                    [FixerFileProcessedEvent::STATUS_LINT],
+                    [FixerFileProcessedEvent::STATUS_FIXED, 3],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 50],
+                    [FixerFileProcessedEvent::STATUS_SKIPPED],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 49],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES],
+                    [FixerFileProcessedEvent::STATUS_INVALID],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 40],
+                    [FixerFileProcessedEvent::STATUS_UNKNOWN],
+                    [FixerFileProcessedEvent::STATUS_NO_CHANGES, 15],
+                ],
+                '...................E......EFFF..................................................S...................... 103 / 189 ( 54%)'.PHP_EOL.
+                '...........................I.I........................................?...............                  189 / 189 (100%)',
+                120,
             ],
         ];
     }


### PR DESCRIPTION
Implements #2834.

Note that with these changes, `ProcessOutput` is able to handle any number of columns. Maybe it would be better to add a new option to define the number of columns like PHPUnit does, i.e. `--columns=<int|"max">`, then we could use it for `run-in` progress output as well. WDYT?