### PR TITLE
Psr0Fixer, Psr4Fixer - ignore "new class" syntax

### DIFF
--- a/src/Fixer/Basic/Psr0Fixer.php
+++ b/src/Fixer/Basic/Psr0Fixer.php
@@ -85,6 +85,11 @@ class InvalidName {}
                     return;
                 }
 
+                $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
+                if ($prevToken->isGivenKind(T_NEW)) {
+                    return;
+                }
+
                 $classyIndex = $tokens->getNextMeaningfulToken($index);
                 $classyName = $tokens[$classyIndex]->getContent();
             }

--- a/src/Fixer/Basic/Psr4Fixer.php
+++ b/src/Fixer/Basic/Psr4Fixer.php
@@ -68,6 +68,11 @@ class InvalidName {}
                     return;
                 }
 
+                $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
+                if ($prevToken->isGivenKind(T_NEW)) {
+                    return;
+                }
+
                 $classyIndex = $tokens->getNextMeaningfulToken($index);
                 $classyName = $tokens[$classyIndex]->getContent();
             }

--- a/tests/Fixer/Basic/Psr0FixerTest.php
+++ b/tests/Fixer/Basic/Psr0FixerTest.php
@@ -176,6 +176,30 @@ EOF;
     }
 
     /**
+     * @requires PHP 7.0
+     */
+    public function testIgnoreAnonymousClass()
+    {
+        $file = $this->getTestFile(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+new class implements Countable {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+new class extends stdClass {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+    }
+
+    /**
      * @param string $filename
      *
      * @dataProvider provideIgnoredCases

--- a/tests/Fixer/Basic/Psr4FixerTest.php
+++ b/tests/Fixer/Basic/Psr4FixerTest.php
@@ -163,6 +163,30 @@ EOF;
     }
 
     /**
+     * @requires PHP 7.0
+     */
+    public function testIgnoreAnonymousClass()
+    {
+        $file = $this->getTestFile(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+new class implements Countable {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+new class extends stdClass {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+    }
+
+    /**
      * @param string $filename
      *
      * @dataProvider provideIgnoredCases


### PR DESCRIPTION
Adds support for PHP 7 anonymous classes.