### PR TITLE
Add NoUnneededCurlyBracesFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -30,6 +30,7 @@ $config = PhpCsFixer\Config::create()
         'no_null_property_initialization' => true,
         'no_short_echo_tag' => true,
         'no_superfluous_elseif' => true,
+        'no_unneeded_curly_braces' => true,
         'no_unreachable_default_argument_value' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,

--- a/README.rst
+++ b/README.rst
@@ -799,6 +799,11 @@ Choose from the list of available rules:
     ``['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case',
     'yield']``
 
+* **no_unneeded_curly_braces**
+
+  Removes unneeded curly braces that are superfluous and aren't part of a
+  control structure's body.
+
 * **no_unreachable_default_argument_value**
 
   In function arguments there must not be arguments with default values

--- a/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ControlStructure;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class NoUnneededCurlyBracesFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Removes unneeded curly braces that are superfluous and aren\'t part of a control structure\'s body.',
+            [
+                new CodeSample(
+                    '<?php {
+    echo 1;
+}
+
+switch ($b) {
+    case 1: {
+        break;
+    }
+}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must be run before NoUselessElseFixer and NoUselessReturnFixer.
+        return 26;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound('}');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($this->findCurlyBraceOpen($tokens) as $index) {
+            if ($this->isOverComplete($tokens, $index)) {
+                $this->clearOverCompleteBraces($tokens, $index, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index));
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $openIndex  index of `{` token
+     * @param int    $closeIndex index of `}` token
+     */
+    private function clearOverCompleteBraces(Tokens $tokens, $openIndex, $closeIndex)
+    {
+        $tokens->clearTokenAndMergeSurroundingWhitespace($closeIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($openIndex);
+    }
+
+    private function findCurlyBraceOpen(Tokens $tokens)
+    {
+        for ($i = count($tokens) - 1; $i > 0; --$i) {
+            if ($tokens[$i]->equals('{')) {
+                yield $i;
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index  index of `{` token
+     *
+     * @return bool
+     */
+    private function isOverComplete(Tokens $tokens, $index)
+    {
+        static $whiteList = ['{', '}', [T_OPEN_TAG], ':', ';'];
+
+        return $tokens[$tokens->getPrevMeaningfulToken($index)]->equalsAny($whiteList);
+    }
+}

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -32,9 +32,9 @@ final class FixerFactoryTest extends TestCase
         $factory->registerBuiltInFixers();
         $fixers = $factory->getFixers();
 
-        $this->assertSame('encoding', $fixers[0]->getName());
-        $this->assertSame('full_opening_tag', $fixers[1]->getName());
-        $this->assertSame('single_blank_line_at_eof', $fixers[count($fixers) - 1]->getName());
+        $this->assertSame('encoding', $fixers[0]->getName(), 'Expected "encoding" fixer to have the highest priority.');
+        $this->assertSame('full_opening_tag', $fixers[1]->getName(), 'Expected "full_opening_tag" fixer has second highest priority.');
+        $this->assertSame('single_blank_line_at_eof', $fixers[count($fixers) - 1]->getName(), 'Expected "single_blank_line_at_eof" to have the lowest priority.');
     }
 
     /**
@@ -169,6 +169,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']], // tested also in: list_syntax,ternary_operator_spaces.test
             [$fixers['void_return'], $fixers['return_type_declaration']], // tested also in: void_return,return_type_declaration.test
             [$fixers['void_return'], $fixers['phpdoc_no_empty_return']], // tested also in: void_return,phpdoc_no_empty_return.test
+            [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_else']], // tested also in: no_unneeded_curly_braces,no_useless_else.test
+            [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_return']], // tested also in: no_unneeded_curly_braces,no_useless_return.test
         ];
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ControlStructure;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ControlStructure\NoUnneededCurlyBracesFixer
+ */
+final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'simple sample, last token candidate' => [
+                '<?php  echo 1;',
+                '<?php { echo 1;}',
+            ],
+            'minimal sample, first token candidate' => [
+                '<?php  // {}',
+                '<?php {} // {}',
+            ],
+            [
+                '<?php
+                      echo 0;   //
+                    echo 1;
+                    switch($a) {
+                        case 2: echo 3; break;
+                    }
+                    echo 4;  echo 5; //
+                ',
+                '<?php
+                    { { echo 0; } } //
+                    {echo 1;}
+                    switch($a) {
+                        case 2: {echo 3; break;}
+                    }
+                    echo 4; { echo 5; }//
+                ',
+            ],
+            'no fixes' => [
+                '<?php
+                    echo ${$a};
+                    echo $a{1};
+
+                    foreach($a as $b){}
+                    while($a){}
+                    do {} while($a);
+
+                    if ($c){}
+                    if ($c){}else{}
+                    if ($c){}elseif($d){}
+                    if ($c) {}elseif($d)/**  */{ } else/**/{  }
+
+                    try {} catch(\Exception $e) {}
+
+                    function test(){}
+                    $a = function() use ($c){};
+
+                    class A extends B {}
+                    interface D {}
+                    trait E {}
+                ',
+            ],
+            'no fixes II' => [
+                '<?php
+                declare(ticks=1) {
+                // entire script here
+                }
+                #',
+            ],
+            'no fix catch/try/finally' => [
+                '<?php
+                    try {
+
+                    } catch(\Exception $e) {
+
+                    } finally {
+
+                    }
+                ',
+            ],
+            'no fix namespace block' => [
+                '<?php
+                    namespace {
+                    }
+                    namespace A {
+                    }
+                    namespace A\B {
+                    }
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7
+     *
+     * @param string $expected
+     *
+     * @dataProvider provideNoFixCases7
+     */
+    public function testNoFix7($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideNoFixCases7()
+    {
+        return [
+            [
+                '<?php
+                    use some\a\{ClassA, ClassB, ClassC as C};
+                    use function some\a\{fn_a, fn_b, fn_c};
+                    use const some\a\{ConstA, ConstB, ConstC};
+                    use some\x\{ClassB, function CC as C, function D, const E, function A\B};
+                    class Foo
+                    {
+                        public function getBar(): array
+                        {
+                        }
+                    }
+                ',
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/no_unneeded_curly_braces,no_useless_else.test
+++ b/tests/Fixtures/Integration/priority/no_unneeded_curly_braces,no_useless_else.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: no_unneeded_curly_braces,no_useless_else.
+--RULESET--
+{"no_unneeded_curly_braces": true, "no_useless_else": true}
+--EXPECT--
+<?php
+$a = false;
+if ($a) {
+     throw $a;  // before useless else
+}  //
+    echo null;
+
+
+--INPUT--
+<?php
+$a = false;
+if ($a) {
+    {{ throw $a; }} // before useless else
+} else {//
+    echo null;
+}

--- a/tests/Fixtures/Integration/priority/no_unneeded_curly_braces,no_useless_return.test
+++ b/tests/Fixtures/Integration/priority/no_unneeded_curly_braces,no_useless_return.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: no_unneeded_curly_braces,no_useless_return.
+--RULESET--
+{"no_unneeded_curly_braces": true, "no_useless_return": true}
+--EXPECT--
+<?php
+function example($b)
+{
+    if ($b) {
+        return;
+    }
+    // before no useless return fixer
+    //
+}
+
+--INPUT--
+<?php
+function example($b)
+{
+    if ($b) {
+        return;
+    }
+    // before no useless return fixer
+    {{return;}}//
+}

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -336,7 +336,8 @@ abstract class AbstractIntegrationTestCase extends TestCase
     {
         $errorStr = '';
         foreach ($errors as $error) {
-            $errorStr .= sprintf("%d: %s\n", $error->getType(), $error->getFilePath());
+            $source = $error->getSource();
+            $errorStr .= sprintf("%d: %s%s\n", $error->getType(), $error->getFilePath(), null === $source ? '' : ' '.$source->getMessage());
         }
 
         return $errorStr;


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2799

closes #2798
closes #1540

$ php php-cs-fixer describe no_unneeded_curly_braces
Description of no_unneeded_curly_braces rule.
Removes unneeded curly braces.

Fixing examples:
 * Example #1.
```diff
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ @@
   -<?php { echo 1; }
   +<?php  echo 1;
   ----------- end diff -----------
```

tested on this repo and SF
