### PR TITLE
Remove @requires PHPUnit 5.2 from test

### DIFF
--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -443,16 +443,17 @@ $a#4
      * @param string $expectedMessage
      *
      * @dataProvider provideInvalidConfigurationCases
-     * @requires PHPUnit 5.2
      */
     public function testInvalidConfig(array $config, $expectedMessage)
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class);
-        $this->expectExceptionMessageRegExp(sprintf(
-            '#^\[%s\] %s$#',
-            $this->fixer->getName(),
-            preg_quote($expectedMessage, '#')
-        ));
+        $this->setExpectedExceptionRegExp(
+            \PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class,
+            sprintf(
+                '#^\[%s\] %s$#',
+                $this->fixer->getName(),
+                preg_quote($expectedMessage, '#')
+            )
+        );
 
         $this->fixer->configure($config);
     }


### PR DESCRIPTION
I've got [this](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3160#discussion_r146700434) instruction from @keradus and I based that `@requires` on this one. So let's change it to avoid similar situation in the future.