### PR TITLE
Remove unused imports

### DIFF
--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -15,7 +15,6 @@ namespace PhpCsFixer\Fixer\ControlStructure;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -15,7 +15,6 @@ namespace PhpCsFixer\Fixer\Whitespace;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -12,7 +12,6 @@
 
 namespace PhpCsFixer\FixerConfiguration;
 
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class FixerConfigurationResolver implements FixerConfigurationResolverInterface


### PR DESCRIPTION
Picked up using PhpStorm's inspector. Obviously these should have been picked up by the `no_unused_imports ` fixer, but I'm not sure if this is desired behaviour?