### PR TITLE
Do not remove imports from GLOBAL namespace

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -171,6 +171,10 @@ final class NoUnusedImportsFixer extends AbstractFixer
                 continue;
             }
 
+            if (1 === preg_match('/^ (function|const)(.+)$/', $declarationContent, $matches)) {
+                $declarationContent = $matches[2];
+            }
+
             $declarationParts = preg_split('/\s+as\s+/i', $declarationContent);
 
             if (1 === count($declarationParts)) {

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -684,6 +684,62 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    public function testFunctionsInTheGlobalNamespaceShouldNotBeRemoved()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use function is_int;
+
+is_int(1);
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use function is_int;
+use function is_float;
+
+is_int(1);
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testConstantsInTheGlobalNamespaceShouldNotBeRemoved()
+    {
+        $expected = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use function PHP_INT_MAX;
+
+echo PHP_INT_MAX;
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+namespace Foo;
+
+use function PHP_INT_MAX;
+use function PHP_INT_MIN;
+
+echo PHP_INT_MAX;
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
     /**
      * @param string      $expected
      * @param null|string $input


### PR DESCRIPTION
When importing functions or constants from the GLOBAL namespace, they
are not  considered as used, because the fixer consider ` function` and
` const` as part of the FQN of the use statement.