### PR TITLE
ReadmeCommandTest - Prevent diff output

### DIFF
--- a/tests/Console/Command/ReadmeCommandTest.php
+++ b/tests/Console/Command/ReadmeCommandTest.php
@@ -40,9 +40,8 @@ final class ReadmeCommandTest extends TestCase
 
         $fileContent = file_get_contents(__DIR__.'/../../../README.rst');
 
-        $this->assertSame(
-            $output->fetch(),
-            $fileContent,
+        $this->assertTrue(
+            $output->fetch() === $fileContent,
             'README.rst file is not up to date! Do not modify it manually! Regenerate readme with command: `php php-cs-fixer readme > README.rst`.'
         );
     }


### PR DESCRIPTION
When the README file is not up-to-date, the test will output a very long diff. This is annoying for lazy devs like me that don't want to scroll up to see if other tests failed too 😁. Furthermore, the diff isn't needed as whatever is wrong in the file, it can (should!) be fixed by running the command to regenerate it, which will be easier to spot:

**before**
```
1) PhpCsFixer\Tests\Console\Command\ReadmeCommandTest::testIfReadmeFileIsCorrect
README.rst file is not up to date! Do not modify it manually! Regenerate readme with command: `php php-cs-fixer readme > README.rst`.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@



[...]



 Fixers
 ~~~~~~
 
 A *fixer* is a class that tries to fix one CS issue (a ``Fixer`` class must
 implement ``FixerInterface``).
 
 Configs
 ~~~~~~~
 
 A *config* knows about the CS rules and the files and directories that must be
 scanned by the tool when run in the directory of your project. It is useful for
 projects that follow a well-known directory structures (like for Symfony
 projects for instance).
 
 .. _php-cs-fixer.phar: http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar
 .. _Atom:              https://github.com/Glavin001/atom-beautify
 .. _NetBeans:          http://plugins.netbeans.org/plugin/49042/php-cs-fixer
 .. _PhpStorm:          https://medium.com/@valeryan/how-to-configure-phpstorm-to-use-php-cs-fixer-1844991e521f
 .. _Sublime Text:      https://github.com/benmatselby/sublime-phpcs
 .. _Vim:               https://github.com/stephpy/vim-php-cs-fixer
 .. _contribute:        https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/CONTRIBUTING.md
```

**after**
```
1) PhpCsFixer\Tests\Console\Command\ReadmeCommandTest::testIfReadmeFileIsCorrect
README.rst file is not up to date! Do not modify it manually! Regenerate readme with command: `php php-cs-fixer readme > README.rst`.
Failed asserting that false is true.
```