### PR TITLE
NativeFunctionInvocationFixer - add scope option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -665,7 +665,8 @@ Choose from the list of available rules:
 
   - ``exclude`` (``array``): list of functions to ignore; defaults to ``[]``
   - ``scope`` (``'global'``, ``'namespaced'``): fix functions only if called in given
-    scope; defaults to ``'global'``
+    scope, global or within user defined namespaces only; defaults to
+    ``'global'``
 
 * **new_with_braces** [@Symfony]
 

--- a/README.rst
+++ b/README.rst
@@ -664,6 +664,8 @@ Choose from the list of available rules:
   Configuration options:
 
   - ``exclude`` (``array``): list of functions to ignore; defaults to ``[]``
+  - ``scope`` (``'global'``, ``'namespaced'``): fix functions only if called in given
+    scope; defaults to ``'global'``
 
 * **new_with_braces** [@Symfony]
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -61,6 +61,17 @@ function baz($options)
 }',
                     ['exclude' => ['json_encode']]
                 ),
+                new CodeSample(
+                    '<?php
+namespace space1 {
+    echo count([1]);
+}
+namespace {
+    echo count([1]);
+}
+',
+                    ['scope' => 'namespaced']
+                ),
             ],
             null,
             'Risky when any of the functions are overridden.'
@@ -121,8 +132,8 @@ function baz($options)
                 }])
                 ->setDefault([])
                 ->getOption(),
-            (new FixerOptionBuilder('scope', 'Fix functions only if called in given scope.'))
-                ->setAllowedValues(['global', 'namespaced']) // everywhere or within user defined namespaces only
+            (new FixerOptionBuilder('scope', 'Fix functions only if called in given scope, global or within user defined namespaces only.'))
+                ->setAllowedValues(['global', 'namespaced'])
                 ->setDefault('global')
                 ->getOption(),
         ]);

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -99,7 +99,7 @@ namespace {
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $functionNames = $this->getFunctionNames();
+        $functionNames = $this->getAllInternalFunctionsNormalized();
 
         if ('namespaced' === $this->configuration['scope']) {
             foreach (array_reverse($this->getUserDefinedNamespaces($tokens)) as $namespace) {
@@ -188,7 +188,7 @@ namespace {
     /**
      * @return string[]
      */
-    private function getFunctionNames()
+    private function getAllInternalFunctionsNormalized()
     {
         static $definedFunctions = null;
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -24,6 +24,7 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * @author Andreas Möller <am@localheinz.com>
+ * @author SpacePossum
  */
 final class NativeFunctionInvocationFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
@@ -58,11 +59,7 @@ function baz($options)
 
     return json_encode($options);
 }',
-                    [
-                        'exclude' => [
-                            'json_encode',
-                        ],
-                    ]
+                    ['exclude' => ['json_encode']]
                 ),
             ],
             null,
@@ -93,53 +90,12 @@ function baz($options)
     {
         $functionNames = $this->getFunctionNames();
 
-        $indexes = [];
-
-        for ($index = 0, $count = $tokens->count(); $index < $count; ++$index) {
-            $token = $tokens[$index];
-
-            $tokenContent = $token->getContent();
-
-            // test if we are at a function call
-            if (!$token->isGivenKind(T_STRING)) {
-                continue;
+        if ('namespaced' === $this->configuration['scope']) {
+            foreach (array_reverse($this->getUserDefinedNamespaces($tokens)) as $namespace) {
+                $this->fixFunctionCalls($tokens, $functionNames, $namespace['open'], $namespace['close']);
             }
-
-            $next = $tokens->getNextMeaningfulToken($index);
-            if (!$tokens[$next]->equals('(')) {
-                continue;
-            }
-
-            $functionNamePrefix = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$functionNamePrefix]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_FUNCTION])) {
-                continue;
-            }
-
-            if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
-                // skip if the call is to a constructor or to a function in a namespace other than the default
-                $prev = $tokens->getPrevMeaningfulToken($functionNamePrefix);
-                if ($tokens[$prev]->isGivenKind([T_STRING, T_NEW])) {
-                    continue;
-                }
-            }
-
-            $lowerFunctionName = \strtolower($tokenContent);
-
-            if (!\in_array($lowerFunctionName, $functionNames, true)) {
-                continue;
-            }
-
-            // do not bother if previous token is already namespace separator
-            if ($tokens[$index - 1]->isGivenKind(T_NS_SEPARATOR)) {
-                continue;
-            }
-
-            $indexes[] = $index;
-        }
-
-        $indexes = \array_reverse($indexes);
-        foreach ($indexes as $index) {
-            $tokens->insertAt($index, new Token([T_NS_SEPARATOR, '\\']));
+        } else {
+            $this->fixFunctionCalls($tokens, $functionNames, 0, count($tokens) - 1);
         }
     }
 
@@ -165,7 +121,57 @@ function baz($options)
                 }])
                 ->setDefault([])
                 ->getOption(),
+            (new FixerOptionBuilder('scope', 'Fix functions only if called in given scope.'))
+                ->setAllowedValues(['global', 'namespaced']) // everywhere or within user defined namespaces only
+                ->setDefault('global')
+                ->getOption(),
         ]);
+    }
+
+    /**
+     * @param Tokens   $tokens
+     * @param string[] $functionNames
+     * @param int      $start
+     * @param int      $end
+     */
+    private function fixFunctionCalls(Tokens $tokens, array $functionNames, $start, $end)
+    {
+        $insertAtIndexes = [];
+        for ($index = $start; $index < $end; ++$index) {
+            // test if we are at a function call
+            if (!$tokens[$index]->isGivenKind(T_STRING)) {
+                continue;
+            }
+
+            if (!$tokens[$tokens->getNextMeaningfulToken($index)]->equals('(')) {
+                continue;
+            }
+
+            $functionNamePrefix = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$functionNamePrefix]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_FUNCTION])) {
+                continue;
+            }
+
+            if ($tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)) {
+                if ($tokens[$tokens->getPrevMeaningfulToken($functionNamePrefix)]->isGivenKind([T_STRING, T_NEW])) {
+                    continue; // skip if the call is to a constructor or to a function in a namespace other than the default
+                }
+            }
+
+            if (!\in_array(\strtolower($tokens[$index]->getContent()), $functionNames, true)) {
+                continue;
+            }
+
+            if ($tokens[$index - 1]->isGivenKind(T_NS_SEPARATOR)) {
+                continue; // do not bother if previous token is already namespace separator
+            }
+
+            $insertAtIndexes[] = $index;
+        }
+
+        foreach (\array_reverse($insertAtIndexes) as $index) {
+            $tokens->insertAt($index, new Token([T_NS_SEPARATOR, '\\']));
+        }
     }
 
     /**
@@ -173,12 +179,65 @@ function baz($options)
      */
     private function getFunctionNames()
     {
-        $definedFunctions = \get_defined_functions();
+        static $definedFunctions = null;
+
+        if (null === $definedFunctions) {
+            $definedFunctions = \get_defined_functions();
+            $definedFunctions = $this->normalizeFunctionNames($definedFunctions['internal']);
+        }
 
         return \array_diff(
-            $this->normalizeFunctionNames($definedFunctions['internal']),
+            $definedFunctions,
             \array_unique($this->normalizeFunctionNames($this->configuration['exclude']))
         );
+    }
+
+    /**
+     * @param Tokens $tokens
+     *
+     * @return array<<|array|string, int>>
+     */
+    private function getUserDefinedNamespaces(Tokens $tokens)
+    {
+        $namespaces = [];
+        for ($index = 1, $count = count($tokens); $index < $count; ++$index) {
+            if (!$tokens[$index]->isGivenKind(T_NAMESPACE)) {
+                continue;
+            }
+
+            $index = $tokens->getNextMeaningfulToken($index);
+            if ($tokens[$index]->equals('{')) { // global namespace
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+
+            while (!$tokens[++$index]->equalsAny(['{', ';', [T_CLOSE_TAG]])) {
+                // no-op
+            }
+
+            if ($tokens[$index]->equals('{')) {
+                // namespace ends at block end of `{`
+                $namespaces[] = [
+                    'open' => $index,
+                    'close' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index),
+                ];
+
+                continue;
+            }
+
+            // namespace ends at next T_NAMESPACE or EOF
+            $close = $tokens->getNextTokenOfKind($index, [[T_NAMESPACE]], false);
+            if (null === $close) {
+                $namespaces[] = ['open' => $index, 'close' => count($tokens) - 1];
+
+                break;
+            }
+
+            $namespaces[] = ['open' => $index, 'close' => $close];
+        }
+
+        return $namespaces;
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -179,7 +179,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return \json_encode($foo);
+        return \JSON_ENCODE($foo);
     }
 }
 ',
@@ -189,7 +189,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return json_encode($foo);
+        return JSON_ENCODE($foo);
     }
 }
 ',
@@ -274,7 +274,7 @@ namespace space1 { ?>
             [
                 '<?php
 namespace Bar {
-    echo \strtolower("in 1");
+    echo \strtoLOWER("in 1");
 }
 
 namespace {
@@ -295,7 +295,7 @@ namespace {
 ',
                 '<?php
 namespace Bar {
-    echo strtolower("in 1");
+    echo strtoLOWER("in 1");
 }
 
 namespace {
@@ -317,7 +317,7 @@ namespace {
             ],
             [
                 '<?php
-namespace space1 ?>
+namespace space11 ?>
 
     <?php
 echo \strtolower(__NAMESPACE__);
@@ -325,7 +325,7 @@ namespace space2;
 echo \strtolower(__NAMESPACE__);
 ',
                 '<?php
-namespace space1 ?>
+namespace space11 ?>
 
     <?php
 echo strtolower(__NAMESPACE__);
@@ -339,7 +339,7 @@ echo strtolower(__NAMESPACE__);
             ],
             [
                 '<?php
-namespace Space1;
+namespace Space12;
 
 echo \count([1]);
 
@@ -349,7 +349,7 @@ echo \count([1]);
 ?>
 ',
                 '<?php
-namespace Space1;
+namespace Space12;
 
 echo count([1]);
 
@@ -364,7 +364,7 @@ echo count([1]);
             ],
             [
                 '<?php
-namespace space1 {
+namespace space13 {
     echo \strtolower("in 1");
 }
 
@@ -377,7 +377,7 @@ namespace { // global
 }
 ',
                 '<?php
-namespace space1 {
+namespace space13 {
     echo strtolower("in 1");
 }
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -240,4 +240,156 @@ class Foo
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFixWithNamespaceConfigurationCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithNamespaceConfiguration($expected, $input = null)
+    {
+        $this->fixer->configure(['scope' => 'namespaced']);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithNamespaceConfigurationCases()
+    {
+        return [
+            [
+                '<?php echo count([1]);',
+            ],
+            [
+                '<?php
+namespace space1 { ?>
+<?php echo \count([2]) ?>
+<?php }namespace {echo count([1]);}
+',
+                '<?php
+namespace space1 { ?>
+<?php echo count([2]) ?>
+<?php }namespace {echo count([1]);}
+',
+            ],
+            [
+                '<?php
+namespace Bar {
+    echo \strtolower("in 1");
+}
+
+namespace {
+    echo strtolower("out 1");
+}
+
+namespace {
+    echo strtolower("out 2");
+}
+
+namespace Bar{
+    echo \strtolower("in 2");
+}
+
+namespace {
+    echo strtolower("out 3");
+}
+',
+                '<?php
+namespace Bar {
+    echo strtolower("in 1");
+}
+
+namespace {
+    echo strtolower("out 1");
+}
+
+namespace {
+    echo strtolower("out 2");
+}
+
+namespace Bar{
+    echo strtolower("in 2");
+}
+
+namespace {
+    echo strtolower("out 3");
+}
+',
+            ],
+            [
+                '<?php
+namespace space1 ?>
+
+    <?php
+echo \strtolower(__NAMESPACE__);
+namespace space2;
+echo \strtolower(__NAMESPACE__);
+',
+                '<?php
+namespace space1 ?>
+
+    <?php
+echo strtolower(__NAMESPACE__);
+namespace space2;
+echo strtolower(__NAMESPACE__);
+',
+            ],
+            [
+                '<?php namespace PhpCsFixer\Tests\Fixer\Casing;\count([1]);',
+                '<?php namespace PhpCsFixer\Tests\Fixer\Casing;count([1]);',
+            ],
+            [
+                '<?php
+namespace Space1;
+
+echo \count([1]);
+
+namespace Space2;
+
+echo \count([1]);
+?>
+',
+                '<?php
+namespace Space1;
+
+echo count([1]);
+
+namespace Space2;
+
+echo count([1]);
+?>
+',
+            ],
+            [
+                '<?php namespace {echo strtolower("out 2");}',
+            ],
+            [
+                '<?php
+namespace space1 {
+    echo \strtolower("in 1");
+}
+
+namespace space2 {
+    echo \strtolower("in 2");
+}
+
+namespace { // global
+    echo strtolower("global 1");
+}
+',
+                '<?php
+namespace space1 {
+    echo strtolower("in 1");
+}
+
+namespace space2 {
+    echo strtolower("in 2");
+}
+
+namespace { // global
+    echo strtolower("global 1");
+}
+',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Calling functions explicit from within the global namespace (`\`) is only more effective if the function is not called from the global namespace already.
This PR adds an option to only fix functions called from within a namespace.