### PR TITLE
Add PhpUnitTestAnnotationFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -44,6 +44,7 @@ $config = PhpCsFixer\Config::create()
         'ordered_class_elements' => true,
         'ordered_imports' => true,
         'php_unit_strict' => true,
+        'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,

--- a/README.rst
+++ b/README.rst
@@ -1101,6 +1101,19 @@ Choose from the list of available rules:
     ``['assertAttributeEquals', 'assertAttributeNotEquals', 'assertEquals',
     'assertNotEquals']``
 
+* **php_unit_test_annotation**
+
+  Adds or removes @test annotations from tests, following configuration.
+
+  *Risky rule: this fixer may change the name of your tests, and could cause incompatibility with abstract classes or interfaces.*
+
+  Configuration options:
+
+  - ``case`` (``'camel'``, ``'snake'``): whether to camel or snake case when adding the
+    test prefix; defaults to ``'camel'``
+  - ``style`` (``'annotation'``, ``'prefix'``): whether to use the @test annotation or
+    not; defaults to ``'prefix'``
+
 * **php_unit_test_class_requires_covers**
 
   Adds a default ``@coversNothing`` annotation to PHPUnit test classes that

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -1,0 +1,587 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * @author Gert de Pagter
+ */
+final class PhpUnitTestAnnotationFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface, WhitespacesAwareFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Adds or removes @test annotations from tests, following configuration.',
+            [
+                new CodeSample('<?php
+class Test extends \\PhpUnit\\FrameWork\\TestCase
+{
+    /**
+     * @test
+     */
+    public function itDoesSomething() {} }'.$this->whitespacesConfig->getLineEnding()),
+                new CodeSample('<?php
+class Test extends \\PhpUnit\\FrameWork\\TestCase
+{
+public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEnding(), ['style' => 'annotation']),
+                ],
+            null,
+            'This fixer may change the name of your tests, and could cause incompatibility with'.
+            ' abstract classes or interfaces.'
+        );
+    }
+
+    public function getPriority()
+    {
+        // must be run before the PhpdocSeparationFixer and PhpdocOrderFixer
+        return 10;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_FUNCTION]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach (array_reverse($this->findPhpUnitClasses($tokens)) as $indexes) {
+            if ('annotation' === $this->configuration['style']) {
+                $this->applyTestAnnotation($tokens, $indexes[0], $indexes[1]);
+            } else {
+                $this->removeTestAnnotation($tokens, $indexes[0], $indexes[1]);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('style', 'Whether to use the @test annotation or not.'))
+                ->setAllowedValues(['prefix', 'annotation'])
+                ->setDefault('prefix')
+                ->getOption(),
+            (new FixerOptionBuilder('case', 'Whether to camel or snake case when adding the test prefix'))
+                ->setAllowedValues(['camel', 'snake'])
+                ->setDefault('camel')
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * @param Tokens $tokens
+     *
+     * @return int[][] array of [start, end] indexes from sooner to later classes
+     */
+    private function findPhpUnitClasses(Tokens $tokens)
+    {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+        $phpunitClasses = [];
+
+        for ($index = 0, $limit = $tokens->count() - 1; $index < $limit; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_CLASS) && $phpUnitTestCaseIndicator->isPhpUnitClass($tokens, $index)) {
+                $index = $tokens->getNextTokenOfKind($index, ['{']);
+                $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+                $phpunitClasses[] = [$index, $endIndex];
+                $index = $endIndex;
+            }
+        }
+
+        return $phpunitClasses;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startIndex
+     * @param int    $endIndex
+     */
+    private function applyTestAnnotation(Tokens $tokens, $startIndex, $endIndex)
+    {
+        for ($i = $endIndex - 1; $i > $startIndex; --$i) {
+            if (!$this->isFunctionTest($tokens, $i)) {
+                continue;
+            }
+
+            $functionNameIndex = $tokens->getNextMeaningfulToken($i);
+            $functionName = $tokens[$functionNameIndex]->getContent();
+
+            //if the function name stats with test, we remove that
+            if ($this->startsWith('test', $functionName)) {
+                $newFunctionName = $this->removeTestFromFunctionName($functionName);
+                $tokens[$functionNameIndex] = new Token([T_STRING, $newFunctionName]);
+            }
+
+            $docBlockIndex = $this->getDockBlockIndex($tokens, $i);
+
+            //Create a new docblock if it didn't have one before;
+            if (!$this->doesFunctionHaveDocBlock($tokens, $i)) {
+                $this->createDocBlock($tokens, $docBlockIndex);
+
+                continue;
+            }
+            $lines = $this->updateDocBlock($tokens, $docBlockIndex);
+
+            $lines = $this->addTestToDocBlockIfNeeded($lines, $tokens, $docBlockIndex);
+
+            $lines = implode($lines);
+            $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startIndex
+     * @param int    $endIndex
+     */
+    private function removeTestAnnotation(Tokens $tokens, $startIndex, $endIndex)
+    {
+        for ($i = $endIndex - 1; $i > $startIndex; --$i) {
+            // We explicitly check again if the function has a doc block to save some time.
+            if (!$this->isFunctionTest($tokens, $i) || !$this->doesFunctionHaveDocBlock($tokens, $i)) {
+                continue;
+            }
+
+            $docBlockIndex = $this->getDockBlockIndex($tokens, $i);
+
+            $lines = $this->updateDocBlock($tokens, $docBlockIndex);
+
+            $lines = implode($lines);
+            $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
+
+            $functionNameIndex = $tokens->getNextMeaningfulToken($i);
+            $functionName = $tokens[$functionNameIndex]->getContent();
+
+            //if the function already starts with test were done
+            if ($this->startsWith('test', $functionName)) {
+                continue;
+            }
+
+            $newFunctionName = $this->addTestToFunctionName($functionName);
+            $tokens[$functionNameIndex] = new Token([T_STRING, $newFunctionName]);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int$index
+     *
+     * @return bool
+     */
+    private function isFunctionTest(Tokens $tokens, $index)
+    {
+        // Check if we are dealing with a (non abstract, non lambda) function
+        if (!$this->isFunction($tokens, $index)) {
+            return false;
+        }
+
+        // if the function name starts with test its a test
+        $functionNameIndex = $tokens->getNextMeaningfulToken($index);
+        $functionName = $tokens[$functionNameIndex]->getContent();
+
+        if ($this->startsWith('test', $functionName)) {
+            return true;
+        }
+        // If the function doesn't have test in its name, and no doc block, its not a test
+        if (!$this->doesFunctionHaveDocBlock($tokens, $index)) {
+            return false;
+        }
+
+        $docBlockIndex = $this->getDockBlockIndex($tokens, $index);
+        $doc = $tokens[$docBlockIndex]->getContent();
+        if (false === strpos($doc, '@test')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isFunction(Tokens $tokens, $index)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        return $tokens[$index]->isGivenKind(T_FUNCTION) && !$tokensAnalyzer->isLambda($index);
+    }
+
+    /**
+     * @param string $needle
+     * @param string $haystack
+     *
+     * @return bool
+     */
+    private function startsWith($needle, $haystack)
+    {
+        $len = strlen($needle);
+
+        return substr($haystack, 0, $len) === $needle;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function doesFunctionHaveDocBlock(Tokens $tokens, $index)
+    {
+        $docBlockIndex = $this->getDockBlockIndex($tokens, $index);
+
+        return $tokens[$docBlockIndex]->isGivenKind(T_DOC_COMMENT);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return int
+     */
+    private function getDockBlockIndex(Tokens $tokens, $index)
+    {
+        do {
+            $index = $tokens->getPrevNonWhitespace($index);
+        } while ($tokens[$index]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_COMMENT]));
+
+        return $index;
+    }
+
+    /**
+     * @param string $functionName
+     *
+     * @return string
+     */
+    private function removeTestFromFunctionName($functionName)
+    {
+        if ($this->startsWith('test_', $functionName)) {
+            if (is_numeric(substr($functionName, 6, 1))) {
+                return $functionName;
+            }
+
+            return  substr($functionName, 5);
+        }
+        if (is_numeric(substr($functionName, 5, 1))) {
+            return $functionName;
+        }
+        $functionName = substr($functionName, 4);
+
+        return lcfirst($functionName);
+    }
+
+    /**
+     * @param string $functionName
+     *
+     * @return string
+     */
+    private function addTestToFunctionName($functionName)
+    {
+        if ('camel' !== $this->configuration['case']) {
+            return 'test_'.$functionName;
+        }
+
+        return'test'.ucfirst($functionName);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return string
+     */
+    private function detectIndent(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index - 1]->isWhitespace()) {
+            return ''; // cannot detect indent
+        }
+
+        $explodedContent = explode($this->whitespacesConfig->getLineEnding(), $tokens[$index - 1]->getContent());
+
+        return end($explodedContent);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     */
+    private function createDocBlock(Tokens $tokens, $docBlockIndex)
+    {
+        $lineEnd = $this->whitespacesConfig->getLineEnding();
+        $originalIndent = $this->detectIndent($tokens, $tokens->getNextNonWhitespace($docBlockIndex));
+        $toInsert = [
+            new Token([T_DOC_COMMENT, '/**'.$lineEnd."${originalIndent} * @test".$lineEnd."${originalIndent} */"]),
+            new Token([T_WHITESPACE, $lineEnd.$originalIndent]),
+        ];
+        $index = $tokens->getNextMeaningfulToken($docBlockIndex);
+        $tokens->insertAt($index, $toInsert);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function updateDocBlock(Tokens $tokens, $docBlockIndex)
+    {
+        $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
+        $lines = $doc->getLines();
+
+        return $this->updateLines($lines, $tokens, $docBlockIndex);
+    }
+
+    /**
+     * @param Line[] $lines
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function updateLines($lines, Tokens $tokens, $docBlockIndex)
+    {
+        $needsAnnotation = 'annotation' === $this->configuration['style'];
+
+        $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
+        for ($i = 0; $i < \count($lines); ++$i) {
+            //If we need to add test annotation and it is a single line comment we need to deal with that separately
+            if ($needsAnnotation && ($lines[$i]->isTheStart() && $lines[$i]->isTheEnd())) {
+                if (!$this->doesDocBlockContainTest($doc)) {
+                    $lines = $this->splitUpDocBlock($lines, $tokens, $docBlockIndex);
+
+                    return $this->updateLines($lines, $tokens, $docBlockIndex);
+                }
+                //One we split it up, we run the function again, so we deal with other things in a proper way
+            }
+
+            if (!$needsAnnotation &&
+                false !== \strpos($lines[$i]->getContent(), ' @test') &&
+                false === \strpos($lines[$i]->getContent(), '@testWith') &&
+                false === \strpos($lines[$i]->getContent(), '@testdox')
+            ) {
+                //We remove @test from the doc block
+                $lines[$i] = new Line(str_replace(' @test', '', $lines[$i]->getContent()));
+            }
+            //ignore the line if it isnt @depends
+            if (false === strpos($lines[$i], '@depends')) {
+                continue;
+            }
+
+            $lines[$i] = $this->updateDepends($lines[$i]);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Take a one line doc block, and turn it into a multi line doc block.
+     *
+     * @param Line[] $lines
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function splitUpDocBlock($lines, Tokens $tokens, $docBlockIndex)
+    {
+        $lineContent = $this->getSingleLineDocBlockEntry($lines);
+        $lineEnd = $this->whitespacesConfig->getLineEnding();
+        $originalIndent = $this->detectIndent($tokens, $tokens->getNextNonWhitespace($docBlockIndex));
+        $lines = [
+            new Line('/**'.$lineEnd),
+            new Line($originalIndent.' * '.$lineContent.$lineEnd),
+            new Line($originalIndent.' */'),
+        ];
+
+        return $lines;
+    }
+
+    /**
+     * @param Line []$line
+     *
+     * @return string
+     */
+    private function getSingleLineDocBlockEntry($line)
+    {
+        $line = $line[0];
+        $line = \str_replace('*/', '', $line);
+        $line = trim($line);
+        $line = \str_split($line);
+        $i = \count($line);
+        do {
+            --$i;
+        } while ('*' !== $line[$i] && '*' !== $line[$i - 1] && '/' !== $line[$i - 2]);
+        if (' ' === $line[$i]) {
+            ++$i;
+        }
+        $line = array_slice($line, $i);
+        $line = implode($line);
+
+        return $line;
+    }
+
+    /**
+     * Updates the depends tag on the current doc block.
+     *
+     * @param Line $line
+     *
+     * @return Line
+     */
+    private function updateDepends(Line $line)
+    {
+        if ('annotation' === $this->configuration['style']) {
+            return $this->removeTestFromDepends($line);
+        }
+
+        return $this->addtestToDepends($line);
+    }
+
+    /**
+     * @param Line $line
+     *
+     * @return Line
+     */
+    private function removeTestFromDepends(Line $line)
+    {
+        $line = \str_split($line->getContent());
+
+        $dependsIndex = $this->findWhereDependsFunctionNameStarts($line);
+        $dependsFunctionName = implode(array_slice($line, $dependsIndex));
+
+        if ($this->startsWith('test', $dependsFunctionName)) {
+            $dependsFunctionName = $this->removeTestFromFunctionName($dependsFunctionName);
+        }
+        array_splice($line, $dependsIndex);
+
+        return new Line(implode($line).$dependsFunctionName);
+    }
+
+    /**
+     * @param Line $line
+     *
+     * @return Line
+     */
+    private function addTestToDepends(Line $line)
+    {
+        $line = \str_split($line->getContent());
+        $dependsIndex = $this->findWhereDependsFunctionNameStarts($line);
+        $dependsFunctionName = implode(array_slice($line, $dependsIndex));
+
+        if (!$this->startsWith('test', $dependsFunctionName)) {
+            $dependsFunctionName = $this->addTestToFunctionName($dependsFunctionName);
+        }
+
+        array_splice($line, $dependsIndex);
+
+        return new Line(implode($line).$dependsFunctionName);
+    }
+
+    /**
+     * Helps to find where the function name in the doc block starts.
+     *
+     * @param array $line
+     *
+     * @return int
+     */
+    private function findWhereDependsFunctionNameStarts(array $line)
+    {
+        $counter = \count($line);
+
+        do {
+            --$counter;
+        } while (' ' !== $line[$counter]);
+
+        return $counter + 1;
+    }
+
+    /**
+     * @param Line[] $lines
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function addTestToDocBlockIfNeeded($lines, Tokens $tokens, $docBlockIndex)
+    {
+        $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
+
+        if (!$this->doesDocBlockContainTest($doc)) {
+            $originalIndent = $this->detectIndent($tokens, $docBlockIndex);
+            $lineEnd = $this->whitespacesConfig->getLineEnding();
+
+            array_splice($lines, 1, 0, $originalIndent.' * @test'.$lineEnd);
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param DocBlock $doc
+     *
+     * @return bool
+     */
+    private function doesDocBlockContainTest(DocBlock $doc)
+    {
+        //If it doesnt have @test at all its not a test
+        if (false === strpos($doc->getContent(), '@test')) {
+            return false;
+        }
+        // if it contains @test and then a new line, its a test
+        if (false !== strpos($doc->getContent(), '@test'.$this->whitespacesConfig->getLineEnding())) {
+            return true;
+        }
+        //If it contains @test and then a space its a new line
+        if (false !== strpos($doc->getContent(), '@test ')) {
+            return true;
+        }
+        //If it contains @test and then a tab its a new line
+        if (false !== strpos($doc->getContent(), '@test\t')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -406,7 +406,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
                 $lines[$i] = new Line(str_replace(' @test', '', $lines[$i]->getContent()));
             }
             //ignore the line if it isnt @depends
-            if (false === strpos($lines[$i], '@depends')) {
+            if (false === strpos($lines[$i]->getContent(), '@depends')) {
                 continue;
             }
 
@@ -552,7 +552,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             $originalIndent = $this->detectIndent($tokens, $docBlockIndex);
             $lineEnd = $this->whitespacesConfig->getLineEnding();
 
-            array_splice($lines, 1, 0, $originalIndent.' * @test'.$lineEnd);
+            array_splice($lines, -1, 0, $originalIndent.' *'.$lineEnd.$originalIndent.' * @test'.$lineEnd);
         }
 
         return $lines;
@@ -565,23 +565,6 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     private function doesDocBlockContainTest(DocBlock $doc)
     {
-        //If it doesnt have @test at all its not a test
-        if (false === strpos($doc->getContent(), '@test')) {
-            return false;
-        }
-        // if it contains @test and then a new line, its a test
-        if (false !== strpos($doc->getContent(), '@test'.$this->whitespacesConfig->getLineEnding())) {
-            return true;
-        }
-        //If it contains @test and then a space its a new line
-        if (false !== strpos($doc->getContent(), '@test ')) {
-            return true;
-        }
-        //If it contains @test and then a tab its a new line
-        if (false !== strpos($doc->getContent(), '@test\t')) {
-            return true;
-        }
-
-        return false;
+        return !empty($doc->getAnnotationsOfType('test'));
     }
 }

--- a/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -39,7 +39,7 @@ final class NoEmptyPhpdocFixer extends AbstractFixer
     public function getPriority()
     {
         // should be run before NoExtraConsecutiveBlankLinesFixer, NoTrailingWhitespaceFixer, NoWhitespaceInBlankLineFixer and
-        // after PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer.
+        // after PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PHPUnitTestAnnotationFixer.
         return 5;
     }
 

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -185,6 +185,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['unary_operator_spaces'], $fixers['not_operator_with_successor_space']],
             [$fixers['void_return'], $fixers['phpdoc_no_empty_return']], // tested also in: void_return,phpdoc_no_empty_return.test
             [$fixers['void_return'], $fixers['return_type_declaration']], // tested also in: void_return,return_type_declaration.test
+            [$fixers['php_unit_test_annotation'], $fixers['no_empty_phpdoc']], // tested also in: php_unit_test_annotation,no_empty_phpdoc.test
+            [$fixers['php_unit_test_annotation'], $fixers['phpdoc_trim']], // tested also in: php_unit_test_annotation,phpdoc_trim.test
         ];
 
         // prepare bulk tests for phpdoc fixers to test that:

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -103,8 +103,9 @@ if (1) {
 class Test extends \PhpUnit\FrameWork\TestCase
 {
     /**
-     * @test
      * @dataProvider blabla
+     *
+     * @test
      */
     public function itDoesSomething() {}
     }',
@@ -130,8 +131,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function helperFunction() {}
 
     /**
-     *
      * @depends testAaa
+     *
+     *
      */
     public function testBbb () {}
 }',
@@ -146,8 +148,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function helperFunction() {}
 
     /**
-     * @test
      * @depends aaa
+     *
+     * @test
      */
     public function bbb () {}
 }',
@@ -163,8 +166,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function aaa () {}
 
     /**
-     * @test
      * @depends aaa
+     *
+     * @test
      */
     public function bbb () {}
 }',
@@ -266,8 +270,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function works_fine () {}
 
     /**
-     * @test
      * @depends works_fine
+     *
+     * @test
      */
     public function works_fine_too() {}
 }',
@@ -329,8 +334,11 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function camelCased () {}
 
     /**
-     * @test
+     * Description.
+     *
      * @depends camelCased
+     *
+     * @test
      */
     public function depends_on_someone () {}
 
@@ -338,14 +346,16 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function a_helper_function () {}
 
     /**
-     * @test
      * @depends depends_on_someone
+     *
+     * @test
      */
     public function moreDepends() {}
 
     /**
-     * @test
      * @depends depends_on_someone
+     *
+     * @test
      */
     public function alreadyAnnotated() {}
 }',
@@ -357,6 +367,8 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function testCamelCased () {}
 
     /**
+     * Description.
+     *
      * @depends testCamelCased
      */
     public function test_depends_on_someone () {}
@@ -370,8 +382,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function testMoreDepends() {}
 
     /**
-     * @test
      * @depends test_depends_on_someone
+     *
+     * @test
      */
     public function alreadyAnnotated() {}
 }',
@@ -639,8 +652,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
 class Test extends \PhpUnit\FrameWork\TestCase
 {
     /**
-     * @test
      * @group Database
+     *
+     * @test
      */
     public function itTestsDatabase() {}
 }',
@@ -657,8 +671,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
 class Test extends \PhpUnit\FrameWork\TestCase
 {
     /**
-     * @test
      * I really like this test, it helps a lot
+     *
+     * @test
      */
     public function itTestsDatabase() {}
 }',
@@ -698,8 +713,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function itTestsDatabase() {}
 
     /**
-     * @test
      * @depends itTestsDatabase
+     *
+     * @test
      */
     public function itDepends() {}
 }',
@@ -766,7 +782,6 @@ final class ProcessLinterProcessBuilderTest extends TestCase
 final class ProcessLinterProcessBuilderTest extends TestCase
 {
     /**
-     * @test
      * @param string $executable
      * @param string $file
      * @param string $expected
@@ -774,6 +789,8 @@ final class ProcessLinterProcessBuilderTest extends TestCase
      * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
      * @requires OS Linux|Darwin
+     *
+     * @test
      */
     public function prepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
     {
@@ -872,8 +889,9 @@ class Test extends \PhpUnit\FrameWork\TestCase
 class Test extends \PhpUnit\FrameWork\TestCase
 {
     /**
-     * @test
      * There is some text here @group Database @group Integration
+     *
+     * @test
      */
     public function whyDoThis() {}
 }',
@@ -918,7 +936,17 @@ class Test extends \PhpUnit\FrameWork\TestCase
     public function testItDoesSomething() {}
     }',
             ],
-            'Annotation does not get added when it is already present in a weird place' => [
+            'Annotation is added when it is already present in a weird place' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * Im a comment @test about the function
+     *
+     * @test
+     */
+    public function iHateMyTestSuite() {}
+}',
                 '<?php
 class Test extends \PhpUnit\FrameWork\TestCase
 {
@@ -927,7 +955,6 @@ class Test extends \PhpUnit\FrameWork\TestCase
      */
     public function iHateMyTestSuite() {}
 }',
-                null,
                 ['style' => 'annotation'],
             ],
             'Docblock does not get converted to a multi line doc block if it already has @test annotation' => [

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1,0 +1,1071 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use PhpCsFixer\WhitespacesFixerConfig;
+
+/**
+ * @author Gert de Pagter
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer
+ */
+final class PhpUnitTestAnnotationFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $config
+     */
+    public function testFix($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFixCases()
+    {
+        return [
+            'Annotation is used, and it should not be' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function testItDoesSomething() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function itDoesSomething() {}
+}',
+                ['style' => 'prefix'],
+            ],
+            'Annotation is not used, but should be' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function itDoesSomething() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testItDoesSomething() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation is not used, but should be, class is extra indented' => [
+                '<?php
+if (1) {
+    class Test extends \PhpUnit\FrameWork\TestCase
+    {
+        /**
+         * @test
+         */
+        public function itDoesSomething() {}
+    }
+}',
+                '<?php
+if (1) {
+    class Test extends \PhpUnit\FrameWork\TestCase
+    {
+        public function testItDoesSomething() {}
+    }
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation is not used, but should be, and there is already a docBlcok' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     * @dataProvider blabla
+     */
+    public function itDoesSomething() {}
+    }',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @dataProvider blabla
+     */
+    public function testItDoesSomething() {}
+    }',
+                ['style' => 'annotation'],
+            ],
+            'Annotation is used, but should not be, and it depends on other tests' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function testAaa () {}
+
+    public function helperFunction() {}
+
+    /**
+     *
+     * @depends testAaa
+     */
+    public function testBbb () {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function aaa () {}
+
+    public function helperFunction() {}
+
+    /**
+     * @test
+     * @depends aaa
+     */
+    public function bbb () {}
+}',
+                ['style' => 'prefix'],
+            ],
+            'Annotation is not used, but should be, and it depends on other tests' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function aaa () {}
+
+    /**
+     * @test
+     * @depends aaa
+     */
+    public function bbb () {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testAaa () {}
+
+    /**
+     * @depends testAaa
+     */
+    public function testBbb () {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation is removed, the function is one word and we want it to use camel case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function testWorks() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function works() {}
+}',
+            ],
+            'Annotation is removed, the function is one word and we want it to use snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function test_works() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function works() {}
+}',
+                ['case' => 'snake'],
+            ],
+            'Annotation is added, and it is snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function it_has_snake_case() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test_it_has_snake_case() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation is removed, and it is snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function test_it_has_snake_case() {}
+
+    public function helper_function() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function it_has_snake_case() {}
+
+    public function helper_function() {}
+}',
+                ['case' => 'snake'],
+            ],
+            'Annotation gets added, it has an @depends, and we use snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function works_fine () {}
+
+    /**
+     * @test
+     * @depends works_fine
+     */
+    public function works_fine_too() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test_works_fine () {}
+
+    /**
+     * @depends test_works_fine
+     */
+    public function test_works_fine_too() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation gets removed, it has an @depends and we use camel case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function test_works_fine () {}
+
+    /**
+     *
+     * @depends test_works_fine
+     */
+    public function test_works_fine_too() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function works_fine () {}
+
+    /**
+     * @test
+     * @depends works_fine
+     */
+    public function works_fine_too() {}
+}',
+                ['case' => 'snake'],
+            ],
+            'Class has both camel and snake case, annotated functions and not, and wants to add annotations' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function snake_cased () {}
+
+    /**
+     * @test
+     */
+    public function camelCased () {}
+
+    /**
+     * @test
+     * @depends camelCased
+     */
+    public function depends_on_someone () {}
+
+    //It even has a comment
+    public function a_helper_function () {}
+
+    /**
+     * @test
+     * @depends depends_on_someone
+     */
+    public function moreDepends() {}
+
+    /**
+     * @test
+     * @depends depends_on_someone
+     */
+    public function alreadyAnnotated() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test_snake_cased () {}
+
+    public function testCamelCased () {}
+
+    /**
+     * @depends testCamelCased
+     */
+    public function test_depends_on_someone () {}
+
+    //It even has a comment
+    public function a_helper_function () {}
+
+    /**
+     * @depends test_depends_on_someone
+     */
+    public function testMoreDepends() {}
+
+    /**
+     * @test
+     * @depends test_depends_on_someone
+     */
+    public function alreadyAnnotated() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation has to be added to multiple functions' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function itWorks() {}
+
+    /**
+     * @test
+     */
+    public function itDoesSomething() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testItWorks() {}
+
+    public function testItDoesSomething() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation has to be removed from multiple functions and we use snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function test_it_works() {}
+
+    /**
+     *
+     */
+    public function test_it_does_something() {}
+
+    public function dataProvider() {}
+
+    /**
+     * @dataprovider dataProvider
+     * @depends test_it_does_something
+     */
+    public function test_it_depend_and_has_provider() {}
+
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function it_works() {}
+
+    /**
+     * @test
+     */
+    public function it_does_something() {}
+
+    public function dataProvider() {}
+
+    /**
+     * @dataprovider dataProvider
+     * @depends it_does_something
+     */
+    public function test_it_depend_and_has_provider() {}
+
+}',
+                ['case' => 'snake'],
+            ],
+            'Class with big doc blocks and multiple functions has to remove annotations' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+
+    /**
+     * This test is part of the database group and has a provider.
+     *
+     * @param int $paramOne
+     * @param bool $paramTwo
+     *
+     *
+     * @dataProvider provides
+     * @group Database
+     */
+    public function testDatabase ($paramOne, $paramTwo) {}
+
+    /**
+     * Provider for the database test function
+     *
+     * @return array
+     */
+    public function provides() {}
+
+    /**
+     * Im just a helper function but i have test in my name.
+     * I also have a doc Block
+     *
+     * @return Foo\Bar
+     */
+    public function help_test() {}
+
+
+    protected function setUp() {}
+
+    /**
+     * I depend on the database function, but i already
+     * had test in my name and a docblock
+     *
+     * @depends testDatabase
+     */
+    public function testDepends () {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+
+    /**
+     * This test is part of the database group and has a provider.
+     *
+     * @param int $paramOne
+     * @param bool $paramTwo
+     *
+     * @test
+     * @dataProvider provides
+     * @group Database
+     */
+    public function database ($paramOne, $paramTwo) {}
+
+    /**
+     * Provider for the database test function
+     *
+     * @return array
+     */
+    public function provides() {}
+
+    /**
+     * Im just a helper function but i have test in my name.
+     * I also have a doc Block
+     *
+     * @return Foo\Bar
+     */
+    public function help_test() {}
+
+
+    protected function setUp() {}
+
+    /**
+     * I depend on the database function, but i already
+     * had test in my name and a docblock
+     *
+     * @depends database
+     */
+    public function testDepends () {}
+}',
+            ],
+            'Class with big doc blocks and multiple functions has to remove annotations, but its snake case' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+
+    /**
+     * This test is part of the database group and has a provider.
+     *
+     * @param int $paramOne
+     * @param bool $paramTwo
+     *
+     *
+     * @dataProvider provides
+     * @group Database
+     */
+    public function test_database ($paramOne, $paramTwo) {}
+
+    /**
+     * Provider for the database test function
+     *
+     * @return array
+     */
+    public function provides() {}
+
+    /**
+     * Im just a helper function but i have test in my name.
+     * I also have a doc Block
+     *
+     * @return Foo\Bar
+     */
+    public function help_test() {}
+
+
+    protected function setUp() {}
+
+    /**
+     * I depend on the database function, but i already
+     * had test in my name and a docblock
+     *
+     * @depends test_database
+     */
+    public function testDepends () {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+
+    /**
+     * This test is part of the database group and has a provider.
+     *
+     * @param int $paramOne
+     * @param bool $paramTwo
+     *
+     * @test
+     * @dataProvider provides
+     * @group Database
+     */
+    public function database ($paramOne, $paramTwo) {}
+
+    /**
+     * Provider for the database test function
+     *
+     * @return array
+     */
+    public function provides() {}
+
+    /**
+     * Im just a helper function but i have test in my name.
+     * I also have a doc Block
+     *
+     * @return Foo\Bar
+     */
+    public function help_test() {}
+
+
+    protected function setUp() {}
+
+    /**
+     * I depend on the database function, but i already
+     * had test in my name and a docblock
+     *
+     * @depends database
+     */
+    public function testDepends () {}
+}',
+                ['case' => 'snake'],
+            ],
+            'Test Annotation has to be removed, but its just one line' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** */
+    public function testItWorks() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** @test */
+    public function itWorks() {}
+}',
+            ],
+            'Test annotation has to be added, but there is already a one line doc block' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     * @group Database
+     */
+    public function itTestsDatabase() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** @group Database */
+    public function testItTestsDatabase() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Test annotation has to be added, but there is already a one line doc block which is a sentence' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     * I really like this test, it helps a lot
+     */
+    public function itTestsDatabase() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** I really like this test, it helps a lot */
+    public function testItTestsDatabase() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Test annotation has to be added, but there is already a one line comment present' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    //I really like this test, it helps a lot
+    /**
+     * @test
+     */
+    public function itTestsDatabase() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    //I really like this test, it helps a lot
+    public function testItTestsDatabase() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Test annotation has to be added, there is a one line doc block which is an @depends tag' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function itTestsDatabase() {}
+
+    /**
+     * @test
+     * @depends itTestsDatabase
+     */
+    public function itDepends() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testItTestsDatabase() {}
+
+    /** @depends testItTestsDatabase */
+    public function testItDepends() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation gets removed, but the function has a @testWith' => [
+                '<?php
+final class ProcessLinterProcessBuilderTest extends TestCase
+{
+    /**
+     *
+     * @param string $executable
+     * @param string $file
+     * @param string $expected
+     *
+     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
+     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @requires OS Linux|Darwin
+     */
+    public function testPrepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
+    {
+        $builder = new ProcessLinterProcessBuilder($executable);
+
+        $this->assertSame(
+            $expected,
+            $builder->build($file)->getCommandLine()
+        );
+    }
+}',
+                '<?php
+final class ProcessLinterProcessBuilderTest extends TestCase
+{
+    /**
+     * @test
+     * @param string $executable
+     * @param string $file
+     * @param string $expected
+     *
+     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
+     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @requires OS Linux|Darwin
+     */
+    public function prepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
+    {
+        $builder = new ProcessLinterProcessBuilder($executable);
+
+        $this->assertSame(
+            $expected,
+            $builder->build($file)->getCommandLine()
+        );
+    }
+}',
+            ],
+            'Annotation gets added, but there is already an @testWith in the doc block' => [
+                '<?php
+final class ProcessLinterProcessBuilderTest extends TestCase
+{
+    /**
+     * @test
+     * @param string $executable
+     * @param string $file
+     * @param string $expected
+     *
+     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
+     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @requires OS Linux|Darwin
+     */
+    public function prepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
+    {
+        $builder = new ProcessLinterProcessBuilder($executable);
+
+        $this->assertSame(
+            $expected,
+            $builder->build($file)->getCommandLine()
+        );
+    }
+}',
+                '<?php
+final class ProcessLinterProcessBuilderTest extends TestCase
+{
+    /**
+     * @param string $executable
+     * @param string $file
+     * @param string $expected
+     *
+     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
+     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @requires OS Linux|Darwin
+     */
+    public function testPrepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
+    {
+        $builder = new ProcessLinterProcessBuilder($executable);
+
+        $this->assertSame(
+            $expected,
+            $builder->build($file)->getCommandLine()
+        );
+    }
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation gets properly removed, even when it is in a weird place' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * Im a comment about the function
+     */
+    public function testIHateMyTestSuite() {}
+
+    /**
+     * Im another comment about a function
+     */
+    public function testThisMakesNoSense() {}
+
+    /**
+     * This comment has   more issues
+     */
+    public function testItUsesTabs() {}
+
+    /**
+     * @depends testItUsesTabs
+     */
+    public function testItDependsReally() {}
+
+    /**
+     * @depends testItUsesTabs
+     */
+    public function testItDependsSomeMore() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * Im a comment @test about the function
+     */
+    public function iHateMyTestSuite() {}
+
+    /**
+     * Im another comment about a function @test
+     */
+    public function thisMakesNoSense() {}
+
+    /**
+     * This comment has @test   more issues
+     */
+    public function itUsesTabs() {}
+
+    /**
+     * @depends itUsesTabs @test
+     */
+    public function itDependsReally() {}
+
+    /**
+     * @test @depends itUsesTabs
+     */
+    public function itDependsSomeMore() {}
+}',
+            ],
+            'Annotation gets added when a single line has doc block has multiple tags already' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     * There is some text here @group Database @group Integration
+     */
+    public function whyDoThis() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** There is some text here @group Database @group Integration */
+    public function testWhyDoThis() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation gets removed when a single line doc block has the tag, but there are other things as well' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** There is some text here @group Database @group Integration */
+    public function testWhyDoThis() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** There is some @test text here @group Database @group Integration */
+    public function testWhyDoThis() {}
+}',
+            ],
+            'Annotation is used, and should be' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function itDoesSomething() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Annotation is not used, and should not be' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testItDoesSomething() {}
+    }',
+            ],
+            'Annotation does not get added when it is already present in a weird place' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * Im a comment @test about the function
+     */
+    public function iHateMyTestSuite() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Docblock does not get converted to a multi line doc block if it already has @test annotation' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /** @test */
+    public function doesSomeThings() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Annotation does not get added if class is not a test' => [
+                '<?php
+class Waterloo
+{
+    public function testDoesSomeThings() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Annotation does not get removed if class is not a test' => [
+                '<?php
+class Waterloo
+{
+    /**
+     * @test
+     */
+    public function doesSomeThings() {}
+}',
+            ],
+            'Annotation does not get added if there are no tests in the test class' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function setUp() {}
+
+    public function itHelpsSomeTests() {}
+
+    public function someMoreChanges() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Abstract test gets annotation removed' => [
+                '<?php
+abstract class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    abstract function testFooBar();
+}',
+                '<?php
+abstract class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    abstract function fooBar();
+}',
+                ['style' => 'prefix'],
+            ],
+            'Abstract test gets annotation added' => [
+                '<?php
+abstract class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    abstract function fooBar();
+}',
+                '<?php
+abstract class Test extends \PhpUnit\FrameWork\TestCase
+{
+    abstract function testFooBar();
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation gets added, but there is a number after the testprefix so it keeps the prefix' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function test123fooBar() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test123fooBar() {}
+}',
+                ['style' => 'annotation'],
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $config
+     *
+     * @dataProvider provideMessyWhitespacesCases
+     */
+    public function testMessyWhitespaces($expected, $input = null, array $config = [])
+    {
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
+        $this->fixer->configure($config);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideMessyWhitespacesCases()
+    {
+        return [
+            [
+                '<?php
+
+                    class FooTest extends \PHPUnit_Framework_TestCase {
+
+                    /**
+                     *
+                     */
+                    public function testFooTest() {}
+                    }
+                ',
+                '<?php
+
+                    class FooTest extends \PHPUnit_Framework_TestCase {
+
+                    /**
+                     * @test
+                     */
+                    public function fooTest() {}
+                    }
+                ',
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_test_annotation,no_empty_phpdoc.test
+++ b/tests/Fixtures/Integration/priority/php_unit_test_annotation,no_empty_phpdoc.test
@@ -6,9 +6,10 @@ Integration of fixers: php_unit_test_annotation,no_empty_phpdoc.
 <?php
 class Test
 {
-
+    
     public function testFooBar() {}
 }
+
 --INPUT--
 <?php
 class Test

--- a/tests/Fixtures/Integration/priority/php_unit_test_annotation,no_empty_phpdoc.test
+++ b/tests/Fixtures/Integration/priority/php_unit_test_annotation,no_empty_phpdoc.test
@@ -1,0 +1,20 @@
+--TEST--
+Integration of fixers: php_unit_test_annotation,no_empty_phpdoc.
+--RULESET--
+{"php_unit_test_annotation": true, "no_empty_phpdoc" : true}
+--EXPECT--
+<?php
+class Test
+{
+
+    public function testFooBar() {}
+}
+--INPUT--
+<?php
+class Test
+{
+    /**
+     * @test
+     */
+    public function fooBar() {}
+}

--- a/tests/Fixtures/Integration/priority/php_unit_test_annotation,phpdoc_trim.test
+++ b/tests/Fixtures/Integration/priority/php_unit_test_annotation,phpdoc_trim.test
@@ -1,0 +1,23 @@
+--TEST--
+Integration of fixers: php_unit_test_annotation,phpdoc_trim
+--RULESET--
+{"php_unit_test_annotation": true, "phpdoc_trim" : true}
+--EXPECT--
+<?php
+class Test
+{
+    /**
+     * It does thing for foo and bar
+     */
+    public function testFooBar() {}
+}
+--INPUT--
+<?php
+class Test
+{
+    /**
+     * It does thing for foo and bar
+     * @test
+     */
+    public function fooBar() {}
+}

--- a/tests/Fixtures/Integration/priority/php_unit_test_annotation,phpdoc_trim.test
+++ b/tests/Fixtures/Integration/priority/php_unit_test_annotation,phpdoc_trim.test
@@ -11,6 +11,7 @@ class Test
      */
     public function testFooBar() {}
 }
+
 --INPUT--
 <?php
 class Test


### PR DESCRIPTION
This PR turns php unit tests into either
```php
    /**
     * @test
     */
    public function seeIfItWorks() {...}
```
or 
```php
    public function testSeeIfItWorks() {...}
```
as mentioned in #3274 

Covered edge cases can be found in the tests.
