### PR TITLE
NoUnusedImportsFixer - fix bug when trying to insert empty token

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -256,7 +256,14 @@ final class NoUnusedImportsFixer extends AbstractFixer
         }
 
         if ($prevToken->isWhitespace() && $nextToken->isWhitespace()) {
-            $tokens[$nextIndex] = new Token(array(T_WHITESPACE, $prevToken->getContent().$nextToken->getContent()));
+            $content = $prevToken->getContent().$nextToken->getContent();
+
+            if ($content) {
+                $tokens[$nextIndex] = new Token(array(T_WHITESPACE, $content));
+            } else {
+                $tokens->clearAt($nextIndex);
+            }
+
             $tokens->clearAt($prevIndex);
         }
     }

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -222,7 +222,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         if ($prevToken->isWhitespace()) {
             $content = rtrim($prevToken->getContent(), " \t");
 
-            if ($content) {
+            if ('' !== $content) {
                 $tokens[$prevIndex] = new Token(array(T_WHITESPACE, $content));
             } else {
                 $tokens->clearAt($prevIndex);
@@ -247,7 +247,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
                 1
             );
 
-            if ($content) {
+            if ('' !== $content) {
                 $tokens[$nextIndex] = new Token(array(T_WHITESPACE, $content));
             } else {
                 $tokens->clearAt($nextIndex);
@@ -258,7 +258,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         if ($prevToken->isWhitespace() && $nextToken->isWhitespace()) {
             $content = $prevToken->getContent().$nextToken->getContent();
 
-            if ($content) {
+            if ('' !== $content) {
                 $tokens[$nextIndex] = new Token(array(T_WHITESPACE, $content));
             } else {
                 $tokens->clearAt($nextIndex);

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -164,6 +164,22 @@ EOF;
 
         $this->doTest($expected, $input);
 
+        $expected = <<<'EOF'
+<?php namespace App\Http\Controllers;
+
+
+EOF;
+
+        $input = <<<'EOF'
+<?php namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+
+EOF;
+
+        $this->doTest($expected, $input);
+
         // the fixer doesn't support file with multiple namespace - test if we don't remove imports in that case
         $expected = <<<'EOF'
 <?php


### PR DESCRIPTION
This bug affects 2.2, 2.3, and master. I've tested these changes on each branch, and tests pass in all cases.

---

Closes #2878.