### PR TITLE
NoUnusedImportsFixer - Fix extra blank line

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -235,7 +235,11 @@ final class NoUnusedImportsFixer extends AbstractFixer
             return;
         }
 
-        $nextIndex = $useDeclaration['end'] + 1;
+        $nextIndex = $tokens->getNonEmptySibling($useDeclaration['end'], 1);
+        if (null === $nextIndex) {
+            return;
+        }
+
         $nextToken = $tokens[$nextIndex];
 
         if ($nextToken->isWhitespace()) {

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -617,4 +617,70 @@ echo 1;';
 
         $this->doTest($expected, $input);
     }
+
+    public function testWithSameNamespaceImportAndUnusedImport()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use Bar\C;
+
+abstract class D extends A implements C
+{
+}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use Bar\C;
+use Foo\A;
+use Foo\Bar\B;
+
+abstract class D extends A implements C
+{
+}
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testWithSameNamespaceImportAndUnusedImportAfterNamespaceStatement()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use Foo\Bar\C;
+
+abstract class D extends A implements C
+{
+}
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use Foo\A;
+use Foo\Bar\B;
+use Foo\Bar\C;
+
+abstract class D extends A implements C
+{
+}
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Fixes an edge case bug with `no_unused_imports` fixer: when removing several consecutive `use` statements, some because they are not used **and** some because they are superfluous (same namespace), the fixer leaves an extra blank line, which then isn't removed by `no_extra_consecutive_blank_lines` fixer. If you run the tool again, the extra line is correctly removed by `no_extra_consecutive_blank_lines`.

Here is the result of one of the tests I added, before the fix:
```diff
 <?php
 
 namespace Foo;
 
-use Foo\A;
-use Foo\Bar\B;
+
 use Foo\Bar\C;
 
 abstract class D extends A implements C
 {
 }
```

I first thought this was a priority issue, but the fixers already run in the correct order (and this is covered by an integration test).

But the issue is that when removing a token, it is actually replaced with an empty one, so you might end up with whitespace tokens being separated by several empty tokens, even when using `Tokens::clearTokenAndMergeSurroundingWhitespace()`. This must be taken into consideration when dealing with whitespaces.