### PR TITLE
NoUnneededFinalMethodFixer - Remove final keyword from private methods

### DIFF
--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -80,7 +80,7 @@ class Foo {
      *
      * @return int
      */
-    private function fixClass(Tokens $tokens, $classOpenIndex, bool $classIsFinal)
+    private function fixClass(Tokens $tokens, $classOpenIndex, $classIsFinal)
     {
         $methodVisibilities = [
             T_PUBLIC,

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -81,7 +81,6 @@ class Foo {
     private function fixClass(Tokens $tokens, $classOpenIndex, $classIsFinal)
     {
         $tokensCount = count($tokens);
-        $previousBlockEnd = -1;
         for ($index = $classOpenIndex + 1; $index < $tokensCount; ++$index) {
             // Class end
             if ($tokens[$index]->equals('}')) {
@@ -91,7 +90,6 @@ class Foo {
             // Skip method content
             if ($tokens[$index]->equals('{')) {
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
-                $previousBlockEnd = $index;
 
                 continue;
             }
@@ -103,7 +101,7 @@ class Foo {
             if (!$classIsFinal) {
                 $isPrivateMethod = false;
 
-                $i = max($classOpenIndex + 1, $previousBlockEnd);
+                $i = max($classOpenIndex + 1, $tokens->getPrevTokenOfKind($index, ['{', '}']));
 
                 while (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
                     if ($tokens[$i]->isGivenKind(T_PRIVATE)) {

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -83,13 +83,13 @@ class Foo {
     private function fixClass(Tokens $tokens, $classOpenIndex, $classIsFinal)
     {
         $methodVisibilities = [
-            T_PUBLIC,
-            T_PROTECTED,
             T_PRIVATE,
         ];
 
-        if (!$classIsFinal) {
+        if ($classIsFinal) {
             $methodVisibilities = [
+                T_PUBLIC,
+                T_PROTECTED,
                 T_PRIVATE,
             ];
         }

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -69,7 +69,7 @@ class Foo {
             $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
             $classIsFinal = $prevToken->isGivenKind(T_FINAL);
 
-            $index = $this->fixClass($tokens, $classOpen, $classIsFinal);
+            $this->fixClass($tokens, $classOpen, $classIsFinal);
         }
     }
 
@@ -77,8 +77,6 @@ class Foo {
      * @param Tokens $tokens
      * @param int    $classOpenIndex
      * @param bool   $classIsFinal
-     *
-     * @return int
      */
     private function fixClass(Tokens $tokens, $classOpenIndex, $classIsFinal)
     {
@@ -87,7 +85,7 @@ class Foo {
         for ($index = $classOpenIndex + 1; $index < $tokensCount; ++$index) {
             // Class end
             if ($tokens[$index]->equals('}')) {
-                return $index;
+                return;
             }
 
             // Skip method content

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -98,24 +98,8 @@ class Foo {
                 continue;
             }
 
-            if (!$classIsFinal) {
-                $isPrivateMethod = false;
-
-                $i = max($classOpenIndex + 1, $tokens->getPrevTokenOfKind($index, ['{', '}']));
-
-                while (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
-                    if ($tokens[$i]->isGivenKind(T_PRIVATE)) {
-                        $isPrivateMethod = true;
-
-                        break;
-                    }
-
-                    ++$i;
-                }
-
-                if (!$isPrivateMethod) {
-                    continue;
-                }
+            if (!$classIsFinal && !$this->isPrivateMethod($tokens, $index, $classOpenIndex)) {
+                continue;
             }
 
             $tokens->clearAt($index);
@@ -125,5 +109,27 @@ class Foo {
                 $tokens->clearAt($nextTokenIndex);
             }
         }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param int    $classOpenIndex
+     *
+     * @return bool
+     */
+    private function isPrivateMethod(Tokens $tokens, $index, $classOpenIndex)
+    {
+        $i = max($classOpenIndex + 1, $tokens->getPrevTokenOfKind($index, ['{', '}']));
+
+        while (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
+            if ($tokens[$i]->isGivenKind(T_PRIVATE)) {
+                return true;
+            }
+
+            ++$i;
+        }
+
+        return false;
     }
 }

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -39,7 +39,7 @@ final class Foo {
                 new CodeSample(
 '<?php
 class Foo {
-    final private function baz() {}
+    final private function bar() {}
 }'
                 ),
             ]

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -120,14 +120,14 @@ class Foo {
      */
     private function isPrivateMethod(Tokens $tokens, $index, $classOpenIndex)
     {
-        $i = max($classOpenIndex + 1, $tokens->getPrevTokenOfKind($index, ['{', '}']));
+        $index = max($classOpenIndex + 1, $tokens->getPrevTokenOfKind($index, ['{', '}']));
 
-        while (!$tokens[$i]->isGivenKind(T_FUNCTION)) {
-            if ($tokens[$i]->isGivenKind(T_PRIVATE)) {
+        while (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
+            if ($tokens[$index]->isGivenKind(T_PRIVATE)) {
                 return true;
             }
 
-            ++$i;
+            ++$index;
         }
 
         return false;

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -112,9 +112,10 @@ class Foo {
                 continue;
             }
 
+            $prevMeaningfulToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
             $nextMeaningfulToken = $tokens[$tokens->getNextMeaningfulToken($index)];
 
-            if (!$nextMeaningfulToken->isGivenKind($methodVisibilities)) {
+            if (!$nextMeaningfulToken->isGivenKind($methodVisibilities) && !$prevMeaningfulToken->isGivenKind($methodVisibilities)) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -246,9 +246,6 @@ final class Foo
             final public function baz()
             {
             }
-            private function qux()
-            {
-            }
         };
     }
 }
@@ -266,6 +263,31 @@ final class Foo
             final public function baz()
             {
             }
+        };
+    }
+}
+',
+            ],
+            'anonymous-class-inside-with-final-private-method' => [
+                '<?php
+class Foo
+{
+    private function bar()
+    {
+        new class {
+            private function qux()
+            {
+            }
+        };
+    }
+}
+',
+                '<?php
+class Foo
+{
+    private function bar()
+    {
+        new class {
             final private function qux()
             {
             }

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -187,6 +187,16 @@ class Foo {
     final private function bar() {}
 }',
             ],
+            'private-method-with-visibility-before-final' => [
+                '<?php
+class Foo {
+    private function bar() {}
+}',
+                '<?php
+class Foo {
+    private final function bar() {}
+}',
+            ],
             'preserve-comment' => [
                 '<?php final class Foo { /* comment */public function foo() {} }',
                 '<?php final class Foo { final/* comment */public function foo() {} }',

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -246,6 +246,9 @@ final class Foo
             final public function baz()
             {
             }
+            private function qux()
+            {
+            }
         };
     }
 }
@@ -261,6 +264,9 @@ final class Foo
     {
         new class {
             final public function baz()
+            {
+            }
+            final private function qux()
             {
             }
         };

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -180,11 +180,11 @@ final class SomeClass {
             'private-method' => [
                 '<?php
 class Foo {
-    private function baz() {}
+    private function bar() {}
 }',
                 '<?php
 class Foo {
-    final private function baz() {}
+    final private function bar() {}
 }',
             ],
             'preserve-comment' => [

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -177,6 +177,16 @@ final class SomeClass {
     static final function baz() {}
 }',
             ],
+            'private-method' => [
+                '<?php
+class Foo {
+    private function baz() {}
+}',
+                '<?php
+class Foo {
+    final private function baz() {}
+}',
+            ],
             'preserve-comment' => [
                 '<?php final class Foo { /* comment */public function foo() {} }',
                 '<?php final class Foo { final/* comment */public function foo() {} }',


### PR DESCRIPTION
This PR

* [x] adjusts the `NoUnneededFinalMethodFixer` to also remove an unnecessary `final` keyword from `private` methods

