### PR TITLE
PhpdocTrimFixer - unicode support

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -122,7 +122,7 @@ final class Foo {}
                     \R[ \t]*(?:\*[ \t]*)?    # lines without useful content
                 )+
                 (\R[ \t]*\*/$)               # DocComment end
-            ~x',
+            ~xu',
             '$1$2',
             $content
         );

--- a/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
@@ -23,19 +23,43 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  */
 final class PhpdocTrimFixerTest extends AbstractFixerTestCase
 {
-    public function testFix()
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
     {
-        $expected = <<<'EOF'
-<?php
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return array(
+            array(
+<<<'EOF'
+                <?php
     /**
      * @param EngineInterface $templating
      *
      * @return void
      */
 
-EOF;
+EOF
+            ),
+            array(
+                '<?php
 
-        $this->doTest($expected);
+/**
+ * @return int количество деактивированных
+ */
+function deactivateCompleted()
+{
+    return 0;
+}',
+            ),
+        );
     }
 
     public function testFixMore()


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3271