### PR TITLE
DiffConsoleFormatter - fix output escaping

### DIFF
--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -40,7 +40,6 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\Console\Output\NullOutput',
         'PhpCsFixer\Console\SelfUpdate\GithubClient',
         'PhpCsFixer\Console\WarningsDetector',
-        'PhpCsFixer\Differ\DiffConsoleFormatter',
         'PhpCsFixer\Doctrine\Annotation\Tokens',
         'PhpCsFixer\FileRemoval',
         'PhpCsFixer\Fixer\Operator\AlignDoubleArrowFixerHelper',

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -46,8 +46,8 @@ final class DescribeCommandTest extends TestCase
 
     public function testExecuteOutput()
     {
-        $expected = <<<'EOT'
-Description of Foo/bar rule.
+        $expected =
+"Description of Foo/bar rule.
 Fixes stuff.
 Replaces bad stuff with good stuff.
 
@@ -65,6 +65,7 @@ Fixing examples:
    @@ @@
    -<?php echo 'bad stuff and bad thing';
    +<?php echo 'good stuff and bad thing';
+   "."
    ----------- end diff -----------
 
  * Example #2. Fixing with configuration: ['functions' => ['foo', 'bar']].
@@ -74,18 +75,17 @@ Fixing examples:
    @@ @@
    -<?php echo 'bad stuff and bad thing';
    +<?php echo 'good stuff and good thing';
+   ".'
    ----------- end diff -----------
 
-
-EOT;
-
+';
         $this->assertSame($expected, $this->execute('Foo/bar', false)->getDisplay(true));
     }
 
     public function testExecuteOutputWithDecoration()
     {
-        $expected = <<<EOT
-\033[32mDescription of\033[39m Foo/bar \033[32mrule\033[39m.
+        $expected =
+"\033[32mDescription of\033[39m Foo/bar \033[32mrule\033[39m.
 Fixes stuff.
 Replaces bad stuff with good stuff.
 
@@ -103,6 +103,7 @@ Fixing examples:
    \033[36m@@ @@\033[39m
    \033[31m-<?php echo 'bad stuff and bad thing';\033[39m
    \033[32m+<?php echo 'good stuff and bad thing';\033[39m
+   "."
 \033[33m   ----------- end diff -----------\033[39m
 
  * Example #2. Fixing with configuration: \033[33m['functions' => ['foo', 'bar']]\033[39m.
@@ -112,11 +113,10 @@ Fixing examples:
    \033[36m@@ @@\033[39m
    \033[31m-<?php echo 'bad stuff and bad thing';\033[39m
    \033[32m+<?php echo 'good stuff and good thing';\033[39m
+   "."
 \033[33m   ----------- end diff -----------\033[39m
 
-
-EOT;
-
+";
         $actual = $this->execute('Foo/bar', true)->getDisplay(true);
 
         if (false !== strpos($actual, "\033[0m")) {

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Differ;
+
+use PhpCsFixer\Differ\DiffConsoleFormatter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Differ\DiffConsoleFormatter
+ */
+final class DiffConsoleFormatterTest extends TestCase
+{
+    /**
+     * @dataProvider provideTestCases
+     *
+     * @param string $expected
+     * @param bool   $isDecoratedOutput
+     * @param string $template
+     * @param string $diff
+     * @param string $lineTemplate
+     */
+    public function testDiffConsoleFormatter($expected, $isDecoratedOutput, $template, $diff, $lineTemplate)
+    {
+        $diffFormatter = new DiffConsoleFormatter($isDecoratedOutput, $template);
+
+        $this->assertSame(
+            str_replace(PHP_EOL, "\n", $expected),
+            str_replace(PHP_EOL, "\n", $diffFormatter->format($diff, $lineTemplate))
+        );
+    }
+
+    public function provideTestCases()
+    {
+        return array(
+            array(
+                sprintf('<comment>   ---------- begin diff ----------</comment>
+   '.'
+   <fg=cyan>%s</fg=cyan>
+    no change
+   <fg=red>%s</fg=red>
+   <fg=green>%s</fg=green>
+   <fg=green>%s</fg=green>
+   '.'
+<comment>   ----------- end diff -----------</comment>',
+                    OutputFormatter::escape('@@ -12,51 +12,151 @@'),
+                    OutputFormatter::escape('-/**\\'),
+                    OutputFormatter::escape('+/*\\'),
+                    OutputFormatter::escape('+A')
+                ),
+                true,
+                sprintf(
+                    '<comment>   ---------- begin diff ----------</comment>%s%%s%s<comment>   ----------- end diff -----------</comment>',
+                    PHP_EOL,
+                    PHP_EOL
+                ),
+                '
+@@ -12,51 +12,151 @@
+ no change
+-/**\
++/*\
++A
+',
+                '   %s',
+            ),
+            array(
+                '[start]
+| '.'
+| @@ -12,51 +12,151 @@
+|  no change
+|  '.'
+| -/**\
+| +/*\
+| +A
+| '.'
+[end]',
+                false,
+                sprintf('[start]%s%%s%s[end]', PHP_EOL, PHP_EOL),
+                '
+@@ -12,51 +12,151 @@
+ no change
+ '.'
+-/**\
++/*\
++A
+',
+                '| %s',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
for ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3290#issuecomment-348929490

cc @Slamdunk thanks for reporting!

TODO:
- [x] Add utest
- [x] Target lowest branch

(tested local using the linked fixer)