### PR TITLE
ConfigurationResolver - Handle empty "rules" value

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -627,6 +627,9 @@ final class ConfigurationResolver
         }
 
         $rules = trim($this->options['rules']);
+        if ('' === $rules) {
+            throw new InvalidConfigurationException('Empty rules value is not allowed.');
+        }
 
         if ('{' === $rules[0]) {
             $rules = json_decode($rules, true);

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -37,7 +37,6 @@ final class ProjectCodeTest extends TestCase
      */
     private static $classesWithoutTests = array(
         'PhpCsFixer\ConfigurationException\InvalidForEnvFixerConfigurationException',
-        'PhpCsFixer\Console\Command\FixCommand',
         'PhpCsFixer\Console\Command\SelfUpdateCommand',
         'PhpCsFixer\Console\Output\NullOutput',
         'PhpCsFixer\Console\SelfUpdate\GithubClient',

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -12,7 +12,6 @@
 
 namespace PhpCsFixer\Tests\Console\Command;
 
-use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
 use PHPUnit\Framework\TestCase;
@@ -41,7 +40,7 @@ final class FixCommandTest extends TestCase
         $this->doTestExecute(
             array('--rules' => ''),
             array(
-                'class' => InvalidConfigurationException::class,
+                'class' => 'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
                 'regex' => '#^Empty rules value is not allowed\.$#',
             )
         );
@@ -60,7 +59,7 @@ final class FixCommandTest extends TestCase
             )
         );
 
-        $this->assertSame(0, $cmdTester->getStatusCode(), 'Expected exit code mismatch.');
+        $this->assertSame(0, $cmdTester->getStatusCode(), "Expected exit code mismatch. Output:\n".$cmdTester->getDisplay());
     }
 
     /**

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Console\Command;
+
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
+use PhpCsFixer\Console\Application;
+use PhpCsFixer\Console\Command\FixCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Console\Command\FixCommand
+ */
+final class FixCommandTest extends TestCase
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp()
+    {
+        $this->application = new Application();
+    }
+
+    public function testEmptyRulesValue()
+    {
+        $this->doTestExecute(
+            array('--rules' => ''),
+            array(
+                'class' => InvalidConfigurationException::class,
+                'regex' => '#^Empty rules value is not allowed\.$#',
+            )
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Expected "yes" or "no" for option "using-cache", other values are deprecated and support will be removed in 3.0. Got "not today", this implicitly set the option to "false".
+     */
+    public function testEmptyFormatValue()
+    {
+        $cmdTester = $this->doTestExecute(
+            array(
+                '--using-cache' => 'not today',
+                '--rules' => 'switch_case_semicolon_to_colon',
+            )
+        );
+
+        $this->assertSame(0, $cmdTester->getStatusCode(), 'Expected exit code mismatch.');
+    }
+
+    /**
+     * @param array      $arguments
+     * @param array|null $expectedException
+     *
+     * @return CommandTester
+     */
+    private function doTestExecute(array $arguments, array $expectedException = null)
+    {
+        $this->application->add(new FixCommand());
+
+        $command = $this->application->find('fix');
+        $commandTester = new CommandTester($command);
+
+        if (null !== $expectedException) {
+            $this->setExpectedExceptionRegExp($expectedException['class'], $expectedException['regex']);
+        }
+
+        $commandTester->execute(
+            array_merge(
+                array('command' => $command->getName()),
+                $this->getDefaultArguments(),
+                $arguments
+            ),
+            array(
+                'interactive' => false,
+                'decorated' => false,
+                'verbosity' => OutputInterface::VERBOSITY_DEBUG,
+            )
+        );
+
+        return $commandTester;
+    }
+
+    private function getDefaultArguments()
+    {
+        return array(
+            'path' => array(__FILE__),
+            '--path-mode' => 'override',
+            '--allow-risky' => true,
+            '--dry-run' => true,
+            '--using-cache' => 'no',
+            '--show-progress' => 'none',
+        );
+    }
+}

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1122,6 +1122,22 @@ final class ConfigurationResolverTest extends TestCase
         );
     }
 
+    public function testWithEmptyRules()
+    {
+        $resolver = new ConfigurationResolver(
+            $this->config,
+            array('rules' => ''),
+            ''
+        );
+
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '/^Empty rules value is not allowed\.$/'
+        );
+
+        $resolver->getRules();
+    }
+
     private function assertSameRules(array $expected, array $actual, $message = '')
     {
         ksort($expected);


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3019