### PR TITLE
PhpdocAnnotationWithoutDotFixer - Restrict lowercasing

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -90,9 +90,14 @@ function foo ($bar) {}
                 $optionalTypeRegEx = $annotation->supportTypes()
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes())))
                     : '';
-                $content = preg_replace_callback('/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(.*)$/', function (array $matches) {
-                    return $matches[1].lcfirst($matches[2]);
-                }, $startLine->getContent(), 1);
+                $content = preg_replace_callback(
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\P{Lu}))(.*)$/',
+                    function (array $matches) {
+                        return $matches[1].strtolower($matches[2]).$matches[3];
+                    },
+                    $startLine->getContent(),
+                    1
+                );
                 $startLine->setContent($content);
             }
 

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -91,7 +91,7 @@ function foo ($bar) {}
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes())))
                     : '';
                 $content = preg_replace_callback(
-                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\P{Lu}))(.*)$/',
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     function (array $matches) {
                         return $matches[1].strtolower($matches[2]).$matches[3];
                     },

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -46,8 +46,11 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      *
      * @param string|null $str   some string
      * @param string $ip         IPv4 is not lowercased
-     * @param string $a          a
+     * @param string $a          A
+     * @param string $a_string   a string
      * @param string $ab         ab
+     * @param string $t34        T34
+     * @param string $s          S§
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。
@@ -69,7 +72,10 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @param string|null $str   Some string.
      * @param string $ip         IPv4 is not lowercased.
      * @param string $a          A.
+     * @param string $a_string   A string.
      * @param string $ab         Ab.
+     * @param string $t34        T34.
+     * @param string $s          S§.
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -45,6 +45,9 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * Description.
      *
      * @param string|null $str   some string
+     * @param string $ip         IPv4 is not lowercased
+     * @param string $a          a
+     * @param string $ab         ab
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。
@@ -64,6 +67,9 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * Description.
      *
      * @param string|null $str   Some string.
+     * @param string $ip         IPv4 is not lowercased.
+     * @param string $a          A.
+     * @param string $ab         Ab.
      * @param string $genrb      Optional. The path to the "genrb" executable
      * @param string $ellipsis1  Ellipsis is this: ...
      * @param string $ellipsis2  Ellipsis is this: 。。。


### PR DESCRIPTION
In particular, if the first two letters of the comment are uppercase, we
no longer lowercase the first.

Fixes #2906.