### PR TITLE
BraceClassInstantiationTransformer - Fix instantiation inside method call braces case

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -349,8 +349,12 @@ class Foo
             for ($nestIndex = $lastCommaIndex; $nestIndex >= $startBraceIndex; --$nestIndex) {
                 $nestToken = $tokens[$nestIndex];
 
-                if ($nestToken->equals(')')) {
-                    $nestIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $nestIndex, false);
+                if ($nestToken->equalsAny(array(')', array(CT::T_BRACE_CLASS_INSTANTIATION_CLOSE)))) {
+                    $nestIndex = $tokens->findBlockEnd(
+                        $nestToken->equals(')') ? Tokens::BLOCK_TYPE_PARENTHESIS_BRACE : Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION,
+                        $nestIndex,
+                        false
+                    );
 
                     continue;
                 }

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverRootless;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -126,20 +127,23 @@ yield(2);
         $loops = array_intersect_key(self::$loops, array_flip($this->configuration['statements']));
 
         foreach ($tokens as $index => $token) {
-            if (!$token->equals('(')) {
+            if (!$token->equalsAny(array('(', array(CT::T_BRACE_CLASS_INSTANTIATION_OPEN)))) {
                 continue;
             }
 
             $blockStartIndex = $index;
             $index = $tokens->getPrevMeaningfulToken($index);
-            $token = $tokens[$index];
+            $prevToken = $tokens[$index];
 
             foreach ($loops as $loop) {
-                if (!$token->isGivenKind($loop['lookupTokens'])) {
+                if (!$prevToken->isGivenKind($loop['lookupTokens'])) {
                     continue;
                 }
 
-                $blockEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $blockStartIndex);
+                $blockEndIndex = $tokens->findBlockEnd(
+                    $token->equals('(') ? Tokens::BLOCK_TYPE_PARENTHESIS_BRACE : Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION,
+                    $blockStartIndex
+                );
                 $blockEndNextIndex = $tokens->getNextMeaningfulToken($blockEndIndex);
 
                 if (!$tokens[$blockEndNextIndex]->equalsAny($loop['neededSuccessors'])) {

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -37,6 +37,7 @@ class Tokens extends \SplFixedArray
     const BLOCK_TYPE_ARRAY_INDEX_CURLY_BRACE = 7;
     const BLOCK_TYPE_GROUP_IMPORT_BRACE = 8;
     const BLOCK_TYPE_DESTRUCTURING_SQUARE_BRACE = 9;
+    const BLOCK_TYPE_BRACE_CLASS_INSTANTIATION = 10;
 
     /**
      * Static class cache.
@@ -224,6 +225,10 @@ class Tokens extends \SplFixedArray
             self::BLOCK_TYPE_DESTRUCTURING_SQUARE_BRACE => array(
                 'start' => array(CT::T_DESTRUCTURING_SQUARE_BRACE_OPEN, '['),
                 'end' => array(CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE, ']'),
+            ),
+            self::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION => array(
+                'start' => array(CT::T_BRACE_CLASS_INSTANTIATION_OPEN, '('),
+                'end' => array(CT::T_BRACE_CLASS_INSTANTIATION_CLOSE, ')'),
             ),
         );
     }

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -38,6 +38,15 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // must run after CurlyBraceTransformer and SquareBraceTransformer
+        return -1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRequiredPhpVersionId()
     {
         return 50000;
@@ -52,11 +61,19 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
             return;
         }
 
-        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
-
-        if (!$tokens[$tokens->getNextMeaningfulToken($closeIndex)]->isGivenKind(array(T_OBJECT_OPERATOR, T_DOUBLE_COLON))) {
+        if ($tokens[$tokens->getPrevMeaningfulToken($index)]->equalsAny(array(
+            array(T_STRING),
+            ']',
+            array(CT::T_ARRAY_SQUARE_BRACE_CLOSE),
+            array(CT::T_ARRAY_INDEX_CURLY_BRACE_CLOSE),
+            array(T_VARIABLE),
+            array(T_CLASS),
+            array(T_ARRAY),
+        ))) {
             return;
         }
+
+        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 
         $tokens[$index] = new Token(array(CT::T_BRACE_CLASS_INSTANTIATION_OPEN, '('));
         $tokens[$closeIndex] = new Token(array(CT::T_BRACE_CLASS_INSTANTIATION_CLOSE, ')'));

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -718,6 +718,28 @@ PHP;
             array(5, '<?php $foo->{$bar};', Tokens::BLOCK_TYPE_DYNAMIC_PROP_BRACE, 3),
             array(4, '<?php list($a) = $b;', Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 2),
             array(6, '<?php if($a){}?>', Tokens::BLOCK_TYPE_CURLY_BRACE, 5),
+            array(11, '<?php $foo = (new Foo());', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5),
+        );
+    }
+
+    /**
+     * @param int    $expectedIndex
+     * @param string $source
+     * @param int    $type
+     * @param int    $searchIndex
+     *
+     * @requires PHP 7.0
+     * @dataProvider provideFindBlockEnd70Cases
+     */
+    public function testFindBlockEnd70($expectedIndex, $source, $type, $searchIndex)
+    {
+        $this->assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
+    }
+
+    public function provideFindBlockEnd70Cases()
+    {
+        return array(
+            array(19, '<?php $foo = (new class () implements Foo {});', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5),
         );
     }
 

--- a/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
@@ -66,36 +66,88 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
             array(
                 '<?php return foo()->bar(new Foo())->bar();',
                 array(
+                    4 => '(',
+                    5 => ')',
                     8 => '(',
+                    12 => '(',
+                    13 => ')',
                     14 => ')',
+                    17 => '(',
+                    18 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(
                 '<?php $foo[0](new Foo())->bar();',
                 array(
                     5 => '(',
+                    9 => '(',
+                    10 => ')',
                     11 => ')',
+                    14 => '(',
+                    15 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(
                 '<?php $foo{0}(new Foo())->bar();',
                 array(
                     5 => '(',
+                    9 => '(',
+                    10 => ')',
                     11 => ')',
+                    14 => '(',
+                    15 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(
                 '<?php $foo(new Foo())->bar();',
                 array(
                     2 => '(',
+                    6 => '(',
+                    7 => ')',
                     8 => ')',
+                    11 => '(',
+                    12 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(
                 '<?php $$foo(new Foo())->bar();',
                 array(
                     3 => '(',
+                    7 => '(',
+                    8 => ')',
                     9 => ')',
+                    12 => '(',
+                    13 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(
@@ -124,7 +176,15 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
                 '<?php $foo = array(new Foo());',
                 array(
                     6 => '(',
+                    10 => '(',
+                    11 => ')',
                     12 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
         );
@@ -151,7 +211,15 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
                 '<?php $foo = new class(new \stdClass()) {};',
                 array(
                     8 => '(',
+                    13 => '(',
+                    14 => ')',
                     15 => ')',
+                ),
+                array(
+                    '(',
+                    ')',
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
             array(

--- a/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
@@ -29,15 +29,12 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
      *
      * @dataProvider provideProcessCases
      */
-    public function testProcess($source, array $expectedTokens)
+    public function testProcess($source, array $expectedTokens, array $observedKinds = array())
     {
         $this->doTest(
             $source,
             $expectedTokens,
-            array(
-                CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
-                CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
-            )
+            $observedKinds
         );
     }
 
@@ -50,12 +47,122 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
                     3 => CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
                     9 => CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
+                array(
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
             ),
             array(
                 '<?php echo (new Process())::getOutput();',
                 array(
                     3 => CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
                     9 => CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+                array(
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+            ),
+            array(
+                '<?php return foo()->bar(new Foo())->bar();',
+                array(
+                    8 => '(',
+                    14 => ')',
+                ),
+            ),
+            array(
+                '<?php $foo[0](new Foo())->bar();',
+                array(
+                    5 => '(',
+                    11 => ')',
+                ),
+            ),
+            array(
+                '<?php $foo{0}(new Foo())->bar();',
+                array(
+                    5 => '(',
+                    11 => ')',
+                ),
+            ),
+            array(
+                '<?php $foo(new Foo())->bar();',
+                array(
+                    2 => '(',
+                    8 => ')',
+                ),
+            ),
+            array(
+                '<?php $$foo(new Foo())->bar();',
+                array(
+                    3 => '(',
+                    9 => ')',
+                ),
+            ),
+            array(
+                '<?php if ($foo){}(new Foo)->foo();',
+                array(
+                    8 => CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    12 => CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+                array(
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+            ),
+            array(
+                '<?php echo (((new \stdClass()))->a);',
+                array(
+                    5 => CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    12 => CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+                array(
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+            ),
+            array(
+                '<?php $foo = array(new Foo());',
+                array(
+                    6 => '(',
+                    12 => ')',
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param string $source
+     *
+     * @dataProvider provideProcessPhp70Cases
+     */
+    public function testProcessPhp70($source, array $expectedTokens, array $observedKinds = array())
+    {
+        $this->doTest(
+            $source,
+            $expectedTokens,
+            $observedKinds
+        );
+    }
+
+    public function provideProcessPhp70Cases()
+    {
+        return array(
+            array(
+                '<?php $foo = new class(new \stdClass()) {};',
+                array(
+                    8 => '(',
+                    15 => ')',
+                ),
+            ),
+            array(
+                '<?php $foo = (new class(new \stdClass()) {});',
+                array(
+                    5 => CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    20 => CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
+                ),
+                array(
+                    CT::T_BRACE_CLASS_INSTANTIATION_OPEN,
+                    CT::T_BRACE_CLASS_INSTANTIATION_CLOSE,
                 ),
             ),
         );


### PR DESCRIPTION
In the following example:
```php
$foo->bar(new Foo());
```
the braces around the instantiation will be transformed into specific `CT::T_BRACE_CLASS_INSTANTIATION_OPEN` and `CT::T_BRACE_CLASS_INSTANTIATION_CLOSE` tokens. I don't think this is expected.