### PR TITLE
Add ExplicitIndirectVariableFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,6 +23,7 @@ $config = PhpCsFixer\Config::create()
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
         'compact_nullable_typehint' => true,
+        'explicit_indirect_variable' => true,
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],

--- a/README.rst
+++ b/README.rst
@@ -537,6 +537,11 @@ Choose from the list of available rules:
 
   *Risky rule: risky if the ``ereg`` function is overridden.*
 
+* **explicit_indirect_variable**
+
+  Add curly braces to indirect variables to make them clear to understand.
+  Requires PHP >= 7.0.
+
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 
   PHP code must use the long ``<?php`` tags or short-echo ``<?=`` tags and not

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -60,7 +60,8 @@ EOT
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
+        for ($index = $tokens->count() - 1; $index > 1; --$index) {
+            $token = $tokens[$index];
             if (!$token->isGivenKind(T_VARIABLE)) {
                 continue;
             }

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -36,8 +36,10 @@ final class ExplicitIndirectVariableFixer extends AbstractFixer
                 new VersionSpecificCodeSample(
 <<<'EOT'
 <?php
+echo $$foo;
 echo $$foo['bar'];
 echo $foo->$bar['baz'];
+echo $foo->$callback($baz);
 
 EOT
 ,

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\LanguageConstruct;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class ExplicitIndirectVariableFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.',
+            [
+                new VersionSpecificCodeSample(
+<<<'EOT'
+<?php
+echo $$foo['bar'];
+echo $foo->$bar['baz'];
+
+EOT
+,
+                    new VersionSpecification(70000)
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return PHP_VERSION_ID >= 70000 && $tokens->isTokenKindFound(T_VARIABLE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_VARIABLE)) {
+                continue;
+            }
+
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            $prevToken = $tokens[$prevIndex];
+            if (!$prevToken->equals('$') && !$prevToken->isGivenKind(T_OBJECT_OPERATOR)) {
+                continue;
+            }
+
+            $openingBrace = CT::T_DYNAMIC_VAR_BRACE_OPEN;
+            $closingBrace = CT::T_DYNAMIC_VAR_BRACE_CLOSE;
+            if ($prevToken->isGivenKind(T_OBJECT_OPERATOR)) {
+                $openingBrace = CT::T_DYNAMIC_PROP_BRACE_OPEN;
+                $closingBrace = CT::T_DYNAMIC_PROP_BRACE_CLOSE;
+            }
+
+            $tokens->overrideRange($index, $index, [
+                new Token([$openingBrace, '{']),
+                new Token([T_VARIABLE, $token->getContent()]),
+                new Token([$closingBrace, '}']),
+            ]);
+        }
+    }
+}

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer
+ */
+final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestFixCases
+     * @requires PHP 7.0
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestFixCases()
+    {
+        return [
+            [
+                '<?php echo ${$foo}[\'bar\'][\'baz\'];',
+                '<?php echo $$foo[\'bar\'][\'baz\'];',
+            ],
+            [
+                '<?php echo $foo->{$bar}[\'baz\'];',
+                '<?php echo $foo->$bar[\'baz\'];',
+            ],
+            [
+                '<?php echo $foo->{$bar}[\'baz\']();',
+                '<?php echo $foo->$bar[\'baz\']();',
+            ],
+            [
+                '<?php echo $
+/* C1 */
+// C2
+{$foo}
+// C3
+;',
+                '<?php echo $
+/* C1 */
+// C2
+$foo
+// C3
+;',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -39,6 +39,10 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
     {
         return [
             [
+                '<?php echo ${$foo}($bar);',
+                '<?php echo $$foo($bar);',
+            ],
+            [
                 '<?php echo ${$foo}[\'bar\'][\'baz\'];',
                 '<?php echo $$foo[\'bar\'][\'baz\'];',
             ],


### PR DESCRIPTION
```diff
-$$foo['bar'];
+${$foo}['bar'];

-$foo->$bar['baz'];
+$foo->{$bar}['baz'];
```
Reference: https://secure.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling

This PR aims to fix only PHP ^7.0 evaluation; PHP < 7.0 evaluation will not be addressed.