### PR TITLE
README.rst - Create title for config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1122,6 +1122,9 @@ fixed but without actually modifying them:
 
     $ php php-cs-fixer.phar fix /path/to/code --dry-run
 
+Config file
+-----------
+
 Instead of using command line options to customize the rule, you can save the
 project configuration in a ``.php_cs.dist`` file in the root directory of your project.
 The file must return an instance of `PhpCsFixer\\ConfigInterface <https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.2.10/src/ConfigInterface.php>`_

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -120,6 +120,9 @@ fixed but without actually modifying them:
 
     <info>$ php %command.full_name% /path/to/code --dry-run</info>
 
+Config file
+-----------
+
 Instead of using command line options to customize the rule, you can save the
 project configuration in a <comment>.php_cs.dist</comment> file in the root directory of your project.
 The file must return an instance of `PhpCsFixer\ConfigInterface` (<url>%%%CONFIG_INTERFACE_URL%%%</url>)


### PR DESCRIPTION
I spent an unusually long time looking for this section of the docs.

The phrase `config file` is used throughout the docs but a section describing the config file is not present. This will make it easier for people to find the docs regarding config files.