### PR TITLE
Fix: Make sure that data providers are named correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
     },
     "conflict": {
-        "hhvm": "<3.18"
+        "hhvm": "<3.18",
+        "doctrine/annotations": "~1.5.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
     },
     "conflict": {
-        "hhvm": "<3.18",
-        "doctrine/annotations": "~1.5.0"
+        "hhvm": "<3.18"
     },
     "config": {
         "sort-packages": true

--- a/tests/AbstractDoctrineAnnotationFixerTestCase.php
+++ b/tests/AbstractDoctrineAnnotationFixerTestCase.php
@@ -24,7 +24,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
     /**
      * @param array $configuration
      *
-     * @dataProvider getInvalidConfigurationCases
+     * @dataProvider provideInvalidConfigurationCases
      */
     public function testConfigureWithInvalidConfiguration(array $configuration)
     {
@@ -36,7 +36,7 @@ abstract class AbstractDoctrineAnnotationFixerTestCase extends AbstractFixerTest
     /**
      * @return array
      */
-    public function getInvalidConfigurationCases()
+    public function provideInvalidConfigurationCases()
     {
         return array(
             array(array('foo' => 'bar')),

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -38,14 +38,14 @@ final class FixerFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider getFixersPriorityCases
+     * @dataProvider provideFixersPriorityCases
      */
     public function testFixersPriority(FixerInterface $first, FixerInterface $second)
     {
         $this->assertLessThan($first->getPriority(), $second->getPriority());
     }
 
-    public function getFixersPriorityCases()
+    public function provideFixersPriorityCases()
     {
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -253,12 +253,15 @@ final class ProjectCodeTest extends TestCase
      * @param string $testClassName
      * @param string $dataProviderMethodName
      */
-    public function testThatDataProvidersAreNotPrefixedWithTest($testClassName, $dataProviderMethodName)
+    public function testThatDataProvidersAreCorrectlyNamed($testClassName, $dataProviderMethodName)
     {
-        $this->assertNotRegExp('/^test/', $dataProviderMethodName, sprintf(
-            'Data providers should not be prefixed with "test", but "%s()" in "%s" is',
+        $regExp = '/^provide[A-Z]\S+Cases$/';
+
+        $this->assertRegExp($regExp, $dataProviderMethodName, sprintf(
+            'Data provider "%s" in "%s" does not match "%s"',
             $dataProviderMethodName,
-            $testClassName
+            $testClassName,
+            $regExp
         ));
     }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -69,7 +69,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @param string $className
      *
-     * @dataProvider provideSrcConcreteClasses
+     * @dataProvider provideSrcConcreteClassCases
      */
     public function testThatSrcClassHaveTestClass($className)
     {
@@ -87,7 +87,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @param string $className
      *
-     * @dataProvider provideSrcClassesNotAbuseInterfaces
+     * @dataProvider provideSrcClassesNotAbuseInterfacesCases
      * @requires PHP 5.4
      */
     public function testThatSrcClassesNotAbuseInterfaces($className)
@@ -154,7 +154,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @param string $className
      *
-     * @dataProvider provideSrcClasses
+     * @dataProvider provideSrcClassCases
      */
     public function testThatSrcClassesNotExposeProperties($className)
     {
@@ -219,7 +219,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @param string $className
      *
-     * @dataProvider provideTestClasses
+     * @dataProvider provideTestClassCases
      */
     public function testThatTestClassesAreAbstractOrFinal($className)
     {
@@ -234,7 +234,7 @@ final class ProjectCodeTest extends TestCase
     /**
      * @param string $className
      *
-     * @dataProvider provideTestClasses
+     * @dataProvider provideTestClassCases
      */
     public function testThatTestClassesAreInternal($className)
     {
@@ -248,7 +248,7 @@ final class ProjectCodeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideTestClassNamesAndDataProviderMethodNames
+     * @dataProvider provideDataProviderMethodNameCases
      *
      * @param string $testClassName
      * @param string $dataProviderMethodName
@@ -262,7 +262,7 @@ final class ProjectCodeTest extends TestCase
         ));
     }
 
-    public function provideSrcClasses()
+    public function provideSrcClassCases()
     {
         return array_map(
             function ($item) {
@@ -272,7 +272,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public function provideSrcClassesNotAbuseInterfaces()
+    public function provideSrcClassesNotAbuseInterfacesCases()
     {
         return array_map(
             function ($item) {
@@ -304,7 +304,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public function provideSrcConcreteClasses()
+    public function provideSrcConcreteClassCases()
     {
         return array_map(
             function ($item) { return array($item); },
@@ -319,7 +319,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public function provideTestClasses()
+    public function provideTestClassCases()
     {
         return array_map(
             function ($item) {
@@ -329,7 +329,7 @@ final class ProjectCodeTest extends TestCase
         );
     }
 
-    public function provideTestClassNamesAndDataProviderMethodNames()
+    public function provideDataProviderMethodNameCases()
     {
         $data = array();
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -258,9 +258,9 @@ final class ProjectCodeTest extends TestCase
         $regExp = '/^provide[A-Z]\S+Cases$/';
 
         $this->assertRegExp($regExp, $dataProviderMethodName, sprintf(
-            'Data provider "%s" in "%s" does not match "%s"',
-            $dataProviderMethodName,
+            'Data provider in "%s" with name "%s" does not match "%s"',
             $testClassName,
+            $dataProviderMethodName,
             $regExp
         ));
     }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -333,10 +333,10 @@ final class ProjectCodeTest extends TestCase
     {
         $data = array();
 
-        $classNames = $this->getTestClasses();
+        $testClassNames = $this->getTestClasses();
 
-        foreach ($classNames as $className) {
-            $reflection = new \ReflectionClass($className);
+        foreach ($testClassNames as $testClassName) {
+            $reflection = new \ReflectionClass($testClassName);
 
             if (!$reflection->isSubclassOf('PHPUnit\Framework\TestCase')) {
                 continue;
@@ -366,7 +366,7 @@ final class ProjectCodeTest extends TestCase
 
             foreach ($dataProviderMethodNames as $dataProviderMethodName) {
                 $data[] = array(
-                    $className,
+                    $testClassName,
                     $dataProviderMethodName,
                 );
             }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -256,7 +256,7 @@ final class ProjectCodeTest extends TestCase
     public function testThatDataProvidersAreCorrectlyNamed($testClassName, $dataProviderMethodName)
     {
         $this->assertRegExp('/^provide[A-Z]\S+Cases$/', $dataProviderMethodName, sprintf(
-            'Data provider in "%s" with name "%s" is not correctly named"',
+            'Data provider in "%s" with name "%s" is not correctly named.',
             $testClassName,
             $dataProviderMethodName
         ));

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -354,7 +354,7 @@ final class ProjectCodeTest extends TestCase
                 $dataProviderAnnotations = $docBlock->getAnnotationsOfType('dataProvider');
 
                 foreach ($dataProviderAnnotations as $dataProviderAnnotation) {
-                    if (false === preg_match('/@dataProvider\s+(?P<methodName>\w+)/', $dataProviderAnnotation->getContent(), $matches)) {
+                    if (0 === preg_match('/@dataProvider\s+(?P<methodName>\w+)/', $dataProviderAnnotation->getContent(), $matches)) {
                         continue;
                     }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -255,13 +255,10 @@ final class ProjectCodeTest extends TestCase
      */
     public function testThatDataProvidersAreCorrectlyNamed($testClassName, $dataProviderMethodName)
     {
-        $regExp = '/^provide[A-Z]\S+Cases$/';
-
-        $this->assertRegExp($regExp, $dataProviderMethodName, sprintf(
-            'Data provider in "%s" with name "%s" does not match "%s"',
+        $this->assertRegExp('/^provide[A-Z]\S+Cases$/', $dataProviderMethodName, sprintf(
+            'Data provider in "%s" with name "%s" is not correctly named"',
             $testClassName,
-            $dataProviderMethodName,
-            $regExp
+            $dataProviderMethodName
         ));
     }
 

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -29,7 +29,7 @@ final class TransformerTest extends TestCase
     /**
      * @param TransformerInterface $transformer
      *
-     * @dataProvider provideTransformers
+     * @dataProvider provideTransformerCases
      */
     public function testTransformersAreFinal(TransformerInterface $transformer)
     {
@@ -44,7 +44,7 @@ final class TransformerTest extends TestCase
     /**
      * @return TransformerInterface[]
      */
-    public function provideTransformers()
+    public function provideTransformerCases()
     {
         static $transformersArray = null;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -115,7 +115,7 @@ final class CacheTest extends TestCase
     }
 
     /**
-     * @dataProvider providerMissingData
+     * @dataProvider provideMissingDataCases
      *
      * @param array $data
      */
@@ -131,7 +131,7 @@ final class CacheTest extends TestCase
     /**
      * @return array
      */
-    public function providerMissingData()
+    public function provideMissingDataCases()
     {
         $data = array(
             'php' => '5.5.5',

--- a/tests/CiIntegrationTest.php
+++ b/tests/CiIntegrationTest.php
@@ -87,7 +87,7 @@ final class CiIntegrationTest extends TestCase
      * @param string[] $expectedResult2Lines
      * @param string   $expectedResult3Files
      *
-     * @dataProvider getIntegrationCases
+     * @dataProvider provideIntegrationCases
      */
     public function testIntegration(
         $branchName,
@@ -168,7 +168,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
         $this->assertSame(0, $result3['code']);
     }
 
-    public function getIntegrationCases()
+    public function provideIntegrationCases()
     {
         return array(
             array(

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -125,7 +125,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param string $progressType
      *
-     * @dataProvider getProgressTypeCases
+     * @dataProvider provideProgressTypeCases
      */
     public function testResolveProgressWithPositiveConfigAndExplicitProgress($progressType)
     {
@@ -147,7 +147,7 @@ final class ConfigurationResolverTest extends TestCase
     /**
      * @param string $progressType
      *
-     * @dataProvider getProgressTypeCases
+     * @dataProvider provideProgressTypeCases
      */
     public function testResolveProgressWithNegativeConfigAndExplicitProgress($progressType)
     {
@@ -166,7 +166,7 @@ final class ConfigurationResolverTest extends TestCase
         $this->assertSame($progressType, $resolver->getProgress());
     }
 
-    public function getProgressTypeCases()
+    public function provideProgressTypeCases()
     {
         return array(
             array('none'),
@@ -699,7 +699,7 @@ final class ConfigurationResolverTest extends TestCase
      * @param bool             $configValue
      * @param null|bool|string $passed
      *
-     * @dataProvider getResolveBooleanOptions
+     * @dataProvider provideResolveBooleanOptionCases
      */
     public function testResolveUsingCacheWithConfigOption($expected, $configValue, $passed)
     {
@@ -804,7 +804,7 @@ final class ConfigurationResolverTest extends TestCase
      * @param bool             $configValue
      * @param null|bool|string $passed
      *
-     * @dataProvider getResolveBooleanOptions
+     * @dataProvider provideResolveBooleanOptionCases
      */
     public function testResolveAllowRiskyWithConfigOption($expected, $configValue, $passed)
     {
@@ -1049,7 +1049,7 @@ final class ConfigurationResolverTest extends TestCase
         $this->assertFalse($resolver->getRiskyAllowed());
     }
 
-    public function getResolveBooleanOptions()
+    public function provideResolveBooleanOptionCases()
     {
         return array(
             array(true, true, 'yes'),

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -28,7 +28,7 @@ final class ProcessOutputTest extends TestCase
      * @param array  $statuses
      * @param string $expectedOutput
      *
-     * @dataProvider getProcessProgressOutputCases
+     * @dataProvider provideProcessProgressOutputCases
      */
     public function testProcessProgressOutput(array $statuses, $expectedOutput)
     {
@@ -45,7 +45,7 @@ final class ProcessOutputTest extends TestCase
         $this->assertSame($expectedOutput, $output->fetch());
     }
 
-    public function getProcessProgressOutputCases()
+    public function provideProcessProgressOutputCases()
     {
         return array(
             array(
@@ -100,7 +100,7 @@ final class ProcessOutputTest extends TestCase
      * @param array  $statuses
      * @param string $expectedOutput
      *
-     * @dataProvider getProcessProgressOutputWithNumbersCases
+     * @dataProvider provideProcessProgressOutputWithNumbersCases
      */
     public function testProcessProgressOutputWithNumbers(array $statuses, $expectedOutput)
     {
@@ -122,7 +122,7 @@ final class ProcessOutputTest extends TestCase
         $this->assertSame($expectedOutput, $output->fetch());
     }
 
-    public function getProcessProgressOutputWithNumbersCases()
+    public function provideProcessProgressOutputWithNumbersCases()
     {
         return array(
             array(

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -87,7 +87,7 @@ final class AnnotationTest extends TestCase
      * @param int    $index
      * @param string $content
      *
-     * @dataProvider provideContent
+     * @dataProvider provideGetContentCases
      */
     public function testGetContent($index, $content)
     {
@@ -98,7 +98,7 @@ final class AnnotationTest extends TestCase
         $this->assertSame($content, (string) $annotation);
     }
 
-    public function provideContent()
+    public function provideGetContentCases()
     {
         $cases = array();
 
@@ -163,7 +163,7 @@ final class AnnotationTest extends TestCase
      * @param int    $index
      * @param string $tag
      *
-     * @dataProvider provideTags
+     * @dataProvider provideGetTagCases
      */
     public function testGetTag($index, $tag)
     {
@@ -173,7 +173,7 @@ final class AnnotationTest extends TestCase
         $this->assertSame($tag, $annotation->getTag()->getName());
     }
 
-    public function provideTags()
+    public function provideGetTagCases()
     {
         $cases = array();
 

--- a/tests/DocBlock/LineTest.php
+++ b/tests/DocBlock/LineTest.php
@@ -119,7 +119,7 @@ final class LineTest extends TestCase
      * @param int    $pos
      * @param string $content
      *
-     * @dataProvider provideLines
+     * @dataProvider provideLinesCases
      */
     public function testPosAndContent($pos, $content)
     {
@@ -132,7 +132,7 @@ final class LineTest extends TestCase
     /**
      * @param int $pos
      *
-     * @dataProvider provideLines
+     * @dataProvider provideLinesCases
      */
     public function testStartOrEndPos($pos)
     {
@@ -156,7 +156,7 @@ final class LineTest extends TestCase
         }
     }
 
-    public function provideLines()
+    public function provideLinesCases()
     {
         $cases = array();
 
@@ -171,7 +171,7 @@ final class LineTest extends TestCase
      * @param int  $pos
      * @param bool $useful
      *
-     * @dataProvider provideLinesWithUseful
+     * @dataProvider provideLinesWithUsefulCases
      */
     public function testUseful($pos, $useful)
     {
@@ -181,7 +181,7 @@ final class LineTest extends TestCase
         $this->assertSame($useful, $line->containsUsefulContent());
     }
 
-    public function provideLinesWithUseful()
+    public function provideLinesWithUsefulCases()
     {
         $cases = array();
 
@@ -196,7 +196,7 @@ final class LineTest extends TestCase
      * @param int  $pos
      * @param bool $tag
      *
-     * @dataProvider provideLinesWithTag
+     * @dataProvider provideLinesWithTagCases
      */
     public function testTag($pos, $tag)
     {
@@ -206,7 +206,7 @@ final class LineTest extends TestCase
         $this->assertSame($tag, $line->containsATag());
     }
 
-    public function provideLinesWithTag()
+    public function provideLinesWithTagCases()
     {
         $cases = array();
 

--- a/tests/Doctrine/Annotation/TokenTest.php
+++ b/tests/Doctrine/Annotation/TokenTest.php
@@ -59,7 +59,7 @@ final class TokenTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsType
+     * @dataProvider provideIsTypeCases
      *
      * @param int       $type
      * @param int|int[] $types
@@ -76,7 +76,7 @@ final class TokenTest extends TestCase
     /**
      * @return array
      */
-    public function providerIsType()
+    public function provideIsTypeCases()
     {
         return array(
             'same-value' => array(
@@ -94,7 +94,7 @@ final class TokenTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsNotType
+     * @dataProvider provideIsNotTypeCases
      *
      * @param int       $type
      * @param int|int[] $types
@@ -111,7 +111,7 @@ final class TokenTest extends TestCase
     /**
      * @return array
      */
-    public function providerIsNotType()
+    public function provideIsNotTypeCases()
     {
         return array(
             'different-value' => array(

--- a/tests/Fixer/Alias/EregToPregFixerTest.php
+++ b/tests/Fixer/Alias/EregToPregFixerTest.php
@@ -27,14 +27,14 @@ final class EregToPregFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php $x = 1;'),

--- a/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/MbStrFunctionsFixerTest.php
@@ -28,14 +28,14 @@ final class MbStrFunctionsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php $x = "strlen";'),

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -28,14 +28,14 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         /** @var $aliases string[] */
         $aliases = static::getStaticAttribute('\PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer', 'aliases');

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -292,7 +292,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideWrongConfig
+     * @dataProvider provideWrongConfigCases
      *
      * @param mixed  $wrongConfig
      * @param string $expectedMessage
@@ -307,7 +307,7 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($wrongConfig);
     }
 
-    public function provideWrongConfig()
+    public function provideWrongConfigCases()
     {
         return array(
             array(

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -77,7 +77,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      * @param array       $config
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null, array $config = array())
     {
@@ -89,7 +89,7 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
     /**
      * @return array[]
      */
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array('<?php $smth->srand($a);'),

--- a/tests/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixerTest.php
@@ -27,14 +27,14 @@ final class NoTrailingCommaInSinglelineArrayFixerTest extends AbstractFixerTestC
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php $x = array();'),

--- a/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
@@ -27,14 +27,14 @@ final class NoWhitespaceBeforeCommaInArrayFixerTest extends AbstractFixerTestCas
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerFix
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerFix()
+    public function provideFixCases()
     {
         return array(
             //old style array

--- a/tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
@@ -27,14 +27,14 @@ final class TrailingCommaInMultilineArrayFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             // long syntax tests
@@ -323,7 +323,7 @@ TWIG
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples55
+     * @dataProvider provideFix55Cases
      * @requires PHP 5.5
      */
     public function testFix55($expected, $input = null)
@@ -331,7 +331,7 @@ TWIG
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples55()
+    public function provideFix55Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ArrayNotation/TrimArraySpacesFixerTest.php
+++ b/tests/Fixer/ArrayNotation/TrimArraySpacesFixerTest.php
@@ -445,7 +445,7 @@ final class TrimArraySpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples55
+     * @dataProvider provideFix55Cases
      * @requires PHP 5.5
      */
     public function testFix55($expected, $input = null)
@@ -453,7 +453,7 @@ final class TrimArraySpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples55()
+    public function provideFix55Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixerTest.php
@@ -27,14 +27,14 @@ final class WhitespaceAfterCommaInArrayFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerFix
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerFix()
+    public function provideFixCases()
     {
         return array(
             //old style array

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -3482,10 +3482,10 @@ declare   (   ticks   =   1   )   {
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provide55Cases
+     * @dataProvider provideFix55Cases
      * @requires PHP 5.5
      */
-    public function test55($expected, $input = null, array $configuration = null)
+    public function testFix55($expected, $input = null, array $configuration = null)
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -3494,7 +3494,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provide55Cases()
+    public function provideFix55Cases()
     {
         return array(
             array(
@@ -3554,10 +3554,10 @@ declare   (   ticks   =   1   )   {
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provide56Cases
+     * @dataProvider provideFix56Cases
      * @requires PHP 5.6
      */
-    public function test56($expected, $input = null, array $configuration = null)
+    public function testFix56($expected, $input = null, array $configuration = null)
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -3566,7 +3566,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provide56Cases()
+    public function provideFix56Cases()
     {
         return array(
             array(
@@ -3591,10 +3591,10 @@ declare   (   ticks   =   1   )   {
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
-    public function test70($expected, $input = null, array $configuration = null)
+    public function testFix70($expected, $input = null, array $configuration = null)
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -3603,7 +3603,7 @@ declare   (   ticks   =   1   )   {
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(
@@ -3910,7 +3910,7 @@ use const some\a\{ConstA, ConstB, ConstC};
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider providePreserveLineAfterControlBrace
+     * @dataProvider providePreserveLineAfterControlBraceCases
      */
     public function testPreserveLineAfterControlBrace($expected, $input = null, array $configuration = null)
     {
@@ -3921,7 +3921,7 @@ use const some\a\{ConstA, ConstB, ConstC};
         $this->doTest($expected, $input);
     }
 
-    public function providePreserveLineAfterControlBrace()
+    public function providePreserveLineAfterControlBraceCases()
     {
         return array(
             array(
@@ -4103,7 +4103,7 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
         );
     }
 
-    public function provideDoWhileLoopInsideAnIfWithoutBrackets()
+    public function provideDoWhileLoopInsideAnIfWithoutBracketsCases()
     {
         return array(
             array(
@@ -4126,7 +4126,7 @@ if (true)
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideDoWhileLoopInsideAnIfWithoutBrackets
+     * @dataProvider provideDoWhileLoopInsideAnIfWithoutBracketsCases
      */
     public function testDoWhileLoopInsideAnIfWithoutBrackets($expected, $input = null)
     {

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -28,14 +28,14 @@ final class EncodingFixerTest extends AbstractFixerTestCase
      * @param string       $input
      * @param \SplFileInfo $file
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input, $file)
     {
         $this->doTest($expected, $input, $file);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             $this->prepareTestCase('test-utf8.case1.php', 'test-utf8.case1-bom.php'),

--- a/tests/Fixer/Casing/LowercaseConstantsFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseConstantsFixerTest.php
@@ -62,14 +62,14 @@ final class LowercaseConstantsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
                 array(
@@ -135,15 +135,15 @@ final class LowercaseConstantsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
-    public function test54($expected, $input = null)
+    public function testFix54($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array('<?php trait False {}'),

--- a/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
@@ -27,14 +27,14 @@ final class LowercaseKeywordsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php $x = (1 and 2);', '<?php $x = (1 AND 2);'),

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -73,14 +73,14 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideFixCases54
+     * @dataProvider provideFix54Cases
      */
     public function testFix54($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases54()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -99,14 +99,14 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.5
-     * @dataProvider provideFixCases55
+     * @dataProvider provideFix55Cases
      */
     public function testFix55($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases55()
+    public function provideFix55Cases()
     {
         return array(
             array(
@@ -125,14 +125,14 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 7.0
-     * @dataProvider provideFixCases70
+     * @dataProvider provideFix70Cases
      */
     public function testFix70($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases70()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/CastNotation/CastSpacesFixerTest.php
+++ b/tests/Fixer/CastNotation/CastSpacesFixerTest.php
@@ -25,14 +25,14 @@ final class CastSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerFixCasts
+     * @dataProvider provideFixCases
      */
-    public function testFixCasts($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerFixCasts()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -27,14 +27,14 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         $cases = array();
         foreach (array('boolean', 'bool', 'integer', 'int', 'double', 'float', 'real', 'float', 'string', 'array', 'object', 'unset', 'binary') as $from) {

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -28,14 +28,14 @@ final class ModernizeTypesCastingFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =

--- a/tests/Fixer/CastNotation/NoShortBoolCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoShortBoolCastFixerTest.php
@@ -25,14 +25,14 @@ final class NoShortBoolCastFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
-    public function testFixer($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -511,7 +511,7 @@ TestInterface3, /**/     TestInterface4   ,
      * @param array  $expected
      *
      * @requires PHP 7.0
-     * @dataProvider provideClassyImplementsInfoCases7
+     * @dataProvider provideClassyInheritanceInfo7Cases
      */
     public function testClassyInheritanceInfo7($source, $label, array $expected)
     {
@@ -592,7 +592,7 @@ namespace {
         );
     }
 
-    public function provideClassyImplementsInfoCases7()
+    public function provideClassyInheritanceInfo7Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/MethodSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/MethodSeparationFixerTest.php
@@ -768,14 +768,14 @@ trait SomeReturnInfo {
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideFixInterfaces
+     * @dataProvider provideFixInterfaceCases
      */
-    public function testFixInterfaces($expected, $input = null)
+    public function testFixInterface($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixInterfaces()
+    public function provideFixInterfaceCases()
     {
         $cases = array();
         $cases[] = array(

--- a/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
@@ -28,7 +28,7 @@ final class NoBlankLinesAfterClassOpeningFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -40,14 +40,14 @@ final class NoBlankLinesAfterClassOpeningFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideTraits
+     * @dataProvider provideFixTraitCases
      */
-    public function testFixTraits($expected, $input = null)
+    public function testFixTrait($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         $cases = array();
 
@@ -134,7 +134,7 @@ class Good
         return $cases;
     }
 
-    public function provideTraits()
+    public function provideFixTraitCases()
     {
         $cases = array();
 

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -27,7 +27,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null)
@@ -35,7 +35,7 @@ final class NoPhp4ConstructorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -27,14 +27,14 @@ final class OrderedClassElementsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -305,7 +305,7 @@ EOT
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases54
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
     public function testFix54($expected, $input = null)
@@ -313,7 +313,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideCases54()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -351,7 +351,7 @@ EOT
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases71
+     * @dataProvider provideFix71Cases
      * @requires PHP 7.1
      */
     public function testFix71($expected, $input = null)
@@ -359,7 +359,7 @@ EOT
         $this->doTest($expected, $input);
     }
 
-    public function provideCases71()
+    public function provideFix71Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -27,14 +27,14 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
         $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
@@ -95,7 +95,7 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function test70Fix($expected, $input = null)
@@ -103,7 +103,7 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
         $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -27,14 +27,14 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -93,7 +93,7 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null)
@@ -101,7 +101,7 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -28,14 +28,14 @@ final class SingleClassElementPerStatementFixerTest extends AbstractFixerTestCas
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -471,7 +471,7 @@ EOF;
      *
      * @group legacy
      * @requires PHP 7.1
-     * @dataProvider provideClassConstTest
+     * @dataProvider provideFixClassConstCases
      * @expectedDeprecation Passing "elements" at the root of the configuration is deprecated and will not be supported in 3.0, use "elements" => array(...) option instead.
      */
     public function testLegacyFixClassConst($expected, $input)
@@ -485,7 +485,7 @@ EOF;
      * @param string $input    PHP source to fix
      *
      * @requires PHP 7.1
-     * @dataProvider provideClassConstTest
+     * @dataProvider provideFixClassConstCases
      */
     public function testFixClassConst($expected, $input)
     {
@@ -493,7 +493,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function provideClassConstTest()
+    public function provideFixClassConstCases()
     {
         return array(
             array(

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -340,7 +340,7 @@ echo 1;'
      * @param null|array $configuration
      * @param string     $exceptionMessage
      *
-     * @dataProvider provideMisconfiguration
+     * @dataProvider provideMisconfigurationCases
      */
     public function testMisconfiguration($configuration, $exceptionMessage)
     {
@@ -352,7 +352,7 @@ echo 1;'
         $this->fixer->configure($configuration);
     }
 
-    public function provideMisconfiguration()
+    public function provideMisconfigurationCases()
     {
         return array(
             array(array(), 'Missing required configuration: The required option "header" is missing.'),

--- a/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
@@ -27,14 +27,14 @@ final class NoTrailingWhitespaceInCommentFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/ControlStructure/IncludeFixerTest.php
+++ b/tests/Fixer/ControlStructure/IncludeFixerTest.php
@@ -28,14 +28,14 @@ final class IncludeFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerFix
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerFix()
+    public function provideFixCases()
     {
         $template = '<?php %s';
         $tests = array(

--- a/tests/Fixer/ControlStructure/NoTrailingCommaInListCallFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoTrailingCommaInListCallFixerTest.php
@@ -27,14 +27,14 @@ final class NoTrailingCommaInListCallFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -72,7 +72,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      * @param null|string $fixStatement
      *
-     * @dataProvider provideFixCases55
+     * @dataProvider provideFix55Cases
      * @requires PHP 5.5
      */
     public function testFix55($expected, $input = null, $fixStatement = null)
@@ -86,7 +86,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
      * @param null|string $fixStatement
      *
      * @group legacy
-     * @dataProvider provideFixCases55
+     * @dataProvider provideFix55Cases
      * @expectedDeprecation Passing "statements" at the root of the configuration is deprecated and will not be supported in 3.0, use "statements" => array(...) option instead.
      * @requires PHP 5.5
      */
@@ -100,7 +100,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      * @param null|string $fixStatement
      *
-     * @dataProvider provideFixCases70
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null, $fixStatement = null)
@@ -114,7 +114,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
      * @param null|string $fixStatement
      *
      * @group legacy
-     * @dataProvider provideFixCases70
+     * @dataProvider provideFix70Cases
      * @expectedDeprecation Passing "statements" at the root of the configuration is deprecated and will not be supported in 3.0, use "statements" => array(...) option instead.
      * @requires PHP 7.0
      */
@@ -453,7 +453,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provideFixCases55()
+    public function provideFix55Cases()
     {
         return array(
             array(
@@ -501,7 +501,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provideFixCases70()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -321,14 +321,14 @@ else?><?php echo 5;',
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideFixNestedIfs
+     * @dataProvider provideFixNestedIfCases
      */
-    public function testFixNestedIfs($expected, $input = null)
+    public function testFixNestedIf($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFixNestedIfs()
+    public function provideFixNestedIfCases()
     {
         return array(
             array(
@@ -753,14 +753,14 @@ else?><?php echo 5;',
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideConditionsWithoutBraces
+     * @dataProvider provideConditionsWithoutBracesCases
      */
     public function testConditionsWithoutBraces($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideConditionsWithoutBraces()
+    public function provideConditionsWithoutBracesCases()
     {
         $cases = array();
         $statements = array(

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -26,7 +26,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixWithBracesCases
+     * @dataProvider provideFixWithBracesCases
      */
     public function testFixWithBraces($expected, $input = null)
     {
@@ -37,7 +37,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixWithBracesCases()
+    public function provideFixWithBracesCases()
     {
         return $this->createTestCases(array(
             array('
@@ -268,7 +268,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixWithoutBracesCases
+     * @dataProvider provideFixWithoutBracesCases
      */
     public function testFixWithoutBraces($expected, $input = null)
     {
@@ -281,7 +281,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixWithoutBracesCases()
+    public function provideFixWithoutBracesCases()
     {
         return $this->createTestCases(array(
             array('
@@ -528,9 +528,9 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getInvalidConfigurationCases()
+    public function provideInvalidConfigurationCases()
     {
-        return array_merge(parent::getInvalidConfigurationCases(), array(
+        return array_merge(parent::provideInvalidConfigurationCases(), array(
             array(array('syntax' => 'foo')),
             array(array(
                 'syntax' => 'foo',

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -26,7 +26,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -36,7 +36,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
     /**
      * @return array
      */
-    public function getFixCases()
+    public function provideFixCases()
     {
         return $this->createTestCases(array(
             array('

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -26,7 +26,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAllCases
+     * @dataProvider provideFixAllCases
      */
     public function testFixAll($expected, $input = null)
     {
@@ -45,7 +45,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAllCases
+     * @dataProvider provideFixAllCases
      */
     public function testFixAllWithDifferentLineEnding($expected, $input = null)
     {
@@ -60,7 +60,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixAllCases()
+    public function provideFixAllCases()
     {
         return $this->createTestCases(array(
             array('
@@ -325,7 +325,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundParenthesesOnlyCases
+     * @dataProvider provideFixAroundParenthesesOnlyCases
      */
     public function testFixAroundParenthesesOnly($expected, $input = null)
     {
@@ -349,7 +349,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundParenthesesOnlyCases
+     * @dataProvider provideFixAroundParenthesesOnlyCases
      */
     public function testFixAroundParenthesesOnlyWithDifferentLineEnding($expected, $input = null)
     {
@@ -364,7 +364,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixAroundParenthesesOnlyCases()
+    public function provideFixAroundParenthesesOnlyCases()
     {
         return $this->createTestCases(array(
             array('
@@ -580,7 +580,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundCommasOnlyCases
+     * @dataProvider provideFixAroundCommasOnlyCases
      */
     public function testFixAroundCommasOnly($expected, $input = null)
     {
@@ -604,7 +604,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundCommasOnlyCases
+     * @dataProvider provideFixAroundCommasOnlyCases
      */
     public function testFixAroundCommasOnlyWithDifferentLineEnding($expected, $input = null)
     {
@@ -619,7 +619,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixAroundCommasOnlyCases()
+    public function provideFixAroundCommasOnlyCases()
     {
         return $this->createTestCases(array(
             array('
@@ -858,7 +858,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundArgumentAssignmentsOnlyCases
+     * @dataProvider provideFixAroundArgumentAssignmentsOnlyCases
      */
     public function testFixAroundArgumentAssignmentsOnly($expected, $input = null)
     {
@@ -882,7 +882,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundArgumentAssignmentsOnlyCases
+     * @dataProvider provideFixAroundArgumentAssignmentsOnlyCases
      */
     public function testFixAroundArgumentAssignmentsOnlyWithDifferentLineEnding($expected, $input = null)
     {
@@ -897,7 +897,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixAroundArgumentAssignmentsOnlyCases()
+    public function provideFixAroundArgumentAssignmentsOnlyCases()
     {
         return $this->createTestCases(array(
             array('
@@ -1128,7 +1128,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundArrayAssignmentsOnlyCases
+     * @dataProvider provideFixAroundArrayAssignmentsOnlyCases
      */
     public function testFixAroundArrayAssignmentsOnly($expected, $input = null)
     {
@@ -1152,7 +1152,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider getFixAroundArrayAssignmentsOnlyCases
+     * @dataProvider provideFixAroundArrayAssignmentsOnlyCases
      */
     public function testFixAroundArrayAssignmentsOnlyWithDifferentLineEnding($expected, $input = null)
     {
@@ -1167,7 +1167,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getFixAroundArrayAssignmentsOnlyCases()
+    public function provideFixAroundArrayAssignmentsOnlyCases()
     {
         return $this->createTestCases(array(
             array('
@@ -1377,9 +1377,9 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
     /**
      * @return array
      */
-    public function getInvalidConfigurationCases()
+    public function provideInvalidConfigurationCases()
     {
-        return array_merge(parent::getInvalidConfigurationCases(), array(
+        return array_merge(parent::provideInvalidConfigurationCases(), array(
             array(array(
                 'around_parentheses' => false,
                 'around_commas' => false,

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -41,7 +41,7 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null, array $configuration = null)
     {
@@ -52,7 +52,7 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -340,10 +340,10 @@ foo#
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
-    public function test54($expected, $input = null, array $configuration = null)
+    public function testFix54($expected, $input = null, array $configuration = null)
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -352,7 +352,7 @@ foo#
         $this->doTest($expected, $input);
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -388,10 +388,10 @@ foo#
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
-    public function test70($expected, $input = null, array $configuration = null)
+    public function testFix70($expected, $input = null, array $configuration = null)
     {
         if (null !== $configuration) {
             $this->fixer->configure($configuration);
@@ -400,7 +400,7 @@ foo#
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array('<?php use function Foo\bar; bar ( 1 );'),

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -27,14 +27,14 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -111,7 +111,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases56
+     * @dataProvider provideFix56Cases
      * @requires PHP 5.6
      */
     public function testFix56($expected, $input = null)
@@ -119,7 +119,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases56()
+    public function provideFix56Cases()
     {
         return array(
             array(
@@ -143,7 +143,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function test70($expected, $input = null)
@@ -151,7 +151,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array('<?php use function some\test\{fn_a, fn_b, fn_c};'),

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -29,7 +29,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      * @param null|array  $configuration
      *
-     * @dataProvider providerFix
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null, array $configuration = null)
     {
@@ -40,7 +40,7 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providerFix()
+    public function provideFixCases()
     {
         return array(
             'default' => array(

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -38,7 +38,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider providerInvalidConfigurationElement
+     * @dataProvider provideInvalidConfigurationElementCases
      *
      * @param mixed $element
      */
@@ -59,7 +59,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     /**
      * @return array
      */
-    public function providerInvalidConfigurationElement()
+    public function provideInvalidConfigurationElementCases()
     {
         return array(
             'null' => array(null),
@@ -128,7 +128,7 @@ PHP;
     }
 
     /**
-     * @dataProvider provideCasesWithDefaultConfiguration
+     * @dataProvider provideFixWithDefaultConfigurationCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -141,7 +141,7 @@ PHP;
     /**
      * @return array
      */
-    public function provideCasesWithDefaultConfiguration()
+    public function provideFixWithDefaultConfigurationCases()
     {
         return array(
             array(
@@ -198,7 +198,7 @@ class Foo
     }
 
     /**
-     * @dataProvider provideCasesWithConfiguredExclude
+     * @dataProvider provideFixWithConfiguredExcludeCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -217,7 +217,7 @@ class Foo
     /**
      * @return array
      */
-    public function provideCasesWithConfiguredExclude()
+    public function provideFixWithConfiguredExcludeCases()
     {
         return array(
             array(

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -27,14 +27,14 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerFix
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerFix()
+    public function provideFixCases()
     {
         return array(
             'test function call' => array(
@@ -151,15 +151,15 @@ $$e(2);
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
-    public function test54($expected, $input = null)
+    public function testFix54($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -173,15 +173,15 @@ $$e(2);
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
-    public function test70($expected, $input = null)
+    public function testFix70($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -22,7 +22,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NoUnreachableDefaultArgumentValueFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -35,7 +35,7 @@ final class NoUnreachableDefaultArgumentValueFixerTest extends AbstractFixerTest
     /**
      * @return array
      */
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -168,7 +168,7 @@ $bar) {}',
     }
 
     /**
-     * @dataProvider provide56Cases
+     * @dataProvider provideFix56Cases
      * @requires PHP 5.6
      *
      * @param string      $expected
@@ -182,7 +182,7 @@ $bar) {}',
     /**
      * @return array
      */
-    public function provide56cases()
+    public function provideFix56Cases()
     {
         return array(
             array(

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -36,7 +36,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
 
     /**
      * @group legacy
-     * @dataProvider providerFixWithSpaceBeforeNone
+     * @dataProvider provideFixWithSpaceBeforeNoneCases
      * @expectedDeprecation Passing NULL to set default configuration is deprecated and will not be supported in 3.0, use an empty array instead.
      *
      * @param string      $expected
@@ -50,7 +50,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider providerFixWithSpaceBeforeNone
+     * @dataProvider provideFixWithSpaceBeforeNoneCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -63,7 +63,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider providerFixWithSpaceBeforeNone
+     * @dataProvider provideFixWithSpaceBeforeNoneCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -77,7 +77,7 @@ final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function providerFixWithSpaceBeforeNone()
+    public function provideFixWithSpaceBeforeNoneCases()
     {
         return array(
             array(
@@ -132,7 +132,7 @@ string {}',
     }
 
     /**
-     * @dataProvider providerFixWithSpaceBeforeOne
+     * @dataProvider provideFixWithSpaceBeforeOneCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -146,7 +146,7 @@ string {}',
         $this->doTest($expected, $input);
     }
 
-    public function providerFixWithSpaceBeforeOne()
+    public function provideFixWithSpaceBeforeOneCases()
     {
         return array(
             array(

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -450,14 +450,14 @@ EOF;
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider providerUseInString
+     * @dataProvider provideFixUseInStringCases
      */
-    public function testUseInString($expected, $input = null)
+    public function testFixUseInString($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function providerUseInString()
+    public function provideFixUseInStringCases()
     {
         $expected1 = <<<'EOF'
 $x=<<<'EOA'

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -649,15 +649,15 @@ B#
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
-    public function test70($expected, $input = null)
+    public function testFix70($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(
@@ -815,7 +815,7 @@ use Foo\Bor\{
     }
 
     /**
-     * @dataProvider provideInvalidSortAlgorithmConfiguration
+     * @dataProvider provideInvalidSortAlgorithmCases
      *
      * @param array  $configuration
      * @param string $expectedValue
@@ -833,7 +833,7 @@ use Foo\Bor\{
         $this->fixer->configure($configuration);
     }
 
-    public function provideInvalidSortAlgorithmConfiguration()
+    public function provideInvalidSortAlgorithmCases()
     {
         return array(
             array(
@@ -1537,10 +1537,10 @@ EOF
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70CasesByLength
+     * @dataProvider provideFix70ByLengthCases
      * @requires PHP 7.0
      */
-    public function test70ByLength($expected, $input = null)
+    public function testFix70ByLength($expected, $input = null)
     {
         $this->fixer->configure(array(
             'sortAlgorithm' => OrderedImportsFixer::SORT_LENGTH,
@@ -1550,7 +1550,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public function provide70CasesByLength()
+    public function provideFix70ByLengthCases()
     {
         return array(
             array(
@@ -1589,13 +1589,13 @@ use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
     }
 
     /**
-     * @dataProvider provide70TypesOrderAndLength
+     * @dataProvider provideFox70TypesOrderAndLengthCases
      * @requires PHP 7.0
      *
      * @param string      $expected
      * @param null|string $input
      */
-    public function test70TypesOrderAndLength($expected, $input = null)
+    public function testFix70TypesOrderAndLength($expected, $input = null)
     {
         $this->fixer->configure(array(
             'sortAlgorithm' => OrderedImportsFixer::SORT_LENGTH,
@@ -1605,7 +1605,7 @@ use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
         $this->doTest($expected, $input);
     }
 
-    public function provide70TypesOrderAndLength()
+    public function provideFox70TypesOrderAndLengthCases()
     {
         return array(
             array(
@@ -1648,14 +1648,14 @@ use function some\f\{fn_c, fn_d, fn_e};
     }
 
     /**
-     * @dataProvider provide70TypesOrderAndAlphabet
+     * @dataProvider provideFix70TypesOrderAndAlphabetCases
      * @requires PHP 7.0
      *
      * @param string      $expected
      * @param null|string $input
      * @param string[]    $importOrder
      */
-    public function test70TypesOrderAndAlphabet($expected, $input = null, array $importOrder = null)
+    public function testFix70TypesOrderAndAlphabet($expected, $input = null, array $importOrder = null)
     {
         $this->fixer->configure(array(
             'sortAlgorithm' => OrderedImportsFixer::SORT_ALPHA,
@@ -1665,7 +1665,7 @@ use function some\f\{fn_c, fn_d, fn_e};
         $this->doTest($expected, $input);
     }
 
-    public function provide70TypesOrderAndAlphabet()
+    public function provideFix70TypesOrderAndAlphabetCases()
     {
         return array(
             array(
@@ -1722,15 +1722,15 @@ use function some\a\{fn_a, fn_b};
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide72Cases
+     * @dataProvider provideFix72Cases
      * @requires PHP 7.2
      */
-    public function test72($expected, $input = null)
+    public function testFix72($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide72Cases()
+    public function provideFix72Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -1589,7 +1589,7 @@ use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
     }
 
     /**
-     * @dataProvider provideFox70TypesOrderAndLengthCases
+     * @dataProvider provideFix70TypesOrderAndLengthCases
      * @requires PHP 7.0
      *
      * @param string      $expected
@@ -1605,7 +1605,7 @@ use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
         $this->doTest($expected, $input);
     }
 
-    public function provideFox70TypesOrderAndLengthCases()
+    public function provideFix70TypesOrderAndLengthCases()
     {
         return array(
             array(

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -29,14 +29,14 @@ final class SingleImportPerStatementFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -214,7 +214,7 @@ use X ?><?php new X(); // run before white space around semicolon',
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function test70($expected, $input = null)
@@ -222,7 +222,7 @@ use X ?><?php new X(); // run before white space around semicolon',
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(
@@ -318,15 +318,15 @@ use D\{
      * @param string $expected
      * @param string $input
      *
-     * @dataProvider provide72Cases
+     * @dataProvider provideFix72Cases
      * @requires PHP 7.2
      */
-    public function test72($expected, $input)
+    public function testFix72($expected, $input)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide72Cases()
+    public function provideFix72Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -28,14 +28,14 @@ final class SingleLineAfterImportsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -360,15 +360,15 @@ namespace Bar {
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
-    public function test70($expected, $input = null)
+    public function testFix70($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -207,7 +207,7 @@ DateTime:: # a
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideFixCases70
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null)
@@ -215,7 +215,7 @@ DateTime:: # a
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases70()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -27,14 +27,14 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -42,7 +42,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
      * @param string $input
      * @param array  $config
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input, array $config)
     {
@@ -50,7 +50,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             'minimal case remove whitespace (default config)' => array(
@@ -109,7 +109,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
      * @param array  $config
      * @param string $expectedMessage
      *
-     * @dataProvider provideInvalidConfig
+     * @dataProvider provideInvalidConfigCases
      */
     public function testInvalidConfig(array $config, $expectedMessage)
     {
@@ -121,7 +121,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($config);
     }
 
-    public function provideInvalidConfig()
+    public function provideInvalidConfigCases()
     {
         return array(
             array(

--- a/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
@@ -28,14 +28,14 @@ final class DirConstantFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -139,7 +139,7 @@ $a =
     /**
      * @param array $config
      *
-     * @dataProvider provideInvalidConfiguration
+     * @dataProvider provideInvalidConfigurationKeysCases
      */
     public function testInvalidConfigurationKeys(array $config)
     {
@@ -151,7 +151,7 @@ $a =
         $this->fixer->configure($config);
     }
 
-    public function provideInvalidConfiguration()
+    public function provideInvalidConfigurationKeysCases()
     {
         return array(
             array(array('functions' => array('a'))),

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -56,7 +56,7 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @dataProvider provideExamples
+     * @dataProvider provideYodaFixCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -78,7 +78,7 @@ final class IsNullFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provideExamples()
+    public function provideYodaFixCases()
     {
         $multiLinePatternToFix = <<<'FIX'
 <?php $x =

--- a/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
@@ -28,14 +28,14 @@ final class BlankLineAfterNamespaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -38,7 +38,7 @@ final class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
     /**
      * @return array
      */
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array("<?php\nnamespace X;"),

--- a/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
@@ -29,14 +29,14 @@ final class NoLeadingNamespaceWhitespaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         $manySpaces = array();
         for ($i = 1; $i <= 100; ++$i) {

--- a/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -38,7 +38,7 @@ final class SingleBlankLineBeforeNamespaceFixerTest extends AbstractFixerTestCas
     /**
      * @return array
      */
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array("<?php\n\nnamespace X;"),

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -33,14 +33,14 @@ final class BinaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -372,7 +372,7 @@ $b;',
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases54
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
     public function testFix54($expected, $input = null)
@@ -380,7 +380,7 @@ $b;',
         $this->doTest($expected, $input);
     }
 
-    public function provideCases54()
+    public function provideFix54Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -27,7 +27,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -38,7 +38,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
     public function testFix54($expected, $input = null)
@@ -50,7 +50,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide56Cases
+     * @dataProvider provideFix56Cases
      * @requires PHP 5.6
      */
     public function testFix56($expected, $input = null)
@@ -62,7 +62,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null)
@@ -70,7 +70,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -249,7 +249,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -263,7 +263,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provide56Cases()
+    public function provideFix56Cases()
     {
         return array(
             array(
@@ -277,7 +277,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
         );
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/NotOperatorWithSpaceFixerTest.php
+++ b/tests/Fixer/Operator/NotOperatorWithSpaceFixerTest.php
@@ -27,14 +27,14 @@ final class NotOperatorWithSpaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/NotOperatorWithSuccessorSpaceFixerTest.php
+++ b/tests/Fixer/Operator/NotOperatorWithSuccessorSpaceFixerTest.php
@@ -27,14 +27,14 @@ final class NotOperatorWithSuccessorSpaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
+++ b/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
@@ -27,14 +27,14 @@ final class ObjectOperatorWithoutWhitespaceFixerTest extends AbstractFixerTestCa
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/PreIncrementFixerTest.php
+++ b/tests/Fixer/Operator/PreIncrementFixerTest.php
@@ -27,14 +27,14 @@ final class PreIncrementFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/StandardizeNotEqualsFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeNotEqualsFixerTest.php
@@ -27,14 +27,14 @@ final class StandardizeNotEqualsFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array('<?php $a = ($b != $c);'),

--- a/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
@@ -27,14 +27,14 @@ final class TernaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      *
      * @param string      $expected
      * @param null|string $input
@@ -35,7 +35,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             // Do not fix cases.

--- a/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/UnaryOperatorSpacesFixerTest.php
@@ -27,14 +27,14 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         $cases = array(
             array(
@@ -109,7 +109,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCasesLT54
+     * @dataProvider provideFixLT54Cases
      * @requires PHP <5.4
      */
     public function testFixLT54($expected, $input = null)
@@ -117,7 +117,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCasesLT54()
+    public function provideFixLT54Cases()
     {
         return array(
             array(
@@ -131,7 +131,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases56
+     * @dataProvider provideFix56Cases
      * @requires PHP 5.6
      */
     public function testFix56($expected, $input = null)
@@ -139,7 +139,7 @@ final class UnaryOperatorSpacesFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCases56()
+    public function provideFix56Cases()
     {
         return array(
             array(

--- a/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
@@ -29,7 +29,7 @@ final class BlankLineAfterOpeningTagFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -41,14 +41,14 @@ final class BlankLineAfterOpeningTagFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideCases54
+     * @dataProvider provideFix54Cases
      */
     public function testFix54($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -116,7 +116,7 @@ Html here
         );
     }
 
-    public function provideCases54()
+    public function provideFix54Cases()
     {
         return array(
             array(

--- a/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/FullOpeningTagFixerTest.php
@@ -109,7 +109,7 @@ TEST;
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideFixCasesLT70
+     * @dataProvider provideFixLT70Cases
      * @requires PHP <7.0
      */
     public function testFixLT70($expected, $input = null)
@@ -117,7 +117,7 @@ TEST;
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCasesLT70()
+    public function provideFixLT70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
+++ b/tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
@@ -29,7 +29,7 @@ final class LinebreakAfterOpeningTagFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -41,14 +41,14 @@ final class LinebreakAfterOpeningTagFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideCases54
+     * @dataProvider provideFix54Cases
      */
     public function testFix54($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(
@@ -91,7 +91,7 @@ Html here
         );
     }
 
-    public function provideCases54()
+    public function provideFix54Cases()
     {
         return array(
             array(

--- a/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
+++ b/tests/Fixer/PhpTag/NoClosingTagFixerTest.php
@@ -25,9 +25,9 @@ final class NoClosingTagFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCasesWithFullOpenTag
+     * @dataProvider provideWithFullOpenTagCases
      */
-    public function testCasesWithFullOpenTag($expected, $input = null)
+    public function testWithFullOpenTag($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
@@ -36,9 +36,9 @@ final class NoClosingTagFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCasesWithShortOpenTag
+     * @dataProvider provideWithShortOpenTagCases
      */
-    public function testCasesWithShortOpenTag($expected, $input = null)
+    public function testWithShortOpenTag($expected, $input = null)
     {
         if (!ini_get('short_open_tag')) {
             $this->markTestSkipped('PHP short open tags are not enabled.');
@@ -49,7 +49,7 @@ final class NoClosingTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideCasesWithFullOpenTag()
+    public function provideWithFullOpenTagCases()
     {
         return array(
             array(
@@ -147,7 +147,7 @@ if (true) {
         );
     }
 
-    public function provideCasesWithShortOpenTag()
+    public function provideWithShortOpenTagCases()
     {
         return array(
             array(

--- a/tests/Fixer/PhpTag/NoShortEchoTagFixerTest.php
+++ b/tests/Fixer/PhpTag/NoShortEchoTagFixerTest.php
@@ -27,9 +27,9 @@ final class NoShortEchoTagFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideClosingTagExamples
+     * @dataProvider provideFixCases
      */
-    public function testOneLineFix($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         if (50400 > PHP_VERSION_ID && !ini_get('short_open_tag')) {
             // On PHP <5.4 short echo tag is parsed as T_INLINE_HTML if short_open_tag is disabled
@@ -40,7 +40,7 @@ final class NoShortEchoTagFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideClosingTagExamples()
+    public function provideFixCases()
     {
         return array(
             array('<?php echo \'Foo\';', '<?= \'Foo\';'),

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -27,7 +27,7 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideInternalTypeMethods
+     * @dataProvider provideInternalTypeMethodsCases
      */
     public function testInternalTypeMethods($expected, $input = null)
     {
@@ -61,7 +61,7 @@ final class PhpUnitDedicateAssertFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideInternalTypeMethods()
+    public function provideInternalTypeMethodsCases()
     {
         $cases = array();
 

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -40,7 +40,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     }
 
     /**
-     * @dataProvider providerInvalidConfigurationValue
+     * @dataProvider provideConfigureRejectsInvalidConfigurationValueCases
      *
      * @param mixed $value
      */
@@ -59,7 +59,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     /**
      * @return array
      */
-    public function providerInvalidConfigurationValue()
+    public function provideConfigureRejectsInvalidConfigurationValueCases()
     {
         return array(
             'null' => array(null),
@@ -294,7 +294,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      * @param null|string $input
      * @param null|array  $config
      *
-     * @dataProvider provideCases70
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null, array $config = null)
@@ -304,7 +304,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideCases70()
+    public function provideFix70Cases()
     {
         return array(
             array(
@@ -335,7 +335,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      * @param null|string $input
      * @param null|array  $config
      *
-     * @dataProvider provideCases71
+     * @dataProvider provideFix71Cases
      * @requires PHP 7.1
      */
     public function testFix71($expected, $input = null, array $config = null)
@@ -345,7 +345,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         $this->doTest($expected, $input);
     }
 
-    public function provideCases71()
+    public function provideFix71Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocIndentFixerTest.php
@@ -27,14 +27,14 @@ final class PhpdocIndentFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideDocblocks
+     * @dataProvider provideFixIndentCases
      */
     public function testFixIndent($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideDocblocks()
+    public function provideFixIndentCases()
     {
         $cases = array();
 

--- a/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
@@ -211,7 +211,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
     public function testFix54($expected, $input = null)
@@ -219,7 +219,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -281,7 +281,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide70Cases
+     * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */
     public function testFix70($expected, $input = null)
@@ -289,7 +289,7 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide70Cases()
+    public function provideFix70Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -179,7 +179,7 @@ class F
      * @param array  $configuration
      * @param string $message
      *
-     * @dataProvider provideInvalidConfiguration
+     * @dataProvider provideInvalidConfigurationCases
      */
     public function testInvalidConfiguration(array $configuration, $message)
     {
@@ -191,7 +191,7 @@ class F
         $this->fixer->configure($configuration);
     }
 
-    public function provideInvalidConfiguration()
+    public function provideInvalidConfigurationCases()
     {
         return array(
             array(

--- a/tests/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixerTest.php
@@ -27,14 +27,14 @@ final class PhpdocSingleLineVarSpacingFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -27,7 +27,7 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideDocblocks
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
@@ -39,14 +39,14 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
      * @param null|string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideTraits
+     * @dataProvider provideTraitsCases
      */
     public function testFixTraits($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideDocblocks()
+    public function provideFixCases()
     {
         $cases = array();
 
@@ -537,7 +537,7 @@ class A
         return $cases;
     }
 
-    public function provideTraits()
+    public function provideTraitsCases()
     {
         return array(
             array(
@@ -559,7 +559,7 @@ trait DocBlocks
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases71
+     * @dataProvider provideFix71Cases
      * @requires PHP 7.1
      */
     public function testFix71($expected, $input = null)
@@ -567,7 +567,7 @@ trait DocBlocks
         $this->doTest($expected, $input);
     }
 
-    public function provideCases71()
+    public function provideFix71Cases()
     {
         return array(
             array(

--- a/tests/Fixer/ReturnNotation/BlankLineBeforeReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/BlankLineBeforeReturnFixerTest.php
@@ -28,14 +28,14 @@ final class BlankLineBeforeReturnFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -27,14 +27,14 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideExamples
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideExamples()
+    public function provideFixCases()
     {
         return array(
             // check correct statements aren't changed

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -365,7 +365,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide54Cases
+     * @dataProvider provideFix54Cases
      * @requires PHP 5.4
      */
     public function testFix54($expected, $input = null)
@@ -373,7 +373,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide54Cases()
+    public function provideFix54Cases()
     {
         return array(
             array(
@@ -395,7 +395,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide55Cases
+     * @dataProvider provideFix55Cases
      * @requires PHP 5.5
      */
     public function testFix55($expected, $input = null)
@@ -403,7 +403,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide55Cases()
+    public function provideFix55Cases()
     {
         return array(
             array(
@@ -526,14 +526,14 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCasesWithShortOpenTag
+     * @dataProvider provideWithShortOpenTagCases
      */
-    public function testCasesWithShortOpenTag($expected, $input = null)
+    public function testWithShortOpenTag($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCasesWithShortOpenTag()
+    public function provideWithShortOpenTagCases()
     {
         $cases = array();
         /*

--- a/tests/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -30,14 +30,14 @@ final class NoMultilineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixer
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixerTest.php
@@ -29,14 +29,14 @@ final class NoSinglelineWhitespaceBeforeSemicolonsFixerTest extends AbstractFixe
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -27,14 +27,14 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
+++ b/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
@@ -27,14 +27,14 @@ final class SpaceAfterSemicolonFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -29,14 +29,14 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         $cases = $this->provideCommonCases();
 

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -105,7 +105,7 @@ EOF;
      * @param null|string[] $config
      *
      * @group legacy
-     * @dataProvider provideConfigTests
+     * @dataProvider provideWithConfigCases
      * @expectedDeprecation Passing "tokens" at the root of the configuration is deprecated and will not be supported in 3.0, use "tokens" => array(...) option instead.
      */
     public function testLegacyWithConfig(array $lineNumberRemoved, array $config)
@@ -119,7 +119,7 @@ EOF;
      * @param int[]         $lineNumberRemoved Line numbers expected to be removed after fixing
      * @param null|string[] $config
      *
-     * @dataProvider provideConfigTests
+     * @dataProvider provideWithConfigCases
      */
     public function testWithConfig(array $lineNumberRemoved, array $config)
     {
@@ -128,7 +128,7 @@ EOF;
         $this->doTest($this->removeLinesFromString($this->template, $lineNumberRemoved), $this->template);
     }
 
-    public function provideConfigTests()
+    public function provideWithConfigCases()
     {
         $tests = array(
             array(
@@ -892,7 +892,7 @@ class Foo
      * @param string $input
      *
      * @requires PHP 5.4
-     * @dataProvider provideBraceCases54
+     * @dataProvider provideBraces54Cases
      */
     public function testBraces54(array $config = null, $expected, $input)
     {
@@ -900,7 +900,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideBraceCases54()
+    public function provideBraces54Cases()
     {
         return array(
             array(

--- a/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
@@ -27,9 +27,9 @@ final class NoSpacesInsideParenthesisFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
-    public function testFixSpaceInsideParenthesis($expected, $input = null)
+    public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
@@ -57,7 +57,7 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -27,14 +27,14 @@ final class NoTrailingWhitespaceFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
+++ b/tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
@@ -28,14 +28,14 @@ final class NoWhitespaceInBlankLineFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             array(

--- a/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
+++ b/tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
@@ -28,14 +28,14 @@ final class SingleBlankLineAtEofFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provideCases
+     * @dataProvider provideFixCases
      */
     public function testFix($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideCases()
+    public function provideFixCases()
     {
         return array(
             'Not adding an empty line in empty file.' => array(

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -54,7 +54,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsSuitableForVersionUsesVersionSpecification
+     * @dataProvider provideIsSuitableForVersionUsesVersionSpecificationCases
      *
      * @param int  $version
      * @param bool $isSatisfied
@@ -78,7 +78,7 @@ final class VersionSpecificCodeSampleTest extends TestCase
     /**
      * @return array
      */
-    public function providerIsSuitableForVersionUsesVersionSpecification()
+    public function provideIsSuitableForVersionUsesVersionSpecificationCases()
     {
         return array(
             'is-satisfied' => array(PHP_VERSION_ID, true),

--- a/tests/FixerDefinition/VersionSpecificationTest.php
+++ b/tests/FixerDefinition/VersionSpecificationTest.php
@@ -32,7 +32,7 @@ final class VersionSpecificationTest extends TestCase
     }
 
     /**
-     * @dataProvider providerInvalidVersion
+     * @dataProvider provideInvalidVersionCases
      *
      * @param mixed $minimum
      */
@@ -44,7 +44,7 @@ final class VersionSpecificationTest extends TestCase
     }
 
     /**
-     * @dataProvider providerInvalidVersion
+     * @dataProvider provideInvalidVersionCases
      *
      * @param mixed $maximum
      */
@@ -61,7 +61,7 @@ final class VersionSpecificationTest extends TestCase
     /**
      * @return array
      */
-    public function providerInvalidVersion()
+    public function provideInvalidVersionCases()
     {
         return array(
             'negative' => array(-1),
@@ -85,7 +85,7 @@ final class VersionSpecificationTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsSatisfiedByReturnsTrue
+     * @dataProvider provideIsSatisfiedByReturnsTrueCases
      *
      * @param null|int $minimum
      * @param null|int $maximum
@@ -104,7 +104,7 @@ final class VersionSpecificationTest extends TestCase
     /**
      * @return array
      */
-    public function providerIsSatisfiedByReturnsTrue()
+    public function provideIsSatisfiedByReturnsTrueCases()
     {
         return array(
             'version-same-as-maximum' => array(null, PHP_VERSION_ID, PHP_VERSION_ID),
@@ -115,7 +115,7 @@ final class VersionSpecificationTest extends TestCase
     }
 
     /**
-     * @dataProvider providerIsSatisfiedByReturnsFalse
+     * @dataProvider provideIsSatisfiedByReturnsFalseCases
      *
      * @param null|int $minimum
      * @param null|int $maximum
@@ -134,7 +134,7 @@ final class VersionSpecificationTest extends TestCase
     /**
      * @return array
      */
-    public function providerIsSatisfiedByReturnsFalse()
+    public function provideIsSatisfiedByReturnsFalseCases()
     {
         return array(
             'version-greater-than-maximum' => array(null, PHP_VERSION_ID, PHP_VERSION_ID + 1),

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -207,7 +207,7 @@ final class FixerFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider provideConflictingFixersRules
+     * @dataProvider provideConflictingFixersCases
      */
     public function testConflictingFixers(RuleSet $ruleSet)
     {
@@ -219,7 +219,7 @@ final class FixerFactoryTest extends TestCase
         FixerFactory::create()->registerBuiltInFixers()->useRuleSet($ruleSet);
     }
 
-    public function provideConflictingFixersRules()
+    public function provideConflictingFixersCases()
     {
         return array(
             array(new RuleSet(array('no_blank_lines_before_namespace' => true, 'single_blank_line_before_namespace' => true))),

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -39,7 +39,7 @@ final class RuleSetTest extends TestCase
      * @param string     $setName
      * @param bool|array $ruleConfig
      *
-     * @dataProvider provideAllRulesFromSets
+     * @dataProvider provideAllRulesFromSetsCases
      */
     public function testIfAllRulesInSetsExists($setName, $ruleName, $ruleConfig)
     {
@@ -68,7 +68,7 @@ final class RuleSetTest extends TestCase
         }
     }
 
-    public function provideAllRulesFromSets()
+    public function provideAllRulesFromSetsCases()
     {
         $cases = array();
         foreach (RuleSet::create()->getSetDefinitionNames() as $setName) {
@@ -93,7 +93,7 @@ final class RuleSetTest extends TestCase
     }
 
     /**
-     * @dataProvider providerSetDefinitionNames
+     * @dataProvider provideSetDefinitionNameCases
      *
      * @param mixed $setName
      */
@@ -226,7 +226,7 @@ final class RuleSetTest extends TestCase
     }
 
     /**
-     * @dataProvider providerSetDefinitionNames
+     * @dataProvider provideSetDefinitionNameCases
      *
      * @param string $setDefinitionName
      */
@@ -259,7 +259,7 @@ final class RuleSetTest extends TestCase
     /**
      * @return array
      */
-    public function providerSetDefinitionNames()
+    public function provideSetDefinitionNameCases()
     {
         $setDefinitionNames = RuleSet::create()->getSetDefinitionNames();
 
@@ -272,7 +272,7 @@ final class RuleSetTest extends TestCase
      * @param array $set
      * @param bool  $safe
      *
-     * @dataProvider provideSafeSets
+     * @dataProvider provideSafeSetCases
      */
     public function testRiskyRulesInSet(array $set, $safe)
     {
@@ -300,7 +300,7 @@ final class RuleSetTest extends TestCase
         );
     }
 
-    public function provideSafeSets()
+    public function provideSafeSetCases()
     {
         return array(
             array(array('@PSR1' => true), true),

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -103,7 +103,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
     }
 
     /**
-     * @dataProvider getTests
+     * @dataProvider provideIntegrationCases
      *
      * @see doTest()
      *
@@ -119,7 +119,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
      *
      * @return IntegrationCase[][]
      */
-    public function getTests()
+    public function provideIntegrationCases()
     {
         $fixturesDir = realpath(static::getFixturesDir());
         if (!is_dir($fixturesDir)) {

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -32,7 +32,7 @@ final class TextDiffTest extends TestCase
      * @param string $format
      * @param bool   $isDecorated
      *
-     * @dataProvider provideDiffReporting
+     * @dataProvider provideDiffReportingCases
      */
     public function testDiffReportingDecorated($expected, $format, $isDecorated)
     {
@@ -64,7 +64,7 @@ final class TextDiffTest extends TestCase
         $this->assertStringMatchesFormat($expected, $commandTester->getDisplay(false));
     }
 
-    public function provideDiffReporting()
+    public function provideDiffReportingCases()
     {
         $expected = <<<'TEST'
 %A$output->writeln('<error>'.(int)$output.'</error>');%A
@@ -84,7 +84,7 @@ TEST;
     }
 
     /**
-     * Test to make sure @see TextDiffTest::provideDiffReporting covers all formats.
+     * Test to make sure @see TextDiffTest::provideDiffReportingCases covers all formats.
      */
     public function testAllFormatsCovered()
     {

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -31,7 +31,7 @@ final class ArgumentsAnalyzerTest extends TestCase
      * @param int    $closeIndex
      * @param array  $arguments
      *
-     * @dataProvider provideCases
+     * @dataProvider provideArgumentsCases
      */
     public function testArguments($code, $openIndex, $closeIndex, array $arguments)
     {
@@ -42,7 +42,7 @@ final class ArgumentsAnalyzerTest extends TestCase
         $this->assertSame($arguments, $analyzer->getArguments($tokens, $openIndex, $closeIndex));
     }
 
-    public function provideCases()
+    public function provideArgumentsCases()
     {
         return array(
             array('<?php fnc();', 2, 3, array()),

--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -33,7 +33,7 @@ final class CTTest extends TestCase
      * @param string $name
      * @param int    $value
      *
-     * @dataProvider provideCTs
+     * @dataProvider provideConstantsCases
      */
     public function testConstants($name, $value)
     {
@@ -41,7 +41,7 @@ final class CTTest extends TestCase
         $this->assertNull(@constant($name), 'The CT name must not use native T_* name.');
     }
 
-    public function provideCTs()
+    public function provideConstantsCases()
     {
         $cases = array();
 

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -319,14 +319,14 @@ final class TokenTest extends TestCase
      * @param Token|array|string $other
      * @param bool               $caseSensitive
      *
-     * @dataProvider provideEquals
+     * @dataProvider provideEqualsCases
      */
     public function testEquals(Token $token, $equals, $other, $caseSensitive = true)
     {
         $this->assertSame($equals, $token->equals($other, $caseSensitive));
     }
 
-    public function provideEquals()
+    public function provideEqualsCases()
     {
         $brace = $this->getBraceToken();
         $function = new Token(array(T_FUNCTION, 'function', 1));
@@ -375,7 +375,7 @@ final class TokenTest extends TestCase
      * @param array $other
      * @param bool  $caseSensitive
      *
-     * @dataProvider provideEqualsAny
+     * @dataProvider provideEqualsAnyCases
      */
     public function testEqualsAny($equalsAny, array $other, $caseSensitive = true)
     {
@@ -384,7 +384,7 @@ final class TokenTest extends TestCase
         $this->assertSame($equalsAny, $token->equalsAny($other, $caseSensitive));
     }
 
-    public function provideEqualsAny()
+    public function provideEqualsAnyCases()
     {
         $brace = $this->getBraceToken();
         $foreach = $this->getForeachToken();
@@ -406,14 +406,14 @@ final class TokenTest extends TestCase
      * @param bool|array $caseSensitive
      * @param int        $key
      *
-     * @dataProvider provideIsKeyCaseSensitive
+     * @dataProvider provideIsKeyCaseSensitiveCases
      */
     public function testIsKeyCaseSensitive($isKeyCaseSensitive, $caseSensitive, $key)
     {
         $this->assertSame($isKeyCaseSensitive, Token::isKeyCaseSensitive($caseSensitive, $key));
     }
 
-    public function provideIsKeyCaseSensitive()
+    public function provideIsKeyCaseSensitiveCases()
     {
         return array(
             array(true, true, 0),

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -263,7 +263,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsLambdaCases70
+     * @dataProvider provideIsLambda70Cases
      * @requires PHP 7.0
      */
     public function testIsLambda70($source, array $expected)
@@ -275,7 +275,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsLambdaCases70()
+    public function provideIsLambda70Cases()
     {
         return array(
             array(
@@ -298,7 +298,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsLambdaCases71
+     * @dataProvider provideIsLambda71Cases
      * @requires PHP 7.1
      */
     public function testIsLambda71($source, array $expected)
@@ -310,7 +310,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsLambdaCases71()
+    public function provideIsLambda71Cases()
     {
         return array(
             array(
@@ -347,7 +347,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsUnarySuccessorOperator
+     * @dataProvider provideIsUnarySuccessorOperatorCases
      */
     public function testIsUnarySuccessorOperator($source, array $expected)
     {
@@ -362,7 +362,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsUnarySuccessorOperator()
+    public function provideIsUnarySuccessorOperatorCases()
     {
         return array(
             array(
@@ -403,7 +403,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsUnaryPredecessorOperator
+     * @dataProvider provideIsUnaryPredecessorOperatorCases
      */
     public function testIsUnaryPredecessorOperator($source, array $expected)
     {
@@ -418,7 +418,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsUnaryPredecessorOperator()
+    public function provideIsUnaryPredecessorOperatorCases()
     {
         return array(
             array(
@@ -467,7 +467,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsUnaryPredecessorOperator56
+     * @dataProvider provideIsUnaryPredecessorOperator56Cases
      * @requires PHP 5.6
      */
     public function testIsUnaryPredecessorOperator56($source, array $expected)
@@ -483,7 +483,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsUnaryPredecessorOperator56()
+    public function provideIsUnaryPredecessorOperator56Cases()
     {
         return array(
             array(
@@ -512,7 +512,7 @@ preg_replace_callback(
     /**
      * @param string $source
      *
-     * @dataProvider provideIsBinaryOperator
+     * @dataProvider provideIsBinaryOperatorCases
      */
     public function testIsBinaryOperator($source, array $expected)
     {
@@ -527,7 +527,7 @@ preg_replace_callback(
         }
     }
 
-    public function provideIsBinaryOperator()
+    public function provideIsBinaryOperatorCases()
     {
         $cases = array(
             array(
@@ -632,7 +632,7 @@ $b;',
     /**
      * @param string $source
      *
-     * @dataProvider provideIsBinaryOperator56
+     * @dataProvider provideIsBinaryOperator56Cases
      * @requires PHP 5.6
      */
     public function testIsBinaryOperator56($source, array $expected)
@@ -648,7 +648,7 @@ $b;',
         }
     }
 
-    public function provideIsBinaryOperator56()
+    public function provideIsBinaryOperator56Cases()
     {
         return array(
             array(
@@ -665,7 +665,7 @@ $b;',
     /**
      * @param string $source
      *
-     * @dataProvider provideIsBinaryOperator70
+     * @dataProvider provideIsBinaryOperator70Cases
      * @requires PHP 7.0
      */
     public function testIsBinaryOperator70($source, array $expected)
@@ -681,7 +681,7 @@ $b;',
         }
     }
 
-    public function provideIsBinaryOperator70()
+    public function provideIsBinaryOperator70Cases()
     {
         return array(
             array(
@@ -818,7 +818,7 @@ $b;',
      * @param string $source
      * @param int    $tokenIndex
      *
-     * @dataProvider provideArrayExceptions
+     * @dataProvider provideArrayExceptionCases
      */
     public function testIsNotArray($source, $tokenIndex)
     {
@@ -831,7 +831,7 @@ $b;',
      * @param string $source
      * @param int    $tokenIndex
      *
-     * @dataProvider provideArrayExceptions
+     * @dataProvider provideArrayExceptionCases
      */
     public function testIsMultiLineArrayException($source, $tokenIndex)
     {
@@ -842,7 +842,7 @@ $b;',
         $tokensAnalyzer->isArrayMultiLine($tokenIndex);
     }
 
-    public function provideArrayExceptions()
+    public function provideArrayExceptionCases()
     {
         $cases = array(
             array('<?php $a;', 1),
@@ -859,9 +859,9 @@ $b;',
      * @param int    $index
      * @param array  $expected
      *
-     * @dataProvider provideGetFunctionProperties
+     * @dataProvider provideGetMethodAttributesCases
      */
-    public function testGetFunctionProperties($source, $index, array $expected)
+    public function testGetMethodAttributes($source, $index, array $expected)
     {
         $tokens = Tokens::fromCode($source);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
@@ -869,7 +869,7 @@ $b;',
         $this->assertSame($expected, $attributes);
     }
 
-    public function provideGetFunctionProperties()
+    public function provideGetMethodAttributesCases()
     {
         $defaultAttributes = array(
             'visibility' => null,
@@ -1006,7 +1006,7 @@ SRC;
      * @param string $input
      * @param bool   $perNamespace
      *
-     * @dataProvider getImportUseIndexesCases
+     * @dataProvider provideGetImportUseIndexesCases
      */
     public function testGetImportUseIndexes(array $expected, $input, $perNamespace = false)
     {
@@ -1015,7 +1015,7 @@ SRC;
         $this->assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
     }
 
-    public function getImportUseIndexesCases()
+    public function provideGetImportUseIndexesCases()
     {
         return array(
             array(
@@ -1081,17 +1081,17 @@ EOF
      * @param string $input
      * @param bool   $perNamespace
      *
-     * @dataProvider getImportUseIndexesCasesPHP70
+     * @dataProvider provideGetImportUseIndexes70Cases
      * @requires PHP 7.0
      */
-    public function testGetImportUseIndexesPHP70(array $expected, $input, $perNamespace = false)
+    public function testGetImportUseIndexes70(array $expected, $input, $perNamespace = false)
     {
         $tokens = Tokens::fromCode($input);
         $tokensAnalyzer = new TokensAnalyzer($tokens);
         $this->assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
     }
 
-    public function getImportUseIndexesCasesPHP70()
+    public function provideGetImportUseIndexes70Cases()
     {
         return array(
             array(

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -50,7 +50,7 @@ final class TokensTest extends TestCase
      * @param null|int   $end
      * @param bool|array $caseSensitive
      *
-     * @dataProvider provideFindSequence
+     * @dataProvider provideFindSequenceCases
      */
     public function testFindSequence(
         $source,
@@ -73,7 +73,7 @@ final class TokensTest extends TestCase
         );
     }
 
-    public function provideFindSequence()
+    public function provideFindSequenceCases()
     {
         return array(
             array(
@@ -280,7 +280,7 @@ final class TokensTest extends TestCase
      * @param string $message
      * @param array  $sequence
      *
-     * @dataProvider provideFindSequenceExceptions
+     * @dataProvider provideFindSequenceExceptionCases
      */
     public function testFindSequenceException($message, array $sequence)
     {
@@ -293,7 +293,7 @@ final class TokensTest extends TestCase
         $tokens->findSequence($sequence);
     }
 
-    public function provideFindSequenceExceptions()
+    public function provideFindSequenceExceptionCases()
     {
         $emptyToken = new Token('');
 
@@ -343,7 +343,7 @@ PHP;
     }
 
     /**
-     * @dataProvider provideMonolithicPhpDetection
+     * @dataProvider provideMonolithicPhpDetectionCases
      *
      * @param string $source
      * @param bool   $isMonolithic
@@ -354,7 +354,7 @@ PHP;
         $this->assertSame($isMonolithic, $tokens->isMonolithicPhp());
     }
 
-    public function provideMonolithicPhpDetection()
+    public function provideMonolithicPhpDetectionCases()
     {
         return array(
             array("<?php\n", true),
@@ -369,7 +369,7 @@ PHP;
     }
 
     /**
-     * @dataProvider provideShortOpenTagMonolithicPhpDetection
+     * @dataProvider provideShortOpenTagMonolithicPhpDetectionCases
      *
      * @param string $source
      * @param bool   $monolithic
@@ -389,7 +389,7 @@ PHP;
         $this->assertSame($monolithic, $tokens->isMonolithicPhp());
     }
 
-    public function provideShortOpenTagMonolithicPhpDetection()
+    public function provideShortOpenTagMonolithicPhpDetectionCases()
     {
         return array(
             array("<?\n", true),
@@ -405,7 +405,7 @@ PHP;
     }
 
     /**
-     * @dataProvider provideShortOpenTagEchoMonolithicPhpDetection
+     * @dataProvider provideShortOpenTagEchoMonolithicPhpDetectionCases
      *
      * @param string $source
      * @param bool   $monolithic
@@ -425,7 +425,7 @@ PHP;
         $this->assertSame($monolithic, $tokens->isMonolithicPhp());
     }
 
-    public function provideShortOpenTagEchoMonolithicPhpDetection()
+    public function provideShortOpenTagEchoMonolithicPhpDetectionCases()
     {
         return array(
             array("<?=' ';\n", true),
@@ -530,7 +530,7 @@ PHP;
      * @param Token[] $expected tokens
      * @param int[]   $indexes  to clear
      *
-     * @dataProvider getClearTokenAndMergeSurroundingWhitespaceCases
+     * @dataProvider provideGetClearTokenAndMergeSurroundingWhitespaceCases
      */
     public function testClearTokenAndMergeSurroundingWhitespace($source, array $indexes, array $expected)
     {
@@ -540,7 +540,7 @@ PHP;
         }
     }
 
-    public function getClearTokenAndMergeSurroundingWhitespaceCases()
+    public function provideGetClearTokenAndMergeSurroundingWhitespaceCases()
     {
         $clearToken = new Token('');
 
@@ -728,14 +728,14 @@ PHP;
      * @param int    $searchIndex
      *
      * @requires PHP 7.1
-     * @dataProvider provideFindBlockEndCases71
+     * @dataProvider provideFindBlockEnd71Cases
      */
     public function testFindBlockEnd71($expectedIndex, $source, $type, $searchIndex)
     {
         $this->assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
     }
 
-    public function provideFindBlockEndCases71()
+    public function provideFindBlockEnd71Cases()
     {
         return array(
             array(10, '<?php use a\{ClassA, ClassB};', Tokens::BLOCK_TYPE_GROUP_IMPORT_BRACE, 5),

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -54,7 +54,7 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
     /**
      * @param string $source
      *
-     * @dataProvider provideProcessCases70
+     * @dataProvider provideProcess70Cases
      * @requires PHP 7.0
      */
     public function testProcess70($source, array $expectedTokens = array())
@@ -199,7 +199,7 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases70()
+    public function provideProcess70Cases()
     {
         return array(
             array(

--- a/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
@@ -227,7 +227,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
      * @param string          $source
      * @param array<int, int> $expectedTokens
      *
-     * @dataProvider provideProcessCases71
+     * @dataProvider provideProcess71Cases
      * @requires PHP 7.1
      */
     public function testProcess71($source, array $expectedTokens)
@@ -244,7 +244,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases71()
+    public function provideProcess71Cases()
     {
         return array(
             array(
@@ -299,7 +299,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
      * @param string          $source
      * @param array<int, int> $expectedTokens
      *
-     * @dataProvider provideProcessCases72
+     * @dataProvider provideProcess72Cases
      * @requires PHP 7.2
      */
     public function testProcess72($source, array $expectedTokens)
@@ -316,7 +316,7 @@ final class SquareBraceTransformerTest extends AbstractTransformerTestCase
         );
     }
 
-    public function provideProcessCases72()
+    public function provideProcess72Cases()
     {
         return array(
             array(


### PR DESCRIPTION
This PR

* [x] asserts that data provider method names match the regular expression `'/^provide[A-Z]\S+Cases$/'`
* [x] renames data providers (and a few tests along the way)

Related to #3017.