### PR TITLE
ProtectedToPrivateFixer: minor optimization

### DIFF
--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -60,7 +60,7 @@ final class Sample
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_CLASS);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_FINAL, T_PROTECTED]);
     }
 
     /**

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -84,6 +84,10 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
                 "<?php final class MyFirstClass { $attributesAndMethodsFixed } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsFixed } ",
                 "<?php final class MyFirstClass { $attributesAndMethodsOriginal } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsOriginal } ",
             ],
+            'minimal-set' => [
+                '<?php final class MyClass { private $v1; }',
+                '<?php final class MyClass { protected $v1; }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Following https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2972#discussion_r133924837 I tried to make this fixer faster, but the [trait check](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.4/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php#L135) doesn't let me skip getting the class close before the main loop.

Any other idea is welcome