### PR TITLE
ConfigurationResolver - hide context while including config file

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -217,7 +217,7 @@ final class ConfigurationResolver
                     continue;
                 }
 
-                $config = include $configFile;
+                $config = self::separatedContextLessInclude($configFile);
 
                 // verify that the config has an instance of Config
                 if (!$config instanceof ConfigInterface) {
@@ -847,5 +847,10 @@ final class ConfigurationResolver
         );
 
         return false;
+    }
+
+    private static function separatedContextLessInclude($path)
+    {
+        return include $path;
     }
 }


### PR DESCRIPTION
ref #3077

before:
```
keradus@keradus:~/github/PHP-CS-Fixer$ git du
diff --git a/.php_cs.dist b/.php_cs.dist
index d4891a77..3a399ac8 100644
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,8 @@
 <?php
 
+var_dump($configFile);
+var_dump($this->options);
+
 $header = <<<'EOF'
 This file is part of PHP CS Fixer.
 
keradus@keradus:~/github/PHP-CS-Fixer$ php php-cs-fixer fix
string(46) "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist"
array(13) {
  ["allow-risky"]=>
  NULL
  ["cache-file"]=>
  NULL
  ["config"]=>
  NULL
  ["diff"]=>
  bool(false)
  ["dry-run"]=>
  bool(false)
  ["format"]=>
  NULL
  ["path"]=>
  array(0) {
  }
  ["path-mode"]=>
  string(8) "override"
  ["rules"]=>
  NULL
  ["show-progress"]=>
  NULL
  ["stop-on-violation"]=>
  bool(false)
  ["using-cache"]=>
  NULL
  ["verbosity"]=>
  int(32)
}
```

after:
```
keradus@keradus:~/github/PHP-CS-Fixer$ git du 
diff --git a/.php_cs.dist b/.php_cs.dist
index d4891a77..b2a84a41 100644
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,8 @@
 <?php
 
+var_dump($path);
+var_dump($this->options);
+
 $header = <<<'EOF'
 This file is part of PHP CS Fixer.
 
diff --git a/src/Console/ConfigurationResolver.php b/src/Console/ConfigurationResolver.php
index ee2c3630..9db76ec2 100644
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -217,7 +217,7 @@ public function getConfig()
                     continue;
                 }
 
-                $config = include $configFile;
+                $config = self::separatedContextLessInclude($configFile);
 
                 // verify that the config has an instance of Config
                 if (!$config instanceof ConfigInterface) {
@@ -848,4 +848,9 @@ private function resolveOptionBooleanValue($optionName)
 
         return false;
     }
+
+    private static function separatedContextLessInclude($path)
+    {
+        return include $path;
+    }
 }
keradus@keradus:~/github/PHP-CS-Fixer$ php php-cs-fixer fix
string(46) "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist"
PHP Fatal error:  Uncaught Error: Using $this when not in object context in /home/keradus/github/PHP-CS-Fixer/.php_cs.dist:4
Stack trace:
#0 /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php(854): include()
#1 /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php(220): PhpCsFixer\Console\ConfigurationResolver::separatedContextLessInclude('/home/keradus/g...')
#2 /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php(577): PhpCsFixer\Console\ConfigurationResolver->getConfig()
#3 /home/keradus/github/PHP-CS-Fixer/src/Console/ConfigurationResolver.php(410): PhpCsFixer\Console\ConfigurationResolver->getFormat()
#4 /home/keradus/github/PHP-CS-Fixer/src/Console/Command/FixCommand.php(148): PhpCsFixer\Console\ConfigurationResolver->getReporter()
#5 /home/keradus/github/PHP-CS-Fixer/vendor/symfony/console/Command/Command.php(264): PhpCsFixer\Console\Command\FixCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutpu in /home/keradus/github/PHP-CS-Fixer/.php_cs.dist on line 4
```