### PR TITLE
IntegrationTest: output exception stack trace

### DIFF
--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -345,7 +345,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
         $errorStr = '';
         foreach ($errors as $error) {
             $source = $error->getSource();
-            $errorStr .= sprintf("%d: %s%s\n", $error->getType(), $error->getFilePath(), null === $source ? '' : ' '.$source->getMessage());
+            $errorStr .= sprintf("%d: %s%s\n", $error->getType(), $error->getFilePath(), null === $source ? '' : ' '.$source->getMessage()."\n\n".$source->getTraceAsString());
         }
 
         return $errorStr;


### PR DESCRIPTION
Adding a simple `key(NULL)` in the `ArraySyntaxFixer` results in an undebaggable IntegrationTest message because the original problem's source is not explicited.
This PR adds the Exception stack trace to the IntegrationTest if errors occur.

`2.2` branch has completely different `implodeError` [content](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.2/tests/Test/AbstractIntegrationTestCase.php#L335), had to put it in the `2.7`.

Before:
```
1) PhpCsFixer\Tests\IntegrationTest::testIntegration with data set #20 (PhpCsFixer\Tests\Test\IntegrationCase Object (...))
Errors reported during fixing of file "priority/array_syntax,binary_operator_spaces.test": 2: /tmp/PHP-CS-Fixer/tests/Fixtures/Integration/.tmp.php key() expects parameter 1 to be array, null given

Failed asserting that an array is empty.

/tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php:220
/tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php:120
```
After:
```
1) PhpCsFixer\Tests\IntegrationTest::testIntegration with data set #23 (PhpCsFixer\Tests\Test\IntegrationCase Object (...))
Errors reported during fixing of file "priority/array_syntax,binary_operator_spaces.test": 2: /tmp/PHP-CS-Fixer/tests/Fixtures/Integration/.tmp.php key() expects parameter 1 to be array, null given

#0 /tmp/PHP-CS-Fixer/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php(105): PHPUnit\Util\ErrorHandler::handleError(2, 'key() expects p...', '/mnt/home/tessa...', 93, Array)
#1 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler::Symfony\Bridge\PhpUnit\{closure}(2, 'key() expects p...', '/mnt/home/tessa...', 93, Array)
#2 /tmp/PHP-CS-Fixer/src/Fixer/ArrayNotation/ArraySyntaxFixer.php(93): key(NULL)
#3 /tmp/PHP-CS-Fixer/src/AbstractFixer.php(73): PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer->applyFix(Object(SplFileInfo), Object(PhpCsFixer\Tokenizer\Tokens))
#4 /tmp/PHP-CS-Fixer/src/Runner/Runner.php(188): PhpCsFixer\AbstractFixer->fix(Object(SplFileInfo), Object(PhpCsFixer\Tokenizer\Tokens))
#5 /tmp/PHP-CS-Fixer/src/Runner/Runner.php(131): PhpCsFixer\Runner\Runner->fixFile(Object(SplFileInfo), Object(PhpCsFixer\Linter\TokenizerLintingResult))
#6 /tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php(223): PhpCsFixer\Runner\Runner->fix()
#7 /tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php(132): PhpCsFixer\Tests\Test\AbstractIntegrationTestCase->doTest(Object(PhpCsFixer\Tests\Test\IntegrationCase))
#8 [internal function]: PhpCsFixer\Tests\Test\AbstractIntegrationTestCase->testIntegration(Object(PhpCsFixer\Tests\Test\IntegrationCase))
#9 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestCase.php(1071): ReflectionMethod->invokeArgs(Object(PhpCsFixer\Tests\IntegrationTest), Array)
#10 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestCase.php(939): PHPUnit\Framework\TestCase->runTest()
#11 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestResult.php(698): PHPUnit\Framework\TestCase->runBare()
#12 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestCase.php(894): PHPUnit\Framework\TestResult->run(Object(PhpCsFixer\Tests\IntegrationTest))
#13 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(744): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))
#14 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/Framework/TestSuite.php(744): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#15 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(537): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#16 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/TextUI/Command.php(195): PHPUnit\TextUI\TestRunner->doRun(Object(PHPUnit\Framework\TestSuite), Array, true)
#17 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/src/TextUI/Command.php(148): PHPUnit\TextUI\Command->run(Array, true)
#18 /tmp/PHP-CS-Fixer/vendor/phpunit/phpunit/phpunit(53): PHPUnit\TextUI\Command::main()
#19 {main}

Failed asserting that an array is empty.

/tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php:228
/tmp/PHP-CS-Fixer/tests/Test/AbstractIntegrationTestCase.php:132
```