### PR TITLE
AccessibleObject - remove most of usage

### DIFF
--- a/src/AbstractFunctionReferenceFixer.php
+++ b/src/AbstractFunctionReferenceFixer.php
@@ -33,20 +33,6 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
     }
 
     /**
-     * Count amount of parameters in a function/method reference.
-     *
-     * @param Tokens $tokens
-     * @param int    $openParenthesis
-     * @param int    $closeParenthesis
-     *
-     * @return int
-     */
-    protected function countArguments(Tokens $tokens, $openParenthesis, $closeParenthesis)
-    {
-        return count($this->getArguments($tokens, $openParenthesis, $closeParenthesis));
-    }
-
-    /**
      * Looks up Tokens sequence for suitable candidates and delivers boundaries information,
      * which can be supplied by other methods in this abstract class.
      *
@@ -96,53 +82,5 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
         $closeParenthesis = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis);
 
         return array($functionName, $openParenthesis, $closeParenthesis);
-    }
-
-    /**
-     * Returns start and end token indexes of arguments.
-     *
-     * Return an array which each index being the first token af an
-     * argument and the value the last. Including non-function tokens
-     * such as comments and white space tokens, but without the separation
-     * tokens like '(', ',' and ')'.
-     *
-     * @param Tokens $tokens
-     * @param int    $openParenthesis
-     * @param int    $closeParenthesis
-     *
-     * @return array<int, int>
-     */
-    protected function getArguments(Tokens $tokens, $openParenthesis, $closeParenthesis)
-    {
-        $arguments = array();
-        $firstSensibleToken = $tokens->getNextMeaningfulToken($openParenthesis);
-        if ($tokens[$firstSensibleToken]->equals(')')) {
-            return $arguments;
-        }
-
-        $paramContentIndex = $openParenthesis + 1;
-        $argumentsStart = $paramContentIndex;
-        for (; $paramContentIndex < $closeParenthesis; ++$paramContentIndex) {
-            $token = $tokens[$paramContentIndex];
-
-            // skip nested (), [], {} constructs
-            $blockDefinitionProbe = Tokens::detectBlockType($token);
-
-            if (null !== $blockDefinitionProbe && true === $blockDefinitionProbe['isStart']) {
-                $paramContentIndex = $tokens->findBlockEnd($blockDefinitionProbe['type'], $paramContentIndex);
-
-                continue;
-            }
-
-            // if comma matched, increase arguments counter
-            if ($token->equals(',')) {
-                $arguments[$argumentsStart] = $paramContentIndex - 1;
-                $argumentsStart = $paramContentIndex + 1;
-            }
-        }
-
-        $arguments[$argumentsStart] = $paramContentIndex - 1;
-
-        return $arguments;
     }
 }

--- a/src/ConfigurationException/InvalidConfigurationException.php
+++ b/src/ConfigurationException/InvalidConfigurationException.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\ConfigurationException;
 
-use PhpCsFixer\Console\Command\FixCommand;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 
 /**
  * Exceptions of this type are thrown on misconfiguration of the Fixer.
@@ -32,7 +32,7 @@ class InvalidConfigurationException extends \InvalidArgumentException
     {
         parent::__construct(
             $message,
-            null === $code ? FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG : $code,
+            null === $code ? FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG : $code,
             $previous
         );
     }

--- a/src/ConfigurationException/InvalidFixerConfigurationException.php
+++ b/src/ConfigurationException/InvalidFixerConfigurationException.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\ConfigurationException;
 
-use PhpCsFixer\Console\Command\FixCommand;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 
 /**
  * Exception thrown by Fixers on misconfiguration.
@@ -37,7 +37,7 @@ class InvalidFixerConfigurationException extends InvalidConfigurationException
     {
         parent::__construct(
             sprintf('[%s] %s', $fixerName, $message),
-            FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG,
+            FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG,
             $previous
         );
         $this->fixerName = $fixerName;

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -38,13 +38,6 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class FixCommand extends Command
 {
-    // Exit status 1 is reserved for environment constraints not matched.
-    const EXIT_STATUS_FLAG_HAS_INVALID_FILES = 4;
-    const EXIT_STATUS_FLAG_HAS_CHANGED_FILES = 8;
-    const EXIT_STATUS_FLAG_HAS_INVALID_CONFIG = 16;
-    const EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG = 32;
-    const EXIT_STATUS_FLAG_EXCEPTION_IN_APP = 64;
-
     /**
      * EventDispatcher instance.
      *
@@ -247,40 +240,13 @@ final class FixCommand extends Command
             }
         }
 
-        return $this->calculateExitStatus(
+        $exitStatusCalculator = new FixCommandExitStatusCalculator();
+
+        return $exitStatusCalculator->calculate(
             $resolver->isDryRun(),
             count($changed) > 0,
             count($invalidErrors) > 0,
             count($exceptionErrors) > 0
         );
-    }
-
-    /**
-     * @param bool $isDryRun
-     * @param bool $hasChangedFiles
-     * @param bool $hasInvalidErrors
-     * @param bool $hasExceptionErrors
-     *
-     * @return int
-     */
-    private function calculateExitStatus($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
-    {
-        $exitStatus = 0;
-
-        if ($isDryRun) {
-            if ($hasChangedFiles) {
-                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_CHANGED_FILES;
-            }
-
-            if ($hasInvalidErrors) {
-                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_INVALID_FILES;
-            }
-        }
-
-        if ($hasExceptionErrors) {
-            $exitStatus |= self::EXIT_STATUS_FLAG_EXCEPTION_IN_APP;
-        }
-
-        return $exitStatus;
     }
 }

--- a/src/Console/Command/FixCommandExitStatusCalculator.php
+++ b/src/Console/Command/FixCommandExitStatusCalculator.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Console\Command;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class FixCommandExitStatusCalculator
+{
+    // Exit status 1 is reserved for environment constraints not matched.
+    const EXIT_STATUS_FLAG_HAS_INVALID_FILES = 4;
+    const EXIT_STATUS_FLAG_HAS_CHANGED_FILES = 8;
+    const EXIT_STATUS_FLAG_HAS_INVALID_CONFIG = 16;
+    const EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG = 32;
+    const EXIT_STATUS_FLAG_EXCEPTION_IN_APP = 64;
+
+    /**
+     * @param bool $isDryRun
+     * @param bool $hasChangedFiles
+     * @param bool $hasInvalidErrors
+     * @param bool $hasExceptionErrors
+     *
+     * @return int
+     */
+    public function calculate($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
+    {
+        $exitStatus = 0;
+
+        if ($isDryRun) {
+            if ($hasChangedFiles) {
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_CHANGED_FILES;
+            }
+
+            if ($hasInvalidErrors) {
+                $exitStatus |= self::EXIT_STATUS_FLAG_HAS_INVALID_FILES;
+            }
+        }
+
+        if ($hasExceptionErrors) {
+            $exitStatus |= self::EXIT_STATUS_FLAG_EXCEPTION_IN_APP;
+        }
+
+        return $exitStatus;
+    }
+}

--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Alias;
 use PhpCsFixer\AbstractFunctionReferenceFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -84,6 +85,7 @@ $a = substr_count($a, $b);
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
         foreach (self::$functions as $functionIdentity => $functionReplacement) {
             $currIndex = 0;
             while (null !== $currIndex) {
@@ -95,7 +97,7 @@ $a = substr_count($a, $b);
                 }
 
                 list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
-                $count = $this->countArguments($tokens, $openParenthesis, $closeParenthesis);
+                $count = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
                 if (!in_array($count, $functionReplacement['argumentCount'], true)) {
                     continue 2;
                 }

--- a/src/Fixer/Alias/PowToExponentiationFixer.php
+++ b/src/Fixer/Alias/PowToExponentiationFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFunctionReferenceFixer;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -67,6 +68,7 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $candidates = $this->findPowCalls($tokens);
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
 
         $numberOfTokensAdded = 0;
         $previousCloseParenthesisIndex = count($tokens);
@@ -82,7 +84,7 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
                 $numberOfTokensAdded = 0;
             }
 
-            $arguments = $this->getArguments($tokens, $candidate[1], $candidate[2]);
+            $arguments = $argumentsAnalyzer->getArguments($tokens, $candidate[1], $candidate[2]);
             if (2 !== count($arguments)) {
                 continue;
             }

--- a/src/Fixer/Alias/RandomApiMigrationFixer.php
+++ b/src/Fixer/Alias/RandomApiMigrationFixer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverRootless;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
@@ -84,6 +85,8 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+
         foreach ($this->configuration['replacements'] as $functionIdentity => $functionReplacement) {
             if ($functionIdentity === $functionReplacement['alternativeName']) {
                 continue;
@@ -99,7 +102,7 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
                 }
 
                 list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
-                $count = $this->countArguments($tokens, $openParenthesis, $closeParenthesis);
+                $count = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
                 if (!in_array($count, $functionReplacement['argumentCount'], true)) {
                     continue 2;
                 }

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\CastNotation;
 use PhpCsFixer\AbstractFunctionReferenceFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -68,6 +69,8 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
              'boolval' => array(T_BOOL_CAST, '(bool)'),
         );
 
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+
         foreach ($replacement as $functionIdentity => $newToken) {
             $currIndex = 0;
             while (null !== $currIndex) {
@@ -84,7 +87,7 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
                 $currIndex = $openParenthesis;
 
                 // indicator that the function is overriden
-                if (1 !== $this->countArguments($tokens, $openParenthesis, $closeParenthesis)) {
+                if (1 !== $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis)) {
                     continue;
                 }
 

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -100,6 +101,8 @@ function f9(string $foo, $bar, $baz) {}',
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+
         for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
             $mainIndex = $index;
             $token = $tokens[$index];
@@ -146,7 +149,7 @@ function f9(string $foo, $bar, $baz) {}',
 
             $arguments = array();
 
-            foreach ($this->getArguments($tokens, $openIndex, $index) as $start => $end) {
+            foreach ($argumentsAnalyzer->getArguments($tokens, $openIndex, $index) as $start => $end) {
                 $argumentInfo = $this->prepareArgumentInformation($tokens, $start, $end);
 
                 if (!$this->configuration['only_untyped'] || '' === $argumentInfo['type']) {

--- a/src/Report/ReporterFactory.php
+++ b/src/Report/ReporterFactory.php
@@ -80,7 +80,10 @@ final class ReporterFactory
      */
     public function getFormats()
     {
-        return array_keys($this->reporters);
+        $formats = array_keys($this->reporters);
+        sort($formats);
+
+        return $formats;
     }
 
     /**

--- a/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author Vladimir Reznichenko <kalessil@gmail.com>
+ *
+ * @internal
+ */
+final class ArgumentsAnalyzer
+{
+    /**
+     * Count amount of parameters in a function/method reference.
+     *
+     * @param Tokens $tokens
+     * @param int    $openParenthesis
+     * @param int    $closeParenthesis
+     *
+     * @return int
+     */
+    public function countArguments(Tokens $tokens, $openParenthesis, $closeParenthesis)
+    {
+        return count($this->getArguments($tokens, $openParenthesis, $closeParenthesis));
+    }
+
+    /**
+     * Returns start and end token indexes of arguments.
+     *
+     * Return an array which each index being the first token af an
+     * argument and the value the last. Including non-function tokens
+     * such as comments and white space tokens, but without the separation
+     * tokens like '(', ',' and ')'.
+     *
+     * @param Tokens $tokens
+     * @param int    $openParenthesis
+     * @param int    $closeParenthesis
+     *
+     * @return array<int, int>
+     */
+    public function getArguments(Tokens $tokens, $openParenthesis, $closeParenthesis)
+    {
+        $arguments = array();
+        $firstSensibleToken = $tokens->getNextMeaningfulToken($openParenthesis);
+        if ($tokens[$firstSensibleToken]->equals(')')) {
+            return $arguments;
+        }
+
+        $paramContentIndex = $openParenthesis + 1;
+        $argumentsStart = $paramContentIndex;
+        for (; $paramContentIndex < $closeParenthesis; ++$paramContentIndex) {
+            $token = $tokens[$paramContentIndex];
+
+            // skip nested (), [], {} constructs
+            $blockDefinitionProbe = Tokens::detectBlockType($token);
+
+            if (null !== $blockDefinitionProbe && true === $blockDefinitionProbe['isStart']) {
+                $paramContentIndex = $tokens->findBlockEnd($blockDefinitionProbe['type'], $paramContentIndex);
+
+                continue;
+            }
+
+            // if comma matched, increase arguments counter
+            if ($token->equals(',')) {
+                $arguments[$argumentsStart] = $paramContentIndex - 1;
+                $argumentsStart = $paramContentIndex + 1;
+            }
+        }
+
+        $arguments[$argumentsStart] = $paramContentIndex - 1;
+
+        return $arguments;
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -36,6 +36,7 @@ final class ProjectCodeTest extends TestCase
      */
     private static $classesWithoutTests = array(
         'PhpCsFixer\ConfigurationException\InvalidForEnvFixerConfigurationException',
+        'PhpCsFixer\Console\Command\FixCommand',
         'PhpCsFixer\Console\Command\SelfUpdateCommand',
         'PhpCsFixer\Console\Output\NullOutput',
         'PhpCsFixer\Differ\DiffConsoleFormatter',

--- a/tests/ConfigurationException/InvalidConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidConfigurationExceptionTest.php
@@ -13,7 +13,7 @@
 namespace PhpCsFixer\Tests\ConfigurationException;
 
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
-use PhpCsFixer\Console\Command\FixCommand;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -39,7 +39,7 @@ final class InvalidConfigurationExceptionTest extends TestCase
         $exception = new InvalidConfigurationException($message);
 
         $this->assertSame($message, $exception->getMessage());
-        $this->assertSame(FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG, $exception->getCode());
+        $this->assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_CONFIG, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }
 

--- a/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
@@ -13,7 +13,7 @@
 namespace PhpCsFixer\Tests\ConfigurationException;
 
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
-use PhpCsFixer\Console\Command\FixCommand;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -37,7 +37,7 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
 
         $this->assertInstanceOf('PhpCsFixer\ConfigurationException\InvalidConfigurationException', $exception);
         $this->assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        $this->assertSame(FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        $this->assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
         $this->assertSame($fixerName, $exception->getFixerName());
         $this->assertNull($exception->getPrevious());
     }
@@ -56,7 +56,7 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
 
         $this->assertInstanceOf('PhpCsFixer\ConfigurationException\InvalidConfigurationException', $exception);
         $this->assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        $this->assertSame(FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        $this->assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
         $this->assertSame($fixerName, $exception->getFixerName());
         $this->assertSame($previous, $exception->getPrevious());
     }

--- a/tests/ConfigurationException/RequiredFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/RequiredFixerConfigurationExceptionTest.php
@@ -13,7 +13,7 @@
 namespace PhpCsFixer\Tests\ConfigurationException;
 
 use PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException;
-use PhpCsFixer\Console\Command\FixCommand;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -46,7 +46,7 @@ final class RequiredFixerConfigurationExceptionTest extends TestCase
         );
 
         $this->assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        $this->assertSame(FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        $this->assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
         $this->assertNull($exception->getPrevious());
     }
 
@@ -63,7 +63,7 @@ final class RequiredFixerConfigurationExceptionTest extends TestCase
         );
 
         $this->assertSame(sprintf('[%s] %s', $fixerName, $message), $exception->getMessage());
-        $this->assertSame(FixCommand::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
+        $this->assertSame(FixCommandExitStatusCalculator::EXIT_STATUS_FLAG_HAS_INVALID_FIXER_CONFIG, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
     }
 }

--- a/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
+++ b/tests/Console/Command/FixCommandExitStatusCalculatorTest.php
@@ -12,8 +12,7 @@
 
 namespace PhpCsFixer\Tests\Console\Command;
 
-use PhpCsFixer\Console\Command\FixCommand;
-use PhpCsFixer\Test\AccessibleObject;
+use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,9 +21,9 @@ use PHPUnit\Framework\TestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Console\Command\FixCommand
+ * @covers \PhpCsFixer\Console\Command\FixCommandExitStatusCalculator
  */
-final class FixCommandTest extends TestCase
+final class FixCommandExitStatusCalculatorTest extends TestCase
 {
     /**
      * @param int  $expected
@@ -33,19 +32,19 @@ final class FixCommandTest extends TestCase
      * @param bool $hasInvalidErrors
      * @param bool $hasExceptionErrors
      *
-     * @dataProvider provideCalculateExitStatusCases
+     * @dataProvider provideCalculateCases
      */
-    public function testCalculateExitStatus($expected, $isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
+    public function testCalculate($expected, $isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
     {
-        $command = new AccessibleObject(new FixCommand());
+        $calculator = new FixCommandExitStatusCalculator();
 
         $this->assertSame(
             $expected,
-            $command->calculateExitStatus($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
+            $calculator->calculate($isDryRun, $hasChangedFiles, $hasInvalidErrors, $hasExceptionErrors)
         );
     }
 
-    public function provideCalculateExitStatusCases()
+    public function provideCalculateCases()
     {
         return array(
             array(0, true, false, false, false),

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -12,7 +12,6 @@
 
 namespace PhpCsFixer\Tests\Fixer\Comment;
 
-use PhpCsFixer\Test\AccessibleObject;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\WhitespacesFixerConfig;
@@ -309,18 +308,18 @@ echo \'x\';',
 
     public function testDefaultConfiguration()
     {
-        $fixer = new AccessibleObject($this->fixer);
         $this->fixer->configure(array('header' => 'a'));
-        $this->assertSame(
-            array(
-                'commentType' => 'comment',
-                'location' => 'after_declare_strict',
-                'separate' => 'both',
-                'header' => 'a',
-            ),
-            $fixer->configuration
+        $this->doTest(
+            '<?php
+
+/*
+ * a
+ */
+
+echo 1;',
+            '<?php
+echo 1;'
         );
-        $this->assertSame("/*\n * a\n */", $fixer->getHeaderAsComment());
     }
 
     /**
@@ -401,13 +400,19 @@ echo \'x\';',
      */
     public function testHeaderGeneration($expected, $header, $type)
     {
-        $fixer = new AccessibleObject($this->fixer);
         $this->fixer->configure(array(
             'header' => $header,
             'commentType' => $type,
         ));
+        $this->doTest(
+            '<?php
 
-        $this->assertSame($expected, $fixer->getHeaderAsComment());
+'.$expected.'
+
+echo 1;',
+            '<?php
+echo 1;'
+        );
     }
 
     public function provideHeaderGenerationCases()

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -13,7 +13,6 @@
 namespace PhpCsFixer\Tests\Report;
 
 use PhpCsFixer\Report\ReporterFactory;
-use PhpCsFixer\Test\AccessibleObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -47,11 +46,14 @@ final class ReporterFactoryTest extends TestCase
     public function testRegisterBuiltInReports()
     {
         $builder = new ReporterFactory();
+
+        $this->assertCount(0, $builder->getFormats());
+
         $builder->registerBuiltInReporters();
-
-        $accessibleFactory = new AccessibleObject($builder);
-
-        $this->assertGreaterThan(0, count($accessibleFactory->reporters));
+        $this->assertSame(
+            ['json', 'junit', 'txt', 'xml'],
+            $builder->getFormats()
+        );
     }
 
     public function testThatCanRegisterAndGetReports()

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -51,7 +51,7 @@ final class ReporterFactoryTest extends TestCase
 
         $builder->registerBuiltInReporters();
         $this->assertSame(
-            ['json', 'junit', 'txt', 'xml'],
+            array('json', 'junit', 'txt', 'xml'),
             $builder->getFormats()
         );
     }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -18,7 +18,6 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\RuleSet;
-use PhpCsFixer\Test\AccessibleObject;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -194,24 +193,22 @@ abstract class AbstractFixerTestCase extends TestCase
     private function assertTokens(Tokens $expectedTokens, Tokens $inputTokens)
     {
         foreach ($expectedTokens as $index => $expectedToken) {
-            $inputToken = $inputTokens[$index];
             $option = array('JSON_PRETTY_PRINT');
+            $inputToken = $inputTokens[$index];
+
             $this->assertTrue(
                 $expectedToken->equals($inputToken),
                 sprintf("The token at index %d must be:\n%s,\ngot:\n%s.", $index, $expectedToken->toJson($option), $inputToken->toJson($option))
             );
-        }
 
-        $this->assertSame($expectedTokens->count(), $inputTokens->count(), 'The collection must have the same length than the expected one.');
-
-        $foundTokenKinds = array_keys(AccessibleObject::create($expectedTokens)->foundTokenKinds);
-
-        foreach ($foundTokenKinds as $tokenKind) {
+            $expectedTokenKind = $expectedToken->isArray() ? $expectedToken->getId() : $expectedToken->getContent();
             $this->assertTrue(
-                $inputTokens->isTokenKindFound($tokenKind),
-                sprintf('The token kind %s must be found in fixed tokens collection.', $tokenKind)
+                $inputTokens->isTokenKindFound($expectedTokenKind),
+                sprintf('The token kind %s must be found in fixed tokens collection.', $expectedTokenKind)
             );
         }
+
+        $this->assertSame($expectedTokens->count(), $inputTokens->count(), 'Both collections must have the same length.');
     }
 
     /**

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -10,9 +10,9 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\Tests;
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer;
 
-use PhpCsFixer\Test\AccessibleObject;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
 
@@ -21,9 +21,9 @@ use PHPUnit\Framework\TestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\AbstractFunctionReferenceFixer
+ * @covers \PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer
  */
-final class AbstractFunctionReferenceFixerTest extends TestCase
+final class ArgumentsAnalyzerTest extends TestCase
 {
     /**
      * @param string $code
@@ -33,13 +33,13 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
      *
      * @dataProvider provideCases
      */
-    public function testCountArguments($code, $openIndex, $closeIndex, array $arguments)
+    public function testArguments($code, $openIndex, $closeIndex, array $arguments)
     {
         $tokens = Tokens::fromCode($code);
-        $mock = new AccessibleObject($this->getMockForAbstractClass('\\PhpCsFixer\\AbstractFunctionReferenceFixer'));
+        $analyzer = new ArgumentsAnalyzer();
 
-        $this->assertSame(count($arguments), $mock->countArguments($tokens, $openIndex, $closeIndex));
-        $this->assertSame($arguments, $mock->getArguments($tokens, $openIndex, $closeIndex));
+        $this->assertSame(count($arguments), $analyzer->countArguments($tokens, $openIndex, $closeIndex));
+        $this->assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
     public function provideCases()


### PR DESCRIPTION
Get rid of `AccessibleObject` usage.
The only remaining one on 2.2 branch is in `RuleSetTest`, which shall be removed with proper decoupling in #2884 