### PR TITLE
PhpUnitTestAnnotationFixer: Only remove prefix if it really is a prefix

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -314,19 +314,13 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     private function removeTestFromFunctionName($functionName)
     {
-        if ($this->startsWith('test_', $functionName)) {
-            if (is_numeric(substr($functionName, 6, 1))) {
-                return $functionName;
-            }
+        $remainder = preg_replace('/^test_?/', '', $functionName);
 
-            return  substr($functionName, 5);
-        }
-        if (is_numeric(substr($functionName, 5, 1))) {
+        if ('' === $remainder || is_numeric($remainder[0])) {
             return $functionName;
         }
-        $functionName = substr($functionName, 4);
 
-        return lcfirst($functionName);
+        return lcfirst($remainder);
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -88,7 +88,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             if ('annotation' === $this->configuration['style']) {
                 $this->applyTestAnnotation($tokens, $indexes[0], $indexes[1]);
             } else {
-                $this->removeTestAnnotation($tokens, $indexes[0], $indexes[1]);
+                $this->applyTestPrefix($tokens, $indexes[0], $indexes[1]);
             }
         }
     }
@@ -140,7 +140,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
     private function applyTestAnnotation(Tokens $tokens, $startIndex, $endIndex)
     {
         for ($i = $endIndex - 1; $i > $startIndex; --$i) {
-            if (!$this->isFunctionTest($tokens, $i)) {
+            if (!$this->isTestMethod($tokens, $i)) {
                 continue;
             }
 
@@ -148,21 +148,21 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             $functionName = $tokens[$functionNameIndex]->getContent();
 
             if ($this->hasTestPrefix($functionName)) {
-                $newFunctionName = $this->removeTestFromFunctionName($functionName);
+                $newFunctionName = $this->removeTestPrefix($functionName);
                 $tokens[$functionNameIndex] = new Token([T_STRING, $newFunctionName]);
             }
 
-            $docBlockIndex = $this->getDockBlockIndex($tokens, $i);
+            $docBlockIndex = $this->getDocBlockIndex($tokens, $i);
 
             // Create a new docblock if it didn't have one before;
-            if (!$this->doesFunctionHaveDocBlock($tokens, $i)) {
+            if (!$this->hasDocBlock($tokens, $i)) {
                 $this->createDocBlock($tokens, $docBlockIndex);
 
                 continue;
             }
             $lines = $this->updateDocBlock($tokens, $docBlockIndex);
 
-            $lines = $this->addTestToDocBlockIfNeeded($lines, $tokens, $docBlockIndex);
+            $lines = $this->addTestAnnotation($lines, $tokens, $docBlockIndex);
 
             $lines = implode($lines);
             $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
@@ -174,15 +174,15 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      * @param int    $startIndex
      * @param int    $endIndex
      */
-    private function removeTestAnnotation(Tokens $tokens, $startIndex, $endIndex)
+    private function applyTestPrefix(Tokens $tokens, $startIndex, $endIndex)
     {
         for ($i = $endIndex - 1; $i > $startIndex; --$i) {
             // We explicitly check again if the function has a doc block to save some time.
-            if (!$this->isFunctionTest($tokens, $i) || !$this->doesFunctionHaveDocBlock($tokens, $i)) {
+            if (!$this->isTestMethod($tokens, $i) || !$this->hasDocBlock($tokens, $i)) {
                 continue;
             }
 
-            $docBlockIndex = $this->getDockBlockIndex($tokens, $i);
+            $docBlockIndex = $this->getDocBlockIndex($tokens, $i);
 
             $lines = $this->updateDocBlock($tokens, $docBlockIndex);
 
@@ -196,7 +196,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
                 continue;
             }
 
-            $newFunctionName = $this->addTestToFunctionName($functionName);
+            $newFunctionName = $this->addTestPrefix($functionName);
             $tokens[$functionNameIndex] = new Token([T_STRING, $newFunctionName]);
         }
     }
@@ -207,10 +207,10 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return bool
      */
-    private function isFunctionTest(Tokens $tokens, $index)
+    private function isTestMethod(Tokens $tokens, $index)
     {
         // Check if we are dealing with a (non abstract, non lambda) function
-        if (!$this->isFunction($tokens, $index)) {
+        if (!$this->isMethod($tokens, $index)) {
             return false;
         }
 
@@ -222,11 +222,11 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             return true;
         }
         // If the function doesn't have test in its name, and no doc block, its not a test
-        if (!$this->doesFunctionHaveDocBlock($tokens, $index)) {
+        if (!$this->hasDocBlock($tokens, $index)) {
             return false;
         }
 
-        $docBlockIndex = $this->getDockBlockIndex($tokens, $index);
+        $docBlockIndex = $this->getDocBlockIndex($tokens, $index);
         $doc = $tokens[$docBlockIndex]->getContent();
         if (false === strpos($doc, '@test')) {
             return false;
@@ -241,7 +241,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return bool
      */
-    private function isFunction(Tokens $tokens, $index)
+    private function isMethod(Tokens $tokens, $index)
     {
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
@@ -267,9 +267,9 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return bool
      */
-    private function doesFunctionHaveDocBlock(Tokens $tokens, $index)
+    private function hasDocBlock(Tokens $tokens, $index)
     {
-        $docBlockIndex = $this->getDockBlockIndex($tokens, $index);
+        $docBlockIndex = $this->getDocBlockIndex($tokens, $index);
 
         return $tokens[$docBlockIndex]->isGivenKind(T_DOC_COMMENT);
     }
@@ -280,7 +280,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return int
      */
-    private function getDockBlockIndex(Tokens $tokens, $index)
+    private function getDocBlockIndex(Tokens $tokens, $index)
     {
         do {
             $index = $tokens->getPrevNonWhitespace($index);
@@ -310,7 +310,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return string
      */
-    private function removeTestFromFunctionName($functionName)
+    private function removeTestPrefix($functionName)
     {
         $remainder = preg_replace('/^test_?/', '', $functionName);
 
@@ -326,7 +326,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return string
      */
-    private function addTestToFunctionName($functionName)
+    private function addTestPrefix($functionName)
     {
         if ('camel' !== $this->configuration['case']) {
             return 'test_'.$functionName;
@@ -418,7 +418,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
                 continue;
             }
 
-            $lines[$i] = $this->updateDepends($lines[$i]);
+            $lines[$i] = $this->updateDependsAnnotation($lines[$i]);
         }
 
         return $lines;
@@ -478,13 +478,13 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return Line
      */
-    private function updateDepends(Line $line)
+    private function updateDependsAnnotation(Line $line)
     {
         if ('annotation' === $this->configuration['style']) {
-            return $this->removeTestFromDepends($line);
+            return $this->removeTestPrefixFromDependsAnnotation($line);
         }
 
-        return $this->addTestToDepends($line);
+        return $this->addTestPrefixToDependsAnnotation($line);
     }
 
     /**
@@ -492,7 +492,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return Line
      */
-    private function removeTestFromDepends(Line $line)
+    private function removeTestPrefixFromDependsAnnotation(Line $line)
     {
         $line = \str_split($line->getContent());
 
@@ -500,7 +500,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
         $dependsFunctionName = implode(array_slice($line, $dependsIndex));
 
         if ($this->startsWith('test', $dependsFunctionName)) {
-            $dependsFunctionName = $this->removeTestFromFunctionName($dependsFunctionName);
+            $dependsFunctionName = $this->removeTestPrefix($dependsFunctionName);
         }
         array_splice($line, $dependsIndex);
 
@@ -512,14 +512,14 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return Line
      */
-    private function addTestToDepends(Line $line)
+    private function addTestPrefixToDependsAnnotation(Line $line)
     {
         $line = \str_split($line->getContent());
         $dependsIndex = $this->findWhereDependsFunctionNameStarts($line);
         $dependsFunctionName = implode(array_slice($line, $dependsIndex));
 
         if (!$this->startsWith('test', $dependsFunctionName)) {
-            $dependsFunctionName = $this->addTestToFunctionName($dependsFunctionName);
+            $dependsFunctionName = $this->addTestPrefix($dependsFunctionName);
         }
 
         array_splice($line, $dependsIndex);
@@ -552,7 +552,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      *
      * @return Line[]
      */
-    private function addTestToDocBlockIfNeeded($lines, Tokens $tokens, $docBlockIndex)
+    private function addTestAnnotation($lines, Tokens $tokens, $docBlockIndex)
     {
         $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
 

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -147,8 +147,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             $functionNameIndex = $tokens->getNextMeaningfulToken($i);
             $functionName = $tokens[$functionNameIndex]->getContent();
 
-            // if the function name stats with test, we remove that
-            if ($this->startsWith('test', $functionName)) {
+            if ($this->hasTestPrefix($functionName)) {
                 $newFunctionName = $this->removeTestFromFunctionName($functionName);
                 $tokens[$functionNameIndex] = new Token([T_STRING, $newFunctionName]);
             }
@@ -193,8 +192,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             $functionNameIndex = $tokens->getNextMeaningfulToken($i);
             $functionName = $tokens[$functionNameIndex]->getContent();
 
-            // if the function already starts with test were done
-            if ($this->startsWith('test', $functionName)) {
+            if ($this->hasTestPrefix($functionName)) {
                 continue;
             }
 

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -294,6 +294,22 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
     /**
      * @param string $functionName
      *
+     * @return bool
+     */
+    private function hasTestPrefix($functionName)
+    {
+        if (!$this->startsWith('test', $functionName) || strlen($functionName) < 5) {
+            return false;
+        }
+
+        $nextCharacter = $functionName[4];
+
+        return $nextCharacter === strtoupper($nextCharacter);
+    }
+
+    /**
+     * @param string $functionName
+     *
      * @return string
      */
     private function removeTestFromFunctionName($functionName)

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1050,6 +1050,78 @@ class Test extends \PhpUnit\FrameWork\TestCase
 }',
                 ['style' => 'annotation'],
             ],
+            'Annotation missing, method qualifies as test, but does not actually have test prefix' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function testarossaIsFromItaly() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function testarossaIsFromItaly() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation present, method qualifies as test, but does not actually have test prefix' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function testarossaIsFromItaly() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
+            'Annotation missing, method qualifies as test, but test prefix cannot be removed' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function test() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation missing, method qualifies as test, but test_ prefix cannot be removed' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function test_() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    public function test_() {}
+}',
+                ['style' => 'annotation'],
+            ],
+            'Annotation present, method qualifies as test, but test_ prefix cannot be removed' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function test_() {}
+}',
+                null,
+                ['style' => 'annotation'],
+            ],
         ];
     }
 

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1018,6 +1018,25 @@ abstract class Test extends \PhpUnit\FrameWork\TestCase
 }',
                 ['style' => 'prefix'],
             ],
+            'Annotation present, but method does not actually have test prefix' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function testTestarossaIsFromItaly() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function testarossaIsFromItaly() {}
+}',
+                ['style' => 'prefix'],
+            ],
             'Abstract test gets annotation added' => [
                 '<?php
 abstract class Test extends \PhpUnit\FrameWork\TestCase


### PR DESCRIPTION
This PR

* [x] adds more test cases
* [x] modifies detection of test prefix
* [x] removes `test` prefix only if the next character is not a number, nor a lower-case letter
* [x] removes a few related comments

Follows #3275.