### PR TITLE
PhpUnitNoExpectationAnnotationFixer - add case with backslashes

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -300,11 +300,9 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         }
 
         if (isset($annotations['expectedExceptionMessage'])) {
-            $replacement = str_replace("'", "\\'", $annotations['expectedExceptionMessage']);
-            $params[] = "'{$replacement}'";
+            $params[] = var_export($annotations['expectedExceptionMessage'], true);
         } elseif (isset($annotations['expectedExceptionMessageRegExp'])) {
-            $replacement = str_replace("'", "\\'", $annotations['expectedExceptionMessageRegExp']);
-            $params[] = "'{$replacement}'";
+            $params[] = var_export($annotations['expectedExceptionMessageRegExp'], true);
         } elseif (isset($annotations['expectedExceptionCode'])) {
             $params[] = 'null';
         }

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -420,9 +420,18 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
     {
         /**
          */
-        public function testElementNonExistent()
+        public function testElementNonExistentOne()
         {
-            $this->setExpectedExceptionRegExp(\Cake\View\Exception\MissingElementException::class, '#^Element file "Element[\\\\/]non_existent_element\.ctp" is missing\.$#');
+            $this->setExpectedException(\Cake\View\Exception\MissingElementException::class, 'A backslash at the end \\');
+
+            $this->View->element('non_existent_element');
+        }
+
+        /**
+         */
+        public function testElementNonExistentTwo()
+        {
+            $this->setExpectedExceptionRegExp(\Cake\View\Exception\MissingElementException::class, '#^Element file "Element[\\\\/]non_existent_element\\.ctp" is missing\\.$#');
 
             $this->View->element('non_existent_element');
         }
@@ -435,9 +444,18 @@ EOT
     {
         /**
          * @expectedException \Cake\View\Exception\MissingElementException
+         * @expectedExceptionMessage A backslash at the end \
+         */
+        public function testElementNonExistentOne()
+        {
+            $this->View->element('non_existent_element');
+        }
+
+        /**
+         * @expectedException \Cake\View\Exception\MissingElementException
          * @expectedExceptionMessageRegExp #^Element file "Element[\\/]non_existent_element\.ctp" is missing\.$#
          */
-        public function testElementNonExistent()
+        public function testElementNonExistentTwo()
         {
             $this->View->element('non_existent_element');
         }

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -413,6 +413,38 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
         }
     }',
             ],
+            'special \\ handling' => [
+<<<'EOT'
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         */
+        public function testElementNonExistent()
+        {
+            $this->setExpectedExceptionRegExp(\Cake\View\Exception\MissingElementException::class, '#^Element file "Element[\\\\/]non_existent_element\.ctp" is missing\.$#');
+
+            $this->View->element('non_existent_element');
+        }
+    }
+EOT
+,
+<<<'EOT'
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * @expectedException \Cake\View\Exception\MissingElementException
+         * @expectedExceptionMessageRegExp #^Element file "Element[\\/]non_existent_element\.ctp" is missing\.$#
+         */
+        public function testElementNonExistent()
+        {
+            $this->View->element('non_existent_element');
+        }
+    }
+EOT
+,
+            ],
         ];
     }
 


### PR DESCRIPTION
Found in https://github.com/cakephp/cakephp/pull/11433/

Probably some experience from #3155 could be helpful

ref https://www.regular-expressions.info/characters.html , `"c:\\\\temp"` sample