### PR TITLE
PhpUnitNoExpectationAnnotationFixer - fix ' handling

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -295,9 +295,11 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         }
 
         if (isset($annotations['expectedExceptionMessage'])) {
-            $params[] = "'{$annotations['expectedExceptionMessage']}'";
+            $replacement = str_replace("'", "\\'", $annotations['expectedExceptionMessage']);
+            $params[] = "'{$replacement}'";
         } elseif (isset($annotations['expectedExceptionMessageRegExp'])) {
-            $params[] = "'{$annotations['expectedExceptionMessageRegExp']}'";
+            $replacement = str_replace("'", "\\'", $annotations['expectedExceptionMessageRegExp']);
+            $params[] = "'{$replacement}'";
         } elseif (isset($annotations['expectedExceptionCode'])) {
             $params[] = 'null';
         }

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -372,6 +372,35 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
          }
     }',
             ],
+            'respect \' and " in expected msg' => [
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * Summary.
+         *
+         */
+        public function testFnc($param)
+        {
+            $this->setExpectedException(\FooException::class, \'Foo \\\' bar " baz\');
+            aaa();
+        }
+    }',
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * Summary.
+         *
+         * @expectedException FooException
+         * @expectedExceptionMessage Foo \' bar " baz
+         */
+        public function testFnc($param)
+        {
+            aaa();
+        }
+    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
gladly, we don't crash the code currently, post-fixing linter catches the issue and don't save the file