### PR TITLE
DescribeCommand - Show which sample uses the default configuration

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -149,11 +149,12 @@ final class DescribeCommand extends Command
         }
 
         if ($fixer instanceof ConfigurationDefinitionFixerInterface) {
-            $output->writeln('Fixer is configurable using following options:');
-
             $configurationDefinition = $fixer->getConfigurationDefinition();
+            $options = $configurationDefinition->getOptions();
 
-            foreach ($configurationDefinition->getOptions() as $option) {
+            $output->writeln(sprintf('Fixer is configurable using following option%s:', 1 === count($options) ? '' : 's'));
+
+            foreach ($options as $option) {
                 $line = '* <info>'.$option->getName().'</info>';
 
                 $allowed = HelpCommand::getDisplayableAllowedValues($option);
@@ -177,7 +178,7 @@ final class DescribeCommand extends Command
                         HelpCommand::toString($option->getDefault())
                     );
                 } else {
-                    $line .= 'required';
+                    $line .= '<comment>required</comment>';
                 }
 
                 $output->writeln($line);
@@ -224,28 +225,30 @@ final class DescribeCommand extends Command
             foreach ($codeSamples as $index => $codeSample) {
                 $old = $codeSample->getCode();
                 $tokens = Tokens::fromCode($old);
+
                 if ($fixer instanceof ConfigurableFixerInterface) {
                     $configuration = $codeSample->getConfiguration();
-
-                    if (null === $configuration) {
-                        $configuration = array();
-                    }
-
-                    $fixer->configure($configuration);
+                    $fixer->configure(null === $configuration ? array() : $configuration);
                 }
 
                 $file = $codeSample instanceof FileSpecificCodeSampleInterface
                     ? $codeSample->getSplFileInfo()
                     : new StdinFileInfo();
-                $fixer->fix($file, $tokens);
-                $new = $tokens->generateCode();
-                $diff = $differ->diff($old, $new);
 
-                if (null === $codeSample->getConfiguration()) {
-                    $output->writeln(sprintf(' * Example #%d.', $index + 1));
+                $fixer->fix($file, $tokens);
+
+                $diff = $differ->diff($old, $tokens->generateCode());
+
+                if ($fixer instanceof ConfigurableFixerInterface) {
+                    if (null === $configuration) {
+                        $output->writeln(sprintf(' * Example #%d. Fixing with the <comment>default</comment> configuration.', $index + 1));
+                    } else {
+                        $output->writeln(sprintf(' * Example #%d. Fixing with configuration: <comment>%s</comment>.', $index + 1, HelpCommand::toString($codeSample->getConfiguration())));
+                    }
                 } else {
-                    $output->writeln(sprintf(' * Example #%d. Fixing with configuration: <comment>%s</comment>.', $index + 1, HelpCommand::toString($codeSample->getConfiguration())));
+                    $output->writeln(sprintf(' * Example #%d.', $index + 1));
                 }
+
                 $output->writeln($diffFormatter->format($diff, '   %s'));
                 $output->writeln('');
             }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -178,7 +178,7 @@ EOT;
     public function testGetAlternativeSuggestion()
     {
         $this->setExpectedExceptionRegExp('InvalidArgumentException', '#^Rule "Foo2/bar" not found\. Did you mean "Foo/bar"\?$#');
-        $this->execute('Foo2/bar', false)->getDisplay(true);
+        $this->execute('Foo2/bar', false);
     }
 
     /**
@@ -241,7 +241,6 @@ EOT
         $fixer->configure(array('functions' => array('foo' => 'bar')))->willReturn(null);
         $fixer->getName()->willReturn('Foo/bar');
         $fixer->getPriority()->willReturn(0);
-        $fixer->isRisky()->willReturn(false);
 
         $generator = new FixerOptionValidatorGenerator();
         $functionNames = array('foo', 'test');

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -20,9 +20,11 @@ use PhpCsFixer\FixerConfiguration\FixerOptionValidatorGenerator;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSetInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -32,12 +34,25 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class DescribeCommandTest extends TestCase
 {
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp()
+    {
+        $this->application = new Application();
+    }
+
     public function testExecuteOutput()
     {
         $expected = <<<'EOT'
 Description of Foo/bar rule.
 Fixes stuff.
 Replaces bad stuff with good stuff.
+
+Fixer applying this rule is risky.
+Can break stuff.
 
 Fixer is configurable using following option:
 * functions (array): list of `function` names to fix; defaults to ['foo', 'test']
@@ -64,7 +79,7 @@ Fixing examples:
 
 EOT;
 
-        $this->assertSame($expected, $this->execute(false)->getDisplay(true));
+        $this->assertSame($expected, $this->execute('Foo/bar', false)->getDisplay(true));
     }
 
     public function testExecuteOutputWithDecoration()
@@ -73,6 +88,9 @@ EOT;
 \033[32mDescription of\033[39m Foo/bar \033[32mrule\033[39m.
 Fixes stuff.
 Replaces bad stuff with good stuff.
+
+\033[37;41mFixer applying this rule is risky.\033[39;49m
+Can break stuff.
 
 Fixer is configurable using following option:
 * \033[32mfunctions\033[39m (\033[33marray\033[39m): list of \033[32m`function`\033[39m names to fix; defaults to \033[33m['foo', 'test']\033[39m
@@ -99,7 +117,7 @@ Fixing examples:
 
 EOT;
 
-        $actual = $this->execute(true)->getDisplay(true);
+        $actual = $this->execute('Foo/bar', true)->getDisplay(true);
 
         if (false !== strpos($actual, "\033[0m")) {
             $expected = str_replace("\033[39m", "\033[0m", $expected);
@@ -110,31 +128,44 @@ EOT;
 
     public function testExecuteStatusCode()
     {
-        $this->assertSame(0, $this->execute(false)->getStatusCode());
+        $this->assertSame(0, $this->execute('Foo/bar', false)->getStatusCode());
     }
 
-    public function testExecuteWithUnknownName()
+    public function testExecuteWithUnknownRuleName()
     {
-        $application = new Application();
-        $application->add(new DescribeCommand(new FixerFactory()));
+        $this->application->add(new DescribeCommand(new FixerFactory()));
 
-        $command = $application->find('describe');
+        $command = $this->application->find('describe');
 
         $commandTester = new CommandTester($command);
 
-        $this->setExpectedException('InvalidArgumentException', 'Rule Foo/bar not found.');
+        $this->setExpectedExceptionRegExp('InvalidArgumentException', '#^Rule "Foo/bar" not found\.$#');
         $commandTester->execute(array(
             'command' => $command->getName(),
             'name' => 'Foo/bar',
         ));
     }
 
+    public function testExecuteWithUnknownSetName()
+    {
+        $this->application->add(new DescribeCommand(new FixerFactory()));
+
+        $command = $this->application->find('describe');
+
+        $commandTester = new CommandTester($command);
+
+        $this->setExpectedExceptionRegExp('InvalidArgumentException', '#^Set "@NoSuchSet" not found\.$#');
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'name' => '@NoSuchSet',
+        ));
+    }
+
     public function testExecuteWithoutName()
     {
-        $application = new Application();
-        $application->add(new DescribeCommand(new FixerFactory()));
+        $this->application->add(new DescribeCommand(new FixerFactory()));
 
-        $command = $application->find('describe');
+        $command = $this->application->find('describe');
 
         $commandTester = new CommandTester($command);
 
@@ -144,17 +175,70 @@ EOT;
         ));
     }
 
+    public function testGetAlternativeSuggestion()
+    {
+        $this->setExpectedExceptionRegExp('InvalidArgumentException', '#^Rule "Foo2/bar" not found\. Did you mean "Foo/bar"\?$#');
+        $this->execute('Foo2/bar', false)->getDisplay(true);
+    }
+
     /**
-     * @param bool $decorated
+     * @param bool   $decorated
+     * @param string $expected
+     *
+     * @dataProvider provideDescribeSetCases
+     */
+    public function testDescribeSet($decorated, $expected)
+    {
+        $this->assertSame(
+            $expected,
+            $this->execute('@testSet', $decorated)->getDisplay(true)
+        );
+    }
+
+    public function provideDescribeSetCases()
+    {
+        return array(
+            array(
+                true,
+<<<EOT
+\033[32mDescription of\033[39m @testSet \033[32mset.\033[39m
+
+ * \033[32mFoo/bar\033[39m \033[37;41mrisky\033[39;49m
+   | Fixes stuff.
+   \033[33m| Configuration: ['functions' => ['foo' => 'bar']]\033[39m
+
+
+EOT
+            ),
+            array(
+                false,
+<<<'EOT'
+Description of @testSet set.
+
+ * Foo/bar risky
+   | Fixes stuff.
+   | Configuration: ['functions' => ['foo' => 'bar']]
+
+
+EOT
+            ),
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param bool   $decorated
+     * @param int    $verbosityLevel
      *
      * @return CommandTester
      */
-    private function execute($decorated)
+    private function execute($name, $decorated, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
         $fixer = $this->prophesize();
         $fixer->willImplement('PhpCsFixer\Fixer\DefinedFixerInterface');
         $fixer->willImplement('PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface');
 
+        $fixer->configure(array('functions' => array('foo' => 'bar')))->willReturn(null);
         $fixer->getName()->willReturn('Foo/bar');
         $fixer->getPriority()->willReturn(0);
         $fixer->isRisky()->willReturn(false);
@@ -187,6 +271,8 @@ EOT;
             'Can break stuff.'
         ));
 
+        $fixer->isRisky()->willReturn(true);
+
         $things = false;
         $fixer->configure(array())->will(function () use (&$things) {
             $things = false;
@@ -209,22 +295,64 @@ EOT;
         $fixerFactory = new FixerFactory();
         $fixerFactory->registerFixer($fixer->reveal(), true);
 
-        $application = new Application();
-        $application->add(new DescribeCommand($fixerFactory));
+        $ruleSet = new TestRuleSet();
+        $fixerFactory->useRuleSet($ruleSet);
 
-        $command = $application->find('describe');
+        $this->application->add(new DescribeCommand($fixerFactory, $ruleSet));
+
+        $command = $this->application->find('describe');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'name' => 'Foo/bar',
+                'name' => $name,
             ),
             array(
                 'decorated' => $decorated,
+                'verbosity' => $verbosityLevel,
             )
         );
 
         return $commandTester;
+    }
+}
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class TestRuleSet implements RuleSetInterface
+{
+    private $rules;
+
+    public function __construct(array $set = array())
+    {
+        $this->rules = array('Foo/bar' => array('functions' => array('foo' => 'bar')));
+    }
+
+    public static function create(array $set = array())
+    {
+        return new self();
+    }
+
+    public function getRuleConfiguration($rule)
+    {
+        return $this->rules[$rule];
+    }
+
+    public function getRules()
+    {
+        return $this->rules;
+    }
+
+    public function getSetDefinitionNames()
+    {
+        return array('@testSet');
+    }
+
+    public function hasRule($rule)
+    {
+        return isset($this->rules[$rule]);
     }
 }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -39,11 +39,11 @@ Description of Foo/bar rule.
 Fixes stuff.
 Replaces bad stuff with good stuff.
 
-Fixer is configurable using following options:
+Fixer is configurable using following option:
 * functions (array): list of `function` names to fix; defaults to ['foo', 'test']
 
 Fixing examples:
- * Example #1.
+ * Example #1. Fixing with the default configuration.
    ---------- begin diff ----------
    --- Original
    +++ New
@@ -74,11 +74,11 @@ EOT;
 Fixes stuff.
 Replaces bad stuff with good stuff.
 
-Fixer is configurable using following options:
+Fixer is configurable using following option:
 * \033[32mfunctions\033[39m (\033[33marray\033[39m): list of \033[32m`function`\033[39m names to fix; defaults to \033[33m['foo', 'test']\033[39m
 
 Fixing examples:
- * Example #1.
+ * Example #1. Fixing with the \033[33mdefault\033[39m configuration.
 \033[33m   ---------- begin diff ----------\033[39m
    \033[31m--- Original\033[39m
    \033[32m+++ New\033[39m

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -67,6 +67,22 @@ final class RuleSetTest extends TestCase
         );
     }
 
+    public function testBuildInSetDefinitionNames()
+    {
+        $setNames = RuleSet::create()->getSetDefinitionNames();
+
+        $this->assertInternalType('array', $setNames);
+        $this->assertNotEmpty($setNames);
+
+        $i = 0;
+        foreach ($setNames as $index => $setName) {
+            $this->assertSame($i, $index);
+            $this->assertInternalType('string', $setName);
+            $this->assertSame('@', substr($setName, 0, 1));
+            ++$i;
+        }
+    }
+
     public function testResolveRulesWithInvalidSet()
     {
         $this->setExpectedException(


### PR DESCRIPTION
old
```
$ php php-cs-fixer describe no_extra_consecutive_blank_lines
Description of no_extra_consecutive_blank_lines rule.
Removes extra blank lines and/or blank lines following configuration.

Fixer is configurable using following options:
* tokens (array): list of tokens to fix; defaults to ['extra']

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php

    $foo = array("foo");

   -
    $bar = "bar";
   ----------- end diff -----------
```

new

```
$ php php-cs-fixer describe no_extra_consecutive_blank_lines
Description of no_extra_consecutive_blank_lines rule.
Removes extra blank lines and/or blank lines following configuration.

Fixer is configurable using following options:
* tokens (array): list of tokens to fix; defaults to ['extra']

Fixing examples:
 * Example #1. Fixing with the default configuration
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
    <?php

    $foo = array("foo");

   -
    $bar = "bar";
   ----------- end diff -----------
```

