### PR TITLE
Fix test classes constructor

### DIFF
--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -23,7 +23,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase as BaseAbstractFixerTestCase;
  */
 abstract class AbstractFixerTestCase extends BaseAbstractFixerTestCase
 {
-    public function __construct()
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         @trigger_error(
             sprintf(
@@ -32,5 +32,7 @@ abstract class AbstractFixerTestCase extends BaseAbstractFixerTestCase
             ),
             E_USER_DEPRECATED
         );
+
+        parent::__construct($name, $data, $dataName);
     }
 }

--- a/src/Test/AbstractIntegrationTestCase.php
+++ b/src/Test/AbstractIntegrationTestCase.php
@@ -23,7 +23,7 @@ use PhpCsFixer\Tests\Test\AbstractIntegrationTestCase as BaseAbstractIntegration
  */
 abstract class AbstractIntegrationTestCase extends BaseAbstractIntegrationTestCase
 {
-    public function __construct()
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         @trigger_error(
             sprintf(
@@ -32,5 +32,7 @@ abstract class AbstractIntegrationTestCase extends BaseAbstractIntegrationTestCa
             ),
             E_USER_DEPRECATED
         );
+
+        parent::__construct($name, $data, $dataName);
     }
 }


### PR DESCRIPTION
Changing PHPUnit's test classes constructor's signature breaks PHPUnit process, at least for tests that use a data provider. Here is an example with `BlankLineAfterOpeningTagFixerTest` extending the deprecated `AbstractFixerTestCase`:

**before**
```
 $ vendor/bin/phpunit --filter BlankLineAfterOpeningTagFixerTest
PHPUnit 5.7.21 by Sebastian Bergmann and contributors.

Testing 
EE                                                                  2 / 2 (100%)

Time: 269 ms, Memory: 26.00MB

There were 2 errors:

1) PhpCsFixer\Tests\Fixer\PhpTag\BlankLineAfterOpeningTagFixerTest::testFix
ArgumentCountError: Too few arguments to function PhpCsFixer\Tests\Fixer\PhpTag\BlankLineAfterOpeningTagFixerTest::testFix(), 0 passed and at least 1 expected

.../tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php:34

2) PhpCsFixer\Tests\Fixer\PhpTag\BlankLineAfterOpeningTagFixerTest::testMessyWhitespaces
ArgumentCountError: Too few arguments to function PhpCsFixer\Tests\Fixer\PhpTag\BlankLineAfterOpeningTagFixerTest::testMessyWhitespaces(), 0 passed and at least 1 expected

.../tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php:118
```

**after**
```
 $ vendor/bin/phpunit --filter BlankLineAfterOpeningTagFixerTest
PHPUnit 5.7.21 by Sebastian Bergmann and contributors.

Testing 
...........                                                       11 / 11 (100%)

Time: 282 ms, Memory: 26.00MB

OK (11 tests, 183 assertions)

Remaining deprecation notices (13)

The "PhpCsFixer\Test\AbstractFixerTestCase" class is deprecated. You should stop using it, as it will be removed in 3.0 version: 13x
    11x in BlankLineAfterOpeningTagFixerTest::__construct from PhpCsFixer\Tests\Fixer\PhpTag
    2x in ReflectionClass::newInstance
```