### PR TITLE
PhpCsFixer\Config::getFinder() can return PhpCsFixer\Finder

### DIFF
--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|string[]|\Traversable|Finder
+     * @return Finder|iterable|string[]|\Traversable
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param iterable|string[]|\Traversable|Finder $finder
+     * @param Finder|iterable|string[]|\Traversable $finder
      *
      * @return self
      */

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|string[]|\Traversable
+     * @return iterable|string[]|\Traversable|Finder
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param iterable|string[]|\Traversable $finder
+     * @param iterable|string[]|\Traversable|Finder $finder
      *
      * @return self
      */

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return \PhpCsFixer\Finder|iterable|string[]|\Traversable
+     * @return iterable|\PhpCsFixer\Finder|string[]|\Traversable
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param \PhpCsFixer\Finder|iterable|string[]|\Traversable $finder
+     * @param iterable|\PhpCsFixer\Finder|string[]|\Traversable $finder
      *
      * @return self
      */

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return Finder|iterable|string[]|\Traversable
+     * @return \PhpCsFixer\Finder|iterable|string[]|\Traversable
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param Finder|iterable|string[]|\Traversable $finder
+     * @param \PhpCsFixer\Finder|iterable|string[]|\Traversable $finder
      *
      * @return self
      */


### PR DESCRIPTION
since `PhpCsFixer\Config::getFinder()` will return an instance of `PhpCsFixer\Finder` by default, it'd be beneficial to type-hint in the docblock that this is the case :)