### PR TITLE
ToolInfo - support installation by branch as well

### DIFF
--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -62,7 +62,13 @@ final class ToolInfo implements ToolInfoInterface
     {
         $package = $this->getComposerInstallationDetails();
 
-        return $package['version'].'#'.$package['dist']['reference'];
+        $versionSuffix = '';
+
+        if (isset($package['dist'])) {
+            $versionSuffix = '#'.$package['dist']['reference'];
+        }
+
+        return $package['version'].$versionSuffix;
     }
 
     public function getVersion()


### PR DESCRIPTION
when installed as branch, eg `dev-master`, then there is no `dist` key in array, resulting in app crash