### PR TITLE
BracesFixer: nowdoc bug on template files

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -405,7 +405,9 @@ class Foo
                         // and it is not a `Foo::{bar}()` situation
                         !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equals('(')) &&
                         // and it is not a `${"a"}->...` and `${"b{$foo}"}->...` situation
-                        !($nestToken->equals('}') && $tokens[$nestIndex - 1]->equalsAny(array('"', "'", array(T_CONSTANT_ENCAPSED_STRING))))
+                        !($nestToken->equals('}') && $tokens[$nestIndex - 1]->equalsAny(array('"', "'", array(T_CONSTANT_ENCAPSED_STRING)))) &&
+                        // and next token is not a closing tag that would break heredoc/nowdoc syntax
+                        !($tokens[$nestIndex - 1]->isGivenKind(T_END_HEREDOC) && $nextNonWhitespaceNestToken->isGivenKind(T_CLOSE_TAG))
                     ) {
                         if (
                             (

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4175,36 +4175,6 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
         );
     }
 
-    public function provideDoWhileLoopInsideAnIfWithoutBracketsCases()
-    {
-        return array(
-            array(
-                '<?php
-if (true) {
-    do {
-        echo 1;
-    } while (false);
-}',
-                '<?php
-if (true)
-    do {
-        echo 1;
-    } while (false);',
-            ),
-        );
-    }
-
-    /**
-     * @param string      $expected
-     * @param null|string $input
-     *
-     * @dataProvider provideDoWhileLoopInsideAnIfWithoutBracketsCases
-     */
-    public function testDoWhileLoopInsideAnIfWithoutBrackets($expected, $input = null)
-    {
-        $this->doTest($expected, $input);
-    }
-
     /**
      * @param string      $expected
      * @param null|string $input

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4223,8 +4223,8 @@ if (true)
                 <<<'EOT'
 <?php
 if (true) {
-    $var = <<<'JS'
-JS;
+    $var = <<<'NOWDOC'
+NOWDOC;
 ?>
 <?php
 }
@@ -4234,8 +4234,32 @@ EOT
                 <<<'EOT'
 <?php
 if (true) {
-$var = <<<'JS'
-JS;
+$var = <<<'NOWDOC'
+NOWDOC;
+?>
+<?php
+}
+
+EOT
+,
+            ),
+            array(
+                <<<'EOT'
+<?php
+if (true) {
+    $var = <<<HEREDOC
+HEREDOC;
+?>
+<?php
+}
+
+EOT
+,
+                <<<'EOT'
+<?php
+if (true) {
+$var = <<<HEREDOC
+HEREDOC;
 ?>
 <?php
 }

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4174,4 +4174,75 @@ if(true) if(true) echo 1; elseif(true) echo 2; else echo 3;',
             ),
         );
     }
+
+    public function provideDoWhileLoopInsideAnIfWithoutBracketsCases()
+    {
+        return array(
+            array(
+                '<?php
+if (true) {
+    do {
+        echo 1;
+    } while (false);
+}',
+                '<?php
+if (true)
+    do {
+        echo 1;
+    } while (false);',
+            ),
+        );
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideDoWhileLoopInsideAnIfWithoutBracketsCases
+     */
+    public function testDoWhileLoopInsideAnIfWithoutBrackets($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideNowdocInTemplatesCases
+     */
+    public function testNowdocInTemplates($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideNowdocInTemplatesCases()
+    {
+        return array(
+            array(
+                <<<'EOT'
+<?php
+if (true) {
+    $var = <<<'JS'
+JS;
+?>
+<?php
+}
+
+EOT
+,
+                <<<'EOT'
+<?php
+if (true) {
+$var = <<<'JS'
+JS;
+?>
+<?php
+}
+
+EOT
+,
+            ),
+        );
+    }
 }


### PR DESCRIPTION
Currently the fixer breaks code if the php tag is closed after a nowdoc syntax:
```diff
 <?php
 if (true) {
     $var = <<<'JS'
-JS;
-?>
+JS; ?>
 <?php
 }
```

- [x] Prove the bug
- [x] Find a solution (I'm scared of BracesFixer source 😨)