### PR TITLE
ProcessLinterTest - Ensure Windows test only runs on Windows, add a Mac test execution

### DIFF
--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -39,7 +39,7 @@ final class ProcessLinterTest extends AbstractLinterTestCase
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"]
      * @requires OS Linux|Darwin
      */
-    public function testPrepareCommandOnPhpOnLinuxAndMac($executable, $file, $expected)
+    public function testPrepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
     {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('Skip tests for PHP compiler when running on HHVM compiler.');

--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -37,9 +37,9 @@ final class ProcessLinterTest extends AbstractLinterTestCase
      *
      * @testWith ["php", "foo.php", "'php' '-l' 'foo.php'"]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"]
-     * @requires OS Linux
+     * @requires OS Linux|Darwin
      */
-    public function testPrepareCommandOnPhpOnLinux($executable, $file, $expected)
+    public function testPrepareCommandOnPhpOnLinuxAndMac($executable, $file, $expected)
     {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('Skip tests for PHP compiler when running on HHVM compiler.');
@@ -58,7 +58,7 @@ final class ProcessLinterTest extends AbstractLinterTestCase
      *
      * @testWith ["php", "foo.php", "php -l foo.php"]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
-     * @requires OS Win
+     * @requires OS ^Win
      */
     public function testPrepareCommandOnPhpOnWindows($executable, $file, $expected)
     {


### PR DESCRIPTION
As requested here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2893#issuecomment-317202736

Not sure on methodology though 😉 

They pass:
<img width="822" alt="screen shot 2017-07-22 at 20 26 56" src="https://user-images.githubusercontent.com/3288888/28494090-2413ccb4-6f1c-11e7-92b1-b1cf048d40a7.png">

cc: @keradus 

---

We should probably open a bug to remind us to remove this hotfix when phpunit is working properly.