### PR TITLE
BlankLineBeforeStatementFixer - Reference fixer instead of test class

### DIFF
--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -20,7 +20,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\WhitespacesFixerConfig;
 
 /**
- * @deprecated since 2.4, replaced by BlankLineBeforeStatementFixerTest
+ * @deprecated since 2.4, replaced by BlankLineBeforeStatementFixer
  *
  * @todo To be removed at 3.0
  *


### PR DESCRIPTION
This PR

* [x] updates a comment to reference fixer instead of the test class

Follows #2384.