### PR TITLE
FunctionToConstantFixer - test with diff. arguments than fixable

### DIFF
--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -126,6 +126,13 @@ $a =
                 '<?php echo phpversion(); echo php_sapi_name(); echo M_PI;',
                 array('functions' => array('pi', 'phpversion')),
             ),
+            'diff argument count than native allows' => array(
+                '<?php
+                    echo phpversion(1);
+                    echo php_sapi_name(1,2);
+                    echo pi(1);
+                ',
+            ),
         );
     }
 


### PR DESCRIPTION
While prep'ing for a nice suggestion from @kalessil here https://github.com/kalessil/phpinspectionsea/commit/79ca0d9e5036156980bfe31387d2fa5728485992#commitcomment-23268362 I noticed we didn't test for some cases we shouldn't fix.
Good news is that we don't touch the cases, but it is nice to have tests to prove it :)