### PR TITLE
PHP 7.2 - Group imports with trailing comma support

### DIFF
--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -151,6 +151,10 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
         for ($i = $groupOpenIndex + 1; $i <= $groupCloseIndex; ++$i) {
             $token = $tokens[$i];
 
+            if ($token->equals(',') && $tokens[$tokens->getNextMeaningfulToken($i)]->equals(array(CT::T_GROUP_IMPORT_BRACE_CLOSE))) {
+                continue;
+            }
+
             if ($token->equalsAny(array(',', array(CT::T_GROUP_IMPORT_BRACE_CLOSE)))) {
                 $statements[] = 'use'.$statement.';';
                 $statement = $groupPrefix;

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1717,4 +1717,32 @@ use function some\a\{fn_a, fn_b};
             ),
         );
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provide72Cases
+     * @requires PHP 7.2
+     */
+    public function test72($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provide72Cases()
+    {
+        return array(
+            array(
+                '<?php
+use A\{B,};
+use C\{D,E,};
+',
+                '<?php
+use C\{D,E,};
+use A\{B,};
+',
+            ),
+        );
+    }
 }

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -273,6 +273,25 @@ use function some\b\A\B;',
     }
 
     /**
+     * @requires PHP 7.0
+     */
+    public function testMessyComments()
+    {
+        $this->doTest(
+            '<?php
+use D\/*1*//*2*//*3*/E;
+use D\/*4*//*5*//*6*//*7*//*8*//*9*/F/*10*//*11*//*12*/;
+',
+            '<?php
+use D\{
+/*1*//*2*//*3*/E,/*4*//*5*//*6*/
+/*7*//*8*//*9*/F/*10*//*11*//*12*/
+};
+'
+        );
+    }
+
+    /**
      * @param string      $expected
      * @param null|string $input
      *
@@ -291,6 +310,36 @@ use function some\b\A\B;',
             array(
                 "<?php\r\n    use FooA;\r\n    use FooB;",
                 "<?php\r\n    use FooA, FooB;",
+            ),
+        );
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provide72Cases
+     * @requires PHP 7.2
+     */
+    public function test72($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provide72Cases()
+    {
+        return array(
+            array(
+                '<?php
+use D\E;
+use D\F;
+use G\H;
+use G\I/*1*//*2*/;
+',
+                '<?php
+use D\{E,F,};
+use G\{H,I/*1*/,/*2*/};
+',
             ),
         );
     }

--- a/tests/Fixtures/Integration/misc/PHP7_2.test
+++ b/tests/Fixtures/Integration/misc/PHP7_2.test
@@ -1,0 +1,41 @@
+--TEST--
+PHP 7.2 test.
+--RULESET--
+{
+    "single_import_per_statement": true
+}
+--REQUIREMENTS--
+{"php": 70200}
+--EXPECT--
+<?php
+
+namespace Foo;
+
+use Bar\A;
+use Bar\B;
+
+class C
+{
+    public function A($a, object $b): object {
+        unset($a);
+        return $b;
+    }
+}
+
+--INPUT--
+<?php
+
+namespace Foo;
+
+use Bar\{
+    A,
+    B,
+};
+
+class C
+{
+    public function A($a, object $b): object {
+        unset($a);
+        return $b;
+    }
+}


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2907

First round of support;
- fix SingleImportPerStatementFixer not handling trailing comma correctly
- additional tests for SingleImportPerStatementFixer
- additional test for OrderedImportsFixerTest

This doesn't solve all issues for PHP 7.2 support, but it is a good first round I think :)