### PR TITLE
RandomApiMigrationFixer - "rand();" to "random_int(0, getrandmax());" fixing

### DIFF
--- a/src/Fixer/Alias/RandomApiMigrationFixer.php
+++ b/src/Fixer/Alias/RandomApiMigrationFixer.php
@@ -111,6 +111,19 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
                 $currIndex = $openParenthesis;
 
                 $tokens[$functionName] = new Token(array(T_STRING, $functionReplacement['alternativeName']));
+
+                if (0 === $count && 'random_int' === $functionReplacement['alternativeName']) {
+                    $tokens->insertAt(++$currIndex, array(
+                        new Token(array(T_LNUMBER, '0')),
+                        new Token(','),
+                        new Token(array(T_WHITESPACE, ' ')),
+                        new Token(array(T_STRING, 'getrandmax')),
+                        new Token('('),
+                        new Token(')'),
+                    ));
+
+                    $currIndex += 5;
+                }
             }
         }
     }

--- a/src/Fixer/Alias/RandomApiMigrationFixer.php
+++ b/src/Fixer/Alias/RandomApiMigrationFixer.php
@@ -113,7 +113,7 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
                 $tokens[$functionName] = new Token(array(T_STRING, $functionReplacement['alternativeName']));
 
                 if (0 === $count && 'random_int' === $functionReplacement['alternativeName']) {
-                    $tokens->insertAt(++$currIndex, array(
+                    $tokens->insertAt($currIndex + 1, array(
                         new Token(array(T_LNUMBER, '0')),
                         new Token(','),
                         new Token(array(T_WHITESPACE, ' ')),
@@ -122,7 +122,7 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
                         new Token(')'),
                     ));
 
-                    $currIndex += 5;
+                    $currIndex += 6;
                 }
             }
         }

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -92,6 +92,26 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
     public function provideFixCases()
     {
         return array(
+            array(
+                '<?php random_int(0, getrandmax());',
+                '<?php rand();',
+                array('replacements' => array('rand' => 'random_int')),
+            ),
+            array(
+                '<?php random_int#1
+                #2
+                (0, getrandmax()#3
+                #4
+                )#5
+                ;',
+                '<?php rand#1
+                #2
+                (#3
+                #4
+                )#5
+                ;',
+                array('replacements' => array('rand' => 'random_int')),
+            ),
             array('<?php $smth->srand($a);'),
             array('<?php srandSmth($a);'),
             array('<?php smth_srand($a);'),


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3022