### PR TITLE
Verbose LintingException after fixing

### DIFF
--- a/src/Console/Output/ErrorOutput.php
+++ b/src/Console/Output/ErrorOutput.php
@@ -100,17 +100,20 @@ final class ErrorOutput
                 }
             }
 
-            if (Error::TYPE_LINT === $error->getType() && $e instanceof LintingException) {
+            if (Error::TYPE_LINT === $error->getType() && 0 < count($error->getAppliedFixers())) {
                 $this->output->writeln('');
-                $this->output->writeln(sprintf('      Applied fixers: <comment>%s</comment>', implode(', ', $e->getAppliedFixers())));
+                $this->output->writeln(sprintf('      Applied fixers: <comment>%s</comment>', implode(', ', $error->getAppliedFixers())));
 
-                $diffFormatter = new DiffConsoleFormatter($this->isDecorated, sprintf(
-                    '<comment>      ---------- begin diff ----------</comment>%s%%s%s<comment>      ----------- end diff -----------</comment>',
-                    PHP_EOL,
-                    PHP_EOL
-                ));
+                $diff = $error->getDiff();
+                if (!empty($diff)) {
+                    $diffFormatter = new DiffConsoleFormatter($this->isDecorated, sprintf(
+                        '<comment>      ---------- begin diff ----------</comment>%s%%s%s<comment>      ----------- end diff -----------</comment>',
+                        PHP_EOL,
+                        PHP_EOL
+                    ));
 
-                $this->output->writeln($diffFormatter->format($e->getDiff()));
+                    $this->output->writeln($diffFormatter->format($diff));
+                }
             }
         }
     }

--- a/src/Console/Output/ErrorOutput.php
+++ b/src/Console/Output/ErrorOutput.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Console\Output;
 
+use PhpCsFixer\Differ\DiffConsoleFormatter;
 use PhpCsFixer\Error\Error;
 use PhpCsFixer\Linter\LintingException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -55,48 +56,61 @@ final class ErrorOutput
         $showTrace = $this->output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG;
         foreach ($errors as $i => $error) {
             $this->output->writeln(sprintf('%4d) %s', $i + 1, $error->getFilePath()));
-            if ($showDetails) {
-                $e = $error->getSource();
-                if (null !== $e) {
-                    $class = sprintf('[%s]', get_class($e));
-                    $message = $e->getMessage();
-                    $code = $e->getCode();
-                    if (0 !== $code) {
-                        $message .= " (${code})";
-                    }
+            $e = $error->getSource();
+            if (!$showDetails || null === $e) {
+                continue;
+            }
 
-                    $length = max(strlen($class), strlen($message));
-                    $lines = [
-                        '',
-                        $class,
-                        $message,
-                        '',
-                    ];
+            $class = sprintf('[%s]', get_class($e));
+            $message = $e->getMessage();
+            $code = $e->getCode();
+            if (0 !== $code) {
+                $message .= " (${code})";
+            }
 
-                    $this->output->writeln('');
+            $length = max(strlen($class), strlen($message));
+            $lines = [
+                '',
+                $class,
+                $message,
+                '',
+            ];
 
-                    foreach ($lines as $line) {
-                        if (strlen($line) < $length) {
-                            $line .= str_repeat(' ', $length - strlen($line));
-                        }
+            $this->output->writeln('');
 
-                        $this->output->writeln(sprintf('      <error>  %s  </error>', $this->prepareOutput($line)));
-                    }
-
-                    if ($showTrace && !$e instanceof LintingException) { // stack trace of lint exception is of no interest
-                        $this->output->writeln('');
-                        $stackTrace = $e->getTrace();
-                        foreach ($stackTrace as $trace) {
-                            if (isset($trace['class'], $trace['function']) && \Symfony\Component\Console\Command\Command::class === $trace['class'] && 'run' === $trace['function']) {
-                                $this->output->writeln('      [ ... ]');
-
-                                break;
-                            }
-
-                            $this->outputTrace($trace);
-                        }
-                    }
+            foreach ($lines as $line) {
+                if (strlen($line) < $length) {
+                    $line .= str_repeat(' ', $length - strlen($line));
                 }
+
+                $this->output->writeln(sprintf('      <error>  %s  </error>', $this->prepareOutput($line)));
+            }
+
+            if ($showTrace && !$e instanceof LintingException) { // stack trace of lint exception is of no interest
+                $this->output->writeln('');
+                $stackTrace = $e->getTrace();
+                foreach ($stackTrace as $trace) {
+                    if (isset($trace['class'], $trace['function']) && \Symfony\Component\Console\Command\Command::class === $trace['class'] && 'run' === $trace['function']) {
+                        $this->output->writeln('      [ ... ]');
+
+                        break;
+                    }
+
+                    $this->outputTrace($trace);
+                }
+            }
+
+            if (Error::TYPE_LINT === $error->getType() && $e instanceof LintingException) {
+                $this->output->writeln('');
+                $this->output->writeln(sprintf('      Applied fixers: <comment>%s</comment>', implode(', ', $e->getAppliedFixers())));
+
+                $diffFormatter = new DiffConsoleFormatter($this->isDecorated, sprintf(
+                    '<comment>      ---------- begin diff ----------</comment>%s%%s%s<comment>      ----------- end diff -----------</comment>',
+                    PHP_EOL,
+                    PHP_EOL
+                ));
+
+                $this->output->writeln($diffFormatter->format($e->getDiff()));
             }
         }
     }

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -52,15 +52,29 @@ final class Error
     private $source;
 
     /**
+     * @var array
+     */
+    private $appliedFixers;
+
+    /**
+     * @var null|string
+     */
+    private $diff;
+
+    /**
      * @param int             $type
      * @param string          $filePath
      * @param null|\Throwable $source
+     * @param array           $appliedFixers
+     * @param null|string     $diff
      */
-    public function __construct($type, $filePath, $source = null)
+    public function __construct($type, $filePath, $source = null, array $appliedFixers = [], $diff = null)
     {
         $this->type = $type;
         $this->filePath = $filePath;
         $this->source = $source;
+        $this->appliedFixers = $appliedFixers;
+        $this->diff = $diff;
     }
 
     /**
@@ -85,5 +99,21 @@ final class Error
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAppliedFixers()
+    {
+        return $this->appliedFixers;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getDiff()
+    {
+        return $this->diff;
     }
 }

--- a/src/Linter/LintingException.php
+++ b/src/Linter/LintingException.php
@@ -14,50 +14,7 @@ namespace PhpCsFixer\Linter;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
- *
- * @internal
  */
-final class LintingException extends \RuntimeException
+class LintingException extends \RuntimeException
 {
-    /**
-     * @var array
-     */
-    private $appliedFixers = [];
-
-    /**
-     * @var null|string
-     */
-    private $diff;
-
-    /**
-     * @param array $appliedFixers List of applied fixers, if Error::TYPE_LINT
-     */
-    public function setAppliedFixers(array $appliedFixers)
-    {
-        $this->appliedFixers = $appliedFixers;
-    }
-
-    /**
-     * @return array
-     */
-    public function getAppliedFixers()
-    {
-        return $this->appliedFixers;
-    }
-
-    /**
-     * @param string $diff Diff of applied fixers, if Error::TYPE_LINT
-     */
-    public function setDiff($diff)
-    {
-        $this->diff = $diff;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getDiff()
-    {
-        return $this->diff;
-    }
 }

--- a/src/Linter/LintingException.php
+++ b/src/Linter/LintingException.php
@@ -14,7 +14,50 @@ namespace PhpCsFixer\Linter;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
  */
-class LintingException extends \RuntimeException
+final class LintingException extends \RuntimeException
 {
+    /**
+     * @var array
+     */
+    private $appliedFixers = [];
+
+    /**
+     * @var null|string
+     */
+    private $diff;
+
+    /**
+     * @param array $appliedFixers List of applied fixers, if Error::TYPE_LINT
+     */
+    public function setAppliedFixers(array $appliedFixers)
+    {
+        $this->appliedFixers = $appliedFixers;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAppliedFixers()
+    {
+        return $this->appliedFixers;
+    }
+
+    /**
+     * @param string $diff Diff of applied fixers, if Error::TYPE_LINT
+     */
+    public function setDiff($diff)
+    {
+        $this->diff = $diff;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getDiff()
+    {
+        return $this->diff;
+    }
 }

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -226,9 +226,17 @@ final class Runner
         // work of other and both of them will mark collection as changed.
         // Therefore we need to check if code hashes changed.
         if ($oldHash !== $newHash) {
+            $fixInfo = [
+                'appliedFixers' => $appliedFixers,
+                'diff' => $this->differ->diff($old, $new),
+            ];
+
             try {
                 $this->linter->lintSource($new)->check();
             } catch (LintingException $e) {
+                $e->setAppliedFixers($fixInfo['appliedFixers']);
+                $e->setDiff($fixInfo['diff']);
+
                 $this->dispatchEvent(
                     FixerFileProcessedEvent::NAME,
                     new FixerFileProcessedEvent(FixerFileProcessedEvent::STATUS_LINT)
@@ -251,11 +259,6 @@ final class Runner
                     );
                 }
             }
-
-            $fixInfo = [
-                'appliedFixers' => $appliedFixers,
-                'diff' => $this->differ->diff($old, $new),
-            ];
         }
 
         $this->cacheManager->setFile($name, $new);

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -234,15 +234,12 @@ final class Runner
             try {
                 $this->linter->lintSource($new)->check();
             } catch (LintingException $e) {
-                $e->setAppliedFixers($fixInfo['appliedFixers']);
-                $e->setDiff($fixInfo['diff']);
-
                 $this->dispatchEvent(
                     FixerFileProcessedEvent::NAME,
                     new FixerFileProcessedEvent(FixerFileProcessedEvent::STATUS_LINT)
                 );
 
-                $this->errorsManager->report(new Error(Error::TYPE_LINT, $name, $e));
+                $this->errorsManager->report(new Error(Error::TYPE_LINT, $name, $e, $fixInfo['appliedFixers'], $fixInfo['diff']));
 
                 return;
             }

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -114,26 +114,22 @@ Files that were not fixed due to errors reported during %s:
 +${diffSpecificContext}
 EOT;
 
-        $exception = new LintingException();
-        $exception->setAppliedFixers([$fixerName]);
-        $exception->setDiff($diff);
+        $lintError = new Error(Error::TYPE_LINT, __FILE__, new LintingException(), [$fixerName], $diff);
 
-        $lintError = new Error(Error::TYPE_LINT, __FILE__, $exception);
+        $noDiffLintFixerName = uniqid('no_diff_');
+        $noDiffLintError = new Error(Error::TYPE_LINT, __FILE__, new LintingException(), [$noDiffLintFixerName]);
 
         $invalidErrorFixerName = uniqid('line_ending_');
         $invalidDiff = uniqid('invalid_diff_');
 
-        $invalidErrorException = new LintingException();
-        $invalidErrorException->setAppliedFixers([$invalidErrorFixerName]);
-        $invalidErrorException->setDiff($invalidDiff);
-
-        $invalidError = new Error(Error::TYPE_INVALID, __FILE__, $invalidErrorException);
+        $invalidError = new Error(Error::TYPE_INVALID, __FILE__, new LintingException(), [$invalidErrorFixerName], $invalidDiff);
 
         $output = $this->createStreamOutput(OutputInterface::VERBOSITY_VERY_VERBOSE);
 
         $errorOutput = new ErrorOutput($output);
         $errorOutput->listErrors(uniqid('process_'), [
             $lintError,
+            $noDiffLintError,
             $invalidError,
         ]);
 
@@ -141,6 +137,8 @@ EOT;
 
         $this->assertContains($fixerName, $displayed);
         $this->assertContains($diffSpecificContext, $displayed);
+
+        $this->assertContains($noDiffLintFixerName, $displayed);
 
         $this->assertNotContains($invalidErrorFixerName, $displayed);
         $this->assertNotContains($invalidDiff, $displayed);

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Tests\Console\Output;
 
 use PhpCsFixer\Console\Output\ErrorOutput;
 use PhpCsFixer\Error\Error;
+use PhpCsFixer\Linter\LintingException;
 use PhpCsFixer\Tests\TestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
@@ -40,19 +41,12 @@ final class ErrorOutputTest extends TestCase
     {
         $source = $error->getSource();
 
-        $output = new StreamOutput(fopen('php://memory', 'wb', false));
-        $output->setDecorated(false);
-        $output->setVerbosity($verbosityLevel);
+        $output = $this->createStreamOutput($verbosityLevel);
 
         $errorOutput = new ErrorOutput($output);
         $errorOutput->listErrors($process, [$error]);
 
-        rewind($output->getStream());
-        $displayed = stream_get_contents($output->getStream());
-        // normalize line breaks,
-        // as we output using SF `writeln` we are not sure what line ending has been used as it is
-        // based on the platform/console/terminal used
-        $displayed = str_replace(PHP_EOL, "\n", $displayed);
+        $displayed = $this->readFullStreamOutput($output);
 
         $startWith = sprintf(
             '
@@ -105,6 +99,82 @@ Files that were not fixed due to errors reported during %s:
             [$error, OutputInterface::VERBOSITY_VERY_VERBOSE, $lineNumber, $exceptionLineNumber, 'VVV'],
             [$error, OutputInterface::VERBOSITY_DEBUG, $lineNumber, $exceptionLineNumber, 'DEBUG'],
         ];
+    }
+
+    public function testLintingExceptionOutputsAppliedFixersAndDiff()
+    {
+        $fixerName = uniqid('braces_');
+        $diffSpecificContext = uniqid('added_');
+        $diff = <<<EOT
+--- Original
++++ New
+@@ @@
+ same line
+-deleted
++${diffSpecificContext}
+EOT;
+
+        $exception = new LintingException();
+        $exception->setAppliedFixers([$fixerName]);
+        $exception->setDiff($diff);
+
+        $lintError = new Error(Error::TYPE_LINT, __FILE__, $exception);
+
+        $invalidErrorFixerName = uniqid('line_ending_');
+        $invalidDiff = uniqid('invalid_diff_');
+
+        $invalidErrorException = new LintingException();
+        $invalidErrorException->setAppliedFixers([$invalidErrorFixerName]);
+        $invalidErrorException->setDiff($invalidDiff);
+
+        $invalidError = new Error(Error::TYPE_INVALID, __FILE__, $invalidErrorException);
+
+        $output = $this->createStreamOutput(OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $errorOutput = new ErrorOutput($output);
+        $errorOutput->listErrors(uniqid('process_'), [
+            $lintError,
+            $invalidError,
+        ]);
+
+        $displayed = $this->readFullStreamOutput($output);
+
+        $this->assertContains($fixerName, $displayed);
+        $this->assertContains($diffSpecificContext, $displayed);
+
+        $this->assertNotContains($invalidErrorFixerName, $displayed);
+        $this->assertNotContains($invalidDiff, $displayed);
+    }
+
+    /**
+     * @param int $verbosityLevel
+     *
+     * @return StreamOutput
+     */
+    private function createStreamOutput($verbosityLevel)
+    {
+        $output = new StreamOutput(fopen('php://memory', 'wb', false));
+        $output->setDecorated(false);
+        $output->setVerbosity($verbosityLevel);
+
+        return $output;
+    }
+
+    /**
+     * @param StreamOutput $output
+     *
+     * @return string
+     */
+    private function readFullStreamOutput($output)
+    {
+        rewind($output->getStream());
+        $displayed = stream_get_contents($output->getStream());
+        // normalize line breaks,
+        // as we output using SF `writeln` we are not sure what line ending has been used as it is
+        // based on the platform/console/terminal used
+        $displayed = str_replace(PHP_EOL, "\n", $displayed);
+
+        return $displayed;
     }
 
     private function getErrorAndLineNumber()


### PR DESCRIPTION
I've had to struggle a few hours finding the root cause of https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3337 because:

1. If a lot of fixers are enabled, LintingException doesn't trace what fixers where used for that specific file
1. If a LintingException occurs after fixing, the file content is (correctly) never altered

But if so, you don't know what caused the parse error, and what is the parse error; the plain PHP parse error doesn't help if the source code is thousands lines and the fixer altered it so much that the line numbers changed drastically.

Don't know the right branch for this change, ping me if a rebase is needed.

Before:

![before](https://user-images.githubusercontent.com/152236/34294828-9db321f8-e70a-11e7-99f6-fbf7a137298e.gif)

After:

![after](https://user-images.githubusercontent.com/152236/34294830-a42bdf7a-e70a-11e7-80ed-e812efd8f646.gif)
