### PR TITLE
Make alignment of multi-line descriptions configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1071,6 +1071,10 @@ Choose from the list of available rules:
 
   Configuration options:
 
+  - ``description_align`` (``'description'``, ``'hint'``, ``'name'``, ``'tag'``): the alignment
+    of a description running over multiple lines; defaults to ``'description'``
+  - ``description_extra_indent`` (``int``): extra indent for a description running
+    over multiple lines; defaults to ``0``
   - ``tags`` (``array``): the tags that should be aligned; defaults to ``['param',
     'return', 'throws', 'type', 'var']``
 

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -875,4 +875,119 @@ final class Sample
             ],
         ];
     }
+
+    public function testDescriptionAlignTag()
+    {
+        $this->fixer->configure(['description_align' => 'tag']);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     * ription
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *    ription
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testDescriptionAlignHint()
+    {
+        $this->fixer->configure(['description_align' => 'hint']);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *        ription
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *    ription
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testDescriptionAlignName()
+    {
+        $this->fixer->configure(['description_align' => 'name']);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *            ription
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *    ription
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testDescriptionAlignDescription()
+    {
+        $this->fixer->configure(['description_align' => 'description']);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *               ription
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *    ription
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testDescriptionExtraIndent()
+    {
+        $this->fixer->configure(['description_extra_indent' => 2]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *                 ription
+     */
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param int $a Desc
+     *    ription
+     */
+EOF;
+
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
This change allows to configure the alignment of multi-line descriptions in the phpdoc_align fixer. Especially useful for `@param` annotations if type hint and variable name are relatively long to avoid very long lines or lots of description lines.