### PR TITLE
Restrict lowercasing in PhpdocAnnotationWithoutDotFixer

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -90,9 +90,14 @@ function foo ($bar) {}
                 $optionalTypeRegEx = $annotation->supportTypes()
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes())))
                     : '';
-                $content = preg_replace_callback('/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(.*)$/', function (array $matches) {
-                    return $matches[1].lcfirst($matches[2]);
-                }, $startLine->getContent(), 1);
+                $content = preg_replace_callback(
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\P{Lu}))(.*)$/',
+                    function (array $matches) {
+                        return $matches[1].strtolower($matches[2]).$matches[3];
+                    },
+                    $startLine->getContent(),
+                    1
+                );
                 $startLine->setContent($content);
             }
 

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -45,6 +45,9 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * Description.
      *
      * @param string|null $str   some string
+     * @param string $ip         IPv4 is not lowercased
+     * @param string $a          a
+     * @param string $ab         ab
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。
@@ -64,6 +67,9 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * Description.
      *
      * @param string|null $str   Some string.
+     * @param string $ip         IPv4 is not lowercased.
+     * @param string $a          A.
+     * @param string $ab         Ab.
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。


### PR DESCRIPTION
In particular, if the first two letters of the comment are uppercase, we
no longer lowercase the first.

Fixes #2906.