### PR TITLE
Diff - add line numbers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-tokenizer": "*",
         "doctrine/annotations": "^1.2",
         "gecko-packages/gecko-php-unit": "^2.0",
-        "sebastian/diff": "^1.4",
+        "php-cs-fixer/diff": "dev-master",
         "symfony/console": "^3.2",
         "symfony/event-dispatcher": "^3.0",
         "symfony/filesystem": "^3.0",

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -12,8 +12,9 @@
 
 namespace PhpCsFixer\Console\Command;
 
+use PhpCsFixer\Diff\Differ;
+use PhpCsFixer\Diff\Output\UnifiedDiffOutputBuilder;
 use PhpCsFixer\Differ\DiffConsoleFormatter;
-use PhpCsFixer\Differ\SebastianBergmannDiffer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
@@ -220,7 +221,7 @@ final class DescribeCommand extends Command
         } else {
             $output->writeln('Fixing examples:');
 
-            $differ = new SebastianBergmannDiffer();
+            $differ = new Differ(new UnifiedDiffOutputBuilder("--- Original\n+++ New", true));
             $diffFormatter = new DiffConsoleFormatter($output->isDecorated(), sprintf(
                 '<comment>   ---------- begin diff ----------</comment>%s%%s%s<comment>   ----------- end diff -----------</comment>',
                 PHP_EOL,

--- a/src/Differ/SebastianBergmannDiffer.php
+++ b/src/Differ/SebastianBergmannDiffer.php
@@ -12,7 +12,8 @@
 
 namespace PhpCsFixer\Differ;
 
-use SebastianBergmann\Diff\Differ;
+use PhpCsFixer\Diff\Differ;
+use PhpCsFixer\Diff\Output\UnifiedDiffOutputBuilder;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -26,7 +27,7 @@ final class SebastianBergmannDiffer implements DifferInterface
 
     public function __construct()
     {
-        $this->differ = new Differ();
+        $this->differ = new Differ(new UnifiedDiffOutputBuilder("--- Original\n+++ New", true));
     }
 
     /**

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -60,7 +60,7 @@ Fixing examples:
    ---------- begin diff ----------
    --- Original
    +++ New
-   @@ @@
+   @@ -1 +1 @@
    -<?php echo 'bad stuff and bad thing';
    +<?php echo 'good stuff and bad thing';
    ----------- end diff -----------
@@ -69,7 +69,7 @@ Fixing examples:
    ---------- begin diff ----------
    --- Original
    +++ New
-   @@ @@
+   @@ -1 +1 @@
    -<?php echo 'bad stuff and bad thing';
    +<?php echo 'good stuff and good thing';
    ----------- end diff -----------
@@ -98,7 +98,7 @@ Fixing examples:
 \033[33m   ---------- begin diff ----------\033[39m
    \033[31m--- Original\033[39m
    \033[32m+++ New\033[39m
-   \033[36m@@ @@\033[39m
+   \033[36m@@ -1 +1 @@\033[39m
    \033[31m-<?php echo 'bad stuff and bad thing';\033[39m
    \033[32m+<?php echo 'good stuff and bad thing';\033[39m
 \033[33m   ----------- end diff -----------\033[39m
@@ -107,7 +107,7 @@ Fixing examples:
 \033[33m   ---------- begin diff ----------\033[39m
    \033[31m--- Original\033[39m
    \033[32m+++ New\033[39m
-   \033[36m@@ @@\033[39m
+   \033[36m@@ -1 +1 @@\033[39m
    \033[31m-<?php echo 'bad stuff and bad thing';\033[39m
    \033[32m+<?php echo 'good stuff and good thing';\033[39m
 \033[33m   ----------- end diff -----------\033[39m

--- a/tests/Differ/SebastianBergmannDifferTest.php
+++ b/tests/Differ/SebastianBergmannDifferTest.php
@@ -28,16 +28,12 @@ final class SebastianBergmannDifferTest extends AbstractDifferTestCase
         $diff = <<<'TXT'
 --- Original
 +++ New
-@@ @@
+@@ -1,3 +1,4 @@
  <?php
  class Foo extends Bar {
 -    function __construct($foo, $bar) {
 +    public function __construct($foo, $bar)
 +    {
-         $this->foo = $foo;
-         $this->bar = $bar;
-     }
- }
 
 TXT;
 


### PR DESCRIPTION
Small patch to add linenumbers to the `diff` output.

closes;
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2993
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/299
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1620
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2529

(2529 also reports on columns, but I don't care about those ATM)

I fix the `diff` output to strict `unified diff` output in another PR some time, including adding the files names and multiple headers etc etc... however that is all none blocking