### PR TITLE
Let configuration files know the ConfigurationResolver

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -215,6 +215,8 @@ final class ConfigurationResolver
                     continue;
                 }
 
+                $configurationResolver = $this;
+
                 $config = include $configFile;
 
                 // verify that the config has an instance of Config


### PR DESCRIPTION
What about letting configuration files know the configuration resolver?

I'd need that because our project uses different rule sets for different files, and letting the configuration know what it's going to be used for would solve this.

I already answer why we need different rules:
1. we use by default the short array syntax and the short echo tags, but we have entry-point files that check the current PHP version and tell the user that they need a newer PHP version (if these files use newer syntax, the old PHP version will fail - see for instance https://3v4l.org/drhYT with PHP 5.3)
2. we use by default the *correct* indentation, but that messes up files with mixed PHP and HTML, so we need to disable indentation fixes for those files
3. we use PSR-4 by default to give the name of the files (file name === base class name), but we have some classes that don't follow that rule, so we sometimes need to disable PSR-4

In order to accomplish that, I currently use `debug_backtrace` to determine the `ConfigurationResolver` instance, but that's a lot hacky...

If you are interested in the current implementation of the above: [here it is](https://github.com/concrete5/concrete5/pull/5971).