### PR TITLE
SelfAccessorFixer - stop modifying traits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
             <<: *STANDARD_TEST_JOB
             stage: Test
             php: 5.3
-            env: SKIP_LINT_TEST_CASES=1 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             dist: precise
 
         -

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
             <<: *STANDARD_TEST_JOB
             stage: Test
             php: 5.3
-            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+            env: SKIP_LINT_TEST_CASES=1 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             dist: precise
 
         -

--- a/README.rst
+++ b/README.rst
@@ -994,8 +994,8 @@ Choose from the list of available rules:
 
 * **self_accessor** [@Symfony]
 
-  Inside a classy element "self" should be preferred to the class name
-  itself.
+  Inside class or interface element "self" should be preferred to the
+  class name itself.
 
 * **semicolon_after_instruction**
 

--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -30,7 +30,7 @@ final class SelfAccessorFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Inside a classy element "self" should be preferred to the class name itself.',
+            'Inside class or interface element "self" should be preferred to the class name itself.',
             array(
                 new CodeSample(
                     '<?php
@@ -54,7 +54,7 @@ class Sample
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds());
+        return $tokens->isAnyTokenKindsFound(array(T_CLASS, T_INTERFACE));
     }
 
     /**
@@ -65,7 +65,7 @@ class Sample
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
         for ($i = 0, $c = $tokens->count(); $i < $c; ++$i) {
-            if (!$tokens[$i]->isClassy() || $tokensAnalyzer->isAnonymousClass($i)) {
+            if (!$tokens[$i]->isGivenKind(array(T_CLASS, T_INTERFACE)) || $tokensAnalyzer->isAnonymousClass($i)) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -86,10 +86,6 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
                 // PHP < 5.4 compatibility: "self" is not available in closures
                 '<?php class Foo { function bar() { function ($a = Foo::BAZ) { new Foo(); }; } }',
             ),
-            array(
-                // In trait "self" will reference the class it's used in, not the actual trait, so we can't replace "Foo" with "self" here
-                '<?php trait Foo { function bar() { Foo::bar(); } }',
-            ),
         );
     }
 
@@ -119,8 +115,12 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
         );
     }
 
+    /**
+     * @requires PHP 5.4
+     */
     public function testFix54()
     {
+        // In trait "self" will reference the class it's used in, not the actual trait, so we can't replace "Foo" with "self" here
         $this->doTest('<?php trait Foo { function bar() { Foo::bar(); } }');
     }
 }

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -86,6 +86,10 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
                 // PHP < 5.4 compatibility: "self" is not available in closures
                 '<?php class Foo { function bar() { function ($a = Foo::BAZ) { new Foo(); }; } }',
             ),
+            array(
+                // In trait "self" will reference the class it's used in, not the actual trait, so we can't replace "Foo" with "self" here
+                '<?php trait Foo { function bar() { Foo::bar(); } }',
+            ),
         );
     }
 
@@ -113,16 +117,5 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
                 '<?php class Foo { protected $foo; function bar() { return $this->foo::find(2); } }',
             ),
         );
-    }
-
-    /**
-     * @requires PHP 5.4
-     */
-    public function testFix54()
-    {
-        $expected = '<?php trait Foo { function bar() { self::bar(); } }';
-        $input = '<?php trait Foo { function bar() { Foo::bar(); } }';
-
-        $this->doTest($expected, $input);
     }
 }

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -118,4 +118,9 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
             ),
         );
     }
+
+    public function testFix54()
+    {
+        $this->doTest('<?php trait Foo { function bar() { Foo::bar(); } }');
+    }
 }


### PR DESCRIPTION
For trait `self` was referring to it until PHP  5.6.5: https://3v4l.org/8bTQK

It was bug: https://bugs.php.net/bug.php?id=65419
Release log with fix: http://www.php.net/ChangeLog-5.php#5.6.5