### PR TITLE
Add ErrorSuppressionFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -575,6 +575,22 @@ Choose from the list of available rules:
 
   *Risky rule: risky if the ``ereg`` function is overridden.*
 
+* **error_suppression** [@Symfony:risky]
+
+  Error control operator should be added to deprecation notices and/or
+  removed from other cases.
+
+  *Risky rule: risky because adding/removing ``@`` might cause changes to code behaviour or if ``trigger_error`` function is overridden.*
+
+  Configuration options:
+
+  - ``mute_deprecation_error`` (``bool``): whether to add ``@`` in deprecation
+    notices; defaults to ``true``
+  - ``noise_remaining_usages`` (``bool``): whether to remove ``@`` in remaining
+    usages; defaults to ``false``
+  - ``noise_remaining_usages_exclude`` (``array``): list of global functions to
+    exclude from removing ``@``; defaults to ``[]``
+
 * **escape_implicit_backslashes**
 
   Escape implicit backslashes in strings and heredocs to ease the
@@ -1462,9 +1478,10 @@ Choose from the list of available rules:
   ``(int)``, ``(double)`` and ``(real)`` as ``(float)``, ``(binary)`` as
   ``(string)``.
 
-* **silenced_deprecation_error** [@Symfony:risky]
+* **silenced_deprecation_error**
 
-  Ensures deprecation notices are silenced.
+  Ensures deprecation notices are silenced. DEPRECATED: use
+  ``error_suppression`` instead.
 
   *Risky rule: silencing of deprecation errors might cause changes to code behaviour.*
 

--- a/src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+++ b/src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\LanguageConstruct;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ * @author Kuba Werłos <werlos@gmail.com>
+ */
+final class ErrorSuppressionFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    const OPTION_MUTE_DEPRECATION_ERROR = 'mute_deprecation_error';
+    const OPTION_NOISE_REMAINING_USAGES = 'noise_remaining_usages';
+    const OPTION_NOISE_REMAINING_USAGES_EXCLUDE = 'noise_remaining_usages_exclude';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Error control operator should be added to deprecation notices and/or removed from other cases.',
+            [
+                new CodeSample("<?php\ntrigger_error('Warning.', E_USER_DEPRECATED);\n"),
+                new CodeSample(
+                    "<?php\n@mkdir(\$dir);\n@unlink(\$path);\n",
+                    [self::OPTION_NOISE_REMAINING_USAGES => true]
+                ),
+                new CodeSample(
+                    "<?php\n@mkdir(\$dir);\n@unlink(\$path);\n",
+                    [
+                        self::OPTION_NOISE_REMAINING_USAGES => true,
+                        self::OPTION_NOISE_REMAINING_USAGES_EXCLUDE => ['unlink'],
+                    ]
+                ),
+            ],
+            null,
+            'Risky because adding/removing `@` might cause changes to code behaviour or if `trigger_error` function is overridden.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound(['@', T_STRING]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder(self::OPTION_MUTE_DEPRECATION_ERROR, 'Whether to add `@` in deprecation notices.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+            (new FixerOptionBuilder(self::OPTION_NOISE_REMAINING_USAGES, 'Whether to remove `@` in remaining usages.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
+            (new FixerOptionBuilder(self::OPTION_NOISE_REMAINING_USAGES_EXCLUDE, 'List of global functions to exclude from removing `@`'))
+                ->setAllowedTypes(['array'])
+                ->setDefault([])
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+        $excludedFunctions = array_map(function ($function) {
+            return strtolower($function);
+        }, $this->configuration[self::OPTION_NOISE_REMAINING_USAGES_EXCLUDE]);
+
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if ($this->configuration[self::OPTION_NOISE_REMAINING_USAGES] && $token->equals('@')) {
+                $tokens->clearAt($index);
+
+                continue;
+            }
+
+            if (!$functionsAnalyzer->isGlobalFunctionIndex($tokens, $index)) {
+                continue;
+            }
+
+            $functionIndex = $index;
+            $startIndex = $index;
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                $startIndex = $prevIndex;
+                $prevIndex = $tokens->getPrevMeaningfulToken($startIndex);
+            }
+
+            $index = $prevIndex;
+
+            if ($this->isDeprecationErrorCall($tokens, $functionIndex)) {
+                if (!$this->configuration[self::OPTION_MUTE_DEPRECATION_ERROR]) {
+                    continue;
+                }
+
+                if ($tokens[$prevIndex]->equals('@')) {
+                    continue;
+                }
+
+                $tokens->insertAt($startIndex, new Token('@'));
+
+                continue;
+            }
+
+            if (!$tokens[$prevIndex]->equals('@')) {
+                continue;
+            }
+
+            if ($this->configuration[self::OPTION_NOISE_REMAINING_USAGES] && !in_array($tokens[$functionIndex]->getContent(), $excludedFunctions, true)) {
+                $tokens->clearAt($index);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isDeprecationErrorCall(Tokens $tokens, $index)
+    {
+        if ('trigger_error' !== strtolower($tokens[$index]->getContent())) {
+            return false;
+        }
+
+        $end = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextTokenOfKind($index, [T_STRING, '(']));
+
+        return $tokens[$tokens->getPrevMeaningfulToken($end)]->equals([T_STRING, 'E_USER_DEPRECATED']);
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -164,6 +164,7 @@ final class RuleSet implements RuleSetInterface
         '@Symfony:risky' => [
             'dir_constant' => true,
             'ereg_to_preg' => true,
+            'error_suppression' => true,
             'function_to_constant' => true,
             'is_null' => true,
             'modernize_types_casting' => true,
@@ -175,7 +176,6 @@ final class RuleSet implements RuleSetInterface
             'php_unit_construct' => true,
             'psr4' => true,
             'self_accessor' => true,
-            'silenced_deprecation_error' => true,
         ],
         '@DoctrineAnnotation' => [
             'doctrine_annotation_array_assignment' => [

--- a/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
@@ -23,6 +23,29 @@ final class FunctionsAnalyzer
 {
     /**
      * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    public function isGlobalFunctionIndex(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index]->isGivenKind(T_STRING)) {
+            return false;
+        }
+
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+        if ($tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {
+            $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
+        }
+
+        $nextIndex = $tokens->getNextMeaningfulToken($index);
+
+        return !$tokens[$prevIndex]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_STRING])
+            && !$tokens[$nextIndex]->isGivenKind([T_DOUBLE_COLON, T_NS_SEPARATOR]);
+    }
+
+    /**
+     * @param Tokens $tokens
      * @param int    $methodIndex
      *
      * @return ArgumentAnalysis[]

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Jules Pietri <jules@heahprod.com>
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\LanguageConstruct\ErrorSuppressionFixer
+ */
+final class ErrorSuppressionFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $config
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null, array $config = null)
+    {
+        if ($config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php trigger_error("This is not a deprecation warning."); ?>',
+            ],
+            [
+                '<?php trigger_error("This is not a deprecation warning.", E_USER_WARNING); ?>',
+            ],
+            [
+                '<?php A\B\trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php \A\B/* */\trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                null,
+                ['mute_deprecation_error' => false],
+            ],
+            [
+                '<?php @\trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php \trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php echo "test";@trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+                '<?php echo "test";trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php //
+@Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>',
+                '<?php //
+Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>',
+            ],
+            [
+                '<?php new trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php new \trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php $foo->trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php Foo::trigger_error("This is not a deprecation warning.", E_USER_DEPRECATED); ?>',
+            ],
+            [
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); mkdir("dir"); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @mkdir("dir"); ?>',
+                ['mute_deprecation_error' => true, 'noise_remaining_usages' => true],
+            ],
+            [
+                '<?php $foo->isBar(); ?>',
+                '<?php @$foo->isBar(); ?>',
+                ['noise_remaining_usages' => true],
+            ],
+            [
+                '<?php Foo::isBar(); ?>',
+                '<?php @Foo::isBar(); ?>',
+                ['noise_remaining_usages' => true],
+            ],
+            [
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @mkdir("dir"); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @mkdir("dir"); ?>',
+                ['mute_deprecation_error' => true, 'noise_remaining_usages' => true, 'noise_remaining_usages_exclude' => ['mkdir']],
+            ],
+            [
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @mkdir("dir"); unlink($path); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @mkdir("dir"); @unlink($path); ?>',
+                ['mute_deprecation_error' => true, 'noise_remaining_usages' => true, 'noise_remaining_usages_exclude' => ['mkdir']],
+            ],
+            [
+                '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @trigger_error("This is not a deprecation warning.", E_USER_WARNING); ?>',
+                '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED); @trigger_error("This is not a deprecation warning.", E_USER_WARNING); ?>',
+                ['mute_deprecation_error' => true, 'noise_remaining_usages' => true, 'noise_remaining_usages_exclude' => ['trigger_error']],
+            ],
+        ];
+    }
+}

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -28,6 +28,72 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class FunctionsAnalyzerTest extends TestCase
 {
     /**
+     * @param bool   $isFunctionIndex
+     * @param string $code
+     * @param int    $index
+     *
+     * @dataProvider provideIsGlobalFunctionIndexCases
+     */
+    public function testIsGlobalFunctionIndex($isFunctionIndex, $code, $index)
+    {
+        $tokens = Tokens::fromCode($code);
+        $analyzer = new FunctionsAnalyzer();
+
+        $this->assertSame($isFunctionIndex, $analyzer->isGlobalFunctionIndex($tokens, $index));
+    }
+
+    public function provideIsGlobalFunctionIndexCases()
+    {
+        return [
+            [
+                true,
+                '<?php foo("bar");',
+                1,
+            ],
+            [
+                false,
+                '<?php \foo("bar");',
+                1,
+            ],
+            [
+                true,
+                '<?php \foo("bar");',
+                2,
+            ],
+            [
+                false,
+                '<?php foo\bar("baz");',
+                1,
+            ],
+            [
+                false,
+                '<?php foo\bar("baz");',
+                3,
+            ],
+            [
+                false,
+                '<?php foo::bar("baz");',
+                1,
+            ],
+            [
+                false,
+                '<?php foo::bar("baz");',
+                3,
+            ],
+            [
+                false,
+                '<?php $foo->bar("baz");',
+                3,
+            ],
+            [
+                false,
+                '<?php new bar("baz");',
+                3,
+            ],
+        ];
+    }
+
+    /**
      * @param string $code
      * @param int    $methodIndex
      * @param array  $expected


### PR DESCRIPTION
#3035

Initial commit - fixer and tests are based on `SilencedDeprecationErrorFixer` thus @HeahDude is added as author.

Option allows only boolean value meaning to do what is should or not.

Having also `null` to ignore option would make `false` doing the opposite to `true`: 
- for `silence_deprecation_error` it would sense - to remove `@` from deprecation notices
- but for `noise_remaining_usages` what would that mean? Add `@` everywhere?

Feel free to propose better naming for options, descriptions and interesting test cases.

My doubt is line 106 in `ErrorSuppressionFixer.php` - I thought it should be something like:

```php
$indexes[$prev] = (true === $this->configuration['noise_remaining_usages']) ? false : null;
```

but that failed some tests. Anyway it's just a hint where to look for flaws.
