### PR TITLE
README: remove deprecated rule from CLI examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ When using combinations of exact and blacklist rules, applying exact rules along
 
 .. code-block:: bash
 
-    $ php php-cs-fixer.phar fix /path/to/project --rules=@Symfony,-@PSR1,-blank_line_before_return,strict_comparison
+    $ php php-cs-fixer.phar fix /path/to/project --rules=@Symfony,-@PSR1,-blank_line_before_statement,strict_comparison
 
 Complete configuration for rules can be supplied using a ``json`` formatted string.
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -83,7 +83,7 @@ using <comment>-name_of_fixer</comment>:
 
 When using combinations of exact and blacklist rules, applying exact rules along with above blacklisted results:
 
-    <info>$ php %command.full_name% /path/to/project --rules=@Symfony,-@PSR1,-blank_line_before_return,strict_comparison</info>
+    <info>$ php %command.full_name% /path/to/project --rules=@Symfony,-@PSR1,-blank_line_before_statement,strict_comparison</info>
 
 Complete configuration for rules can be supplied using a ``json`` formatted string.
 


### PR DESCRIPTION
`blank_line_before_return` rule is deprecated, `blank_line_before_statement` should be used instead