### PR TITLE
Add non-UTF8 test cases

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
@@ -59,6 +59,17 @@ function deactivateCompleted()
     return 0;
 }',
             ),
+            array(
+                mb_convert_encoding('
+<?php
+
+/**
+ * Test à
+ */
+function foo(){}
+
+', 'Windows-1252', 'UTF-8'),
+            ),
         );
     }
 


### PR DESCRIPTION
Reference: #3304

- [ ] Add test cases for all charset-aware fixers in 2.2 (waiting #3296)
- [ ] Add test cases for all charset-aware fixers new in 2.8 (different PR required)
- [ ] None of the above if the charset-aware part will be a wrapping part of fixers

As written in #3304 I have tons of code in different charsets that can in theory be well managed and fixed by this library if it will became charset-aware.

Relying on `/u` modifier of preg functions doesn't solve the issue (#3296 #3272), even though it is now more likely to encounter UTF8 files than non-UTF8 files.

A big hurdle here is that files don't declare their charset.

Making fixers charset-aware would be a nightmare: too much code to test and be aware of.

The first solution that comes into my mind is to let [Runner\Runner::fixFile](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.8/src/Runner/Runner.php#L149) do the dirty job:

1. Guess file charset right after `file_get_contents`, or (better) we can give the possibility to the user to set the charset of all sources during configuration, instead of guessing it
1. If not UTF8 convert it into UTF8
1. Keep track of original charset
1. Generate tokens and run fixers in UTF8-only
1. Generate code in UTF8
1. Re-convert to original charset just before `file_put_contents`

Requiring `iconv` and/or `mbstring` will be mandatory 😐 

Well, we would also need to:

1. Wrap every preg function to ensure `/u` flag
1. Write an AutoReview that ensure every preg function is wrapped (https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3296#issuecomment-349591603)
1. Move every non-byte safe function to multibyte-safe ([MbStrFunctionsFixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.8.3/src/Fixer/Alias/MbStrFunctionsFixer.php))