### PR TITLE
Multibyte character in array key makes alignment incorect

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -747,7 +747,7 @@ $h = $i===  $j;
                 if (self::ALIGN !== $alignStrategy) {
                     // move place holders to match strategy
                     foreach ($group as $index) {
-                        $currentPosition = strpos(utf8_decode($lines[$index]), $placeholder);
+                        $currentPosition = strpos($lines[$index], $placeholder);
                         $before = substr($lines[$index], 0, $currentPosition);
 
                         if (self::ALIGN_SINGLE_SPACE === $alignStrategy) {
@@ -760,7 +760,7 @@ $h = $i===  $j;
                             }
                         }
 
-                        $lines[$index] = $before.mb_substr($lines[$index], $currentPosition);
+                        $lines[$index] = $before.substr($lines[$index], $currentPosition);
                     }
                 }
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -760,7 +760,7 @@ $h = $i===  $j;
                             }
                         }
 
-                        $lines[$index] = $before.substr($lines[$index], $currentPosition);
+                        $lines[$index] = $before.mb_substr($lines[$index], $currentPosition);
                     }
                 }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -2044,4 +2044,16 @@ $a = $ae?? $b;
             ],
         ];
     }
+
+    public function testWithMultibyteCharacterInArrayKey()
+    {
+        $this->fixer->configure(['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]]);
+        $this->doTest(
+            '<?php
+                $map = [
+                    "ø" => "oe",
+                ];
+            '
+        );
+    }
 }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -322,17 +322,17 @@ $a//
             ],
             [
                 '<?php $a = 1 + 2; $b = array(
-                    13 => 3,
-                    4  => 3,
-                    5  => 2,
+                    $øøø => $ø0ø0ø,
+                    $ø4  => $ø1ø1ø,
+                    $ø5  => $ø2ø2ø,
                 );
                 $a = 12 + 1;
                 $a = 13 + 41;
                 ',
                 '<?php $a    =   1   +    2; $b = array(
-                    13 =>3,
-                    4  =>  3,
-                    5=>2,
+                    $øøø =>$ø0ø0ø,
+                    $ø4  =>  $ø1ø1ø,
+                    $ø5=>$ø2ø2ø,
                 );
                 $a = 12   +  1;
                 $a = 13+41;
@@ -377,17 +377,27 @@ $a//
             'align correctly with multibyte characters in array key' => [
                 '<?php
                     $inflect_male = array(
-                        "aitė\b" => "as",
-                        "ytė\b"  => "is",
-                        "iūtė\b" => "ius",
-                        "utė\b"  => "us",
+                        "aitė\b" => "øasø",
+                        "ytė\b"  => "øisø",
+                        "iūtė\b" => "øiusø",
+                        "utė\b"  => array(
+                            "aitė\b" => "øas",
+                            "ytė\b"  => "øis",
+                            "iūtė\b" => $øøius,
+                            "utė\b"  => "us",
+                        ),
                     );',
                 '<?php
                     $inflect_male = array(
-                        "aitė\b" => "as",
-                        "ytė\b" => "is",
-                        "iūtė\b" => "ius",
-                        "utė\b" => "us",
+                        "aitė\b" => "øasø",
+                        "ytė\b" => "øisø",
+                        "iūtė\b" => "øiusø",
+                        "utė\b" => array(
+                            "aitė\b" => "øas",
+                            "ytė\b" => "øis",
+                            "iūtė\b" => $øøius,
+                            "utė\b"  =>     "us",
+                        ),
                     );',
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
             ],

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -365,6 +365,32 @@ $a//
                 ',
                 ['operators' => ['=' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
             ],
+            'do not align with multibyte character in array key' => [
+                '<?php
+                    $map = [
+                        "ø" => "oe",
+                    ];
+                ',
+                null,
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
+            'align correctly with multibyte characters in array key' => [
+                '<?php
+                    $inflect_male = array(
+                        "aitė\b" => "as",
+                        "ytė\b"  => "is",
+                        "iūtė\b" => "ius",
+                        "utė\b"  => "us",
+                    );',
+                '<?php
+                    $inflect_male = array(
+                        "aitė\b" => "as",
+                        "ytė\b" => "is",
+                        "iūtė\b" => "ius",
+                        "utė\b" => "us",
+                    );',
+                ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
+            ],
         ];
     }
 
@@ -2043,17 +2069,5 @@ $a = $ae?? $b;
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
             ],
         ];
-    }
-
-    public function testWithMultibyteCharacterInArrayKey()
-    {
-        $this->fixer->configure(['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]]);
-        $this->doTest(
-            '<?php
-                $map = [
-                    "ø" => "oe",
-                ];
-            '
-        );
     }
 }


### PR DESCRIPTION
Running:

```bash
php php-cs-fixer fix --rules=mb_str_functions src/Fixer/Operator/BinaryOperatorSpacesFixer.php
```

would solve a problem, but is that what we want?