### PR TITLE
companion to FriendsOfPHP/PHP-CS-Fixer#3297, type hinting that \PhpCs…

### DIFF
--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|string[]|\Traversable
+     * @return iterable|\PhpCsFixer\Finder|string[]|\Traversable
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param iterable|string[]|\Traversable $finder
+     * @param iterable|\PhpCsFixer\Finder|string[]|\Traversable $finder
      *
      * @return self
      */


### PR DESCRIPTION
companion to FriendsOfPHP/PHP-CS-Fixer#3297, type hinting that \PhpCsFixer\Config::getFinder() can return \PhpCsFixer\Fixer