### PR TITLE
TokenizerLinter - fix lack of linting when code is cached

### DIFF
--- a/src/Linter/TokenizerLinter.php
+++ b/src/Linter/TokenizerLinter.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Linter;
 
+use PhpCsFixer\Tokenizer\CodeHasher;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -52,8 +53,12 @@ final class TokenizerLinter implements LinterInterface
     public function lintSource($source)
     {
         try {
-            // it will throw ParseError on syntax error
-            // if not, it will cache the tokenized version of code, which is great for Runner
+            // To lint, we will parse the source into Tokens.
+            // During that process, it might throw ParseError.
+            // If it won't, cache of tokenized version of source will be kept, which is great for Runner.
+            // Yet, first we need to clear already existing cache to not hit it and lint the code indeed.
+            $codeHash = CodeHasher::calculateCodeHash($source);
+            Tokens::clearCache($codeHash);
             Tokens::fromCode($source);
 
             return new TokenizerLintingResult();

--- a/src/Tokenizer/CodeHasher.php
+++ b/src/Tokenizer/CodeHasher.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class CodeHasher
+{
+    /**
+     * Calculate hash for code.
+     *
+     * @param string $code
+     *
+     * @return string
+     */
+    public static function calculateCodeHash($code)
+    {
+        return (string) crc32($code);
+    }
+}

--- a/src/Tokenizer/CodeHasher.php
+++ b/src/Tokenizer/CodeHasher.php
@@ -19,6 +19,11 @@ namespace PhpCsFixer\Tokenizer;
  */
 final class CodeHasher
 {
+    private function __construct()
+    {
+        // cannot create instance of util. class
+    }
+
     /**
      * Calculate hash for code.
      *

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1195,7 +1195,7 @@ class Tokens extends \SplFixedArray
      */
     private static function calculateCodeHash($code)
     {
-        return (string) crc32($code);
+        return CodeHasher::calculateCodeHash($code);
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -159,7 +159,7 @@ class Tokens extends \SplFixedArray
      */
     public static function fromCode($code)
     {
-        $codeHash = self::calculateCodeHash($code);
+        $codeHash = CodeHasher::calculateCodeHash($code);
 
         if (self::hasCache($codeHash)) {
             $tokens = self::getCache($codeHash);
@@ -484,7 +484,7 @@ class Tokens extends \SplFixedArray
     public function generateCode()
     {
         $code = $this->generatePartialCode(0, count($this) - 1);
-        $this->changeCodeHash(self::calculateCodeHash($code));
+        $this->changeCodeHash(CodeHasher::calculateCodeHash($code));
 
         return $code;
     }
@@ -1010,7 +1010,7 @@ class Tokens extends \SplFixedArray
         }
 
         $this->rewind();
-        $this->changeCodeHash(self::calculateCodeHash($code));
+        $this->changeCodeHash(CodeHasher::calculateCodeHash($code));
         $this->changed = true;
     }
 
@@ -1184,18 +1184,6 @@ class Tokens extends \SplFixedArray
         }
 
         $this->clearAt($nextIndex);
-    }
-
-    /**
-     * Calculate hash for code.
-     *
-     * @param string $code
-     *
-     * @return string
-     */
-    private static function calculateCodeHash($code)
-    {
-        return CodeHasher::calculateCodeHash($code);
     }
 
     /**

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -159,7 +159,7 @@ class Tokens extends \SplFixedArray
      */
     public static function fromCode($code)
     {
-        $codeHash = CodeHasher::calculateCodeHash($code);
+        $codeHash = self::calculateCodeHash($code);
 
         if (self::hasCache($codeHash)) {
             $tokens = self::getCache($codeHash);
@@ -484,7 +484,7 @@ class Tokens extends \SplFixedArray
     public function generateCode()
     {
         $code = $this->generatePartialCode(0, count($this) - 1);
-        $this->changeCodeHash(CodeHasher::calculateCodeHash($code));
+        $this->changeCodeHash(self::calculateCodeHash($code));
 
         return $code;
     }
@@ -1010,7 +1010,7 @@ class Tokens extends \SplFixedArray
         }
 
         $this->rewind();
-        $this->changeCodeHash(CodeHasher::calculateCodeHash($code));
+        $this->changeCodeHash(self::calculateCodeHash($code));
         $this->changed = true;
     }
 
@@ -1184,6 +1184,18 @@ class Tokens extends \SplFixedArray
         }
 
         $this->clearAt($nextIndex);
+    }
+
+    /**
+     * Calculate hash for code.
+     *
+     * @param string $code
+     *
+     * @return string
+     */
+    private static function calculateCodeHash($code)
+    {
+        return CodeHasher::calculateCodeHash($code);
     }
 
     /**

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -57,6 +57,7 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\Runner\FileFilterIterator',
         'PhpCsFixer\Runner\FileLintingIterator',
         'PhpCsFixer\StdinFileInfo',
+        'PhpCsFixer\Tokenizer\CodeHasher',
         'PhpCsFixer\Tokenizer\Transformers',
     );
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -57,7 +57,6 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\Runner\FileFilterIterator',
         'PhpCsFixer\Runner\FileLintingIterator',
         'PhpCsFixer\StdinFileInfo',
-        'PhpCsFixer\Tokenizer\CodeHasher',
         'PhpCsFixer\Tokenizer\Transformers',
     );
 

--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -13,6 +13,8 @@
 namespace PhpCsFixer\Tests\Linter;
 
 use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +25,17 @@ use PHPUnit\Framework\TestCase;
 abstract class AbstractLinterTestCase extends TestCase
 {
     abstract public function testIsAsync();
+
+    public function testLintingAfterTokenManipulation()
+    {
+        $linter = $this->createLinter();
+
+        $tokens = Tokens::fromCode("<?php \n#EOF\n");
+        $tokens->insertAt(1, new Token(array(T_NS_SEPARATOR, '\\')));
+
+        $this->expectException('\PhpCsFixer\Linter\LintingException');
+        $linter->lintSource($tokens->generateCode())->check();
+    }
 
     /**
      * @param string      $file

--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -33,7 +33,7 @@ abstract class AbstractLinterTestCase extends TestCase
         $tokens = Tokens::fromCode("<?php \n#EOF\n");
         $tokens->insertAt(1, new Token(array(T_NS_SEPARATOR, '\\')));
 
-        $this->expectException('\PhpCsFixer\Linter\LintingException');
+        $this->setExpectedException('\PhpCsFixer\Linter\LintingException');
         $linter->lintSource($tokens->generateCode())->check();
     }
 

--- a/tests/Tokenizer/CodeHasherTest.php
+++ b/tests/Tokenizer/CodeHasherTest.php
@@ -16,7 +16,7 @@ use PhpCsFixer\Tokenizer\CodeHasher;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ * @author SpacePossum
  *
  * @internal
  *

--- a/tests/Tokenizer/CodeHasherTest.php
+++ b/tests/Tokenizer/CodeHasherTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer;
+
+use PhpCsFixer\Tokenizer\CodeHasher;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\CodeHasher
+ */
+final class CodeHasherTest extends TestCase
+{
+    public function testCodeHasher()
+    {
+        $this->assertSame('322920910', CodeHasher::calculateCodeHash('<?php echo 1;'));
+        $this->assertSame('322920910', CodeHasher::calculateCodeHash('<?php echo 1;')); // calling twice, hashes should always be the same when the input doesn't change.
+    }
+}


### PR DESCRIPTION
ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3205

The issue seems that the linter doesn't check because of caching, i.e. it thinks the tokens are not changed, however these are. 