### PR TITLE
StdinFileInfo - drop getContents

### DIFF
--- a/src/StdinFileInfo.php
+++ b/src/StdinFileInfo.php
@@ -34,11 +34,6 @@ final class StdinFileInfo extends \SplFileInfo
         return 'php://stdin';
     }
 
-    public function getContents()
-    {
-        return file_get_contents($this->getRealpath());
-    }
-
     public function getATime()
     {
         return 0;


### PR DESCRIPTION
method does not exist in parent class, it's not used as well.
class is internal, so we could drop it.