### PR TITLE
Add ExplicitStringVariableFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,6 +24,7 @@ $config = PhpCsFixer\Config::create()
         'combine_consecutive_unsets' => true,
         'compact_nullable_typehint' => true,
         'explicit_indirect_variable' => true,
+        'explicit_string_variable' => true,
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],

--- a/README.rst
+++ b/README.rst
@@ -545,7 +545,7 @@ Choose from the list of available rules:
 
 * **explicit_string_variable**
 
-  Convert implicit variables into explicit ones in double-quoted strings.
+  Converts implicit variables into explicit ones in double-quoted strings.
 
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 

--- a/README.rst
+++ b/README.rst
@@ -543,6 +543,10 @@ Choose from the list of available rules:
   Add curly braces to indirect variables to make them clear to understand.
   Requires PHP >= 7.0.
 
+* **explicit_string_variable**
+
+  Convert implicit variables into explicit ones in double quoted strings.
+
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 
   PHP code must use the long ``<?php`` tags or short-echo ``<?=`` tags and not

--- a/README.rst
+++ b/README.rst
@@ -545,7 +545,8 @@ Choose from the list of available rules:
 
 * **explicit_string_variable**
 
-  Converts implicit variables into explicit ones in double-quoted strings.
+  Converts implicit variables into explicit ones in double-quoted strings
+  or heredoc syntax.
 
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 

--- a/README.rst
+++ b/README.rst
@@ -545,7 +545,7 @@ Choose from the list of available rules:
 
 * **explicit_string_variable**
 
-  Convert implicit variables into explicit ones in double quoted strings.
+  Convert implicit variables into explicit ones in double-quoted strings.
 
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 

--- a/src/Console/Output/ErrorOutput.php
+++ b/src/Console/Output/ErrorOutput.php
@@ -62,7 +62,7 @@ final class ErrorOutput
                     $message = $e->getMessage();
                     $code = $e->getCode();
                     if (0 !== $code) {
-                        $message .= " ($code)";
+                        $message .= " (${code})";
                     }
 
                     $length = max(strlen($class), strlen($message));

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -92,7 +92,7 @@ class Tag
             throw new \RuntimeException('Cannot set name on unknown tag.');
         }
 
-        $this->line->setContent(preg_replace("/@$current/", "@$name", $this->line->getContent(), 1));
+        $this->line->setContent(preg_replace("/@${current}/", "@${name}", $this->line->getContent(), 1));
 
         $this->name = $name;
     }

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -183,7 +183,7 @@ switch ($foo) {
 
         $text = preg_quote($this->configuration['comment_text'], '~');
 
-        return preg_match("~^((//|#)\s*$text\s*)|(/\*\*?\s*$text\s*\*/)$~i", $token->getContent());
+        return preg_match("~^((//|#)\s*${text}\s*)|(/\*\*?\s*${text}\s*\*/)$~i", $token->getContent());
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -296,7 +296,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         if ($this->configuration['use_class_const']) {
             $params[] = $exceptionClass.'::class';
         } else {
-            $params[] = "'$exceptionClass'";
+            $params[] = "'${exceptionClass}'";
         }
 
         if (isset($annotations['expectedExceptionMessage'])) {

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -60,7 +60,8 @@ final class ExplicitStringVariableFixer extends AbstractFixer
 
             $prevToken = $tokens[$index - 1];
             if (
-                   $prevToken->isGivenKind(T_ENCAPSED_AND_WHITESPACE)
+                $prevToken->isGivenKind(T_ENCAPSED_AND_WHITESPACE)
+                || $prevToken->isGivenKind(T_START_HEREDOC)
                 || '"' === $prevToken->getContent()
             ) {
                 $tokens->overrideRange($index, $index, [

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -30,8 +30,15 @@ final class ExplicitStringVariableFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Convert implicit variables into explicit ones in double quoted strings.',
-            [new CodeSample('<?php $a = "My name is $name!";')]
+            'Convert implicit variables into explicit ones in double-quoted strings.',
+            [new CodeSample('<?php $a = "My name is $name!";')],
+            implode(PHP_EOL, [
+                'The reasoning behind this rule are the following:',
+                '- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow',
+                '- PHP manual marks "$var" sintax as implicit and "${var}" syntax as explicit: explicit code should always be preferred',
+                '- Explicit syntax allows word concatenation inside strings, e.g. "${var}IsAVar", implicit doesn\'t',
+                '- Explicit syntax is easier to detect for IDE/editors and therefore has colors/hightlight with higher contrast, which is easier to read',
+            ])
         );
     }
 

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -30,7 +30,7 @@ final class ExplicitStringVariableFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Convert implicit variables into explicit ones in double-quoted strings.',
+            'Converts implicit variables into explicit ones in double-quoted strings.',
             [new CodeSample('<?php $a = "My name is $name!";')],
             'The reasoning behind this rule is the following:'
                 ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow'

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -32,10 +32,10 @@ final class ExplicitStringVariableFixer extends AbstractFixer
         return new FixerDefinition(
             'Convert implicit variables into explicit ones in double-quoted strings.',
             [new CodeSample('<?php $a = "My name is $name!";')],
-            'The reasoning behind this rule are the following:'
+            'The reasoning behind this rule is the following:'
                 ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow'
-                ."\n".'- PHP manual marks "$var" sintax as implicit and "${var}" syntax as explicit: explicit code should always be preferred'
-                ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. "${var}IsAVar", implicit doesn\'t'
+                ."\n".'- PHP manual marks `"$var"` syntax as implicit and `"${var}"` syntax as explicit: explicit code should always be preferred'
+                ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. `"${var}IsAVar"`, implicit doesn\'t'
                 ."\n".'- Explicit syntax is easier to detect for IDE/editors and therefore has colors/hightlight with higher contrast, which is easier to read'
         );
     }

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -30,7 +30,7 @@ final class ExplicitStringVariableFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Converts implicit variables into explicit ones in double-quoted strings.',
+            'Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.',
             [new CodeSample('<?php $a = "My name is $name!";')],
             'The reasoning behind this rule is the following:'
                 ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow'

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\StringNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class ExplicitStringVariableFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Convert implicit variables into explicit ones in double quoted strings.',
+            [new CodeSample('<?php $a = "My name is $name!";')]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_VARIABLE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_VARIABLE)) {
+                continue;
+            }
+
+            $prevToken = $tokens[$index - 1];
+            if (
+                   $prevToken->isGivenKind(T_ENCAPSED_AND_WHITESPACE)
+                || '"' === $prevToken->getContent()
+            ) {
+                $tokens->overrideRange($index, $index, [
+                    new Token([T_DOLLAR_OPEN_CURLY_BRACES, '${']),
+                    new Token([T_STRING_VARNAME, substr($token->getContent(), 1)]),
+                    new Token([CT::T_DOLLAR_CLOSE_CURLY_BRACES, '}']),
+                ]);
+            }
+        }
+    }
+}

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -31,7 +31,7 @@ final class ExplicitStringVariableFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.',
-            [new CodeSample('<?php $a = "My name is $name!";')],
+            [new CodeSample('<?php $a = "My name is $name!";'."\n")],
             'The reasoning behind this rule is the following:'
                 ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow'
                 ."\n".'- PHP manual marks `"$var"` syntax as implicit and `"${var}"` syntax as explicit: explicit code should always be preferred'

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -32,13 +32,11 @@ final class ExplicitStringVariableFixer extends AbstractFixer
         return new FixerDefinition(
             'Convert implicit variables into explicit ones in double-quoted strings.',
             [new CodeSample('<?php $a = "My name is $name!";')],
-            implode(PHP_EOL, [
-                'The reasoning behind this rule are the following:',
-                '- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow',
-                '- PHP manual marks "$var" sintax as implicit and "${var}" syntax as explicit: explicit code should always be preferred',
-                '- Explicit syntax allows word concatenation inside strings, e.g. "${var}IsAVar", implicit doesn\'t',
-                '- Explicit syntax is easier to detect for IDE/editors and therefore has colors/hightlight with higher contrast, which is easier to read',
-            ])
+            'The reasoning behind this rule are the following:'
+                ."\n".'- When there are two valid ways of doing the same thing, using both is confusing, there should be a coding standard to follow'
+                ."\n".'- PHP manual marks "$var" sintax as implicit and "${var}" syntax as explicit: explicit code should always be preferred'
+                ."\n".'- Explicit syntax allows word concatenation inside strings, e.g. "${var}IsAVar", implicit doesn\'t'
+                ."\n".'- Explicit syntax is easier to detect for IDE/editors and therefore has colors/hightlight with higher contrast, which is easier to read'
         );
     }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -144,7 +144,7 @@ final class ProjectCodeTest extends TestCase
                 "Class '%s' should not have public methods that are not part of implemented interfaces.\nViolations:\n%s",
                 $className,
                 implode("\n", array_map(function ($item) {
-                    return " * $item";
+                    return " * ${item}";
                 }, $extraMethods))
             )
         );
@@ -212,7 +212,7 @@ final class ProjectCodeTest extends TestCase
                 "Class '%s' should not have protected properties.\nViolations:\n%s",
                 $className,
                 implode("\n", array_map(function ($item) {
-                    return " * $item";
+                    return " * ${item}";
                 }, $extraProps))
             )
         );

--- a/tests/CiIntegrationTest.php
+++ b/tests/CiIntegrationTest.php
@@ -102,14 +102,14 @@ final class CiIntegrationTest extends TestCase
     ) {
         static::executeCommand(implode(' && ', array_merge(
             [
-                "git checkout -b $branchName -q",
+                "git checkout -b ${branchName} -q",
             ],
             $caseCommands
         )));
 
         $integrationScript = explode("\n", str_replace('vendor/bin/', './../../../', file_get_contents(__DIR__.'/../dev-tools/ci-integration.sh')));
         $steps = [
-            "COMMIT_RANGE=\"master..$branchName\"",
+            "COMMIT_RANGE=\"master..${branchName}\"",
             $integrationScript[3],
             $integrationScript[4],
             $integrationScript[5],
@@ -153,7 +153,7 @@ If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, 
 ';
 
         $executionDetails = "Loaded config default from \".php_cs.dist\".
-$expectedResult3Files
+${expectedResult3Files}
 Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error";
 
         $this->assertRegExp(
@@ -268,7 +268,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                 "Cannot execute `%s`:\n%s\nCode: %s\nExit text: %s\nError output: %s\nDetails:\n%s",
                 $command,
                 './'.static::$tmpFileName === $command
-                    ? implode('', array_map(function ($line) { return "$ $line"; }, file(static::$tmpFilePath)))."\n"
+                    ? implode('', array_map(function ($line) { return "$ ${line}"; }, file(static::$tmpFilePath)))."\n"
                     : '',
                 $result['code'],
                 $process->getExitCodeText(),

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -43,20 +43,20 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
         $cases = [];
         foreach ($aliases as $alias => $master) {
             // valid cases
-            $cases[] = ["<?php \$smth->$alias(\$a);"];
+            $cases[] = ["<?php \$smth->${alias}(\$a);"];
             $cases[] = ["<?php {$alias}Smth(\$a);"];
-            $cases[] = ["<?php smth_$alias(\$a);"];
-            $cases[] = ["<?php new $alias(\$a);"];
-            $cases[] = ["<?php new Smth\\$alias(\$a);"];
-            $cases[] = ["<?php Smth\\$alias(\$a);"];
-            $cases[] = ["<?php namespace\\$alias(\$a);"];
-            $cases[] = ["<?php Smth::$alias(\$a);"];
-            $cases[] = ["<?php new $alias\\smth(\$a);"];
-            $cases[] = ["<?php $alias::smth(\$a);"];
-            $cases[] = ["<?php $alias\\smth(\$a);"];
+            $cases[] = ["<?php smth_${alias}(\$a);"];
+            $cases[] = ["<?php new ${alias}(\$a);"];
+            $cases[] = ["<?php new Smth\\${alias}(\$a);"];
+            $cases[] = ["<?php Smth\\${alias}(\$a);"];
+            $cases[] = ["<?php namespace\\${alias}(\$a);"];
+            $cases[] = ["<?php Smth::${alias}(\$a);"];
+            $cases[] = ["<?php new ${alias}\\smth(\$a);"];
+            $cases[] = ["<?php ${alias}::smth(\$a);"];
+            $cases[] = ["<?php ${alias}\\smth(\$a);"];
             $cases[] = ['<?php "SELECT ... '.$alias.'(\$a) ...";'];
             $cases[] = ['<?php "SELECT ... '.strtoupper($alias).'($a) ...";'];
-            $cases[] = ["<?php 'test'.'$alias' . 'in concatenation';"];
+            $cases[] = ["<?php 'test'.'${alias}' . 'in concatenation';"];
             $cases[] = ['<?php "test" . "'.$alias.'"."in concatenation";'];
             $cases[] = [
                 '<?php
@@ -80,38 +80,38 @@ class '.$alias.' extends '.ucfirst($alias).'ing{
 
             // cases to be fixed
             $cases[] = [
-                "<?php $master(\$a);",
-                "<?php $alias(\$a);",
+                "<?php ${master}(\$a);",
+                "<?php ${alias}(\$a);",
             ];
             $cases[] = [
-                "<?php \\$master(\$a);",
-                "<?php \\$alias(\$a);",
+                "<?php \\${master}(\$a);",
+                "<?php \\${alias}(\$a);",
             ];
             $cases[] = [
-                "<?php \$ref = &$master(\$a);",
-                "<?php \$ref = &$alias(\$a);",
+                "<?php \$ref = &${master}(\$a);",
+                "<?php \$ref = &${alias}(\$a);",
             ];
             $cases[] = [
-                "<?php \$ref = &\\$master(\$a);",
-                "<?php \$ref = &\\$alias(\$a);",
+                "<?php \$ref = &\\${master}(\$a);",
+                "<?php \$ref = &\\${alias}(\$a);",
             ];
             $cases[] = [
-                "<?php $master
+                "<?php ${master}
                             (\$a);",
-                "<?php $alias
+                "<?php ${alias}
                             (\$a);",
             ];
             $cases[] = [
-                "<?php /* foo */ $master /** bar */ (\$a);",
-                "<?php /* foo */ $alias /** bar */ (\$a);",
+                "<?php /* foo */ ${master} /** bar */ (\$a);",
+                "<?php /* foo */ ${alias} /** bar */ (\$a);",
             ];
             $cases[] = [
-                "<?php a($master());",
-                "<?php a($alias());",
+                "<?php a(${master}());",
+                "<?php a(${alias}());",
             ];
             $cases[] = [
-                "<?php a(\\$master());",
-                "<?php a(\\$alias());",
+                "<?php a(\\${master}());",
+                "<?php a(\\${alias}());",
             ];
         }
 

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -41,22 +41,22 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
 
         return [
             'final-extends' => [
-                "<?php final class MyClass extends MyAbstractClass { $attributesAndMethodsOriginal }",
+                "<?php final class MyClass extends MyAbstractClass { ${attributesAndMethodsOriginal} }",
             ],
             'normal-extends' => [
-                "<?php class MyClass extends MyAbstractClass { $attributesAndMethodsOriginal }",
+                "<?php class MyClass extends MyAbstractClass { ${attributesAndMethodsOriginal} }",
             ],
             'abstract' => [
-                "<?php abstract class MyAbstractClass { $attributesAndMethodsOriginal }",
+                "<?php abstract class MyAbstractClass { ${attributesAndMethodsOriginal} }",
             ],
             'normal' => [
-                "<?php class MyClass { $attributesAndMethodsOriginal }",
+                "<?php class MyClass { ${attributesAndMethodsOriginal} }",
             ],
             'trait' => [
-                "<?php trait MyTrait { $attributesAndMethodsOriginal }",
+                "<?php trait MyTrait { ${attributesAndMethodsOriginal} }",
             ],
             'final-with-trait' => [
-                "<?php final class MyClass { use MyTrait; $attributesAndMethodsOriginal }",
+                "<?php final class MyClass { use MyTrait; ${attributesAndMethodsOriginal} }",
             ],
             'multiline-comment' => [
                 '<?php final class MyClass { /* public protected private */ }',
@@ -65,24 +65,24 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
                 "<?php final class MyClass { \n // public protected private \n }",
             ],
             'final' => [
-                "<?php final class MyClass { $attributesAndMethodsFixed }",
-                "<?php final class MyClass { $attributesAndMethodsOriginal }",
+                "<?php final class MyClass { ${attributesAndMethodsFixed} }",
+                "<?php final class MyClass { ${attributesAndMethodsOriginal} }",
             ],
             'final-implements' => [
-                "<?php final class MyClass implements MyInterface { $attributesAndMethodsFixed }",
-                "<?php final class MyClass implements MyInterface { $attributesAndMethodsOriginal }",
+                "<?php final class MyClass implements MyInterface { ${attributesAndMethodsFixed} }",
+                "<?php final class MyClass implements MyInterface { ${attributesAndMethodsOriginal} }",
             ],
             'final-with-use-before' => [
-                "<?php use stdClass; final class MyClass { $attributesAndMethodsFixed }",
-                "<?php use stdClass; final class MyClass { $attributesAndMethodsOriginal }",
+                "<?php use stdClass; final class MyClass { ${attributesAndMethodsFixed} }",
+                "<?php use stdClass; final class MyClass { ${attributesAndMethodsOriginal} }",
             ],
             'final-with-use-after' => [
-                "<?php final class MyClass { $attributesAndMethodsFixed } use stdClass;",
-                "<?php final class MyClass { $attributesAndMethodsOriginal } use stdClass;",
+                "<?php final class MyClass { ${attributesAndMethodsFixed} } use stdClass;",
+                "<?php final class MyClass { ${attributesAndMethodsOriginal} } use stdClass;",
             ],
             'multiple-classes' => [
-                "<?php final class MyFirstClass { $attributesAndMethodsFixed } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsFixed } ",
-                "<?php final class MyFirstClass { $attributesAndMethodsOriginal } class MySecondClass { $attributesAndMethodsOriginal } final class MyThirdClass { $attributesAndMethodsOriginal } ",
+                "<?php final class MyFirstClass { ${attributesAndMethodsFixed} } class MySecondClass { ${attributesAndMethodsOriginal} } final class MyThirdClass { ${attributesAndMethodsFixed} } ",
+                "<?php final class MyFirstClass { ${attributesAndMethodsOriginal} } class MySecondClass { ${attributesAndMethodsOriginal} } final class MyThirdClass { ${attributesAndMethodsOriginal} } ",
             ],
             'minimal-set' => [
                 '<?php final class MyClass { private $v1; }',
@@ -113,12 +113,12 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
                 "<?php
 final class Foo
 {
-    $attributesAndMethodsFixed
+    ${attributesAndMethodsFixed}
 
     private function bar()
     {
         new class {
-            $attributesAndMethodsOriginal
+            ${attributesAndMethodsOriginal}
         };
     }
 }
@@ -126,12 +126,12 @@ final class Foo
                 "<?php
 final class Foo
 {
-    $attributesAndMethodsOriginal
+    ${attributesAndMethodsOriginal}
 
     protected function bar()
     {
         new class {
-            $attributesAndMethodsOriginal
+            ${attributesAndMethodsOriginal}
         };
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
@@ -75,27 +75,27 @@ final class PhpUnitStrictFixerTest extends AbstractFixerTestCase
         ];
 
         foreach ($methodsMap as $methodBefore => $methodAfter) {
-            $cases[] = ["<?php \$sth->$methodBefore(1, 1);"];
-            $cases[] = ["<?php \$sth->$methodAfter(1, 1);"];
+            $cases[] = ["<?php \$sth->${methodBefore}(1, 1);"];
+            $cases[] = ["<?php \$sth->${methodAfter}(1, 1);"];
             $cases[] = [
-                "<?php \$this->$methodAfter(1, 2);",
-                "<?php \$this->$methodBefore(1, 2);",
+                "<?php \$this->${methodAfter}(1, 2);",
+                "<?php \$this->${methodBefore}(1, 2);",
             ];
             $cases[] = [
-                "<?php \$this->$methodAfter(1, 2); \$this->$methodAfter(1, 2);",
-                "<?php \$this->$methodBefore(1, 2); \$this->$methodBefore(1, 2);",
+                "<?php \$this->${methodAfter}(1, 2); \$this->${methodAfter}(1, 2);",
+                "<?php \$this->${methodBefore}(1, 2); \$this->${methodBefore}(1, 2);",
             ];
             $cases[] = [
-                "<?php \$this->$methodAfter(1, 2, 'descr');",
-                "<?php \$this->$methodBefore(1, 2, 'descr');",
+                "<?php \$this->${methodAfter}(1, 2, 'descr');",
+                "<?php \$this->${methodBefore}(1, 2, 'descr');",
             ];
             $cases[] = [
-                "<?php \$this->/*aaa*/$methodAfter \t /**bbb*/  ( /*ccc*/1  , 2);",
-                "<?php \$this->/*aaa*/$methodBefore \t /**bbb*/  ( /*ccc*/1  , 2);",
+                "<?php \$this->/*aaa*/${methodAfter} \t /**bbb*/  ( /*ccc*/1  , 2);",
+                "<?php \$this->/*aaa*/${methodBefore} \t /**bbb*/  ( /*ccc*/1  , 2);",
             ];
             $cases[] = [
-                "<?php \$this->$methodAfter(\$expectedTokens->count() + 10, \$tokens->count() ? 10 : 20 , 'Test');",
-                "<?php \$this->$methodBefore(\$expectedTokens->count() + 10, \$tokens->count() ? 10 : 20 , 'Test');",
+                "<?php \$this->${methodAfter}(\$expectedTokens->count() + 10, \$tokens->count() ? 10 : 20 , 'Test');",
+                "<?php \$this->${methodBefore}(\$expectedTokens->count() + 10, \$tokens->count() ? 10 : 20 , 'Test');",
             ];
         }
 

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\StringNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer
+ */
+final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestFixCases()
+    {
+        return [
+            [
+                '<?php $a = "My name is ${name}!";',
+                '<?php $a = "My name is $name!";',
+            ],
+            [
+                '<?php $a = "${b}";',
+                '<?php $a = "$b";',
+            ],
+            ['<?php $a = \'My name is $name!\';'],
+            ['<?php $a = "My name is " . $name;'],
+            ['<?php $a = "My name is {$user->name}";'],
+        ];
+    }
+}

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -42,13 +42,45 @@ final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
                 '<?php $a = "My name is $name!";',
             ],
             [
+'<?php $a = <<<EOF
+My name is ${name}!
+EOF;
+',
+'<?php $a = <<<EOF
+My name is $name!
+EOF;
+',
+            ],
+            [
                 '<?php $a = "${b}";',
                 '<?php $a = "$b";',
+            ],
+            [
+'<?php $a = <<<EOF
+${b}
+EOF;
+',
+'<?php $a = <<<EOF
+$b
+EOF;
+',
             ],
             ['<?php $a = \'My name is $name!\';'],
             ['<?php $a = "My name is " . $name;'],
             ['<?php $a = "My name is {$name}!";'],
+            [
+'<?php $a = <<<EOF
+My name is {$name}!
+EOF;
+',
+],
             ['<?php $a = "My name is {$user->name}";'],
+            [
+'<?php $a = <<<EOF
+My name is {$user->name}
+EOF;
+',
+],
         ];
     }
 }

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -36,7 +36,17 @@ final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
 
     public function provideTestFixCases()
     {
+        $input = $expected = '<?php';
+        for ($inc = 1; $inc < 15; ++$inc) {
+            $input .= " \$var${inc} = \"My name is \$name!\";";
+            $expected .= " \$var${inc} = \"My name is \${name}!\";";
+        }
+
         return [
+            [
+                $expected,
+                $input,
+            ],
             [
                 '<?php $a = "My name is ${name}!";',
                 '<?php $a = "My name is $name!";',

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -47,6 +47,7 @@ final class ExplicitStringVariableFixerTest extends AbstractFixerTestCase
             ],
             ['<?php $a = \'My name is $name!\';'],
             ['<?php $a = "My name is " . $name;'],
+            ['<?php $a = "My name is {$name}!";'],
             ['<?php $a = "My name is {$user->name}";'],
         ];
     }

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -91,6 +91,12 @@ My name is {$user->name}
 EOF;
 ',
 ],
+            [
+'<?php $a = <<<\'EOF\'
+$b
+EOF;
+',
+            ],
         ];
     }
 }

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -204,7 +204,7 @@ abstract class AbstractFixerTestCase extends TestCase
         try {
             $this->linter->lintSource($source)->check();
         } catch (\Exception $e) {
-            return $e->getMessage()."\n\nSource:\n$source";
+            return $e->getMessage()."\n\nSource:\n${source}";
         }
     }
 


### PR DESCRIPTION
```diff
-$a = "My name is $name!";
+$a = "My name is ${name}!";
```
Some notes:

1. `SingleQuoteFixer` is triggered by `T_CONSTANT_ENCAPSED_STRING` while this one is triggered by pure variable strings like `"$var"` or by `T_ENCAPSED_AND_WHITESPACE`, so no conflict between the two should happen
1. It seems that the fixer can be built only with tokenization, without involving regex, so I marked it as **non-risky**
1. Only [Simple sintax](https://secure.php.net/manual/en/language.types.string.php#language.types.string.parsing.simple) is involved, [Complex (curly) sintax](https://secure.php.net/manual/en/language.types.string.php#language.types.string.parsing.complex) (e.g. `"{$var}"`) is unaffected
1. Thanks to tokenization, current test cases seem the minimal set needed, but to me it's too good to be true, help in finding edge cases is welcome