### PR TITLE
README.rst - Fixed bullet list formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ The ``--dry-run`` flag will run the fixer without making changes to your files.
 The ``--diff`` flag can be used to let the fixer output all the changes it makes.
 
 The ``--diff-format`` option allows to specify in which format the fixer should output the changes it makes:
+
 * ``udiff``: unified diff format;
 * ``sbd``: Sebastianbergmann/diff format (default when using `--diff` without specifying `diff-format`).
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -100,6 +100,7 @@ The <comment>--dry-run</comment> flag will run the fixer without making changes 
 The <comment>--diff</comment> flag can be used to let the fixer output all the changes it makes.
 
 The <comment>--diff-format</comment> option allows to specify in which format the fixer should output the changes it makes:
+
 * <comment>udiff</comment>: unified diff format;
 * <comment>sbd</comment>: Sebastianbergmann/diff format (default when using `--diff` without specifying `diff-format`).
 


### PR DESCRIPTION
The formatting of the bullet list under the `diff-format` item wasn't correctly formatted