### PR TITLE
BinaryOperatorSpacesFixer - Fix spaces around multiple exception catching (|)

### DIFF
--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -461,6 +461,7 @@ final class TokensAnalyzer
                 T_SR => true,                   // >>
                 T_SR_EQUAL => true,             // >>=
                 T_XOR_EQUAL => true,            // ^=
+                CT::T_TYPE_ALTERNATION => true, // |
             );
 
             if (defined('T_POW')) {

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1516,4 +1516,15 @@ $b;',
             '
         );
     }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testSpacesMultipleException()
+    {
+        $this->doTest(
+            '<?php try {} catch (A | B $e) {}',
+            '<?php try {} catch (A   |     B $e) {}'
+        );
+    }
 }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -889,6 +889,35 @@ $b;',
 
     /**
      * @param string $source
+     *
+     * @dataProvider provideIsBinaryOperator71Cases
+     * @requires PHP 7.1
+     */
+    public function testIsBinaryOperator71($source, array $expected)
+    {
+        $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
+
+        foreach ($expected as $index => $isBinary) {
+            $this->assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            if ($isBinary) {
+                $this->assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                $this->assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+            }
+        }
+    }
+
+    public function provideIsBinaryOperator71Cases()
+    {
+        return array(
+            array(
+                '<?php try {} catch (A | B $e) {}',
+                array(11 => true),
+            ),
+        );
+    }
+
+    /**
+     * @param string $source
      * @param int    $tokenIndex
      *
      * @dataProvider provideArrayExceptionCases


### PR DESCRIPTION
Continued from #3210, sorry for the new PR, couldn't figure out how to rebase it to 2.2. Closes #3207