### PR TITLE
Add custom rulesets

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -32,6 +32,7 @@ class Config implements ConfigInterface
     private $name;
     private $phpExecutable;
     private $rules = ['@PSR2' => true];
+    private $customRuleSets = [];
     private $usingCache = true;
 
     public function __construct($name = 'default')
@@ -61,6 +62,14 @@ class Config implements ConfigInterface
     public function getCustomFixers()
     {
         return $this->customFixers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomRuleSets()
+    {
+        return $this->customRuleSets;
     }
 
     /**
@@ -172,6 +181,16 @@ class Config implements ConfigInterface
     public function setCacheFile($cacheFile)
     {
         $this->cacheFile = $cacheFile;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCustomRuleSets(array $ruleSets)
+    {
+        $this->customRuleSets = $ruleSets;
 
         return $this;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,7 @@ class Config implements ConfigInterface
 {
     private $cacheFile = '.php_cs.cache';
     private $customFixers = [];
+    private $customRuleSets = [];
     private $finder;
     private $format = 'txt';
     private $hideProgress = false;
@@ -32,7 +33,6 @@ class Config implements ConfigInterface
     private $name;
     private $phpExecutable;
     private $rules = ['@PSR2' => true];
-    private $customRuleSets = [];
     private $usingCache = true;
 
     public function __construct($name = 'default')

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -35,6 +35,15 @@ interface ConfigInterface
     public function getCustomFixers();
 
     /**
+     * Get rule sets.
+     *
+     * Keys of array are names of ruleset, values are the rules.
+     *
+     * @return array
+     */
+    public function getCustomRuleSets();
+
+    /**
      * Returns files to scan.
      *
      * @return iterable|\Traversable|string[]
@@ -119,6 +128,18 @@ interface ConfigInterface
      * @return self
      */
     public function setCacheFile($cacheFile);
+
+    /**
+     * Set rule sets.
+     *
+     * Keys of array are names of ruleset names.
+     * Value for rulesets are the rules (@see ConfigInterface::setRules).
+     *
+     * @param array $ruleSets
+     *
+     * @return self
+     */
+    public function setCustomRuleSets(array $ruleSets);
 
     /**
      * @param iterable|\Traversable|string[] $finder

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -578,7 +578,7 @@ final class ConfigurationResolver
             $rules = $this->parseRules();
             $this->validateRules($rules);
 
-            $this->ruleSet = new RuleSet($rules);
+            $this->ruleSet = new RuleSet($rules, $this->getConfig()->getCustomRuleSets());
         }
 
         return $this->ruleSet;

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -185,6 +185,13 @@ final class RuleSet implements RuleSetInterface
     ];
 
     /**
+     * The custom set definitions.
+     *
+     * @var array
+     */
+    private $customSetDefinitions = [];
+
+    /**
      * Set that was used to generate group of rules.
      *
      * The key is name of rule or set, value is bool if the rule/set should be used.
@@ -203,7 +210,7 @@ final class RuleSet implements RuleSetInterface
      */
     private $rules;
 
-    public function __construct(array $set = [])
+    public function __construct(array $set = [], array $customSetDefinitions = [])
     {
         foreach ($set as $key => $value) {
             if (is_int($key)) {
@@ -212,12 +219,13 @@ final class RuleSet implements RuleSetInterface
         }
 
         $this->set = $set;
+        $this->customSetDefinitions = $customSetDefinitions;
         $this->resolveSet();
     }
 
-    public static function create(array $set = [])
+    public static function create(array $set = [], array $customSetDefinitions = [])
     {
-        return new self($set);
+        return new self($set, $customSetDefinitions);
     }
 
     /**
@@ -225,7 +233,7 @@ final class RuleSet implements RuleSetInterface
      */
     public function hasRule($rule)
     {
-        return array_key_exists($rule, $this->rules);
+        return array_key_exists($rule, $this->getRules());
     }
 
     /**
@@ -237,11 +245,13 @@ final class RuleSet implements RuleSetInterface
             throw new \InvalidArgumentException(sprintf('Rule "%s" is not in the set.', $rule));
         }
 
-        if ($this->rules[$rule] === true) {
+        $rules = $this->getRules();
+
+        if ($rules[$rule] === true) {
             return null;
         }
 
-        return $this->rules[$rule];
+        return $rules[$rule];
     }
 
     /**
@@ -257,7 +267,7 @@ final class RuleSet implements RuleSetInterface
      */
     public function getSetDefinitionNames()
     {
-        return array_keys($this->setDefinitions);
+        return array_keys(array_replace($this->customSetDefinitions, $this->setDefinitions));
     }
 
     /**
@@ -267,11 +277,13 @@ final class RuleSet implements RuleSetInterface
      */
     private function getSetDefinition($name)
     {
-        if (!isset($this->setDefinitions[$name])) {
+        $setDefinitions = array_replace_recursive($this->customSetDefinitions, $this->setDefinitions);
+
+        if (!isset($setDefinitions[$name])) {
             throw new \InvalidArgumentException(sprintf('Set "%s" does not exist.', $name));
         }
 
-        return $this->setDefinitions[$name];
+        return $setDefinitions[$name];
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -210,6 +210,9 @@ final class RuleSet implements RuleSetInterface
      */
     private $rules;
 
+    /**
+     * {@inheritdoc}
+     */
     public function __construct(array $set = [], array $customSetDefinitions = [])
     {
         foreach ($set as $key => $value) {
@@ -223,6 +226,9 @@ final class RuleSet implements RuleSetInterface
         $this->resolveSet();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public static function create(array $set = [], array $customSetDefinitions = [])
     {
         return new self($set, $customSetDefinitions);

--- a/src/RuleSetInterface.php
+++ b/src/RuleSetInterface.php
@@ -24,7 +24,7 @@ interface RuleSetInterface
     /**
      * Constructs the set of rules.
      *
-     * @param array $set the set of rules.
+     * @param array $set                  the set of rules
      * @param array $customSetDefinitions the custom set definitions
      */
     public function __construct(array $set = [], array $customSetDefinitions = []);
@@ -32,7 +32,7 @@ interface RuleSetInterface
     /**
      * Static creation for the rule set.
      *
-     * @param array $set the set of rules.
+     * @param array $set                  the set of rules
      * @param array $customSetDefinitions the custom set definitions
      *
      * @return mixed

--- a/src/RuleSetInterface.php
+++ b/src/RuleSetInterface.php
@@ -21,8 +21,22 @@ namespace PhpCsFixer;
  */
 interface RuleSetInterface
 {
+    /**
+     * Constructs the set of rules.
+     *
+     * @param array $set the set of rules.
+     * @param array $customSetDefinitions the custom set definitions
+     */
     public function __construct(array $set = [], array $customSetDefinitions = []);
 
+    /**
+     * Static creation for the rule set.
+     *
+     * @param array $set the set of rules.
+     * @param array $customSetDefinitions the custom set definitions
+     *
+     * @return mixed
+     */
     public static function create(array $set = [], array $customSetDefinitions = []);
 
     /**

--- a/src/RuleSetInterface.php
+++ b/src/RuleSetInterface.php
@@ -21,9 +21,9 @@ namespace PhpCsFixer;
  */
 interface RuleSetInterface
 {
-    public function __construct(array $set = []);
+    public function __construct(array $set = [], array $customSetDefinitions = []);
 
-    public static function create(array $set = []);
+    public static function create(array $set = [], array $customSetDefinitions = []);
 
     /**
      * Get configuration for given rule.

--- a/tests/Fixtures/.php_cs_custom.php
+++ b/tests/Fixtures/.php_cs_custom.php
@@ -42,6 +42,14 @@ final class CustomConfig implements ConfigInterface
     /**
      * {@inheritdoc}
      */
+    public function getCustomRuleSets()
+    {
+        return array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getFinder()
     {
         return array(__FILE__);
@@ -130,6 +138,14 @@ final class CustomConfig implements ConfigInterface
      * {@inheritdoc}
      */
     public function setCacheFile($cacheFile)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCustomRuleSets(array $ruleSets)
     {
         return $this;
     }

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -555,4 +555,97 @@ final class RuleSetTest extends TestCase
 
         return $testSet;
     }
+
+    /**
+     * Tests the custom rule set for definition name existance.
+     *
+     * @param string $definitionName
+     * @param array $customSetDefinition
+     *
+     * @dataProvider provideCustomRuleSetDefinitionData
+     */
+    public function testCustomRuleSetWithDefinitionName($definitionName, array $customSetDefinition)
+    {
+        $ruleSet = new RuleSet([], $customSetDefinition);
+        $this->assertArraySubset(array($definitionName), $ruleSet->getSetDefinitionNames());
+    }
+
+    public function provideCustomRuleSetDefinitionData()
+    {
+        return [
+            [
+                '@Custom',
+                [
+                    '@Custom' => [
+                    ]
+                ],
+                '@CustomExtended',
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true
+                    ],
+                    '@Custom' => [
+                    ]
+                ],
+                '@Custom',
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true
+                    ],
+                    '@Custom' => [
+                    ]
+                ],
+            ]
+        ];
+    }
+
+    /**
+     * Tests the custom rules set against the rule resolver
+     *
+     * @param array $rules
+     * @param array $customSetDefinition
+     *
+     * @dataProvider provideResolveCustomRuleSetsCases
+     */
+    public function testCustomRuleSetWithResolveRules(array $rules, array $customSetDefinition)
+    {
+        $rulesWithCustomSet = (new RuleSet($rules, $customSetDefinition))->getRules();
+        $ruleWithoutCustomSet = (new RuleSet(['single_line_after_imports' => true]))->getRules();
+
+        $this->assertEquals($ruleWithoutCustomSet, $rulesWithCustomSet);
+    }
+
+    public function provideResolveCustomRuleSetsCases()
+    {
+        return [
+            [
+                [
+                    '@Custom' => true
+                ],
+                [
+                    '@Custom' => [
+                        'single_line_after_imports' => true
+                    ]
+                ]],
+            [
+                [
+                    '@CustomExtended' => true
+                ],
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true
+                    ],
+                    '@Custom' => [
+                        'single_line_after_imports' => true
+                    ]
+                ]
+            ],
+            [
+                [
+                    'single_line_after_imports' => true
+                ],
+                []
+            ]
+        ];
+    }
 }

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -464,6 +464,99 @@ final class RuleSetTest extends TestCase
         $ruleSet->getRuleConfiguration('_not_exists');
     }
 
+    /**
+     * Tests the custom rule set for definition name existance.
+     *
+     * @param string $definitionName
+     * @param array  $customSetDefinition
+     *
+     * @dataProvider provideCustomRuleSetDefinitionData
+     */
+    public function testCustomRuleSetWithDefinitionName($definitionName, array $customSetDefinition)
+    {
+        $ruleSet = new RuleSet([], $customSetDefinition);
+        $this->assertArraySubset([$definitionName], $ruleSet->getSetDefinitionNames());
+    }
+
+    public function provideCustomRuleSetDefinitionData()
+    {
+        return [
+            [
+                '@Custom',
+                [
+                    '@Custom' => [
+                    ],
+                ],
+                '@CustomExtended',
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true,
+                    ],
+                    '@Custom' => [
+                    ],
+                ],
+                '@Custom',
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true,
+                    ],
+                    '@Custom' => [
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Tests the custom rules set against the rule resolver.
+     *
+     * @param array $rules
+     * @param array $customSetDefinition
+     *
+     * @dataProvider provideResolveCustomRuleSetsCases
+     */
+    public function testCustomRuleSetWithResolveRules(array $rules, array $customSetDefinition)
+    {
+        $rulesWithCustomSet = (new RuleSet($rules, $customSetDefinition))->getRules();
+        $ruleWithoutCustomSet = (new RuleSet(['single_line_after_imports' => true]))->getRules();
+
+        $this->assertSame($ruleWithoutCustomSet, $rulesWithCustomSet);
+    }
+
+    public function provideResolveCustomRuleSetsCases()
+    {
+        return [
+            [
+                [
+                    '@Custom' => true,
+                ],
+                [
+                    '@Custom' => [
+                        'single_line_after_imports' => true,
+                    ],
+                ], ],
+            [
+                [
+                    '@CustomExtended' => true,
+                ],
+                [
+                    '@CustomExtended' => [
+                        '@Custom' => true,
+                    ],
+                    '@Custom' => [
+                        'single_line_after_imports' => true,
+                    ],
+                ],
+            ],
+            [
+                [
+                    'single_line_after_imports' => true,
+                ],
+                [],
+            ],
+        ];
+    }
+
     private function assertSameRules(array $expected, array $actual, $message = '')
     {
         ksort($expected);
@@ -554,98 +647,5 @@ final class RuleSetTest extends TestCase
         ];
 
         return $testSet;
-    }
-
-    /**
-     * Tests the custom rule set for definition name existance.
-     *
-     * @param string $definitionName
-     * @param array $customSetDefinition
-     *
-     * @dataProvider provideCustomRuleSetDefinitionData
-     */
-    public function testCustomRuleSetWithDefinitionName($definitionName, array $customSetDefinition)
-    {
-        $ruleSet = new RuleSet([], $customSetDefinition);
-        $this->assertArraySubset(array($definitionName), $ruleSet->getSetDefinitionNames());
-    }
-
-    public function provideCustomRuleSetDefinitionData()
-    {
-        return [
-            [
-                '@Custom',
-                [
-                    '@Custom' => [
-                    ]
-                ],
-                '@CustomExtended',
-                [
-                    '@CustomExtended' => [
-                        '@Custom' => true
-                    ],
-                    '@Custom' => [
-                    ]
-                ],
-                '@Custom',
-                [
-                    '@CustomExtended' => [
-                        '@Custom' => true
-                    ],
-                    '@Custom' => [
-                    ]
-                ],
-            ]
-        ];
-    }
-
-    /**
-     * Tests the custom rules set against the rule resolver
-     *
-     * @param array $rules
-     * @param array $customSetDefinition
-     *
-     * @dataProvider provideResolveCustomRuleSetsCases
-     */
-    public function testCustomRuleSetWithResolveRules(array $rules, array $customSetDefinition)
-    {
-        $rulesWithCustomSet = (new RuleSet($rules, $customSetDefinition))->getRules();
-        $ruleWithoutCustomSet = (new RuleSet(['single_line_after_imports' => true]))->getRules();
-
-        $this->assertEquals($ruleWithoutCustomSet, $rulesWithCustomSet);
-    }
-
-    public function provideResolveCustomRuleSetsCases()
-    {
-        return [
-            [
-                [
-                    '@Custom' => true
-                ],
-                [
-                    '@Custom' => [
-                        'single_line_after_imports' => true
-                    ]
-                ]],
-            [
-                [
-                    '@CustomExtended' => true
-                ],
-                [
-                    '@CustomExtended' => [
-                        '@Custom' => true
-                    ],
-                    '@Custom' => [
-                        'single_line_after_imports' => true
-                    ]
-                ]
-            ],
-            [
-                [
-                    'single_line_after_imports' => true
-                ],
-                []
-            ]
-        ];
     }
 }


### PR DESCRIPTION
Hi everybody,

We are using the Fixer in company for different projects with different technologies. We have a default Styleguide and some concrete styleguides for those frameworks.
So we would have a company wide ruleset with will be extended by these frameworks.

With this pull request you are able to add a new RuleSetDefinition from the configuration file to the whole fix process, eg:
```
<?php
return PhpCsFixer\Config::create()
    ->setCustomRuleSets([
        '@MyCompany' => [
            '@PSR2' => true,
            'array_syntax' => ['syntax' => 'short'],
        ],
        '@MyCompanyFramework1' => [
            '@MyCompany' => true,
            'no_useless_else' => false,
        ],
        '@MyCompanyFramework2' => [
            '@MyCompany' => true,
            'phpdoc_order' => false,
        ]
    ])
    ->setRules([
        '@MyCompanyFramework2' => true
    ]);
```

Please leave a note about that improvement.