### PR TITLE
Add missing files to archive files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
 /tests export-ignore
+/tests/Test/AbstractFixerTestCase.php -export-ignore
+/tests/Test/AbstractIntegrationTestCase.php -export-ignore
+/tests/Test/IntegrationCase.php -export-ignore
+/tests/Test/IntegrationCaseFactory.php -export-ignore
 .appveyor.yml export-ignore
 .composer-require-checker.json export-ignore
 .editorconfig export-ignore

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase as BaseAbstractFixerTestCase;
  * @TODO 3.0 While removing, `gecko-packages/gecko-php-unit` shall be moved from `require` to `require-dev` and removed from `.composer-require-checker.json`.
  * @TODO 3.0 While removing, remove from `.composer-require-checker.json`.
  * @TODO 3.0 While removing, remove loading `tests/Test` from `autoload` section of `composer.json`.
+ * @TODO 3.0 While removing, remove `tests/Test` files from archive files in .gitattributes.
  */
 abstract class AbstractFixerTestCase extends BaseAbstractFixerTestCase
 {

--- a/src/Test/AbstractIntegrationTestCase.php
+++ b/src/Test/AbstractIntegrationTestCase.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tests\Test\AbstractIntegrationTestCase as BaseAbstractIntegration
  * @TODO 3.0 While removing, `gecko-packages/gecko-php-unit` shall be moved from `require` to `require-dev` and removed from `.composer-require-checker.json`.
  * @TODO 3.0 While removing, remove from `.composer-require-checker.json`.
  * @TODO 3.0 While removing, remove loading `tests/Test` from `autoload` section of `composer.json`.
+ * @TODO 3.0 While removing, remove `tests/Test` files from archive files in .gitattributes.
  */
 abstract class AbstractIntegrationTestCase extends BaseAbstractIntegrationTestCase
 {

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tests\Test\IntegrationCase as BaseIntegrationCase;
  *
  * @TODO 3.0 While removing, remove from `.composer-require-checker.json`.
  * @TODO 3.0 While removing, remove loading `tests/Test` from `autoload` section of `composer.json`.
+ * @TODO 3.0 While removing, remove `tests/Test` files from archive files in .gitattributes.
  */
 final class IntegrationCase
 {


### PR DESCRIPTION
Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/3e8c18aa08d388cb8c081fb56956aa84d5b0d1a4#commitcomment-22903963

Note: the file `/tests/Test/Assert/AssertTokensTrait.php` must be added when merging up to 2.3.