### PR TITLE
NoExtraConsecutiveBlankLinesFixer - do not crash on ^M LF only

### DIFF
--- a/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
@@ -357,25 +357,12 @@ switch($a) {
 
     private function removeMultipleBlankLines($index)
     {
-        $token = $this->tokens[$index];
-        $content = '';
-        $count = 0;
-        $parts = explode("\n", $token->getContent());
+        $parts = \preg_split('/(.*\R)/', $this->tokens[$index]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $count = \count($parts);
 
-        for ($i = 0, $last = count($parts) - 1; $i <= $last; ++$i) {
-            if ('' === $parts[$i] || "\r" === $parts[$i]) {
-                // if part is empty then we are between two "\n"
-                ++$count;
-            } else {
-                $content .= $parts[$i];
-            }
-
-            if ($i !== $last && $count < 3) {
-                $content .= $this->whitespacesConfig->getLineEnding();
-            }
+        if ($count > 2) {
+            $this->tokens[$index] = new Token([T_WHITESPACE, $parts[0].$parts[1].rtrim($parts[$count - 1], "\r\n")]);
         }
-
-        $this->tokens[$index] = new Token([T_WHITESPACE, $content]);
     }
 
     private function fixAfterToken($index)

--- a/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixerTest.php
@@ -436,11 +436,54 @@ EOF
         ];
     }
 
-    public function testFixWithWindowsLineBreaks()
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideLineBreakCases
+     */
+    public function testFixWithLineBreaks($expected, $input = null)
     {
-        $input = "<?php\r\n//a\r\n\r\n\r\n\r\n\$a =1;";
-        $expected = "<?php\r\n//a\n\n\$a =1;";
         $this->doTest($expected, $input);
+    }
+
+    public function provideLineBreakCases()
+    {
+        $input = '<?php //
+
+
+$a = 1;
+
+
+$b = 1;
+';
+        $expected = '<?php //
+
+$a = 1;
+
+$b = 1;
+';
+
+        return [
+            [
+                "<?php\r\n//a\r\n\r\n\$a =1;",
+                "<?php\r\n//a\r\n\r\n\r\n\r\n\$a =1;",
+            ],
+            [
+                $expected,
+                $input,
+            ],
+            [
+                str_replace("\n", "\r\n", $expected),
+                str_replace("\n", "\r\n", $input),
+            ],
+            [
+                str_replace("\n", "\r", $input),
+            ],
+            [
+                str_replace("\n", "\r", $expected),
+            ],
+        ];
     }
 
     public function testWrongConfig()


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3240