### PR TITLE
AlignMultilineCommentFixer - handle uni code

### DIFF
--- a/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+++ b/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
@@ -117,7 +117,8 @@ with a line not prefixed with asterisk
             }
 
             $indentation = $matches[1];
-            $lines = preg_split('/\R/', $token->getContent());
+            $lines = preg_split('/\R/u', $token->getContent());
+
             foreach ($lines as $lineNumber => $line) {
                 if (0 === $lineNumber) {
                     continue;

--- a/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
@@ -151,6 +151,23 @@ $a = 1;
    //
       //',
             ],
+            'uni code test' => [
+                '<?php
+class A
+{
+    /**
+     * @SWG\Get(
+     *     path="/api/v0/cards",
+     *     operationId="listCards",
+     *     tags={"Банковские карты"},
+     *     summary="Возвращает список банковских карт."
+     *  )
+     */
+    public function indexAction()
+    {
+    }
+}',
+            ],
         ];
     }
 


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2967

target 2.4 as fixer does not exist on lower branches