### PR TITLE
Unify description of deprecated fixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,8 +255,8 @@ Choose from the list of available rules:
 
 * **blank_line_before_return**
 
-  An empty line feed should precede a return statement (deprecated, use
-  ``blank_line_before_statement`` instead).
+  An empty line feed should precede a return statement. DEPRECATED: use
+  ``blank_line_before_statement`` instead.
 
 * **blank_line_before_statement** [@Symfony]
 
@@ -548,7 +548,7 @@ Choose from the list of available rules:
 * **hash_to_slash_comment** [@Symfony]
 
   Single line comments should use double slashes ``//`` and not hash ``#``.
-  DEPRECATED: Use "single_line_comment_style" instead.
+  DEPRECATED: use ``single_line_comment_style`` instead.
 
 * **header_comment**
 

--- a/src/Fixer/Comment/HashToSlashCommentFixer.php
+++ b/src/Fixer/Comment/HashToSlashCommentFixer.php
@@ -31,7 +31,7 @@ final class HashToSlashCommentFixer extends AbstractProxyFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            sprintf('Single line comments should use double slashes `//` and not hash `#`. DEPRECATED: Use "%s" instead.', $this->proxyFixer->getName()),
+            sprintf('Single line comments should use double slashes `//` and not hash `#`. DEPRECATED: use `%s` instead.', $this->proxyFixer->getName()),
             [new CodeSample('<?php # comment')]
         );
     }

--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -35,7 +35,7 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Whi
     public function getDefinition()
     {
         return new FixerDefinition(
-            'An empty line feed should precede a return statement (deprecated, use `blank_line_before_statement` instead).',
+            'An empty line feed should precede a return statement. DEPRECATED: use `blank_line_before_statement` instead.',
             [new CodeSample("<?php\nfunction A()\n{\n    echo 1;\n    return 1;\n}")]
         );
     }

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -168,6 +168,29 @@ final class FixerTest extends TestCase
         $this->assertInstanceOf(\PhpCsFixer\Fixer\DefinedFixerInterface::class, $fixer);
     }
 
+    /**
+     * @dataProvider provideFixerDefinitionsCases
+     */
+    public function testDeprecatedFixersHaveCorrectSummary(FixerInterface $fixer)
+    {
+        $reflection = new \ReflectionClass($fixer);
+        $comment = $reflection->getDocComment();
+
+        if (is_string($comment) && false !== strpos($comment, '@deprecated')) {
+            $this->assertRegExp(
+                '/\. DEPRECATED: use `[a-z_]+` instead\.$/',
+                $fixer->getDefinition()->getSummary(),
+                'Deprecated fixer must contain correct "DEPRECATED" note in summary'
+            );
+        } else {
+            $this->assertNotRegExp(
+                '/DEPRECATED/',
+                $fixer->getDefinition()->getSummary(),
+                'Non-deprecated fixer cannot contain word "DEPRECATED" in summary'
+            );
+        }
+    }
+
     public function provideFixerDefinitionsCases()
     {
         return array_map(function (FixerInterface $fixer) {


### PR DESCRIPTION
Right now 2 of 3 deprecated fixers have capitalised word "DEPRECATED" as new sentence - let's make third one looks the same.