### PR TITLE
Tokens - improve block end lookup

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -47,6 +47,13 @@ class Tokens extends \SplFixedArray
     private static $cache = [];
 
     /**
+     * Cache of block edges. Any change in collection will invalidate it.
+     *
+     * @var array<int, int>
+     */
+    private $blockEndCache = [];
+
+    /**
      * crc32 hash of code string.
      *
      * @var string
@@ -301,6 +308,8 @@ class Tokens extends \SplFixedArray
      */
     public function offsetSet($index, $newval)
     {
+        $this->blockEndCache = [];
+
         if (!$this[$index] || !$this[$index]->equals($newval)) {
             $this->changed = true;
         }
@@ -437,6 +446,10 @@ class Tokens extends \SplFixedArray
             throw new \InvalidArgumentException(sprintf('Invalid param type: %s.', $type));
         }
 
+        if (isset($this->blockEndCache[$searchIndex])) {
+            return $this->blockEndCache[$searchIndex];
+        }
+
         $startEdge = $blockEdgeDefinitions[$type]['start'];
         $endEdge = $blockEdgeDefinitions[$type]['end'];
         $startIndex = $searchIndex;
@@ -478,6 +491,9 @@ class Tokens extends \SplFixedArray
         if (!$this[$index]->equals($endEdge)) {
             throw new \UnexpectedValueException(sprintf('Missing block %s.', $findEnd ? 'end' : 'start'));
         }
+
+        $this->blockEndCache[$startIndex] = $index;
+        $this->blockEndCache[$index] = $startIndex;
 
         return $index;
     }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -446,7 +446,7 @@ class Tokens extends \SplFixedArray
             throw new \InvalidArgumentException(sprintf('Invalid param type: %s.', $type));
         }
 
-        if (isset($this->blockEndCache[$searchIndex])) {
+        if (!self::isLegacyMode() && isset($this->blockEndCache[$searchIndex])) {
             return $this->blockEndCache[$searchIndex];
         }
 


### PR DESCRIPTION
Before:
> Fixed all files in 17.040 seconds, 14.000 MB memory used
> Fixed all files in 17.615 seconds, 14.000 MB memory used
> Fixed all files in 17.188 seconds, 14.000 MB memory used

After:
> Fixed all files in 16.581 seconds, 14.000 MB memory used
> Fixed all files in 16.579 seconds, 14.000 MB memory used
> Fixed all files in 16.456 seconds, 14.000 MB memory used

few % improved