### PR TITLE
BlankLineBeforeStatementFixerTest - Fix covered class

### DIFF
--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -23,7 +23,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixerTest
+ * @covers \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer
  */
 final class BlankLineBeforeStatementFixerTest extends AbstractFixerTestCase
 {


### PR DESCRIPTION
Fixes warnings when collecting coverage (see https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/258473696#L761) and should improve it.