### PR TITLE
Add PHP 7.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
           env: DEPLOY=yes TASK_TESTS_COVERAGE=1
         - php: nightly
           env: TASK_SCA=1 COMPOSER_FLAGS="--ignore-platform-reqs" SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_IGNORE_ENV=1
+        - php: 7.2
+          env: TASK_SCA=1 COMPOSER_FLAGS="--ignore-platform-reqs" SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_IGNORE_ENV=1
         - php: 5.3
           env: SKIP_LINT_TEST_CASES=1 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
           dist: precise


### PR DESCRIPTION
This is the same as #3006 but for the 2.2 branch, as requested.

> This is needed to test any development of #2907, since php: nightly on Travis now points to 7.3, and requiring 7.2 goes to BETA3 instead.