### PR TITLE
BlankLineBeforeStatementFixer - Add more statements

### DIFF
--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -43,6 +43,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
         'exit' => T_EXIT,
         'for' => T_FOR,
         'foreach' => T_FOREACH,
+        'goto' => T_GOTO,
         'if' => T_IF,
         'include' => T_INCLUDE,
         'include_once' => T_INCLUDE_ONCE,
@@ -149,6 +150,19 @@ if ($foo === false) {
 ',
                     [
                         'statements' => ['exit'],
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+if ($foo === false) {
+    goto a;
+} else {
+    $bar = 9000;
+    goto b;
+}
+',
+                    [
+                        'statements' => ['goto'],
                     ]
                 ),
                 new CodeSample(

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -38,6 +38,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
         'break' => T_BREAK,
         'continue' => T_CONTINUE,
         'declare' => T_DECLARE,
+        'die' => T_EXIT,
         'do' => T_DO,
         'exit' => T_EXIT,
         'for' => T_FOR,
@@ -111,6 +112,19 @@ foreach ($foo as $bar) {
 }',
                     [
                         'statements' => ['continue'],
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+if ($foo === false) {
+    die(0);
+} else {
+    $bar = 9000;
+    die(1);
+}
+',
+                    [
+                        'statements' => ['die'],
                     ]
                 ),
                 new CodeSample(

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -153,6 +153,8 @@ if ($foo === false) {
                 ),
                 new CodeSample(
                     '<?php
+a:
+
 if ($foo === false) {
     goto a;
 } else {

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -122,8 +122,7 @@ if ($foo === false) {
 } else {
     $bar = 9000;
     die(1);
-}
-',
+}',
                     [
                         'statements' => ['die'],
                     ]
@@ -146,8 +145,7 @@ if ($foo === false) {
 } else {
     $bar = 9000;
     exit(1);
-}
-',
+}',
                     [
                         'statements' => ['exit'],
                     ]
@@ -159,8 +157,7 @@ if ($foo === false) {
 } else {
     $bar = 9000;
     goto b;
-}
-',
+}',
                     [
                         'statements' => ['goto'],
                     ]

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -128,7 +128,7 @@ do {
                     '<?php
 if ($foo === false) {
     exit(0);
-else {
+} else {
     $bar = 9000;
     exit(1);
 }

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -39,6 +39,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
         'continue' => T_CONTINUE,
         'declare' => T_DECLARE,
         'do' => T_DO,
+        'exit' => T_EXIT,
         'for' => T_FOR,
         'foreach' => T_FOREACH,
         'if' => T_IF,
@@ -121,6 +122,19 @@ do {
 ',
                     [
                         'statements' => ['do'],
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+if ($foo === false) {
+    exit(0);
+else {
+    $bar = 9000;
+    exit(1);
+}
+',
+                    [
+                        'statements' => ['exit'],
                     ]
                 ),
                 new CodeSample(

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -54,6 +54,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
         'throw' => T_THROW,
         'try' => T_TRY,
         'while' => T_WHILE,
+        'yield' => T_YIELD,
     ];
 
     /**
@@ -214,6 +215,17 @@ try {
 }',
                     [
                         'statements' => ['try'],
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+
+if (true) {
+    $foo = $bar;
+    yield $foo;
+}',
+                    [
+                        'statements' => ['yield'],
                     ]
                 ),
             ]

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -474,7 +474,6 @@ if ($foo === $bar) {
             ],
         ];
     }
-
     /**
      * @dataProvider providerFixWithFor
      *
@@ -503,6 +502,56 @@ if ($foo === $bar) {
                     echo 1;
                     for(;;){break;}
                 ',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFixWithGoto
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithGoto($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['goto'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+    /**
+     * @return array
+     */
+    public function providerFixWithGoto()
+    {
+        return [
+            [
+                '<?php
+if ($foo === $bar) {
+    goto a;
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    goto a;
+}',
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+    goto a;
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    goto a;
+}',
             ],
         ];
     }

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -307,6 +307,71 @@ declare(ticks=1);',
     }
 
     /**
+     * @dataProvider providerFixWithDie
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithDie($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['die'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+
+    /**
+     * @return array
+     */
+    public function providerFixWithDie()
+    {
+        return [
+            [
+                '<?php
+if ($foo === $bar) {
+    die();
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    die();
+}',
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+    die();
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    die();
+}',
+            ],
+            [
+                '<?php
+mysqli_connect() or die();
+',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    $bar = 9001;
+    mysqli_connect() or die();
+}
+',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider providerFixWithDo
      *
      * @param string      $expected
@@ -346,6 +411,7 @@ do {
         ];
     }
 
+
     /**
      * @dataProvider providerFixWithExit
      *
@@ -360,8 +426,6 @@ do {
 
         $this->doTest($expected, $input);
     }
-
-
     /**
      * @return array
      */

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -526,7 +526,7 @@ if ($foo === $bar) {
             [
                 '<?php
 a:
-                
+
 if ($foo === $bar) {
     goto a;
 }',
@@ -534,7 +534,7 @@ if ($foo === $bar) {
             [
                 '<?php
 a:
-                
+
 if ($foo === $bar) {
     echo $baz;
 

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -357,16 +357,14 @@ if ($foo === $bar) {
             ],
             [
                 '<?php
-mysqli_connect() or die();
-',
+mysqli_connect() or die();',
             ],
             [
                 '<?php
 if ($foo === $bar) {
     $bar = 9001;
     mysqli_connect() or die();
-}
-',
+}',
             ],
         ];
     }
@@ -461,16 +459,14 @@ if ($foo === $bar) {
             ],
             [
                 '<?php
-mysqli_connect() or exit();
-',
+mysqli_connect() or exit();',
             ],
             [
                 '<?php
 if ($foo === $bar) {
     $bar = 9001;
     mysqli_connect() or exit();
-}
-',
+}',
             ],
         ];
     }

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -321,7 +321,6 @@ declare(ticks=1);',
         $this->doTest($expected, $input);
     }
 
-
     /**
      * @return array
      */
@@ -409,7 +408,6 @@ do {
         ];
     }
 
-
     /**
      * @dataProvider providerFixWithExit
      *
@@ -424,6 +422,7 @@ do {
 
         $this->doTest($expected, $input);
     }
+
     /**
      * @return array
      */
@@ -470,6 +469,7 @@ if ($foo === $bar) {
             ],
         ];
     }
+
     /**
      * @dataProvider providerFixWithFor
      *
@@ -516,6 +516,7 @@ if ($foo === $bar) {
 
         $this->doTest($expected, $input);
     }
+
     /**
      * @return array
      */

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -347,6 +347,71 @@ do {
     }
 
     /**
+     * @dataProvider providerFixWithExit
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithExit($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['exit'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+
+    /**
+     * @return array
+     */
+    public function providerFixWithExit()
+    {
+        return [
+            [
+                '<?php
+if ($foo === $bar) {
+    exit();
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    exit();
+}',
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+    exit();
+}',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    echo $baz;
+
+    exit();
+}',
+            ],
+            [
+                '<?php
+mysqli_connect() or exit();
+',
+            ],
+            [
+                '<?php
+if ($foo === $bar) {
+    $bar = 9001;
+    mysqli_connect() or exit();
+}
+',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider providerFixWithFor
      *
      * @param string      $expected

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -525,18 +525,24 @@ if ($foo === $bar) {
         return [
             [
                 '<?php
+a:
+                
 if ($foo === $bar) {
     goto a;
 }',
             ],
             [
                 '<?php
+a:
+                
 if ($foo === $bar) {
     echo $baz;
 
     goto a;
 }',
                 '<?php
+a:
+
 if ($foo === $bar) {
     echo $baz;
     goto a;
@@ -544,6 +550,8 @@ if ($foo === $bar) {
             ],
             [
                 '<?php
+a:
+
 if ($foo === $bar) {
     echo $baz;
 

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1141,6 +1141,70 @@ do {
     }
 
     /**
+     * @dataProvider providerFixWithYield
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithYield($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['yield'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @yield array
+     */
+    public function providerFixWithYield()
+    {
+        return [
+            [
+                '<?php
+function foo() {
+    yield $a;
+}',
+            ],
+            [
+                '<?php
+function foo() {
+    yield $a;
+
+    yield $b;
+}',
+                '<?php
+function foo() {
+    yield $a;
+    yield $b;
+}',
+            ],
+            [
+                '<?php
+function foo() {
+    $a = $a;
+
+    yield $a;
+}',
+            ],
+            [
+                '<?php
+function foo() {
+    $a = $a;
+
+    yield $a;
+}',
+                '<?php
+function foo() {
+    $a = $a;
+    yield $a;
+}',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideFixWithMultipleConfigStatements
      *
      * @param string[]    $statements


### PR DESCRIPTION
This PR

* [x] adds more statements to the `BlankLineBeforeStatement` fixer
    * [x] `die()`
    * [x] `exit()`
    * [x] `goto`
    * [x] `yield`

Follows #2384.

💁‍♂️ Not sure what I missed out, can you think of any other statements we could/should add?