### PR TITLE
DocBlock\Annotation - Fix parsing of collections with multiple key types

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -44,7 +44,7 @@ class Annotation
             (?<generic>
                 (?&simple)
                 <
-                    (?:(?&simple),\s*)?(?:(?&types)|(?&generic))
+                    (?:(?&types),\s*)?(?:(?&types)|(?&generic))
                 >
             )
         )

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -301,6 +301,10 @@ final class AnnotationTest extends TestCase
                 '/** @return $SELF|int */',
                 array('$SELF', 'int'),
             ),
+            array(
+                '/** @var array<string|int, string>',
+                array('array<string|int, string>'),
+            ),
         );
     }
 


### PR DESCRIPTION
This fixes parsing collections that have key types like `foo|bar`. Parsing still fails with key types like `foo|bar<baz>` but I'm not sure we do want to support that.