### PR TITLE
StrictMethodsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1223,6 +1223,12 @@ Choose from the list of available rules:
 
   *Risky rule: changing comparisons to strict might change code behavior.*
 
+* **strict_methods**
+
+  Force strict types in class methods. Requires PHP >= 7.0.
+
+  *Risky rule: .*
+
 * **strict_param**
 
   Functions should be used with ``$strict`` param set to ``true``.

--- a/src/Fixer/Strict/StrictMethodsFixer.php
+++ b/src/Fixer/Strict/StrictMethodsFixer.php
@@ -1,0 +1,261 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Strict;
+
+use PhpCsFixer\AbstractFunctionReferenceFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author VeeWee <toonverwerft@gmail.com>
+ */
+final class StrictMethodsFixer extends AbstractFunctionReferenceFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Force strict types in class methods. Requires PHP >= 7.0.',
+            [
+                new VersionSpecificCodeSample(
+                    '<?php ',
+                    new VersionSpecification(70000)
+                ),
+            ],
+            null,
+            ''
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // must ran before ?????.
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return PHP_VERSION_ID >= 70000 && $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $doc = new DocBlock($token->getContent());
+            $annotations = $doc->getAnnotationsOfType(['param', 'return']);
+
+            if (empty($annotations)) {
+                continue;
+            }
+
+            $this->useAnnotatedTypesAsStrictTypes($tokens, $index, $annotations);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     * @param Annotation[] $annotations
+     */
+    private function useAnnotatedTypesAsStrictTypes(Tokens $tokens, $docBlockIndex, array $annotations)
+    {
+        $functionTokenIndex = $this->detectNextFunctionToken($tokens, $docBlockIndex);
+        if ($functionTokenIndex === null) {
+            return;
+        }
+
+        $arguments = $this->detectFunctionArguments($tokens, $functionTokenIndex);
+
+        $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
+
+        foreach ($arguments as $variable => $argument) {
+            foreach ($doc->getAnnotationsOfType('param') as $annotation) {
+                if (!preg_match('/' . preg_quote($variable, '/') . '\b/', $annotation->getContent())) {
+                    continue;
+                }
+
+                $types = $annotation->getTypes();
+                if (count($types) !== 1) {
+                    continue;
+                }
+
+                if ($argument['type'] !== '' && $types[0] !== $argument['type']) {
+                    continue;
+                }
+
+                // TODO: Add type to argument
+                $annotation->remove();
+            }
+        }
+
+        if ($this->detectFunctionReturnType($tokens, $functionTokenIndex) === null) {
+            $annotations = $doc->getAnnotationsOfType('return');
+            if (count($annotations) === 1) {
+                $types = $annotations[0]->getTypes();
+                if (count($types) === 1) {
+                    // TODO: Add type to method
+                    $annotations[0]->remove();
+                }
+            }
+        }
+
+        $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return int|null
+     */
+    private function detectNextFunctionToken(Tokens $tokens, $docBlockIndex)
+    {
+        $allowedIntermediateToken = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_STATIC];
+        $currentIndex = $docBlockIndex;
+        do {
+            $currentIndex = $tokens->getNextMeaningfulToken($currentIndex);
+            $token = $tokens[$currentIndex];
+
+            if ($token->isGivenKind(T_FUNCTION)) {
+                return $currentIndex;
+            }
+
+            if (!$token->isGivenKind($allowedIntermediateToken)) {
+                return null;
+            }
+
+
+        } while($currentIndex < count($tokens));
+
+        return null;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int $methodIndex
+     *
+     * @return array
+     */
+    private function detectFunctionArguments(Tokens $tokens, $methodIndex)
+    {
+        $argumentsStart = $tokens->getNextTokenOfKind($methodIndex, ['(']);
+        $argumentsEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $argumentsStart);
+        $arguments = [];
+        foreach ($this->getArguments($tokens, $argumentsStart, $argumentsEnd) as $start => $end) {
+            $argumentInfo = $this->prepareArgumentInformation($tokens, $start, $end);
+            $arguments[$argumentInfo['name']] = $argumentInfo;
+        }
+
+        if (!count($arguments)) {
+            return [];
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int   $methodIndex
+     *
+     * @return int|null
+     */
+    private function detectFunctionReturnType(Tokens $tokens, $methodIndex)
+    {
+        $argumentsStart = $tokens->getNextTokenOfKind($methodIndex, ['(']);
+        $argumentsEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $argumentsStart);
+
+        $colonIndex = $tokens->getNextMeaningfulToken($argumentsEnd);
+        if (!$tokens[$colonIndex]->isGivenKind([CT::T_TYPE_COLON])) {
+            return null;
+        }
+
+        return $tokens->getNextMeaningfulToken($colonIndex);
+    }
+
+    /**
+     * TODO: This method is copied from \PhpCsFixer\Fixer\Phpdoc\PhpdocAddMissingParamAnnotationFixer We might abstract here?
+     *
+     *
+     * @param Tokens $tokens
+     * @param int    $start
+     * @param int    $end
+     *
+     * @return array
+     */
+    private function prepareArgumentInformation(Tokens $tokens, $start, $end)
+    {
+        $info = [
+            'default' => '',
+            'name' => '',
+            'type' => '',
+        ];
+
+        $sawName = false;
+
+        for ($index = $start; $index <= $end; ++$index) {
+            $token = $tokens[$index];
+
+            if ($token->isComment() || $token->isWhitespace()) {
+                continue;
+            }
+
+            if ($token->isGivenKind(T_VARIABLE)) {
+                $sawName = true;
+                $info['name'] = $token->getContent();
+
+                continue;
+            }
+
+            if ($token->equals('=')) {
+                continue;
+            }
+
+            if ($sawName) {
+                $info['default'] .= $token->getContent();
+            } else {
+                $info['type'] .= $token->getContent();
+            }
+        }
+
+        return $info;
+    }
+}

--- a/src/Fixer/Strict/StrictMethodsFixer.php
+++ b/src/Fixer/Strict/StrictMethodsFixer.php
@@ -12,11 +12,12 @@
 
 namespace PhpCsFixer\Fixer\Strict;
 
-use PhpCsFixer\AbstractFunctionReferenceFixer;
+use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -24,7 +25,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author VeeWee <toonverwerft@gmail.com>
  */
-final class StrictMethodsFixer extends AbstractFunctionReferenceFixer
+final class StrictMethodsFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}
@@ -74,8 +75,10 @@ final class StrictMethodsFixer extends AbstractFunctionReferenceFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
-            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+        $lastIndex = $tokens->count() - 1;
+
+        for ($index = $lastIndex; $index >= 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
@@ -212,8 +215,10 @@ final class StrictMethodsFixer extends AbstractFunctionReferenceFixer
     {
         $argumentsStart = $tokens->getNextTokenOfKind($methodIndex, ['(']);
         $argumentsEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $argumentsStart);
+        $argumentAnalyzer = new ArgumentsAnalyzer();
         $arguments = [];
-        foreach ($this->getArguments($tokens, $argumentsStart, $argumentsEnd) as $start => $end) {
+
+        foreach ($argumentAnalyzer->getArguments($tokens, $argumentsStart, $argumentsEnd) as $start => $end) {
             $argumentInfo = $this->prepareArgumentInformation($tokens, $start, $end);
             $arguments[$argumentInfo['name']] = $argumentInfo;
         }

--- a/tests/Fixer/Strict/StrictMethodsFixerTest.php
+++ b/tests/Fixer/Strict/StrictMethodsFixerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Strict;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author VeeWee <toonverwerft@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Strict\StrictMethodsFixer
+ */
+final class StrictMethodsFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     * @requires PHP 7.0
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+namespace A\B\C;
+class A {
+    /**
+     * @param int $test
+     * @param int $test1
+     * @param int|bool $test2
+     */
+    public function myFunction($test, string $test1, $test2)
+    {
+    }
+}',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Strict/StrictMethodsFixerTest.php
+++ b/tests/Fixer/Strict/StrictMethodsFixerTest.php
@@ -42,26 +42,117 @@ final class StrictMethodsFixerTest extends AbstractFixerTestCase
                 '<?php
 namespace A\B\C;
 class A {
+
     /**
-     * @param int $test1
-     * @param int|bool $test2
+     * @var string
      */
-    public function myFunction(int $test, string $test1, $test2)
+    private $someprop;
+
+    /**
+     * @param int $invalidDocType
+     * @param int|bool $multipleDocTypes
+     * @return null|string
+     */
+    public function a(int $replaceMe, string $invalidDocType, $multipleDocTypes)
+    {
+    }
+
+    public function b($noDocBlocks, string $withType)
+    {
+    }
+
+    /**
+     * @param string $doesNotExist
+     * @param mixed $mixed
+     */
+    public function c(string $doesExist, $mixed): string
     {
     }
 }',
                 '<?php
 namespace A\B\C;
 class A {
+
     /**
-     * @param int $test
-     * @param int $test1
-     * @param int|bool $test2
+     * @var string
      */
-    public function myFunction($test, string $test1, $test2)
+    private $someprop;
+
+    /**
+     * @param int $replaceMe
+     * @param int $invalidDocType
+     * @param int|bool $multipleDocTypes
+     * @return null|string
+     */
+    public function a($replaceMe, string $invalidDocType, $multipleDocTypes)
+    {
+    }
+
+    public function b($noDocBlocks, string $withType)
+    {
+    }
+
+    /**
+     * @param string $doesNotExist
+     * @param $doesExist
+     * @param mixed $mixed
+     * @return string
+     */
+    public function c(string $doesExist, $mixed)
     {
     }
 }',
+            ],
+            [
+                '<?php
+
+function x(SomeClass ...$classes): SomeCollection
+{
+}',
+                '<?php
+/**
+ * @param SomeClass $classes
+ * @return SomeCollection
+ */
+function x(SomeClass ...$classes)
+{
+}',
+            ],
+            [
+                '<?php
+
+function x(int $a=((1*(2+3))/(5+6)), string $b = (\'\' . (\'\'))): self
+{
+}',
+                '<?php
+/**
+ * @param int $a
+ * @param string $b
+ * @return self
+ */
+function x($a=((1*(2+3))/(5+6)), string $b = (\'\' . (\'\')))
+{
+}',
+            ],
+            [
+                '<?php
+namespace SomeNamespace;
+
+function x(SomeClass $x, \SomeNameSpace\SomeClass $y): SomeClass
+{
+}',
+                '<?php
+namespace SomeNamespace;
+
+/**
+ * @param \SomeNamespace\SomeClass $x;
+ * @param SomeClass $y
+ * @return \SomeNamespace\SomeClass
+ */
+function x(SomeClass $x, \SomeNameSpace\SomeClass $y): SomeClass
+{
+}
+',
             ],
         ];
     }

--- a/tests/Fixer/Strict/StrictMethodsFixerTest.php
+++ b/tests/Fixer/Strict/StrictMethodsFixerTest.php
@@ -43,6 +43,17 @@ final class StrictMethodsFixerTest extends AbstractFixerTestCase
 namespace A\B\C;
 class A {
     /**
+     * @param int $test1
+     * @param int|bool $test2
+     */
+    public function myFunction(int $test, string $test1, $test2)
+    {
+    }
+}',
+                '<?php
+namespace A\B\C;
+class A {
+    /**
      * @param int $test
      * @param int $test1
      * @param int|bool $test2


### PR DESCRIPTION
Hi,

Since PHP 7 it doesnt make much sense anymore to have "@param" and "@return" tags in the docblocks. Lots of people are dropping those tags in favour for strict types. It would be great if we could use a fixer that is capable of adding strict types to the method and in the same time remove the annotation.

e.g:

From:
```php
/**
 * @param SomeClass $classes
 * @return SomeClass
 */
function x($class)
{
}
```

To:
```php
function x(SomeClass $class): SomeClass
{
}
```

I've started working on something, but there still are some issues to be resolved (it's a bit slow according to the tests, namespaces/alias support, edge cases ...)

If you think this could be of any value, feel free to give me some feedback and I'll try to work something out within my limited timeframe. If not: no problem, I had a lot of fun digging into the code of this project :)
