### PR TITLE
.php_cs.dist - handling UnexpectedValueException

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -50,6 +50,8 @@ try {
         ->useRuleSet(new PhpCsFixer\RuleSet($config->getRules()));
 } catch (PhpCsFixer\ConfigurationException\InvalidConfigurationException $e) {
     $config->setRules(array());
+} catch (UnexpectedValueException $e) {
+    $config->setRules(array());
 }
 
 return $config;


### PR DESCRIPTION
Execution is thrown when fixer of lower version is executing `fabbot` detection code of higher version,
eg 2.2 trying to load 2.5 config, inside which we have `no_homoglyph_names` rule not available, is throwing this exception