### PR TITLE
CastSpacesFixer - add space option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,7 +256,12 @@ Choose from the list of available rules:
 
 * **cast_spaces** [@Symfony]
 
-  A single space should be between cast and variable.
+  A single space or none should be between cast and variable.
+
+  Configuration options:
+
+  - ``space`` (``'none'``, ``'single'``): spacing to apply between cast and variable;
+    defaults to ``'single'``
 
 * **class_definition** [@PSR2, @Symfony]
 

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -13,6 +13,9 @@
 namespace PhpCsFixer\Fixer\CastNotation;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
@@ -21,15 +24,27 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class CastSpacesFixer extends AbstractFixer
+final class CastSpacesFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
+    /**
+     * @internal
+     */
+    const INSIDE_CAST_SPACE_REPLACE_MAP = [
+        ' ' => '',
+        "\t" => '',
+        "\n" => '',
+        "\r" => '',
+        "\0" => '',
+        "\x0B" => '',
+    ];
+
     /**
      * {@inheritdoc}
      */
     public function getDefinition()
     {
         return new FixerDefinition(
-            'A single space should be between cast and variable.',
+            'A single space or none should be between cast and variable.',
             [new CodeSample("<?php\n\$bar = ( string )  \$a;\n\$foo = (int)\$b;")]
         );
     }
@@ -56,22 +71,17 @@ final class CastSpacesFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        static $insideCastSpaceReplaceMap = [
-            ' ' => '',
-            "\t" => '',
-            "\n" => '',
-            "\r" => '',
-            "\0" => '',
-            "\x0B" => '',
-        ];
-
         foreach ($tokens as $index => $token) {
-            if ($token->isCast()) {
-                $tokens[$index] = new Token([
-                    $token->getId(),
-                    strtr($token->getContent(), $insideCastSpaceReplaceMap),
-                ]);
+            if (!$token->isCast()) {
+                continue;
+            }
 
+            $tokens[$index] = new Token([
+                $token->getId(),
+                strtr($token->getContent(), self::INSIDE_CAST_SPACE_REPLACE_MAP),
+            ]);
+
+            if ($this->configuration['space'] === 'single') {
                 // force single whitespace after cast token:
                 if ($tokens[$index + 1]->isWhitespace(" \t")) {
                     // - if next token is whitespaces that contains only spaces and tabs - override next token with single space
@@ -80,7 +90,25 @@ final class CastSpacesFixer extends AbstractFixer
                     // - if next token is not whitespaces that contains spaces, tabs and new lines - append single space to current token
                     $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
                 }
+            } else {
+                // force no whitespace after cast token:
+                if ($tokens[$index + 1]->isWhitespace()) {
+                    $tokens->clearAt($index + 1);
+                }
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('space', 'spacing to apply between cast and variable.'))
+                ->setAllowedValues(['none', 'single'])
+                ->setDefault('single')
+                ->getOption(),
+        ]);
     }
 }

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -81,7 +81,7 @@ final class CastSpacesFixer extends AbstractFixer implements ConfigurationDefini
                 strtr($token->getContent(), self::INSIDE_CAST_SPACE_REPLACE_MAP),
             ]);
 
-            if ($this->configuration['space'] === 'single') {
+            if ('single' === $this->configuration['space']) {
                 // force single whitespace after cast token:
                 if ($tokens[$index + 1]->isWhitespace(" \t")) {
                     // - if next token is whitespaces that contains only spaces and tabs - override next token with single space

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -90,11 +90,13 @@ final class CastSpacesFixer extends AbstractFixer implements ConfigurationDefini
                     // - if next token is not whitespaces that contains spaces, tabs and new lines - append single space to current token
                     $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
                 }
-            } else {
-                // force no whitespace after cast token:
-                if ($tokens[$index + 1]->isWhitespace()) {
-                    $tokens->clearAt($index + 1);
-                }
+
+                continue;
+            }
+
+            // force no whitespace after cast token:
+            if ($tokens[$index + 1]->isWhitespace()) {
+                $tokens->clearAt($index + 1);
             }
         }
     }

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -45,7 +45,19 @@ final class CastSpacesFixer extends AbstractFixer implements ConfigurationDefini
     {
         return new FixerDefinition(
             'A single space or none should be between cast and variable.',
-            [new CodeSample("<?php\n\$bar = ( string )  \$a;\n\$foo = (int)\$b;")]
+            [
+                new CodeSample(
+                    "<?php\n\$bar = ( string )  \$a;\n\$foo = (int)\$b;"
+                ),
+                new CodeSample(
+                    "<?php\n\$bar = ( string )  \$a;\n\$foo = (int)\$b;",
+                    ['space' => 'single']
+                ),
+                new CodeSample(
+                    "<?php\n\$bar = ( string )  \$a;\n\$foo = (int) \$b;",
+                    ['space' => 'none']
+                ),
+            ]
         );
     }
 

--- a/tests/Fixer/CastNotation/CastSpacesFixerTest.php
+++ b/tests/Fixer/CastNotation/CastSpacesFixerTest.php
@@ -21,18 +21,50 @@ use PhpCsFixer\Test\AbstractFixerTestCase;
  */
 final class CastSpacesFixerTest extends AbstractFixerTestCase
 {
+    public function testInvalidConfigMissingKey()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '#^\[cast_spaces\] Invalid configuration: The option "a" does not exist\. Defined options are: "space"\.$#'
+        );
+
+        $this->fixer->configure(['a' => 1]);
+    }
+
+    public function testInvalidConfigValue()
+    {
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            '#^\[cast_spaces\] Invalid configuration: The option "space" with value "double" is invalid\. Accepted values are: "none", "single"\.$#'
+        );
+
+        $this->fixer->configure(['space' => 'double']);
+    }
+
     /**
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider testFixCastsProvider
+     * @dataProvider provideSingleSpaceCases
      */
-    public function testFixCasts($expected, $input = null)
+    public function testFixCastsWithDefaultConfiguration($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function testFixCastsProvider()
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideSingleSpaceCases
+     */
+    public function testFixCastsSingleSpace($expected, $input = null)
+    {
+        $this->fixer->configure(['space' => 'single']);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideSingleSpaceCases()
     {
         return [
             [
@@ -82,6 +114,73 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
                 "<?php \$bar = (int)\n \$foo;",
             ],
             [
+                "<?php \$bar = (int)\r\n \$foo;",
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideNoneSpaceFix
+     */
+    public function testFixCastsNoneSpace($expected, $input = null)
+    {
+        $this->fixer->configure(['space' => 'none']);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideNoneSpaceFix()
+    {
+        return [
+            [
+                '<?php echo "( int ) $foo";',
+            ],
+            [
+                '<?php $bar = (int)$foo;',
+                '<?php $bar = ( int)$foo;',
+            ],
+            [
+                '<?php $bar = (int)$foo;',
+                '<?php $bar = (	int)$foo;',
+            ],
+            [
+                '<?php $bar = (int)$foo;',
+                '<?php $bar = (int)	$foo;',
+            ],
+            [
+                '<?php $bar = (string)(int)$foo;',
+                '<?php $bar = ( string )( int )$foo;',
+            ],
+            [
+                '<?php $bar = (string)(int)$foo;',
+            ],
+            [
+                '<?php $bar = (string)(int)$foo;',
+                '<?php $bar = ( string   )    (   int )$foo;',
+            ],
+            [
+                '<?php $bar = (string)$foo;',
+                '<?php $bar = ( string )   $foo;',
+            ],
+            [
+                '<?php $bar = (float)Foo::bar();',
+                '<?php $bar = (float )Foo::bar();',
+            ],
+            [
+                '<?php $bar = Foo::baz((float)Foo::bar());',
+                '<?php $bar = Foo::baz((float )Foo::bar());',
+            ],
+            [
+                '<?php $bar = $query["params"] = (array)$query["params"];',
+            ],
+            [
+                '<?php $bar = (int)$foo;',
+                "<?php \$bar = (int)\n \$foo;",
+            ],
+            [
+                '<?php $bar = (int)$foo;',
                 "<?php \$bar = (int)\r\n \$foo;",
             ],
         ];


### PR DESCRIPTION
This one resolves #2853.

It's not BC break, original behaviour set by `'cast_spaces' => true` is replaced by default value.