### PR TITLE
Tokens - fix ensureWhitespaceAtIndex

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -352,7 +352,11 @@ class Tokens extends \SplFixedArray
 
         if ($this[$index]->isWhitespace()) {
             $whitespace = $removeLastCommentLine($this, $index - 1, $indexOffset, $whitespace);
-            $this[$index] = new Token(array(T_WHITESPACE, $whitespace));
+            if ('' === $whitespace) {
+                $this->clearAt($index);
+            } else {
+                $this[$index] = new Token(array(T_WHITESPACE, $whitespace));
+            }
 
             return false;
         }

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -909,6 +909,27 @@ PHP;
     {
         return array(
             array(
+                '<?php echo 1;',
+                '<?php  echo 1;',
+                1,
+                1,
+                ' ',
+            ),
+            array(
+                '<?php echo 7;',
+                '<?php   echo 7;',
+                1,
+                1,
+                ' ',
+            ),
+            array(
+                '<?php  ',
+                '<?php  ',
+                1,
+                1,
+                '  ',
+            ),
+            array(
                 '<?php $a. $b;',
                 '<?php $a.$b;',
                 2,


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2837
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2836

ping @GrahamCampbell 

the reason the test pass on 2.2 is because we allow;
> $whitespace = '';
>$this[$index] = new Token(array(T_WHITESPACE, $whitespace));

on master we don't.
UTest covers both path's