### PR TITLE
DoctrineAnnotationIndentationFixer - Restore test case

### DIFF
--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -315,6 +315,17 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  *     @fixme
  *     @override
  */'],
+            ['
+/**
+ * @Foo({
+ * @Bar()}
+ * )
+ */', '
+/**
+ * @Foo({
+ *     @Bar()}
+ * )
+ */'],
         ]);
     }
 
@@ -605,8 +616,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  * @Foo({
  *     @Bar()}
  * )
- */
-'],
+ */'],
         ]);
     }
 }


### PR DESCRIPTION
Test case added in #3104 and merged in branch 2.2 is missing in branch 2.6.