### PR TITLE
FinalInternalClassFixer - fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -582,9 +582,9 @@ Choose from the list of available rules:
 
   - ``annotation-black-list`` (``array``): class level annotations tags that must be
     omitted to fix the class, even if all of the white list ones are used
-    as well. (case in sensitive); defaults to ``['@final', '@Entity', '@ORM']``
+    as well. (case insensitive); defaults to ``['@final', '@Entity', '@ORM']``
   - ``annotation-white-list`` (``array``): class level annotations tags that must be
-    set in order to fix the class. (case in sensitive); defaults to
+    set in order to fix the class. (case insensitive); defaults to
     ``['@internal']``
 
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -134,13 +134,13 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
         };
 
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('annotation-white-list', 'Class level annotations tags that must be set in order to fix the class. (case in sensitive)'))
+            (new FixerOptionBuilder('annotation-white-list', 'Class level annotations tags that must be set in order to fix the class. (case insensitive)'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues($annotationsAsserts)
                 ->setDefault(['@internal'])
                 ->setNormalizer($annotationsNormalizer)
                 ->getOption(),
-            (new FixerOptionBuilder('annotation-black-list', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case in sensitive)'))
+            (new FixerOptionBuilder('annotation-black-list', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues($annotationsAsserts)
                 ->setDefault(['@final', '@Entity', '@ORM'])


### PR DESCRIPTION
This PR

* [x] fixes a typo

💁‍♂️ It should be *case insensitive*, rather than *case in sensitive*.