### PR TITLE
Travis: fail early, spare resources, save the Earth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
 
 
         - &STANDARD_TEST_JOB
-            stage: Test
+            stage: Fast Test
             php: 7.0
             install:
                 # Composer: enforce given Symfony components version
@@ -57,32 +57,38 @@ jobs:
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 5.3
             env: SKIP_LINT_TEST_CASES=1 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             dist: precise
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 5.4
             env: SKIP_LINT_TEST_CASES=1
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 5.5
             env: SKIP_LINT_TEST_CASES=1
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 5.6
             env: SYMFONY_VERSION="^2.8"
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 7.1
             env: PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="^4.0" MIN_STABILITY=dev
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: 7.2
             env: COLLECT_COVERAGE=1 SYMFONY_DEPRECATIONS_HELPER=weak
             before_script:
@@ -99,6 +105,7 @@ jobs:
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: nightly
             env: COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 SYMFONY_DEPRECATIONS_HELPER=weak
             script:
@@ -109,6 +116,7 @@ jobs:
 
         -
             <<: *STANDARD_TEST_JOB
+            stage: Test
             php: hhvm
             env: SKIP_LINT_TEST_CASES=1
             sudo: required

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -27,6 +27,11 @@ use PHPUnit\Framework\TestCase;
  */
 final class UtilsTest extends TestCase
 {
+    public function testFastTest()
+    {
+        $this->assertFalse(true);
+    }
+
     /**
      * @param string $expected Camel case string
      * @param string $input    Input string

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -27,11 +27,6 @@ use PHPUnit\Framework\TestCase;
  */
 final class UtilsTest extends TestCase
 {
-    public function testFastTest()
-    {
-        $this->assertFalse(true);
-    }
-
     /**
      * @param string $expected Camel case string
      * @param string $input    Input string


### PR DESCRIPTION
Hi, before digging into the solution, here's the problem:

1. a lot of PRs fail at first
1. 99% PRs fail in all PHP versions
1. Travis is free but the Earth is not, we shouldn't waste resources
1. Waiting Travis for 20 minutes is boring

Like the "*Static Code Analysis*" stage, I would like to skip PHP 5.6 slowness if the failing test if failing for all.

So here you are: I moved the PHP version without specific envs to a new, second stage.

WDYT?

- [x] Split fast and slow tests
- [ ] Remove example failing test before PR merge