### PR TITLE
YodaStyleFixer - Clarify configuration parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1283,16 +1283,17 @@ Choose from the list of available rules:
 
 * **yoda_style** [@Symfony]
 
-  Write conditions in Yoda style or not based on configuration.
+  Write conditions in Yoda style (``true``), non-Yoda style (``false``) or
+  ignore those conditions (``null``) based on configuration.
 
   Configuration options:
 
-  - ``equal`` (``bool``, ``null``): change equal (``==``, ``!=``) statements; defaults to
+  - ``equal`` (``bool``, ``null``): style for equal (``==``, ``!=``) statements; defaults to
     ``true``
-  - ``identical`` (``bool``, ``null``): change identical (``===``, ``!==``) statements;
+  - ``identical`` (``bool``, ``null``): style for identical (``===``, ``!==``) statements;
     defaults to ``true``
-  - ``less_and_greater`` (``bool``, ``null``): change less and greater than (``<``, ``<=``,
-    ``>``, ``>=``) statements; defaults to ``null``
+  - ``less_and_greater`` (``bool``, ``null``): style for less and greater than (``<``,
+    ``<=``, ``>``, ``>=``) statements; defaults to ``null``
 
 
 The ``--dry-run`` option displays the files that need to be

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -55,7 +55,7 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Write conditions in Yoda style or not based on configuration.',
+            'Write conditions in Yoda style (`true`), non-Yoda style (`false`) or ignore those conditions (`null`) based on configuration.',
             [
                 new CodeSample(
                     '<?php
@@ -102,15 +102,15 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
     protected function createConfigurationDefinition()
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('equal', 'Change equal (`==`, `!=`) statements.'))
+            (new FixerOptionBuilder('equal', 'Style for equal (`==`, `!=`) statements.'))
                 ->setAllowedTypes(['bool', 'null'])
                 ->setDefault(true)
                 ->getOption(),
-            (new FixerOptionBuilder('identical', 'Change identical (`===`, `!==`) statements.'))
+            (new FixerOptionBuilder('identical', 'Style for identical (`===`, `!==`) statements.'))
                 ->setAllowedTypes(['bool', 'null'])
                 ->setDefault(true)
                 ->getOption(),
-            (new FixerOptionBuilder('less_and_greater', 'Change less and greater than (`<`, `<=`, `>`, `>=`) statements.'))
+            (new FixerOptionBuilder('less_and_greater', 'Style for less and greater than (`<`, `<=`, `>`, `>=`) statements.'))
                 ->setAllowedTypes(['bool', 'null'])
                 ->setDefault(null)
                 ->getOption(),


### PR DESCRIPTION
@SpacePossum Great job on this fixer. However, the configuration description is unclear... 

```
yoda_style [@Symfony]

Write conditions in Yoda style or not based on configuration.

Configuration options:

equal (bool, null): change equal (==, !=) statements; defaults to true
identical (bool, null): change identical (===, !==) statements; defaults to true
less_and_greater (bool, null): change less and greater than (<, <=, >, >=) statements; defaults to null
```

They all say: "Change X (if true) or not (if false)". That's not right and doesn't document the actual (great) possibilities of this fixer. It actually does:

true = Force to yoda style.
false = Force to non-yoda style.
null = Do nothing (ignore these statements).

This pull request tries to clarify the values. I hope the new descriptions are okay @keradus. I did not see any other fixers document params in this way. Because no other multi-option fixers used values in this weird way. ;-) It would have been better if the values had been a string: `'yoda'` or `'non-yoda'` or `'ignore'`. But since it has been released as 2.6, that can't be changed now without breaking backwards compatibility with 2.x of PHP-CS-Fixer. So improving the docs to explain true/false/null is the best we can do.