### PR TITLE
[bug] NoUnusedImportsFixer - import not removed when class name is part of constant

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -101,7 +101,8 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $usages = array();
 
         foreach ($useDeclarations as $shortName => $useDeclaration) {
-            $usages[$shortName] = (bool) preg_match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
+            $usages[$shortName] = preg_match('/(?<!\$|\\\\|->|-)\b'.preg_quote($shortName, '/').'(?![\w\-])/i', $content)
+                || preg_match('/\b'.preg_quote($shortName, '/').'::/i', $content);
         }
 
         return $usages;

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -684,6 +684,136 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    public function testWhenImportedClassNameIsPrefixWithDashOfConstant()
+    {
+        $expected = <<<'EOF'
+<?php
+
+
+class Dummy
+{
+    const C = 'bar-bados';
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use Foo\Bar;
+
+class Dummy
+{
+    const C = 'bar-bados';
+}
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testWhenImportedClassNameIsSuffixWithDashOfConstant()
+    {
+        $expected = <<<'EOF'
+<?php
+
+
+class Dummy
+{
+    const C = 'tool-bar';
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use Foo\Bar;
+
+class Dummy
+{
+    const C = 'tool-bar';
+}
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testWhenImportedClassNameIsInsideWithDashOfConstant()
+    {
+        $expected = <<<'EOF'
+<?php
+
+
+class Dummy
+{
+    const C = 'tool-bar-bados';
+}
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+use Foo\Bar;
+
+class Dummy
+{
+    const C = 'tool-bar-bados';
+}
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideWhenImportedClassIsUsedForConstantsCases
+     */
+    public function testWhenImportedClassIsUsedForConstants($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideWhenImportedClassIsUsedForConstantsCases()
+    {
+        return array(
+            array(
+                '<?php
+use A\ABC;
+$a = 5-ABC::Test;
+$a = 5-ABC::Test-5;
+$a = ABC::Test-5;
+',
+            ),
+            array(
+                '<?php
+use A\ABC;
+$a = 5-ABC::Test;
+$a = 5-ABC::Test-5;
+',
+            ),
+            array(
+                '<?php
+use A\ABC;
+$a = 5-ABC::Test;
+',
+            ),
+            array('<?php
+use A\ABC;
+$a = ABC::Test-5;
+',
+            ),
+            array('<?php
+use A\ABC;
+$a = 5-ABC::Test-5;
+',
+            ),
+            array('<?php
+use A\ABC;
+$b = $a-->ABC::Test;
+',
+            ),
+        );
+    }
+
     /**
      * @param string      $expected
      * @param null|string $input


### PR DESCRIPTION
When I remove dash it will work fine.