### PR TITLE
[WIP] BracesFixer: Add position_after_return_type_hint option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,6 +282,9 @@ Choose from the list of available rules:
     the opening brace should be placed on "next" or "same" line after
     classy constructs (non-anonymous classes, interfaces, traits, methods
     and non-lambda functions); defaults to ``'next'``
+  - ``position_after_return_type_hint`` (``'next'``, ``'same'``): whether the opening
+    brace following a return type hint should be placed on "next" or "same"
+    line; defaults to ``'same'``
 
 * **cast_spaces** [@Symfony]
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -485,7 +485,7 @@ class Foo
                         $tokens->ensureWhitespaceAtIndex(
                             $startBraceIndex - 1,
                             1,
-                            self::LINE_NEXT === $this->configuration['position_after_return_type_hint'] && $token->isGivenKind(T_FUNCTION) && ':' === $tokens[$tokens->getNextNonWhitespace($closingParenthesisIndex)]->getContent() ?
+                            self::LINE_NEXT === $this->configuration['position_after_return_type_hint'] && $token->isGivenKind(T_FUNCTION) && $tokens[$tokens->getNextNonWhitespace($closingParenthesisIndex)]->equals([CT::T_TYPE_COLON, ':']) ?
                                 $this->whitespacesConfig->getLineEnding().$indent
                                 : ' '
                         );
@@ -498,7 +498,7 @@ class Foo
                             || $token->isGivenKind($classyTokens) && !$tokensAnalyzer->isAnonymousClass($index)
                         )
                         && !$tokens[$tokens->getPrevNonWhitespace($startBraceIndex)]->isComment()
-                        && !(self::LINE_NEXT === $this->configuration['position_after_return_type_hint'] && $token->isGivenKind(T_FUNCTION) && ':' === $tokens[$tokens->getNextNonWhitespace($closingParenthesisIndex)]->getContent())
+                        && !(self::LINE_NEXT === $this->configuration['position_after_return_type_hint'] && $token->isGivenKind(T_FUNCTION) && $tokens[$tokens->getNextNonWhitespace($closingParenthesisIndex)]->equals([CT::T_TYPE_COLON, ':']))
                     ) {
                         $ensuredWhitespace = ' ';
                     } else {

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -27,6 +27,7 @@ final class BracesFixerTest extends AbstractFixerTestCase
     private static $configurationOopPositionSameLine = ['position_after_functions_and_oop_constructs' => 'same'];
     private static $configurationCtrlStructPositionNextLine = ['position_after_control_structures' => 'next'];
     private static $configurationAnonymousPositionNextLine = ['position_after_anonymous_constructs' => 'next'];
+    private static $configurationAfterReturnTypeHintNextLine = ['position_after_return_type_hint' => 'next'];
 
     public function testInvalidConfigurationClassyConstructs()
     {
@@ -4670,5 +4671,246 @@ if (true)
     public function testDoWhileLoopInsideAnIfWithoutBrackets($expected, $input = null)
     {
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $configuration
+     *
+     * @dataProvider provideBraceNextLineReturnTypeHint
+     * @requires PHP 7.0
+     */
+    public function testBraceNextLineReturnTypeHint($expected, $input = null, array $configuration = null)
+    {
+        if (null !== $configuration) {
+            $this->fixer->configure($configuration);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideBraceNextLineReturnTypeHint()
+    {
+        return [
+            [
+                '<?php
+        function foo($bar): void
+        {
+        }',
+                null,
+            ],
+            [
+                '<?php
+        function foo($bar): void
+        {
+        }',
+                null,
+                self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void {
+        }',
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void
+        {
+        }',
+            ],
+            [
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void
+        {
+        }',
+                null,
+                self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void {
+        }',
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void
+        {
+        }',
+                self::$configurationOopPositionSameLine,
+            ],
+            [
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void {
+        }',
+                null,
+                self::$configurationOopPositionSameLine,
+            ],
+            [
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void
+        {
+        }',
+                '<?php
+        function foo(
+            $bar,
+            $boo
+        ): void {
+        }',
+                self::$configurationOopPositionSameLine + self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        function foo($bar): void {
+        }',
+                null,
+                self::$configurationOopPositionSameLine,
+            ],
+            [
+                '<?php
+        function foo($bar): void
+        {
+        }',
+                '<?php
+        function foo($bar): void {
+        }',
+                self::$configurationOopPositionSameLine + self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        $foo = function ($bar): void
+        {
+        };',
+                null,
+                self::$configurationAnonymousPositionNextLine,
+            ],
+            [
+                '<?php
+        $foo = function ($bar): void
+        {
+        };',
+                null,
+                self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        $foo = function ($bar): void
+        {
+        };',
+                null,
+                self::$configurationAnonymousPositionNextLine + self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void {
+        };',
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void
+        {
+        };',
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void {
+        };',
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void
+        {
+        };',
+                self::$configurationAnonymousPositionNextLine,
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void
+        {
+        };',
+                null,
+                self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void {
+        };',
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void
+        {
+        };',
+                self::$configurationAnonymousPositionNextLine,
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void {
+        };',
+                null,
+                self::$configurationAnonymousPositionNextLine,
+            ],
+            [
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void
+        {
+        };',
+                '<?php
+        $foo = function (
+            $bar,
+            $boo
+        ): void {
+        };',
+                self::$configurationAnonymousPositionNextLine + self::$configurationAfterReturnTypeHintNextLine,
+            ],
+            [
+                '<?php
+        $foo = function ($bar): void
+        {
+        };',
+                '<?php
+        $foo = function ($bar): void {
+        };',
+                self::$configurationAnonymousPositionNextLine + self::$configurationAfterReturnTypeHintNextLine,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Add option to determine whether the opening brace following a return type hint should be placed on "next" or "same" line.

See text in latter part of this comment for what this implements: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2684#issuecomment-297846431