### PR TITLE
AbstractLinesBeforeNamespaceFixer - add min. and max. option, not only single target count

### DIFF
--- a/src/AbstractLinesBeforeNamespaceFixer.php
+++ b/src/AbstractLinesBeforeNamespaceFixer.php
@@ -27,13 +27,14 @@ use PhpCsFixer\Tokenizer\Tokens;
 abstract class AbstractLinesBeforeNamespaceFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
 {
     /**
-     * Make sure the expected number of new lines prefix a namespace.
+     * Make sure # of line breaks prefixing namespace is within given range.
      *
      * @param Tokens $tokens
      * @param int    $index
-     * @param int    $expected
+     * @param int    $expectedMin min. # of line breaks
+     * @param int    $expectedMax max. # of line breaks
      */
-    protected function fixLinesBeforeNamespace(Tokens $tokens, $index, $expected)
+    protected function fixLinesBeforeNamespace(Tokens $tokens, $index, $expectedMin, $expectedMax)
     {
         // Let's determine the total numbers of new lines before the namespace
         // and the opening token
@@ -59,14 +60,14 @@ abstract class AbstractLinesBeforeNamespaceFixer extends AbstractFixer implement
             }
         }
 
-        if ($expected === $precedingNewlines) {
+        if ($precedingNewlines >= $expectedMin && $precedingNewlines <= $expectedMax) {
             return;
         }
 
         $previousIndex = $index - 1;
         $previous = $tokens[$previousIndex];
 
-        if (0 === $expected) {
+        if (0 === $expectedMax) {
             // Remove all the previous new lines
             if ($previous->isWhitespace()) {
                 $tokens->clearAt($previousIndex);
@@ -80,7 +81,7 @@ abstract class AbstractLinesBeforeNamespaceFixer extends AbstractFixer implement
         }
 
         $lineEnding = $this->whitespacesConfig->getLineEnding();
-        $newlinesForWhitespaceToken = $expected;
+        $newlinesForWhitespaceToken = $expectedMax;
         if (null !== $openingToken) {
             // Use the configured line ending for the PHP opening tag
             $content = rtrim($openingToken->getContent());

--- a/src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
@@ -57,7 +57,7 @@ final class NoBlankLinesBeforeNamespaceFixer extends AbstractLinesBeforeNamespac
                 continue;
             }
 
-            $this->fixLinesBeforeNamespace($tokens, $index, 1);
+            $this->fixLinesBeforeNamespace($tokens, $index, 0, 1);
         }
     }
 }

--- a/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
@@ -53,7 +53,7 @@ final class SingleBlankLineBeforeNamespaceFixer extends AbstractLinesBeforeNames
             $token = $tokens[$index];
 
             if ($token->isGivenKind(T_NAMESPACE)) {
-                $this->fixLinesBeforeNamespace($tokens, $index, 2);
+                $this->fixLinesBeforeNamespace($tokens, $index, 2, 2);
             }
         }
     }

--- a/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
@@ -46,6 +46,7 @@ final class NoBlankLinesBeforeNamespaceFixerTest extends AbstractFixerTestCase
     public function provideFixCases()
     {
         return array(
+            array('<?php namespace Some\Name\Space;'),
             array("<?php\nnamespace X;"),
             array("<?php\nnamespace X;", "<?php\n\n\n\nnamespace X;"),
             array("<?php\r\nnamespace X;"),


### PR DESCRIPTION

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3204