### PR TITLE
allow Symfony 4.0 on 1.x too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": "^5.3.6 || >=7.0 <7.2",
         "ext-tokenizer": "*",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/event-dispatcher": "^2.1 || ^3.0",
-        "symfony/filesystem": "^2.1 || ^3.0",
-        "symfony/finder": "^2.1 || ^3.0",
-        "symfony/process": "^2.3 || ^3.0",
-        "symfony/stopwatch": "^2.5 || ^3.0",
+        "symfony/console": "^2.3 || ^3.0 || ^4.0",
+        "symfony/event-dispatcher": "^2.1 || ^3.0 || ^4.0",
+        "symfony/filesystem": "^2.1 || ^3.0 || ^4.0",
+        "symfony/finder": "^2.1 || ^3.0 || ^4.0",
+        "symfony/process": "^2.3 || ^3.0 || ^4.0",
+        "symfony/stopwatch": "^2.5 || ^3.0 || ^4.0",
         "sebastian/diff": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
I would like to see this package allowing Symfony 4.0 on 1.x branch too, as we use it in https://github.com/Soullivaneuh/php-cs-fixer-styleci-bridge and would like to have Symfony 4.0 support there to. The migration into php-cs-fixer 2.x would be really hard.