### PR TITLE
Skip slow test when Xdebug is loaded

### DIFF
--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -331,6 +331,10 @@ final class ProjectCodeTest extends TestCase
 
     public function provideDataProviderMethodNameCases()
     {
+        if (extension_loaded('xdebug') && false === getenv('CI')) {
+            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
+        }
+
         $data = array();
 
         $testClassNames = $this->getTestClasses();


### PR DESCRIPTION
When loaded, Xdebug slows down the data provider a lot. As the data provider is executed even when the related test is excluded with e.g. `--filter` option, this makes debugging tests with Xdebug a bit painful.

Not sure this is the best solution, I'm open to suggestions :)