### PR TITLE
SimplifiedNullReturnFixer - handle nullable return types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1016,8 +1016,6 @@ Choose from the list of available rules:
 
   A return statement wishing to return ``void`` should not return ``null``.
 
-  *Risky rule: risky since PHP 7.1 as ``null`` and ``void`` can be hinted as return type and have different meaning.*
-
 * **single_blank_line_at_eof** [@PSR2, @Symfony]
 
   A PHP file without end tag must always end with a single empty line

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -130,15 +130,15 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     {
         $functionIndex = $index;
         do {
-            $functionIndex = $tokens->getPrevTokenOfKind($functionIndex, [[T_FUNCTION]]);
+            $functionIndex = $tokens->getPrevTokenOfKind($functionIndex, array(array(T_FUNCTION)));
             if (null === $functionIndex) {
                 return false;
             }
-            $openingCurlyBraceIndex = $tokens->getNextTokenOfKind($functionIndex, ['{']);
+            $openingCurlyBraceIndex = $tokens->getNextTokenOfKind($functionIndex, array('{'));
             $closingCurlyBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openingCurlyBraceIndex);
         } while ($closingCurlyBraceIndex < $index);
 
-        $nullableTypeIndex = $tokens->getNextTokenOfKind($functionIndex, [[CT::T_NULLABLE_TYPE]]);
+        $nullableTypeIndex = $tokens->getNextTokenOfKind($functionIndex, array(array(CT::T_NULLABLE_TYPE)));
 
         return null !== $nullableTypeIndex && $nullableTypeIndex < $openingCurlyBraceIndex;
     }

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -30,9 +30,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'A return statement wishing to return `void` should not return `null`.',
-            array(new CodeSample('<?php return null;')),
-            null,
-            'Risky since PHP 7.1 as `null` and `void` can be hinted as return type and have different meaning.'
+            array(new CodeSample('<?php return null;'))
         );
     }
 
@@ -51,14 +49,6 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     public function isCandidate(Tokens $tokens)
     {
         return $tokens->isTokenKindFound(T_RETURN);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isRisky()
-    {
-        return true;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -138,8 +138,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             $closingCurlyBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openingCurlyBraceIndex);
         } while ($closingCurlyBraceIndex < $index);
 
-        $functionLastBraceIndex = $tokens->getPrevTokenOfKind($openingCurlyBraceIndex, [')']);
-        $nullableTypeIndex = $tokens->getNextTokenOfKind($functionLastBraceIndex, [[CT::T_NULLABLE_TYPE]]);
+        $nullableTypeIndex = $tokens->getNextTokenOfKind($functionIndex, [[CT::T_NULLABLE_TYPE]]);
 
         return null !== $nullableTypeIndex && $nullableTypeIndex < $openingCurlyBraceIndex;
     }

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -15,6 +15,8 @@ namespace PhpCsFixer\Fixer\ReturnNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -30,7 +32,20 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'A return statement wishing to return `void` should not return `null`.',
-            array(new CodeSample('<?php return null;'))
+            array(
+                new CodeSample('<?php return null;'),
+                new VersionSpecificCodeSample(
+<<<'EOT'
+<?php
+function foo() { return null; }
+function bar(): int { return null; }
+function baz(): ?int { return null; }
+function xyz(): void { return null; }
+EOT
+                    ,
+                    new VersionSpecification(70100)
+                ),
+            )
         );
     }
 

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -134,14 +134,14 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             if (null === $functionIndex) {
                 return false;
             }
-            $openingBraceIndex = $tokens->getNextTokenOfKind($functionIndex, ['{']);
-            $closingBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openingBraceIndex);
-        } while ($closingBraceIndex < $index);
+            $openingCurlyBraceIndex = $tokens->getNextTokenOfKind($functionIndex, ['{']);
+            $closingCurlyBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openingCurlyBraceIndex);
+        } while ($closingCurlyBraceIndex < $index);
 
-        $returnTypeIndex = $tokens->getPrevMeaningfulToken($openingBraceIndex);
-        $nullableIndex = $tokens->getPrevMeaningfulToken($returnTypeIndex);
+        $functionLastBraceIndex = $tokens->getPrevTokenOfKind($openingCurlyBraceIndex, [')']);
+        $nullableTypeIndex = $tokens->getNextTokenOfKind($functionLastBraceIndex, [[CT::T_NULLABLE_TYPE]]);
 
-        return $tokens[$nullableIndex]->isGivenKind(CT::T_NULLABLE_TYPE);
+        return null !== $nullableTypeIndex && $nullableTypeIndex < $openingCurlyBraceIndex;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -122,7 +122,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
      * Is the return within a function with a nullable return type?
      *
      * @param Tokens $tokens
-     * @param int    $index
+     * @param int    $index  Current token index
      *
      * @return bool
      */

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -73,6 +73,8 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
         return array(
             array('<?php function foo(): ? /* C */ int { return null; }'),
             array('<?php function foo(): ?int { if (false) { return null; } }'),
+            array('<?php function foo(): int { return null; }'),
+            array('<?php function foo(): A\B\C { return null; }'),
             array(
                 '<?php function foo(): ?int { return null; } return;',
                 '<?php function foo(): ?int { return null; } return null;',
@@ -84,10 +86,6 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
             array(
                 '<?php function foo(): ?int { $bar = function() { return; }; return null; }',
                 '<?php function foo(): ?int { $bar = function() { return null; }; return null; }',
-            ),
-            array(
-                '<?php function foo(): int { return; }',
-                '<?php function foo(): int { return null; }',
             ),
             array(
                 '<?php function foo(): void { return; }',

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -55,4 +55,40 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
             array('<?php return;', "<?php return\n(\nnull\n)\n;"),
         );
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provide71Cases
+     * @requires PHP 7.1
+     */
+    public function test71ReturnTypes($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provide71Cases()
+    {
+        return [
+            ['<?php function foo(): ? /* C */ int { return null; }'],
+            ['<?php function foo(): ?int { if (false) { return null; } }'],
+            [
+                '<?php function foo(): ?int { return null; } return;',
+                '<?php function foo(): ?int { return null; } return null;',
+            ],
+            [
+                '<?php function foo(): ?int { $bar = function() { return; }; return null; }',
+                '<?php function foo(): ?int { $bar = function() { return null; }; return null; }',
+            ],
+            [
+                '<?php function foo(): int { return; }',
+                '<?php function foo(): int { return null; }',
+            ],
+            [
+                '<?php function foo(): void { return; }',
+                '<?php function foo(): void { return null; }',
+            ],
+        ];
+    }
 }

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -78,6 +78,10 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
                 '<?php function foo(): ?int { return null; } return null;',
             ],
             [
+                '<?php function foo() { return; } function bar(): ?A\B\C\D { return null; } function baz() { return; }',
+                '<?php function foo() { return null; } function bar(): ?A\B\C\D { return null; } function baz() { return null; }',
+            ],
+            [
                 '<?php function foo(): ?int { $bar = function() { return; }; return null; }',
                 '<?php function foo(): ?int { $bar = function() { return null; }; return null; }',
             ],

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -70,29 +70,29 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
 
     public function provideNullableReturnTypeCases()
     {
-        return [
-            ['<?php function foo(): ? /* C */ int { return null; }'],
-            ['<?php function foo(): ?int { if (false) { return null; } }'],
-            [
+        return array(
+            array('<?php function foo(): ? /* C */ int { return null; }'),
+            array('<?php function foo(): ?int { if (false) { return null; } }'),
+            array(
                 '<?php function foo(): ?int { return null; } return;',
                 '<?php function foo(): ?int { return null; } return null;',
-            ],
-            [
+            ),
+            array(
                 '<?php function foo() { return; } function bar(): ?A\B\C\D { return null; } function baz() { return; }',
                 '<?php function foo() { return null; } function bar(): ?A\B\C\D { return null; } function baz() { return null; }',
-            ],
-            [
+            ),
+            array(
                 '<?php function foo(): ?int { $bar = function() { return; }; return null; }',
                 '<?php function foo(): ?int { $bar = function() { return null; }; return null; }',
-            ],
-            [
+            ),
+            array(
                 '<?php function foo(): int { return; }',
                 '<?php function foo(): int { return null; }',
-            ],
-            [
+            ),
+            array(
                 '<?php function foo(): void { return; }',
                 '<?php function foo(): void { return null; }',
-            ],
-        ];
+            ),
+        );
     }
 }

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -60,7 +60,7 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @dataProvider provide71Cases
+     * @dataProvider provideNullableReturnTypeCases
      * @requires PHP 7.1
      */
     public function test71ReturnTypes($expected, $input = null)
@@ -68,7 +68,7 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provide71Cases()
+    public function provideNullableReturnTypeCases()
     {
         return [
             ['<?php function foo(): ? /* C */ int { return null; }'],


### PR DESCRIPTION
Which is the right branch for this kind of improvement?

- [x] Don't fix nullable return types
- [x] Remove `risky` flag