### PR TITLE
SpaceAfterSemicolonFixer - Add option to remove space in empty for expressions

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -45,6 +45,7 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_types_order' => true,
         'semicolon_after_instruction' => true,
         'single_line_comment_style' => true,
+        'space_after_semicolon' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'yoda_style' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -45,7 +45,6 @@ $config = PhpCsFixer\Config::create()
         'phpdoc_types_order' => true,
         'semicolon_after_instruction' => true,
         'single_line_comment_style' => true,
-        'space_after_semicolon' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'yoda_style' => true,

--- a/README.rst
+++ b/README.rst
@@ -1213,6 +1213,11 @@ Choose from the list of available rules:
 
   Fix whitespace after a semicolon.
 
+  Configuration options:
+
+  - ``remove_in_empty_for_expressions`` (``bool``): whether spaces should be removed
+    for empty ``for`` expressions; defaults to ``false``
+
 * **standardize_not_equals** [@Symfony]
 
   Replace all ``<>`` with ``!=``.

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -269,7 +269,7 @@ class Example
                 'static' => false,
             ];
 
-            for ($i = $startIndex; ; ++$i) {
+            for ($i = $startIndex;; ++$i) {
                 $token = $tokens[$i];
 
                 // class end

--- a/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
@@ -66,7 +66,7 @@ final class SwitchCaseSemicolonToColonFixer extends AbstractFixer
             }
 
             $ternariesCount = 0;
-            for ($colonIndex = $index + 1; ; ++$colonIndex) {
+            for ($colonIndex = $index + 1;; ++$colonIndex) {
                 // We have to skip ternary case for colons.
                 if ($tokens[$colonIndex]->equals('?')) {
                     ++$ternariesCount;

--- a/src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
@@ -65,7 +65,7 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
             }
 
             $ternariesCount = 0;
-            for ($colonIndex = $index + 1; ; ++$colonIndex) {
+            for ($colonIndex = $index + 1;; ++$colonIndex) {
                 // We have to skip ternary case for colons.
                 if ($tokens[$colonIndex]->equals('?')) {
                     ++$ternariesCount;

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -359,7 +359,7 @@ use function CCC\AA;
                         for ($k1 = $k + 1; $k1 < $namespaceTokensCount; ++$k1) {
                             $comment = '';
                             $namespacePart = '';
-                            for ($k2 = $k1; ; ++$k2) {
+                            for ($k2 = $k1;; ++$k2) {
                                 if ($namespaceTokens[$k2]->equalsAny([',', [CT::T_GROUP_IMPORT_BRACE_CLOSE]])) {
                                     break;
                                 }

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -101,7 +101,7 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
     {
         $groupPrefix = '';
         $comment = '';
-        for ($i = $index + 1; ; ++$i) {
+        for ($i = $index + 1;; ++$i) {
             if ($tokens[$i]->isGivenKind(CT::T_GROUP_IMPORT_BRACE_OPEN)) {
                 $groupOpenIndex = $i;
 

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
@@ -125,7 +125,7 @@ final class CombineConsecutiveIssetsFixer extends AbstractFixer
         $braceOpenCount = 1;
         $meaningfulTokenIndexes = [$openIndex];
 
-        for ($i = $openIndex + 1; ; ++$i) {
+        for ($i = $openIndex + 1;; ++$i) {
             if ($tokens[$i]->isWhitespace() || $tokens[$i]->isComment()) {
                 continue;
             }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -137,7 +137,9 @@ final class RuleSet implements RuleSetInterface
             'single_blank_line_before_namespace' => true,
             'single_class_element_per_statement' => true,
             'single_quote' => true,
-            'space_after_semicolon' => true,
+            'space_after_semicolon' => [
+                'remove_in_empty_for_expressions' => true,
+            ],
             'standardize_not_equals' => true,
             'ternary_operator_spaces' => true,
             'trailing_comma_in_multiline_array' => true,

--- a/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
+++ b/tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
@@ -34,6 +34,20 @@ final class SpaceAfterSemicolonFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFixWithSpacesInEmptyForExpressions($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'remove_in_empty_for_expressions' => false,
+        ]);
+        $this->doTest($expected, $input);
+    }
+
     public function provideFixCases()
     {
         return [
@@ -243,6 +257,246 @@ final class SpaceAfterSemicolonFixerTest extends AbstractFixerTestCase
                     for ($u7 = 0;    $u7 < 7;    ++$u7) {
                     }
                 ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixWithoutSpacesInEmptyForExpressionsCases
+     */
+    public function testFixWithoutSpacesInEmptyForExpressions($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'remove_in_empty_for_expressions' => true,
+        ]);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithoutSpacesInEmptyForExpressionsCases()
+    {
+        return [
+            [
+                '<?php
+                    test1();
+                    $a; // test
+                ',
+            ],
+            [
+                '<?php test2();',
+            ],
+            [
+                '<?php test3(); ',
+            ],
+            [
+                '<?php test4();   ',
+            ],
+            [
+                '<?php
+                    test5();     // test
+                ',
+            ],
+            [
+                '<?php test6();       /* */ //',
+            ],
+            [
+                '<?php test7a(); /* */',
+                '<?php test7a();/* */',
+            ],
+            [
+                '<?php test7b(); /* *//**/',
+                '<?php test7b();/* *//**/',
+            ],
+            [
+                '<?php
+                    test8(); $a = 4;
+                ',
+                '<?php
+                    test8();     $a = 4;
+                ',
+            ],
+            [
+                '<?php
+                    test9(); $b = 7;
+                ',
+                '<?php
+                    test9();$b = 7;
+                ',
+            ],
+            [
+                '<?php
+                    for (;;) {
+                    }
+                ',
+                '<?php
+                    for (; ;) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (;; ++$u1) {
+                    }
+                ',
+                '<?php
+                    for (;;++$u1) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (; $u2 < 0;) {
+                    }
+                ',
+                '<?php
+                    for (;$u2 < 0;) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (; $u3 < 3; ++$u3) {
+                    }
+                ',
+                '<?php
+                    for (;$u3 < 3;++$u3) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u4 = 0;;) {
+                    }
+                ',
+                '<?php
+                    for ($u4 = 0; ;) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u5 = 0;; ++$u5) {
+                    }
+                ',
+                '<?php
+                    for ($u5 = 0;;++$u5) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u6 = 0; $u6 < 6;) {
+                    }
+                ',
+                '<?php
+                    for ($u6 = 0;$u6 < 6;) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u7 = 0; $u7 < 7; ++$u7) {
+                    }
+                ',
+                '<?php
+                    for ($u7 = 0;$u7 < 7;++$u7) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (;;) {
+                    }
+                ',
+                '<?php
+                    for (;    ;    ) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (;; ++$u1) {
+                    }
+                ',
+                '<?php
+                    for (;    ;    ++$u1) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (; $u2 < 0;) {
+                    }
+                ',
+                '<?php
+                    for (;    $u2 < 0;    ) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (; $u3 < 3; ++$u3) {
+                    }
+                ',
+                '<?php
+                    for (;    $u3 < 3;    ++$u3) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($ui4 = 0;;) {
+                    }
+                ',
+                '<?php
+                    for ($ui4 = 0;    ;    ) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u5 = 0;; ++$u5) {
+                    }
+                ',
+                '<?php
+                    for ($u5 = 0;    ;    ++$u5) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u6 = 0; $u6 < 6;) {
+                    }
+                ',
+                '<?php
+                    for ($u6 = 0;    $u6 < 6;    ) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for ($u7 = 0; $u7 < 7; ++$u7) {
+                    }
+                ',
+                '<?php
+                    for ($u7 = 0;    $u7 < 7;    ++$u7) {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    for (
+                        $u7 = 0;
+                        ;
+                        ++$u7
+                    ) {
+                    }
+                ',
+            ],
+            [
+                '<?php for ( /* foo */ ; /* bar */ ; /* baz */ ) { }',
             ],
         ];
     }


### PR DESCRIPTION
This new option allows to apply the following change:
```diff
 <?php
-for ($i = 0; ; ++$i) {
+for ($i = 0;; ++$i) {
 }
```

I added it to the `@Symfony` rule set as the framework currently follows this rule for consistency (see https://github.com/symfony/symfony/pull/22931#discussion_r121027128).