### PR TITLE
[2.4] SingleLineCommentStyleFixer - don't convert PHP annotations

### DIFF
--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -120,7 +120,7 @@ $c = 3;',
 
                 continue;
             }
-            if (!$this->asteriskEnabled || '/*' !== substr($content, 0, 2) || 1 === preg_match('/[^\s\*].*\R.*[^\s\*]/s', $commentContent)) {
+            if (!$this->asteriskEnabled || '/*' !== substr($content, 0, 2) || 1 === preg_match('/[^\s\*].*\R.*[^\s\*]/s', $commentContent) || 1 === preg_match('/@var.*/', $commentContent)) {
                 continue;
             }
 

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -207,6 +207,13 @@ second line*/',
             [
                 '<?php # test',
             ],
+            [
+                '<?php
+
+/* @var User $user */
+/** @var User $user */
+$user->doSomething();',
+            ],
         ];
     }
 


### PR DESCRIPTION
Now, when you add PHP annotations to help your IDE do resolve variable type like this:

```
<?php

/* @var User $user */
$user->doSomething();'
```

SingleLineCommentStyleFixer will change this into 

```
<?php

// @var User $user
$user->doSomething();'
```

what will make this annotation useless.