### PR TITLE
CombineConsecutiveIssetsFixer - fix priority

### DIFF
--- a/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
@@ -39,8 +39,8 @@ final class CombineConsecutiveIssetsFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        // should ran before NoMultilineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer and NoWhitespaceInBlankLineFixer.
-        return 1;
+        // should ran before NoMultilineWhitespaceBeforeSemicolonsFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer and NoSpacesInsideParenthesisFixer.
+        return 3;
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -174,6 +174,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['combine_consecutive_issets'], $fixers['no_multiline_whitespace_before_semicolons']], // tested also in: combine_consecutive_issets,no_multiline_whitespace_before_semicolons.test
             [$fixers['combine_consecutive_issets'], $fixers['no_trailing_whitespace']], // tested also in: combine_consecutive_issets,no_trailing_whitespace.test
             [$fixers['combine_consecutive_issets'], $fixers['no_whitespace_in_blank_line']], // tested also in: combine_consecutive_issets,no_whitespace_in_blank_line.test
+            [$fixers['combine_consecutive_issets'], $fixers['no_spaces_inside_parenthesis']], // tested also in: combine_consecutive_issets,no_spaces_inside_parenthesis.test
         ];
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixtures/Integration/priority/combine_consecutive_issets,no_spaces_inside_parenthesis.test
+++ b/tests/Fixtures/Integration/priority/combine_consecutive_issets,no_spaces_inside_parenthesis.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: combine_consecutive_issets,no_spaces_inside_parenthesis.
+--RULESET--
+{"combine_consecutive_issets": true, "no_spaces_inside_parenthesis": true}
+--EXPECT--
+<?php
+if (isset($x->foo, $x->bar)) {
+}
+
+--INPUT--
+<?php
+if (isset($x->foo) && isset($x->bar)) {
+}


### PR DESCRIPTION
... vs. NoSpacesInsideParenthesisFixer.

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3050