### PR TITLE
ConfigurationResolver - Fix doubled directory separator

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -729,7 +729,7 @@ final class ConfigurationResolver
             if (is_file($path)) {
                 $pathsByType['file'][] = $path;
             } else {
-                $pathsByType['dir'][] = $path.DIRECTORY_SEPARATOR;
+                $pathsByType['dir'][] = ($path === '/' || substr($path, -1, 1) !== DIRECTORY_SEPARATOR) ? $path : substr($path, 0, strlen($path) - 1);
             }
         }
 

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -134,8 +134,16 @@ final class Runner
             Tokens::clearCache();
 
             if ($fixInfo) {
-                $name = $this->directory->getRelativePathTo($file);
-                $changed[$name] = $fixInfo;
+                $path = $file->getPathname();
+
+                /* workaround for Symfony/Finder setting doubled slash for root folders in
+                SplFileInfo. See `RecursiveDirectoryIterator::current()`. */
+                if (substr($path, 0, 2) === '//') {
+                    $path = substr($path, 1);
+                }
+
+                $path = $this->directory->getRelativePathTo($path);
+                $changed[$path] = $fixInfo;
 
                 if ($this->stopOnViolation) {
                     break;


### PR DESCRIPTION
It seems that `php-cs-fixer` displays annoying double (or even triple for disks'
root folders) slashes after main path on both Windows and Debian:

1. Windows
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run soap
Loaded config default.
Using cache file ".php_cs.cache".
   1) soap\\src\client.php
   2) soap\\src\test\client.php
```

2. Windows, root D:
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run d:
Loaded config default.
Using cache file ".php_cs.cache".
   1) D:\\\broken.php
   2) D:\\\sub1\broken.php
   3) D:\\\sub1\sub2\broken.php
   4) D:\\\sub3\broken.php
   5) D:\\\sub3\sub4\broken.php
```

3. Windows, root D:, with trailing slash:
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run d:\
Loaded config default.
Using cache file ".php_cs.cache".
   1) D:\\\broken.php
   2) D:\\\sub1\broken.php
   3) D:\\\sub1\sub2\broken.php
   4) D:\\\sub3\broken.php
   5) D:\\\sub3\sub4\broken.php
```

4. Windows, with trailing slash:
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run soap/
Loaded config default.
Using cache file ".php_cs.cache".
   1) soap\\src\client.php
   2) soap\\src\test\client.php
```

5. Windows, absolute path:
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run C:\Users\bartosz\idct\soap
Loaded config default.
Using cache file ".php_cs.cache".
   1) soap\\src\client.php
   2) soap\\src\test\client.php
```

6. Windows, absolute path, with trailing slash:
```dos
C:\Users\bartosz\idct>php-cs-fixer fix --dry-run C:\Users\bartosz\idct\soap\
Loaded config default.
Using cache file ".php_cs.cache".
   1) soap\\src\client.php
   2) soap\\src\test\client.php
```

7. Debian
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run ../fail
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail//broken.php
   2) /srv/home/bpacholek/fail//sub/broken.php
```

8. Debian, with trailing slash
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run ../fail/
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail//broken.php
   2) /srv/home/bpacholek/fail//sub/broken.php
```

9. Debian, absolute path
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run /srv/home/bpacholek/fail
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail//broken.php
   2) /srv/home/bpacholek/fail//sub/broken.php
```

10. Debian, absolute path, with trailing slash
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run /srv/home/bpacholek/fail/
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail//broken.php
   2) /srv/home/bpacholek/fail//sub/broken.php
```

It seems that we need not only disable adding of the trailing slash in the
`resolveFinder` of `ConfigurationResolver` but also remove it when added by
`realpath`.

After the change:

__Windows env__

1. Windows
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run ../soap
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) C:\Users\bartosz\idct\soap\src\client.php
   2) C:\Users\bartosz\idct\soap\src\test\client.php
```

2. Windows, root D:
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run d:
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) D:\broken.php
   2) D:\sub1\broken.php
   3) D:\sub1\sub2\broken.php
   4) D:\sub3\broken.php
   5) D:\sub3\sub4\broken.php
```

3. Windows, root D:, with trailing slash:
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run d:\
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) D:\broken.php
   2) D:\sub1\broken.php
   3) D:\sub1\sub2\broken.php
   4) D:\sub3\broken.php
   5) D:\sub3\sub4\broken.php
```

4. Windows, with trailing slash:
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run ../soap/
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) C:\Users\bartosz\idct\soap\src\client.php
   2) C:\Users\bartosz\idct\soap\src\test\client.php
```

5. Windows, absolute path:
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run c:\Users\bartosz\idct\soap
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) C:\Users\bartosz\idct\soap\src\client.php
   2) C:\Users\bartosz\idct\soap\src\test\client.php
```

6. Windows, absolute path, with trailing slash:
```dos
C:\Users\bartosz\idct\fixer>php php-cs-fixer fix --dry-run c:\Users\bartosz\idct\soap\
Loaded config default from "C:\Users\bartosz\idct\fixer\.php_cs.dist".
   1) C:\Users\bartosz\idct\soap\src\client.php
   2) C:\Users\bartosz\idct\soap\src\test\client.php
```

7. Debian:
```bash
Checked all files in 0.269 seconds, 10.500 MB memory used
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run ../fail
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail/broken.php
   2) /srv/home/bpacholek/fail/sub/broken.php
```

8. Debian, with trailing slash:
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run ../fail/
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail/broken.php
   2) /srv/home/bpacholek/fail/sub/broken.php
```

9. Debian, absolute path:
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run /srv/home/bpacholek/fail
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail/broken.php
   2) /srv/home/bpacholek/fail/sub/broken.php
```

10. Debian, absolute path, with trailing slash:
```bash
[bpacholek@dev01 fixer]$ ./php-cs-fixer fix --dry-run /srv/home/bpacholek/fail/
Loaded config default from "/srv/home/bpacholek/fixer/.php_cs.dist".
   1) /srv/home/bpacholek/fail/broken.php
   2) /srv/home/bpacholek/fail/sub/broken.php
```

---

I believe this could be done in a more elegant way for somebody who knows the
code better, yet it solves the problem. _Sorry if I missed something._

`HeaderCommentFixerTest`, `NoWhitespaceInBlankLineFixerTest`, `NoEmptyStatementFixerTest` tests failures are not related to my changes.

I used the branch `2.4` as it is the default one.
