### PR TITLE
Symfony:risky ruleset - add no_homoglyph_names

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -28,7 +28,6 @@ $config = PhpCsFixer\Config::create()
         'list_syntax' => ['syntax' => 'long'],
         'method_argument_space' => ['ensure_fully_multiline' => true],
         'no_extra_consecutive_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
-        'no_homoglyph_names' => true,
         'no_null_property_initialization' => true,
         'no_short_echo_tag' => true,
         'no_superfluous_elseif' => true,

--- a/README.rst
+++ b/README.rst
@@ -722,7 +722,7 @@ Choose from the list of available rules:
 
   - ``tokens`` (``array``): list of tokens to fix; defaults to ``['extra']``
 
-* **no_homoglyph_names**
+* **no_homoglyph_names** [@Symfony:risky]
 
   Replace accidental usage of homoglyphs (non ascii characters) in names.
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -153,6 +153,7 @@ final class RuleSet implements RuleSetInterface
             'is_null' => true,
             'modernize_types_casting' => true,
             'no_alias_functions' => true,
+            'no_homoglyph_names' => true,
             'non_printable_character' => true,
             'php_unit_construct' => true,
             'php_unit_dedicate_assert' => true,


### PR DESCRIPTION
I hoped to add it to PSR ruleset, but I cannot find it in spec :(
Symfony follows it.