### PR TITLE
MethodArgumentSpaceFixer - Skip body of fixed function

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -163,6 +163,12 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 continue;
             }
 
+            if ($token->equals('}')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index, false);
+
+                continue;
+            }
+
             if ($token->equals(',')) {
                 $this->fixSpace2($tokens, $index);
                 if (!$isMultiline && $this->isNewline($tokens[$index + 1])) {
@@ -218,6 +224,12 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             // skip nested arrays
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index, false);
+
+                continue;
+            }
+
+            if ($token->equals('}')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index, false);
 
                 continue;
             }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -648,6 +648,39 @@ UNAFFECTED
                 null,
                 ['ensure_fully_multiline' => true],
             ],
+            'test function argument with multiline echo in it' => [
+            <<<'UNAFFECTED'
+<?php
+call_user_func(function ($arguments) {
+    echo 'a',
+      'b';
+}, $argv);
+UNAFFECTED
+            ,
+                null,
+                ['ensure_fully_multiline' => true],
+            ],
+            'test function argument with oneline echo in it' => [
+            <<<'EXPECTED'
+<?php
+call_user_func(
+    function ($arguments) {
+    echo 'a', 'b';
+},
+$argv
+);
+EXPECTED
+            ,
+            <<<'INPUT'
+<?php
+call_user_func(function ($arguments) {
+    echo 'a', 'b';
+},
+$argv);
+INPUT
+            ,
+                ['ensure_fully_multiline' => true],
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixer is supposed to fix arguments, not the body of the function
itself, so just skip it, be it when parsing or when fixing.
Fixes #2958