### PR TITLE
NoBreakCommentFixer - Fix handling comment text with PCRE characters

### DIFF
--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -166,7 +166,7 @@ switch ($foo) {
             return false;
         }
 
-        $text = $this->configuration['comment_text'];
+        $text = preg_quote($this->configuration['comment_text'], '~');
 
         return preg_match("~^((//|#)\s*$text\s*)|(/\*\*?\s*$text\s*\*/)$~i", $token->getContent());
     }

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -22,6 +22,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * Fixer for rule defined in PSR2 ¶5.2.
@@ -79,6 +80,9 @@ switch ($foo) {
                         return true;
                     },
                 ])
+                ->setNormalizer(function (Options $options, $value) {
+                    return rtrim($value);
+                })
                 ->setDefault('no break')
                 ->getOption(),
         ]);

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * Fixer for rule defined in PSR2 ¶5.2.
@@ -69,6 +70,15 @@ switch ($foo) {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('comment_text', 'The text to use in the added comment and to detect it.'))
                 ->setAllowedTypes(['string'])
+                ->setAllowedValues([
+                    function ($value) {
+                        if (is_string($value) && preg_match('/\R/', $value)) {
+                            throw new InvalidOptionsException('The comment text must not contain new lines.');
+                        }
+
+                        return true;
+                    },
+                ])
                 ->setDefault('no break')
                 ->getOption(),
         ]);

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1057,6 +1057,31 @@ switch ($foo) {
         );
     }
 
+    public function testFixWithCommentTextWithTrailingSpaces()
+    {
+        $this->fixer->configure([
+            'comment_text' => 'no break     ',
+        ]);
+
+        $this->doTest(
+            '<?php
+switch ($foo) {
+    case 1:
+        foo();
+        // no break
+    default:
+        baz();
+}',
+            '<?php
+switch ($foo) {
+    case 1:
+        foo();
+    default:
+        baz();
+}'
+        );
+    }
+
     /**
      * @param string $text
      *

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1026,6 +1026,37 @@ switch ($foo) {
         return $cases;
     }
 
+    public function testFixWithCommentTextWithSpecialRegexpCharacters()
+    {
+        $this->fixer->configure([
+            'comment_text' => '~***(//[No break here.]\\\\)***~',
+        ]);
+
+        $this->doTest(
+            '<?php
+switch ($foo) {
+    case 1:
+        foo();
+        // ~***(//[No break here.]\\\\)***~
+    case 2:
+        bar();
+        // ~***(//[No break here.]\\\\)***~
+    default:
+        baz();
+}',
+            '<?php
+switch ($foo) {
+    case 1:
+        foo();
+        // ~***(//[No break here.]\\\\)***~
+    case 2:
+        bar();
+    default:
+        baz();
+}'
+        );
+    }
+
     public function testConfigureWithInvalidOptions()
     {
         $this->expectException(InvalidFixerConfigurationException::class);

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1057,10 +1057,35 @@ switch ($foo) {
         );
     }
 
+    /**
+     * @param string $text
+     *
+     * @dataProvider provideFixWithCommentTextContainingNewLinesCases
+     */
+    public function testFixWithCommentTextContainingNewLines($text)
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessageRegExp('/^\[no_break_comment\] Invalid configuration: The comment text must not contain new lines\.$/');
+
+        $this->fixer->configure([
+            'comment_text' => $text,
+        ]);
+    }
+
+    public function provideFixWithCommentTextContainingNewLinesCases()
+    {
+        return [
+            ["No\nbreak"],
+            ["No\r\nbreak"],
+            ["No\rbreak"],
+        ];
+    }
+
     public function testConfigureWithInvalidOptions()
     {
         $this->expectException(InvalidFixerConfigurationException::class);
         $this->expectExceptionMessageRegExp('/^\[no_break_comment\] Invalid configuration: The option "foo" does not exist\. Defined options are: "comment_text"\.$/');
+
         $this->fixer->configure(['foo' => true]);
     }
 }


### PR DESCRIPTION
Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3155#discussion_r151517076.