### PR TITLE
Add Doctrine Annotation ruleset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -347,7 +347,7 @@ Choose from the list of available rules:
 
   *Risky rule: risky when the function ``dirname()`` is overridden.*
 
-* **doctrine_annotation_array_assignment**
+* **doctrine_annotation_array_assignment** [@DoctrineAnnotation]
 
   Doctrine annotations must use configured operator for assignment in
   arrays.
@@ -376,7 +376,7 @@ Choose from the list of available rules:
     'startuml', 'fix', 'FIXME', 'fixme', 'override']``
   - ``operator`` (``':'``, ``'='``): the operator to use; defaults to ``'='``
 
-* **doctrine_annotation_braces**
+* **doctrine_annotation_braces** [@DoctrineAnnotation]
 
   Doctrine annotations without arguments must use the configured syntax.
 
@@ -405,7 +405,7 @@ Choose from the list of available rules:
   - ``syntax`` (``'with_braces'``, ``'without_braces'``): whether to add or remove
     braces; defaults to ``'without_braces'``
 
-* **doctrine_annotation_indentation**
+* **doctrine_annotation_indentation** [@DoctrineAnnotation]
 
   Doctrine annotations must be indented with four spaces.
 
@@ -434,7 +434,7 @@ Choose from the list of available rules:
   - ``indent_mixed_lines`` (``bool``): whether to indent lines that have content
     before closing parenthesis; defaults to ``false``
 
-* **doctrine_annotation_spaces**
+* **doctrine_annotation_spaces** [@DoctrineAnnotation]
 
   Fixes spaces in Doctrine annotations.
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -155,6 +155,16 @@ final class RuleSet implements RuleSetInterface
             'psr4' => true,
             'silenced_deprecation_error' => true,
         ],
+        '@DoctrineAnnotation' => [
+            'doctrine_annotation_array_assignment' => [
+                'operator' => ':',
+            ],
+            'doctrine_annotation_braces' => true,
+            'doctrine_annotation_indentation' => true,
+            'doctrine_annotation_spaces' => [
+                'before_array_assignments_colon' => false,
+            ],
+        ],
         '@PHP56Migration' => [
             'pow_to_exponentiation' => true,
         ],

--- a/tests/Fixtures/Integration/set/@DoctrineAnnotation.test
+++ b/tests/Fixtures/Integration/set/@DoctrineAnnotation.test
@@ -1,0 +1,4 @@
+--TEST--
+Integration of @DoctrineAnnotation.
+--RULESET--
+{"@DoctrineAnnotation": true}

--- a/tests/Fixtures/Integration/set/@DoctrineAnnotation.test-in.php
+++ b/tests/Fixtures/Integration/set/@DoctrineAnnotation.test-in.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @Bar()
+ * @Baz(
+ *   arg1 = "baz" ,
+ *       arg2 ={
+ *       "baz" =true
+ *       }
+ *  )
+ */
+class Foo
+{
+}

--- a/tests/Fixtures/Integration/set/@DoctrineAnnotation.test-out.php
+++ b/tests/Fixtures/Integration/set/@DoctrineAnnotation.test-out.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @Bar
+ * @Baz(
+ *     arg1="baz",
+ *     arg2={
+ *         "baz": true
+ *     }
+ * )
+ */
+class Foo
+{
+}


### PR DESCRIPTION
Adds a ruleset with all Doctrine Annotation related rules.

Current default options of these rules are based on examples found in [Doctrine Annotation documentation](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html) and [Symfony documentation](http://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/routing.html). I changed some options in the ruleset based on discussion in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2693.