### PR TITLE
Use just the PHP Version without PHP_EXTRA_VERSION

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -184,7 +184,7 @@ final class ConfigurationResolver
                 $this->cacheManager = new FileCacheManager(
                     new FileHandler($this->getCacheFile()),
                     new Signature(
-                        PHP_VERSION,
+                        PHP_VERSION_ID,
                         ToolInfo::getVersion(),
                         $this->getRules()
                     ),


### PR DESCRIPTION
By using a more generalised version number for PHP, running php-cs-fixer in a container (`PHP 7.0.20-2~ubuntu16.04.1+deb.sury.org+1`) vs a host (`PHP 7.0.20`) means the cache file is acceptable in both instances.

This extends to a slightly more optimized approach for using PHP-CS-FIXER in a pipeline.

Adding the following lines to your `.gitattributes` file ...
```
# Always use local .php_cs.cache and don't overwrite it in a merge.
.php_cs.cache merge=ours
```
in conjunction with the appropriate tooling to update the repo when code is fixed, will provide for a far faster analysis of the code.

If the pipeline can differentiate by branch, then you can add a --no-cache option to the master branch, forcing a full scan on changes to master.
