### PR TITLE
[RFC] Add deprecation error for deprecated fixers

### DIFF
--- a/src/Fixer/Comment/HashToSlashCommentFixer.php
+++ b/src/Fixer/Comment/HashToSlashCommentFixer.php
@@ -26,6 +26,17 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
  */
 final class HashToSlashCommentFixer extends AbstractProxyFixer implements DeprecatedFixerInterface
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        @trigger_error(sprintf(
+            'Fixer "%s" is deprecated and will be removed in 3.0. Use "%s" instead.',
+            $this->getName(),
+            current($this->proxyFixers)->getName()
+        ), E_USER_DEPRECATED);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/FixerFactory.php
+++ b/src/FixerFactory.php
@@ -79,6 +79,8 @@ final class FixerFactory
      */
     public function getFixers()
     {
+        $this->fixers = array_map([$this, 'retrieveFixer'], $this->fixers);
+
         $this->fixers = Utils::sortFixers($this->fixers);
 
         return $this->fixers;
@@ -104,7 +106,7 @@ final class FixerFactory
         }
 
         foreach ($builtInFixers as $class) {
-            $this->registerFixer(new $class(), false);
+            $this->registerFixer(new FixerProxy($class), false);
         }
 
         return $this;
@@ -167,7 +169,7 @@ final class FixerFactory
                 throw new \UnexpectedValueException(sprintf('Rule "%s" does not exist.', $name));
             }
 
-            $fixer = $this->fixersByName[$name];
+            $fixer = $this->retrieveFixer($this->fixersByName[$name]);
 
             $config = $ruleSet->getRuleConfiguration($name);
             if (null !== $config) {
@@ -253,5 +255,19 @@ final class FixerFactory
         }
 
         return $message;
+    }
+
+    /**
+     * @param FixerInterface $fixer
+     *
+     * @return FixerInterface
+     */
+    private function retrieveFixer(FixerInterface $fixer)
+    {
+        if ($fixer instanceof FixerProxy) {
+            return $fixer->retrieveFixer();
+        }
+
+        return $fixer;
     }
 }

--- a/src/FixerProxy.php
+++ b/src/FixerProxy.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class FixerProxy implements FixerInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var FixerInterface
+     */
+    private $fixer;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return FixerInterface
+     */
+    public function retrieveFixer()
+    {
+        if (null === $this->fixer) {
+            $name = $this->name;
+            \set_error_handler(function () { return false; }, E_USER_DEPRECATED);
+            $this->fixer = new $name();
+            \restore_error_handler();
+        }
+
+        return $this->fixer;
+    }
+
+    public function isCandidate(Tokens $tokens)
+    {
+        return $this->retrieveFixer()->isCandidate($tokens);
+    }
+
+    public function isRisky()
+    {
+        return $this->retrieveFixer()->isRisky();
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens)
+    {
+        return $this->retrieveFixer()->fix($file, $tokens);
+    }
+
+    public function getName()
+    {
+        return $this->retrieveFixer()->getName();
+    }
+
+    public function getPriority()
+    {
+        return $this->retrieveFixer()->getPriority();
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return $this->retrieveFixer()->supports($file);
+    }
+}

--- a/tests/Fixer/Comment/HashToSlashCommentFixerTest.php
+++ b/tests/Fixer/Comment/HashToSlashCommentFixerTest.php
@@ -27,7 +27,9 @@ final class HashToSlashCommentFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
+     * @group legacy
      * @dataProvider provideFixCases
+     * @expectedDeprecation Fixer "hash_to_slash_comment" is deprecated and will be removed in 3.0. Use "single_line_comment_style" instead.
      */
     public function testFix($expected, $input = null)
     {

--- a/tests/FixerProxyTest.php
+++ b/tests/FixerProxyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests;
+
+use PhpCsFixer\FixerProxy;
+use PhpCsFixer\Tests\Fixtures\FixerProxy\DeprecatedFixer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\FixerProxy
+ */
+final class FixerProxyTest extends TestCase
+{
+    public function testUserDeprecatedErrorIsSilenced()
+    {
+        $proxy = new FixerProxy(DeprecatedFixer::class);
+
+        $this->assertInstanceOf(DeprecatedFixer::class, $proxy->retrieveFixer());
+    }
+}

--- a/tests/Fixtures/FixerProxy/DeprecatedFixer.php
+++ b/tests/Fixtures/FixerProxy/DeprecatedFixer.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Input for @see \PhpCsFixer\TestsFixerProxyTest
+ *
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+namespace PhpCsFixer\Tests\Fixtures\FixerProxy;
+
+class DeprecatedFixer
+{
+    public function __construct()
+    {
+        @trigger_error('I am deprecated, please do not use me', E_USER_DEPRECATED);
+    }
+}


### PR DESCRIPTION
Follow up to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3065. There's only "small" problem:

```
Remaining deprecation notices (7049)

Fixer "hash_to_slash_comment" is deprecated and will be removed in 3.0. Use "single_line_comment_style" instead: 7049x
(...)
```

The source for all of them is `FixerFactory::registerBuiltInFixers` which is used in tests and I haven't figured out how to solve it nicely. I have tried to add parameter `$triggerError` set by default to `true` and in tests to `false`, but that doesn't seem right. Also I have tried to add dummy interface `DeprecatedFixerInterface` and in 2nd `foreach` add `if` for instance of it - better, but still a little bit hacky.

Any suggestions? If not I'd say we could go with the interface solution (with added checks in auto review tests). 

Other fixers will be done after the solution is agreed.