### PR TITLE
Risky rules cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -927,7 +927,7 @@ Choose from the list of available rules:
 
   @var and @type annotations should not contain the variable name.
 
-* **pow_to_exponentiation** [@PHP56Migration, @PHP70Migration, @PHP71Migration]
+* **pow_to_exponentiation** [@PHP56Migration:risky, @PHP70Migration:risky]
 
   Converts ``pow()`` to the ``**`` operator. Requires PHP >= 5.6.
 
@@ -959,7 +959,7 @@ Choose from the list of available rules:
 
   *Risky rule: this fixer may change you class name, which will break the code that is depended on old name.*
 
-* **random_api_migration** [@PHP70Migration, @PHP71Migration]
+* **random_api_migration** [@PHP70Migration:risky]
 
   Replaces ``rand``, ``srand``, ``getrandmax`` functions calls with their ``mt_*``
   analogs.

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -151,19 +151,20 @@ final class RuleSet implements RuleSetInterface
             'psr4' => true,
             'silenced_deprecation_error' => true,
         ),
-        '@PHP56Migration' => array(
+        '@PHP56Migration' => array(),
+        '@PHP56Migration:risky' => array(
             'pow_to_exponentiation' => true,
         ),
         '@PHP70Migration' => array(
-            '@PHP56Migration' => true,
+            'ternary_to_null_coalescing' => true,
+        ),
+        '@PHP70Migration:risky' => array(
+            '@PHP56Migration:risky' => true,
+            'declare_strict_types' => true,
             'random_api_migration' => array('replacements' => array(
                 'mt_rand' => 'random_int',
                 'rand' => 'random_int',
             )),
-            'ternary_to_null_coalescing' => true,
-        ),
-        '@PHP70Migration:risky' => array(
-            'declare_strict_types' => true,
         ),
         '@PHP71Migration' => array(
             '@PHP70Migration' => true,

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -306,6 +306,8 @@ final class RuleSetTest extends TestCase
             array(array('@PSR1' => true), true),
             array(array('@PSR2' => true), true),
             array(array('@Symfony' => true), true),
+            array(array('@Symfony:risky' => true), false),
+            array(array('@PHP56Migration:risky' => true), false),
             array(
                 array(
                     '@Symfony:risky' => true,
@@ -313,13 +315,31 @@ final class RuleSetTest extends TestCase
                 ),
                 false,
             ),
-            array(
-                array(
-                    '@Symfony:risky' => true,
-                ),
-                false,
-            ),
         );
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testPHP70MigrationSet()
+    {
+        $this->testRiskyRulesInSet(array('@PHP70Migration' => true), true);
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testPHP70MigrationRiskySet()
+    {
+        $this->testRiskyRulesInSet(array('@PHP70Migration:risky' => true), false);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testPHP71MigrationSet()
+    {
+        $this->testRiskyRulesInSet(array('@PHP71Migration' => true), true);
     }
 
     public function testInvalidConfigNestedSets()

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -319,27 +319,42 @@ final class RuleSetTest extends TestCase
     }
 
     /**
+     * @param array $set
+     * @param bool  $safe
+     *
+     * @dataProvider providePhp70SafeSets
      * @requires PHP 7.0
      */
-    public function testPHP70MigrationSet()
+    public function testPhp70MigrationSet(array $set, $safe)
     {
-        $this->testRiskyRulesInSet(array('@PHP70Migration' => true), true);
+        $this->testRiskyRulesInSet($set, $safe);
+    }
+
+    public function providePhp70SafeSets()
+    {
+        return array(
+            array(array('@PHP70Migration' => true), true),
+            array(array('@PHP70Migration:risky' => true), false),
+        );
     }
 
     /**
-     * @requires PHP 7.0
-     */
-    public function testPHP70MigrationRiskySet()
-    {
-        $this->testRiskyRulesInSet(array('@PHP70Migration:risky' => true), false);
-    }
-
-    /**
+     * @param array $set
+     * @param bool  $safe
+     *
+     * @dataProvider providePhp71SafeSets
      * @requires PHP 7.1
      */
-    public function testPHP71MigrationSet()
+    public function testPhp71MigrationSet(array $set, $safe)
     {
-        $this->testRiskyRulesInSet(array('@PHP71Migration' => true), true);
+        $this->testRiskyRulesInSet($set, $safe);
+    }
+
+    public function providePhp71SafeSets()
+    {
+        return array(
+            array(array('@PHP71Migration' => true), true),
+        );
     }
 
     public function testInvalidConfigNestedSets()


### PR DESCRIPTION
`PowToExponentiationFixer` is a risky fixer therefore it should be in `@PHP56Migration:risky` group, not `@PHP56Migration`.

