### PR TITLE
Config - fix handling rule without value

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -649,9 +649,15 @@ final class ConfigurationResolver
          *
          * @see RuleSet::resolveSet()
          */
-        $ruleSet = RuleSet::create(array_map(function () {
-            return true;
-        }, $rules));
+        $ruleSet = array();
+        foreach ($rules as $key => $value) {
+            if (is_int($key)) {
+                throw new InvalidConfigurationException(sprintf('Missing value for "%s" rule/set.', $value));
+            }
+
+            $ruleSet[$key] = true;
+        }
+        $ruleSet = new RuleSet($ruleSet);
 
         /** @var string[] $configuredFixers */
         $configuredFixers = array_keys($ruleSet->getRules());


### PR DESCRIPTION
```
ker@dus:~/github/PHP-CS-Fixer$ git du
diff --git a/.php_cs.dist b/.php_cs.dist
index 6078cd32..bc4adb41 100644
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,7 @@ return PhpCsFixer\Config::create()
         'semicolon_after_instruction' => true,
         'strict_comparison' => true,
         'strict_param' => true,
+        'aaa',
     ))
     ->setFinder(
         PhpCsFixer\Finder::create()
ker@dus:~/github/PHP-CS-Fixer$ 
```

----------------------

before:
```
ker@dus:~/github/PHP-CS-Fixer$ php php-cs-fixer fix -v
Loaded config default from "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist".

                                   
  [InvalidArgumentException]       
  Missing value for "1" rule/set.  
                                   

Exception trace:
 () at /home/keradus/github/PHP-CS-Fixer/src/RuleSet.php:201
 PhpCsFixer\RuleSet->__construct() at /home/keradus/github/PHP-CS-Fixer/src/RuleSet.php:211
 PhpCsFixer\RuleSet::create() at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:654
 PhpCsFixer\Console\ConfigurationResolver->validateRules() at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:571
 PhpCsFixer\Console\ConfigurationResolver->getRuleSet() at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:290
 PhpCsFixer\Console\ConfigurationResolver->getFixers() at /home/keradus/github/PHP-CS-Fixer/src/Console/Command/FixCommand.php:197
 PhpCsFixer\Console\Command\FixCommand->execute() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Command/Command.php:264
 Symfony\Component\Console\Command\Command->run() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:869
 Symfony\Component\Console\Application->doRunCommand() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:223
 Symfony\Component\Console\Application->doRun() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:130
 Symfony\Component\Console\Application->run() at /home/keradus/github/PHP-CS-Fixer/php-cs-fixer:55
```

after:
```
ker@dus:~/github/PHP-CS-Fixer$ php php-cs-fixer fix -v
Loaded config default from "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist".

                                                                          
  [PhpCsFixer\ConfigurationException\InvalidConfigurationException (16)]  
  Missing value for "aaa" rule/set.                                       
                                                                          

Exception trace:
 () at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:655
 PhpCsFixer\Console\ConfigurationResolver->validateRules() at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:571
 PhpCsFixer\Console\ConfigurationResolver->getRuleSet() at /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php:290
 PhpCsFixer\Console\ConfigurationResolver->getFixers() at /home/keradus/github/PHP-CS-Fixer/src/Console/Command/FixCommand.php:197
 PhpCsFixer\Console\Command\FixCommand->execute() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Command/Command.php:264
 Symfony\Component\Console\Command\Command->run() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:869
 Symfony\Component\Console\Application->doRunCommand() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:223
 Symfony\Component\Console\Application->doRun() at /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Application.php:130
 Symfony\Component\Console\Application->run() at /home/keradus/github/PHP-CS-Fixer/php-cs-fixer:55
```