### PR TITLE
Add PHP_CS_FIXER_FUTURE_MODE env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             php: 7.2
-            env: COLLECT_COVERAGE=1 PHP_CS_FIXER_FUTURE_MODE=1
+            env: COLLECT_COVERAGE=1
             before_script:
                 # check phpdbg
                 - phpdbg --version 2> /dev/null || { echo 'No phpdbg'; export COLLECT_COVERAGE=0; }
@@ -82,7 +82,7 @@ jobs:
             script:
                 - if [ $COLLECT_COVERAGE == 0 ]; then vendor/bin/phpunit || travis_terminate 1; fi
                 - if [ $COLLECT_COVERAGE == 1 ]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover build/logs/clover.xml || travis_terminate 1; fi
-                - php php-cs-fixer --diff --dry-run -v fix || travis_terminate 1
+                - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer --diff --dry-run -v fix || travis_terminate 1
                 - if [ $COLLECT_COVERAGE == 1 ]; then php vendor/bin/coveralls -v; fi
 
         -

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             php: 7.2
-            env: COLLECT_COVERAGE=1 SYMFONY_DEPRECATIONS_HELPER=weak
+            env: COLLECT_COVERAGE=1 PHP_CS_FIXER_FUTURE_MODE=1
             before_script:
                 # check phpdbg
                 - phpdbg --version 2> /dev/null || { echo 'No phpdbg'; export COLLECT_COVERAGE=0; }

--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,13 @@ automatically fix anything:
 
     $ cat foo.php | php php-cs-fixer.phar fix --diff -
 
+Finally, if you don't need BC kept on CLI level, you might use `PHP_CS_FIXER_FUTURE_MODE` to start using options that
+would be default in next MAJOR release (differ, progress indicator):
+
+.. code-block:: bash
+
+    $ PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer.phar fix -v --diff
+
 Choose from the list of available rules:
 
 * **align_multiline_comment**

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ automatically fix anything:
     $ cat foo.php | php php-cs-fixer.phar fix --diff -
 
 Finally, if you don't need BC kept on CLI level, you might use `PHP_CS_FIXER_FUTURE_MODE` to start using options that
-would be default in next MAJOR release (differ, progress indicator):
+would be default in next MAJOR release (unified differ, estimating, full-width progress indicator):
 
 .. code-block:: bash
 

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -117,7 +117,7 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
 
         if (null === $configuration) {
             if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                throw new \InvalidArgumentException('Parameter must not be `null`.');
+                throw new \InvalidArgumentException('Parameter must not be `null`. This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.');
             }
 
             @trigger_error(

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -116,6 +116,10 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
         }
 
         if (null === $configuration) {
+            if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                throw new \InvalidArgumentException('Parameter must not be `null`.');
+            }
+
             @trigger_error(
                 'Passing NULL to set default configuration is deprecated and will not be supported in 3.0, use an empty array instead.',
                 E_USER_DEPRECATED

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -17,7 +17,8 @@ namespace PhpCsFixer\Cache;
  *
  * @internal
  */
-final class Cache implements CacheInterface {
+final class Cache implements CacheInterface
+{
     /**
      * @var SignatureInterface
      */

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -17,8 +17,7 @@ namespace PhpCsFixer\Cache;
  *
  * @internal
  */
-final class Cache implements CacheInterface
-{
+final class Cache implements CacheInterface {
     /**
      * @var SignatureInterface
      */

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -175,7 +175,7 @@ final class FixCommand extends Command
             );
         }
 
-        // @TODO remove `run-in` and `estimating` in 3.0
+        // @TODO 3.0 remove `run-in` and `estimating`
         if ('none' === $progressType || null === $stdErr) {
             $progressOutput = new NullOutput();
         } elseif ('run-in' === $progressType) {

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -150,7 +150,7 @@ final class FixCommand extends Command
         if (null !== $stdErr) {
             if (null !== $passedConfig && null !== $passedRules) {
                 if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                    throw new \RuntimeException('Passing both `config` and `rules` options is not possible.');
+                    throw new \RuntimeException('Passing both `config` and `rules` options is not possible. This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.');
                 }
 
                 $stdErr->writeln([

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -149,6 +149,10 @@ final class FixCommand extends Command
 
         if (null !== $stdErr) {
             if (null !== $passedConfig && null !== $passedRules) {
+                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                    throw new \RuntimeException('Passing both `config` and `rules` options is not possible.');
+                }
+
                 $stdErr->writeln([
                     sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', 'When passing both "--config" and "--rules" the rules within the configuration file are not used.'),
                     sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', 'Passing both options is deprecated; version v3.0 PHP-CS-Fixer will exit with a configuration error code.'),

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -124,6 +124,11 @@ automatically fix anything:
 
     <info>$ cat foo.php | php %command.full_name% --diff -</info>
 
+Finally, if you don't need BC kept on CLI level, you might use `PHP_CS_FIXER_FUTURE_MODE` to start using options that
+would be default in next MAJOR release (differ, progress indicator):
+
+    <info>$ PHP_CS_FIXER_FUTURE_MODE=1 php %command.full_name% -v --diff</info>
+
 Choose from the list of available rules:
 
 %%%FIXERS_DETAILS%%%

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -125,7 +125,7 @@ automatically fix anything:
     <info>$ cat foo.php | php %command.full_name% --diff -</info>
 
 Finally, if you don't need BC kept on CLI level, you might use `PHP_CS_FIXER_FUTURE_MODE` to start using options that
-would be default in next MAJOR release (differ, progress indicator):
+would be default in next MAJOR release (unified differ, estimating, full-width progress indicator):
 
     <info>$ PHP_CS_FIXER_FUTURE_MODE=1 php %command.full_name% -v --diff</info>
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -396,7 +396,13 @@ final class ConfigurationResolver
                 $progressTypes = ['none', 'run-in', 'estimating', 'estimating-max'];
 
                 if (null === $progressType) {
-                    $progressType = $this->getConfig()->getHideProgress() ? 'none' : 'run-in';
+                    $default = 'run-in';
+
+                    if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                        $default = 'estimating-max';
+                    }
+
+                    $progressType = $this->getConfig()->getHideProgress() ? 'none' : $default;
                 } elseif (!in_array($progressType, $progressTypes, true)) {
                     throw new InvalidConfigurationException(sprintf(
                         'The progress type "%s" is not defined, supported are "%s".',

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -880,7 +880,7 @@ final class ConfigurationResolver
         }
 
         if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-            throw new InvalidConfigurationException(sprintf('Expected "yes" or "no" for option "%s", got "%s".', $optionName, $value));
+            throw new InvalidConfigurationException(sprintf('Expected "yes" or "no" for option "%s", got "%s".  This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.', $optionName, $value));
         }
 
         @trigger_error(

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -273,7 +273,13 @@ final class ConfigurationResolver
                     ));
                 }
             } else {
-                $option = $this->options['diff'] ? 'sbd' : 'null'; // TODO: change to udiff as default on 3.0
+                $default = 'sbd'; // @TODO: 3.0 change to udiff as default
+
+                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                    $default = 'udiff';
+                }
+
+                $option = $this->options['diff'] ? $default : 'null';
             }
 
             $this->differ = $mapper[$option]();

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -873,6 +873,10 @@ final class ConfigurationResolver
             return false;
         }
 
+        if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+            throw new InvalidConfigurationException(sprintf('Expected "yes" or "no" for option "%s", got "%s".', $optionName, $value));
+        }
+
         @trigger_error(
             sprintf('Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".', $optionName, $value),
             E_USER_DEPRECATED

--- a/src/Console/Output/ProcessOutput.php
+++ b/src/Console/Output/ProcessOutput.php
@@ -64,7 +64,7 @@ final class ProcessOutput implements ProcessOutputInterface
     private $symbolsPerLine;
 
     /**
-     * @TODO make all parameters mandatory (`null` not allowed) in 3.0
+     * @TODO 3.0 make all parameters mandatory (`null` not allowed)
      *
      * @param OutputInterface $output
      * @param EventDispatcher $dispatcher

--- a/src/Console/WarningsDetector.php
+++ b/src/Console/WarningsDetector.php
@@ -28,7 +28,7 @@ final class WarningsDetector
 
     public function detectOldMajor()
     {
-        // @TODO to be activated at v3
+        // @TODO 3.0 to be activated with new MAJOR release
         // $this->warnings[] = 'You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.';
     }
 

--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -103,7 +103,7 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('use_escape_sequences_in_strings', 'Whether characters should be replaced with escape sequences in strings.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(false) // @TODO change to true in 3.0
+                ->setDefault(false) // @TODO 3.0 change to true
                 ->setNormalizer(function (Options $options, $value) {
                     if (PHP_VERSION_ID < 70000 && $value) {
                         throw new InvalidOptionsForEnvException('Escape sequences require PHP 7.0+.');

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -129,7 +129,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 'Ensure every argument of a multiline argument list is on its own line'
             ))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(false) // @TODO should be true at 3.0
+                ->setDefault(false) // @TODO 3.0 should be true
                 ->getOption(),
         ]);
     }

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -118,7 +118,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
         $content = $tokens[$index]->getContent();
         $previousTokenHasTrailingLinebreak = false;
 
-        // TODO on 3.x this can be removed when we have a transformer for "T_OPEN_TAG" to "T_OPEN_TAG + T_WHITESPACE"
+        // @TODO 3.0 this can be removed when we have a transformer for "T_OPEN_TAG" to "T_OPEN_TAG + T_WHITESPACE"
         if (false !== strpos($tokens[$index - 1]->getContent(), "\n")) {
             $content = "\n".$content;
             $previousTokenHasTrailingLinebreak = true;

--- a/src/FixerConfiguration/FixerConfigurationResolverRootless.php
+++ b/src/FixerConfiguration/FixerConfigurationResolverRootless.php
@@ -65,6 +65,13 @@ final class FixerConfigurationResolverRootless implements FixerConfigurationReso
     public function resolve(array $options)
     {
         if (!empty($options) && !array_key_exists($this->root, $options)) {
+            if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                throw new \RuntimeException(sprintf(
+                    'Passing "%1$s" at the root of the configuration is deprecated and will not be supported in 3.0, use "%1$s" => array(...) option instead.',
+                    $this->root
+                ));
+            }
+
             @trigger_error(sprintf(
                 'Passing "%1$s" at the root of the configuration is deprecated and will not be supported in 3.0, use "%1$s" => array(...) option instead.',
                 $this->root

--- a/src/FixerConfiguration/FixerConfigurationResolverRootless.php
+++ b/src/FixerConfiguration/FixerConfigurationResolverRootless.php
@@ -67,7 +67,7 @@ final class FixerConfigurationResolverRootless implements FixerConfigurationReso
         if (!empty($options) && !array_key_exists($this->root, $options)) {
             if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
                 throw new \RuntimeException(sprintf(
-                    'Passing "%1$s" at the root of the configuration is deprecated and will not be supported in 3.0, use "%1$s" => array(...) option instead.',
+                    'Passing "%1$s" at the root of the configuration is deprecated and will not be supported in 3.0, use "%1$s" => array(...) option instead.  This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.',
                     $this->root
                 ));
             }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -111,6 +111,10 @@ class Tokens extends \SplFixedArray
      */
     public static function setLegacyMode($isLegacy)
     {
+        if (getenv('PHP_CS_FIXER_FUTURE_MODE') && $isLegacy) {
+            throw new \RuntimeException('Cannot enable `legacy mode` when using `future mode`.');
+        }
+
         self::$isLegacyMode = $isLegacy;
     }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -112,7 +112,7 @@ class Tokens extends \SplFixedArray
     public static function setLegacyMode($isLegacy)
     {
         if (getenv('PHP_CS_FIXER_FUTURE_MODE') && $isLegacy) {
-            throw new \RuntimeException('Cannot enable `legacy mode` when using `future mode`.');
+            throw new \RuntimeException('Cannot enable `legacy mode` when using `future mode`.  This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.');
         }
 
         self::$isLegacyMode = $isLegacy;

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -121,7 +121,7 @@ final class ProjectCodeTest extends TestCase
             'setWhitespacesConfig', // due to AbstractFixer::setWhitespacesConfig
         ];
 
-        // @TODO: should be removed at 3.0
+        // @TODO: 3.0 should be removed
         $exceptionMethodsPerClass = [
             \PhpCsFixer\Config::class => ['create'],
             \PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer::class => ['fixSpace'],


### PR DESCRIPTION
Adds `PHP_CS_FIXER_FUTURE_MODE` env variable, which make fixer configuration to work like we want it to work on 3.0, like changing default progress and differ.

It doesn't check fixer default configuration, as it would change behaviour of given fixer depends on that option, making run of that fixer unstable (in terms that run of fixer will not provide same output depends on env variable, which will break cache and CI integration)