### PR TITLE
NoUnneededFinalMethodFixer - Add test cases

### DIFF
--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -51,6 +51,132 @@ final class Foo {
     final private function baz() {}
 }',
             ],
+            'final-after-visibility' => [
+                '<?php
+final class Foo {
+    public function foo() {}
+    protected function bar() {}
+    private function baz() {}
+}',
+                '<?php
+final class Foo {
+    public final function foo() {}
+    protected final function bar() {}
+    private final function baz() {}
+}',
+            ],
+            'default-static' => [
+                '<?php
+final class SomeClass {
+    public static function foo() {}
+    protected static function bar() {}
+    private static function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    final public static function foo() {}
+    final protected static function bar() {}
+    final private static function baz() {}
+}',
+            ],
+            'visibility-then-final-then-static' => [
+                '<?php
+final class SomeClass {
+    public static function foo() {}
+    protected static function bar() {}
+    private static function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    public final static function foo() {}
+    protected final static function bar() {}
+    private final static function baz() {}
+}',
+            ],
+            'visibility-then-static-then-final' => [
+                '<?php
+final class SomeClass {
+    public static function foo() {}
+    protected static function bar() {}
+    private static function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    public static final function foo() {}
+    protected static final function bar() {}
+    private static final function baz() {}
+}',
+            ],
+            'static-then-visibility-then-final' => [
+                '<?php
+final class SomeClass {
+    static public function foo() {}
+    static protected function bar() {}
+    static private function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    static public final function foo() {}
+    static protected final function bar() {}
+    static private final function baz() {}
+}',
+            ],
+            'static-then-final-then-visibility' => [
+                '<?php
+final class SomeClass {
+    static public function foo() {}
+    static protected function bar() {}
+    static private function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    static final public function foo() {}
+    static final protected function bar() {}
+    static final private function baz() {}
+}',
+            ],
+            'no-visibility' => [
+                '<?php
+final class Foo {
+    function foo() {}
+    function bar() {}
+    function baz() {}
+}',
+                '<?php
+final class Foo {
+    final function foo() {}
+    final function bar() {}
+    final function baz() {}
+}',
+            ],
+            'no-visibility-final-then-static' => [
+                '<?php
+final class SomeClass {
+    static function foo() {}
+    static function bar() {}
+    static function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    final static function foo() {}
+    final static function bar() {}
+    final static function baz() {}
+}',
+            ],
+            'no-visibility-static-then-final' => [
+                '<?php
+final class SomeClass {
+    static function foo() {}
+    static function bar() {}
+    static function baz() {}
+}',
+                '<?php
+final class SomeClass {
+    static final function foo() {}
+    static final function bar() {}
+    static final function baz() {}
+}',
+            ],
             'preserve-comment' => [
                 '<?php final class Foo { /* comment */public function foo() {} }',
                 '<?php final class Foo { final/* comment */public function foo() {} }',


### PR DESCRIPTION
As spotted in #3093, `final` keyword may be after the visibility keyword. This PR also adds tests with final static methods.