### PR TITLE
SingleLineCommentStyleFixer - do not transform asterisk comment if it…

### DIFF
--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -116,13 +116,21 @@ $c = 3;
             }
 
             $content = $token->getContent();
-            $commentContent = substr($content, 2, -2);
+
             if ($this->hashEnabled && '#' === $content[0]) {
                 $tokens[$index] = new Token([$token->getId(), '//'.substr($content, 1)]);
 
                 continue;
             }
-            if (!$this->asteriskEnabled || '/*' !== substr($content, 0, 2) || 1 === preg_match('/[^\s\*].*\R.*[^\s\*]/s', $commentContent)) {
+
+            $commentContent = substr($content, 2, -2);
+
+            if (
+                !$this->asteriskEnabled
+                || '/*' !== substr($content, 0, 2)
+                || 1 === preg_match('/[^\s\*].*\R.*[^\s\*]/s', $commentContent)
+                || false !== strpos($commentContent, '?>')
+            ) {
                 continue;
             }
 
@@ -140,6 +148,7 @@ $c = 3;
             if (1 === preg_match('/[^\s\*]/', $commentContent)) {
                 $content = '// '.preg_replace('/[\s\*]*([^\s\*](?:.+[^\s\*])?)[\s\*]*/', '\1', $commentContent);
             }
+
             $tokens[$index] = new Token([$token->getId(), $content]);
         }
     }

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -47,6 +47,9 @@ final class SingleLineCommentStyleFixerTest extends AbstractFixerTestCase
     {
         return [
             [
+                "<?php\n/* ?> */",
+            ],
+            [
                 '<?php
 // lonely line
 ',
@@ -149,7 +152,6 @@ $a = 1; /* after code */
 s    *
      */',
             ],
-
             // Untouched cases
             [
                 '<?php
@@ -251,7 +253,6 @@ second line*/',
                     # test 4
                 ',
             ],
-
             // Untouched cases
             [
                 '<?php


### PR DESCRIPTION
… contains a PHP closing tag.

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3315