### PR TITLE
documentation - fix typos

### DIFF
--- a/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
@@ -39,7 +39,7 @@ final class ArgumentsAnalyzer
     /**
      * Returns start and end token indexes of arguments.
      *
-     * Return an array which each index being the first token af an
+     * Returns an array with each key being the first token of an
      * argument and the value the last. Including non-function tokens
      * such as comments and white space tokens, but without the separation
      * tokens like '(', ',' and ')'.

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -430,9 +430,9 @@ class Token
     }
 
     /**
-     * Check if token is a whitespace.
+     * Check if token is whitespace.
      *
-     * @param null|string $whitespaces whitespaces characters, default is " \t\n\r\0\x0B"
+     * @param null|string $whitespaces whitespace characters, default is " \t\n\r\0\x0B"
      *
      * @return bool
      */


### PR DESCRIPTION
This PR

* [x] fixes a small typo / wording issue in a docblock