### PR TITLE
Tokens - ensureWhitespaceAtIndex - Clear tokens before compare.

### DIFF
--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -895,7 +895,7 @@ PHP;
     {
         $tokens = Tokens::fromCode($input);
         $tokens->ensureWhitespaceAtIndex($index, $offset, $whiteSpace);
-
+        $tokens->clearEmptyTokens();
         $this->assertTokens(Tokens::fromCode($expected), $tokens);
     }
 


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2861
needed for https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2851 on 2.3/master