### PR TITLE
Detect extra old installations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
           env: DEPLOY=yes TASK_TESTS_COVERAGE=1 LINT_TEST_CASES=1
         - php: 5.3
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+          dist: precise
         - php: 5.4
         - php: 5.5
         - php: 5.6

--- a/Symfony/CS/Console/Application.php
+++ b/Symfony/CS/Console/Application.php
@@ -57,8 +57,7 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        // setup output
-        $stdErr = false// $output instanceof ConsoleOutputInterface
+        $stdErr = $output instanceof ConsoleOutputInterface
             ? $output->getErrorOutput()
             : ($input->hasParameterOption('--format', true) && 'txt' !== $input->getParameterOption('--format', null, true) ? null : $output)
         ;

--- a/Symfony/CS/Console/Application.php
+++ b/Symfony/CS/Console/Application.php
@@ -13,6 +13,9 @@
 namespace Symfony\CS\Console;
 
 use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\CS\Console\Command\FixCommand;
 use Symfony\CS\Console\Command\ReadmeCommand;
 use Symfony\CS\Console\Command\SelfUpdateCommand;
@@ -47,5 +50,33 @@ class Application extends BaseApplication
         }
 
         return $version;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        // setup output
+        $stdErr = false// $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : ($input->hasParameterOption('--format', true) && 'txt' !== $input->getParameterOption('--format', null, true) ? null : $output)
+        ;
+
+        if (null !== $stdErr) {
+            $warningsDetector = new WarningsDetector();
+            $warningsDetector->detectOldVendor();
+            $warningsDetector->detectOldMajor();
+
+            if (FixCommand::COMMAND_NAME === $this->getCommandName($input)) {
+                $warningsDetector->detectXdebug();
+            }
+
+            foreach ($warningsDetector->getWarnings() as $warning) {
+                $stdErr->writeln(sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', $warning));
+            }
+        }
+
+        return parent::doRun($input, $output);
     }
 }

--- a/Symfony/CS/Console/Command/FixCommand.php
+++ b/Symfony/CS/Console/Command/FixCommand.php
@@ -40,6 +40,8 @@ use Symfony\CS\Utils;
  */
 class FixCommand extends Command
 {
+    const COMMAND_NAME = 'fix';
+
     const EXIT_STATUS_FLAG_HAS_INVALID_CONFIG = 16;
     const EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG = 32;
 
@@ -104,7 +106,7 @@ class FixCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('fix')
+            ->setName(self::COMMAND_NAME)
             ->setDefinition(
                 array(
                     new InputArgument('path', InputArgument::OPTIONAL, 'The path', null),
@@ -300,10 +302,6 @@ EOF
             ? $output->getErrorOutput()
             : ('txt' === $input->getOption('format') ? $output : null)
         ;
-
-        if (null !== $stdErr && extension_loaded('xdebug')) {
-            $stdErr->writeln(sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', 'You are running php-cs-fixer with xdebug enabled. This has a major impact on runtime performance.'));
-        }
 
         $verbosity = $output->getVerbosity();
 

--- a/Symfony/CS/Console/Command/ReadmeCommand.php
+++ b/Symfony/CS/Console/Command/ReadmeCommand.php
@@ -21,13 +21,15 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ReadmeCommand extends Command
 {
+    const COMMAND_NAME = 'readme';
+
     /**
      * @see Command
      */
     protected function configure()
     {
         $this
-            ->setName('readme')
+            ->setName(self::COMMAND_NAME)
             ->setDescription('Generates the README content, based on the fix command help')
         ;
     }

--- a/Symfony/CS/Console/Command/SelfUpdateCommand.php
+++ b/Symfony/CS/Console/Command/SelfUpdateCommand.php
@@ -27,13 +27,15 @@ use Symfony\CS\ToolInfo;
  */
 class SelfUpdateCommand extends Command
 {
+    const COMMAND_NAME = 'self-update';
+
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
         $this
-            ->setName('self-update')
+            ->setName(self::COMMAND_NAME)
             ->setAliases(array('selfupdate'))
             ->setDefinition(
                 array(

--- a/Symfony/CS/Console/WarningsDetector.php
+++ b/Symfony/CS/Console/WarningsDetector.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\CS\Console;
+
+use Symfony\CS\ToolInfo;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class WarningsDetector
+{
+    /**
+     * @var string[]
+     */
+    private $warnings = array();
+
+    public function detectOldMajor()
+    {
+        // @TODO to be removed at v2
+        $this->warnings[] = 'You are running PHP CS Fixer v1, which is not maintained anymore. Please update to v2.';
+
+        // @TODO to be activated at v3
+        // $this->warnings[] = 'You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.';
+    }
+
+    public function detectOldVendor()
+    {
+        if (ToolInfo::isInstalledByComposer()) {
+            $details = ToolInfo::getComposerInstallationDetails();
+            if (ToolInfo::COMPOSER_LEGACY_PACKAGE_NAME === $details['name']) {
+                $this->warnings[] = sprintf(
+                    'You are running PHP CS Fixer installed with old vendor `%s`. Please update to `%s`.',
+                    ToolInfo::COMPOSER_LEGACY_PACKAGE_NAME,
+                    ToolInfo::COMPOSER_PACKAGE_NAME
+                );
+            }
+        }
+    }
+
+    public function detectXdebug()
+    {
+        if (extension_loaded('xdebug')) {
+            $this->warnings[] = 'You are running PHP CS Fixer with xdebug enabled. This has a major impact on runtime performance.';
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getWarnings()
+    {
+        if (!count($this->warnings)) {
+            return array();
+        }
+
+        return array_unique(array_merge(
+            $this->warnings,
+            array('If you need help while solving warnings, ask at https://gitter.im/FriendsOfPHP/PHP-CS-Fixer, we will help you!')
+        ));
+    }
+}

--- a/Symfony/CS/ToolInfo.php
+++ b/Symfony/CS/ToolInfo.php
@@ -19,7 +19,11 @@ namespace Symfony\CS;
  */
 class ToolInfo
 {
+    /**
+     * @deprecated
+     */
     const COMPOSER_INSTALLED_FILE = '/../../composer/installed.json';
+
     const COMPOSER_PACKAGE_NAME = 'friendsofphp/php-cs-fixer';
 
     public static function getComposerVersion()
@@ -27,11 +31,11 @@ class ToolInfo
         static $result;
 
         if (!self::isInstalledByComposer()) {
-            throw new \LogicException('Can not get composer version for tool not installed by composer.');
+            throw new \LogicException('Cannot get composer version for tool not installed by composer.');
         }
 
         if (null === $result) {
-            $composerInstalled = json_decode(file_get_contents(self::getScriptDir().self::COMPOSER_INSTALLED_FILE), true);
+            $composerInstalled = json_decode(file_get_contents(self::getComposerInstalledFile()), true);
 
             foreach ($composerInstalled as $package) {
                 if (self::COMPOSER_PACKAGE_NAME === $package['name']) {
@@ -69,33 +73,14 @@ class ToolInfo
         static $result;
 
         if (null === $result) {
-            $result = !self::isInstalledAsPhar() && file_exists(self::getScriptDir().self::COMPOSER_INSTALLED_FILE);
+            $result = !self::isInstalledAsPhar() && file_exists(self::getComposerInstalledFile());
         }
 
         return $result;
     }
 
-    private static function getScriptDir()
+    private static function getComposerInstalledFile()
     {
-        static $result;
-
-        if (null === $result) {
-            $script = $_SERVER['SCRIPT_NAME'];
-
-            if (is_link($script)) {
-                $linkTarget = readlink($script);
-
-                // If the link target is relative to the link
-                if (false === realpath($linkTarget)) {
-                    $linkTarget = dirname($script).'/'.$linkTarget;
-                }
-
-                $script = $linkTarget;
-            }
-
-            $result = dirname($script);
-        }
-
-        return $result;
+        return __DIR__.'/../../../composer/installed.json';
     }
 }

--- a/Symfony/CS/ToolInfo.php
+++ b/Symfony/CS/ToolInfo.php
@@ -26,7 +26,15 @@ class ToolInfo
 
     const COMPOSER_PACKAGE_NAME = 'friendsofphp/php-cs-fixer';
 
-    public static function getComposerVersion()
+    /**
+     * @internal
+     */
+    const COMPOSER_LEGACY_PACKAGE_NAME = 'fabpot/php-cs-fixer';
+
+    /**
+     * @internal
+     */
+    public static function getComposerInstallationDetails()
     {
         static $result;
 
@@ -38,11 +46,26 @@ class ToolInfo
             $composerInstalled = json_decode(file_get_contents(self::getComposerInstalledFile()), true);
 
             foreach ($composerInstalled as $package) {
-                if (self::COMPOSER_PACKAGE_NAME === $package['name']) {
-                    $result = $package['version'].'#'.$package['dist']['reference'];
+                if (
+                    self::COMPOSER_PACKAGE_NAME === $package['name'] ||
+                    self::COMPOSER_LEGACY_PACKAGE_NAME === $package['name']
+                ) {
+                    $result = $package;
                     break;
                 }
             }
+        }
+
+        return $result;
+    }
+
+    public static function getComposerVersion()
+    {
+        static $result;
+
+        if (null === $result) {
+            $package = self::getComposerInstallationDetails();
+            $result = $package['version'].'#'.$package['dist']['reference'];
         }
 
         return $result;

--- a/Symfony/CS/ToolInfo.php
+++ b/Symfony/CS/ToolInfo.php
@@ -46,10 +46,7 @@ class ToolInfo
             $composerInstalled = json_decode(file_get_contents(self::getComposerInstalledFile()), true);
 
             foreach ($composerInstalled as $package) {
-                if (
-                    self::COMPOSER_PACKAGE_NAME === $package['name'] ||
-                    self::COMPOSER_LEGACY_PACKAGE_NAME === $package['name']
-                ) {
+                if (in_array($package['name'], array(self::COMPOSER_PACKAGE_NAME, self::COMPOSER_LEGACY_PACKAGE_NAME), true)) {
                     $result = $package;
                     break;
                 }

--- a/Symfony/CS/ToolInfo.php
+++ b/Symfony/CS/ToolInfo.php
@@ -104,6 +104,6 @@ class ToolInfo
 
     private static function getComposerInstalledFile()
     {
-        return __DIR__.'/../../../composer/installed.json';
+        return __DIR__.'/../../../../composer/installed.json';
     }
 }


### PR DESCRIPTION
When instlaled via composer, there are about:
- 2500 daily installation with old vendor name (regardless of version)
- 3000 daily installation of v1 (with new vendor name)

For that, we have >5k daily downloads of version we do not support.
Let us try to reduce that numer.