### PR TITLE
Fix stdin handling and add tests for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,10 +128,7 @@ jobs:
             php: 7.1
             install: ./dev-tools/build.sh
             script:
-                - php php-cs-fixer.phar --version
-                - php php-cs-fixer.phar readme
-                - php php-cs-fixer.phar describe header_comment
-                - php php-cs-fixer.phar fix src/Config.php -vvv --dry-run --diff
+                - vendor/bin/phpunit tests/Smoke/PharTest.php
             deploy:
                 provider: releases
                 api_key:

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "require-dev": {
         "johnkary/phpunit-speedtrap": "^1.0.1",
         "justinrainbow/json-schema": "^5.0",
+        "keradus/cli-executor": "^1.0",
         "mikey179/vfsStream": "^1.6",
         "php-coveralls/php-coveralls": "^1.0.2",
         "phpunit/phpunit": "^4.8.35 || ^5.4.3",

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -18,5 +18,5 @@ composer global show kherge/box -q || composer global require --no-interaction -
 php -d phar.readonly=false $(composer config home)/vendor/bin/box build
 
 # revert changes to composer
-git co composer.json
+git checkout composer.json
 composer update --no-interaction --no-progress -q

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -16,3 +16,7 @@ composer global show kherge/box -q || composer global require --no-interaction -
 
 # build phar file
 php -d phar.readonly=false $(composer config home)/vendor/bin/box build
+
+# revert changes to composer
+git co composer.json
+composer update --no-interaction --no-progress -q

--- a/src/FileReader.php
+++ b/src/FileReader.php
@@ -36,7 +36,7 @@ final class FileReader
     /**
      * @return self
      */
-    public static function createSingletone()
+    public static function createSingleton()
     {
         if (null === self::$instance) {
             self::$instance = new self();

--- a/src/FileReader.php
+++ b/src/FileReader.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * File reader that unify access to regular file and stdin-alike file.
+ *
+ * Regular file could be read multiple times with `file_get_contents`, but file provided on stdin can not.
+ * Consecutive try will provide empty content for stdin-alike file.
+ * This reader unifies access to them.
+ *
+ * @internal
+ */
+final class FileReader
+{
+    /**
+     * @var ?self
+     */
+    private static $instance;
+
+    /**
+     * @var ?string
+     */
+    private $stdinContent;
+
+    /**
+     * @return self
+     */
+    public static function createSingletone()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @return string
+     */
+    public function read($filePath)
+    {
+        if ('php://stdin' === $filePath) {
+            if (null === $this->stdinContent) {
+                $this->stdinContent = $this->readRaw($filePath);
+            }
+
+            return $this->stdinContent;
+        }
+
+        return $this->readRaw($filePath);
+    }
+
+    /**
+     * @param string $realPath
+     *
+     * @return string
+     */
+    private function readRaw($realPath)
+    {
+        return file_get_contents($realPath);
+    }
+}

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -118,7 +118,7 @@ final class ProcessLinter implements LinterInterface
     {
         // in case php://stdin
         if (!is_file($path)) {
-            return $this->createProcessForSource(FileReader::createSingletone()->read($path));
+            return $this->createProcessForSource(FileReader::createSingleton()->read($path));
         }
 
         $process = $this->processBuilder->build($path);

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Linter;
 
+use PhpCsFixer\FileReader;
 use PhpCsFixer\FileRemoval;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -117,7 +118,7 @@ final class ProcessLinter implements LinterInterface
     {
         // in case php://stdin
         if (!is_file($path)) {
-            return $this->createProcessForSource(file_get_contents($path));
+            return $this->createProcessForSource(FileReader::createSingletone()->read($path));
         }
 
         $process = $this->processBuilder->build($path);

--- a/src/Linter/TokenizerLinter.php
+++ b/src/Linter/TokenizerLinter.php
@@ -45,7 +45,7 @@ final class TokenizerLinter implements LinterInterface
      */
     public function lintFile($path)
     {
-        return $this->lintSource(FileReader::createSingletone()->read($path));
+        return $this->lintSource(FileReader::createSingleton()->read($path));
     }
 
     /**

--- a/src/Linter/TokenizerLinter.php
+++ b/src/Linter/TokenizerLinter.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Linter;
 
+use PhpCsFixer\FileReader;
 use PhpCsFixer\Tokenizer\CodeHasher;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -44,7 +45,7 @@ final class TokenizerLinter implements LinterInterface
      */
     public function lintFile($path)
     {
-        return $this->lintSource(file_get_contents($path));
+        return $this->lintSource(FileReader::createSingletone()->read($path));
     }
 
     /**

--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Runner;
 
 use PhpCsFixer\Cache\CacheManagerInterface;
+use PhpCsFixer\FileReader;
 use PhpCsFixer\FixerFileProcessedEvent;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -74,7 +75,7 @@ final class FileFilterIterator extends \FilterIterator
             return false;
         }
 
-        $content = @file_get_contents($path);
+        $content = @FileReader::createSingletone()->read($path);
         if (false === $content) {
             $error = error_get_last();
 

--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -75,7 +75,7 @@ final class FileFilterIterator extends \FilterIterator
             return false;
         }
 
-        $content = @FileReader::createSingletone()->read($path);
+        $content = @FileReader::createSingleton()->read($path);
         if (false === $content) {
             $error = error_get_last();
 

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Cache\DirectoryInterface;
 use PhpCsFixer\Differ\DifferInterface;
 use PhpCsFixer\Error\Error;
 use PhpCsFixer\Error\ErrorsManager;
+use PhpCsFixer\FileReader;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFileProcessedEvent;
 use PhpCsFixer\Linter\LinterInterface;
@@ -163,7 +164,7 @@ final class Runner
             return;
         }
 
-        $old = file_get_contents($file->getRealPath());
+        $old = FileReader::createSingletone()->read($file->getRealPath());
         $tokens = Tokens::fromCode($old);
         $oldHash = $tokens->getCodeHash();
 

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -164,7 +164,7 @@ final class Runner
             return;
         }
 
-        $old = FileReader::createSingletone()->read($file->getRealPath());
+        $old = FileReader::createSingleton()->read($file->getRealPath());
         $tokens = Tokens::fromCode($old);
         $oldHash = $tokens->getCodeHash();
 

--- a/src/StdinFileInfo.php
+++ b/src/StdinFileInfo.php
@@ -31,6 +31,7 @@ final class StdinFileInfo extends \SplFileInfo
     public function getRealPath()
     {
         // So file_get_contents & friends will work.
+        // Warning - this stream is not seekable, so `file_get_contents` will work only once!
         return 'php://stdin';
     }
 

--- a/src/StdinFileInfo.php
+++ b/src/StdinFileInfo.php
@@ -31,7 +31,7 @@ final class StdinFileInfo extends \SplFileInfo
     public function getRealPath()
     {
         // So file_get_contents & friends will work.
-        // Warning - this stream is not seekable, so `file_get_contents` will work only once!
+        // Warning - this stream is not seekable, so `file_get_contents` will work only once! Consider using `FileReader`.
         return 'php://stdin';
     }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -41,6 +41,7 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\Console\SelfUpdate\GithubClient',
         'PhpCsFixer\Console\WarningsDetector',
         'PhpCsFixer\Doctrine\Annotation\Tokens',
+        'PhpCsFixer\FileReader',
         'PhpCsFixer\FileRemoval',
         'PhpCsFixer\Fixer\Operator\AlignDoubleArrowFixerHelper',
         'PhpCsFixer\Fixer\Operator\AlignEqualsFixerHelper',

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -40,12 +40,13 @@ final class FixCommandTest extends TestCase
 
     public function testEmptyRulesValue()
     {
+        $this->setExpectedExceptionRegExp(
+            'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
+            '#^Empty rules value is not allowed\.$#'
+        );
+
         $this->doTestExecute(
-            array('--rules' => ''),
-            array(
-                'class' => 'PhpCsFixer\ConfigurationException\InvalidConfigurationException',
-                'regex' => '#^Empty rules value is not allowed\.$#',
-            )
+            array('--rules' => '')
         );
     }
 
@@ -66,21 +67,16 @@ final class FixCommandTest extends TestCase
     }
 
     /**
-     * @param array      $arguments
-     * @param null|array $expectedException
+     * @param array $arguments
      *
      * @return CommandTester
      */
-    private function doTestExecute(array $arguments, array $expectedException = null)
+    private function doTestExecute(array $arguments)
     {
         $this->application->add(new FixCommand(new ToolInfo()));
 
         $command = $this->application->find('fix');
         $commandTester = new CommandTester($command);
-
-        if (null !== $expectedException) {
-            $this->setExpectedExceptionRegExp($expectedException['class'], $expectedException['regex']);
-        }
 
         $commandTester->execute(
             array_merge(

--- a/tests/Fixtures/ci-integration/.gitignore
+++ b/tests/Fixtures/ci-integration/.gitignore
@@ -1,2 +1,3 @@
 # reset all ignore rules to create sandbox for integration test
 !/**
+/tmp-*.sh

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -10,10 +10,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\Tests;
+namespace PhpCsFixer\Tests\Smoke;
 
-use PhpCsFixer\FileRemoval;
-use Symfony\Component\Process\Process;
+use Keradus\CliExecutor\BashScriptExecutor;
+use Keradus\CliExecutor\CommandExecutor;
+use PhpCsFixer\Tests\TestCase;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -22,41 +23,27 @@ use Symfony\Component\Process\Process;
  *
  * @requires OS Linux|Darwin
  * @coversNothing
+ * @large
  */
 final class CiIntegrationTest extends TestCase
 {
     public static $fixtureDir;
 
-    /**
-     * @var FileRemoval
-     */
-    private static $fileRemoval;
-
-    private static $tmpFilePath;
-    private static $tmpFileName;
-
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
 
-        static::$fixtureDir = __DIR__.'/Fixtures/ci-integration';
-
-        static::$tmpFileName = 'tmp.sh';
-        static::$tmpFilePath = static::$fixtureDir.'/'.static::$tmpFileName;
-        file_put_contents(static::$tmpFilePath, '');
-        chmod(static::$tmpFilePath, 0777);
-        self::$fileRemoval = new FileRemoval();
-        self::$fileRemoval->observe(static::$tmpFilePath);
+        self::$fixtureDir = __DIR__.'/../Fixtures/ci-integration';
 
         try {
-            static::executeCommand(implode(' && ', array(
+            self::executeScript(array(
                 'rm -rf .git',
                 'git init -q',
                 'git config user.name test',
                 'git config user.email test',
                 'git add .',
                 'git commit -m "init" -q',
-            )));
+            ));
         } catch (\RuntimeException $e) {
             self::markTestSkipped($e->getMessage());
         }
@@ -66,21 +53,19 @@ final class CiIntegrationTest extends TestCase
     {
         parent::tearDownAfterClass();
 
-        static::executeCommand('rm -rf .git');
-
-        self::$fileRemoval->delete(static::$tmpFilePath);
+        self::executeCommand('rm -rf .git');
     }
 
     public function tearDown()
     {
         parent::tearDown();
 
-        static::executeCommand(implode(' && ', array(
+        self::executeScript(array(
             'git reset . -q',
             'git checkout . -q',
             'git clean -fdq',
             'git checkout master -q',
-        )));
+        ));
     }
 
     /**
@@ -99,14 +84,14 @@ final class CiIntegrationTest extends TestCase
         array $expectedResult2Lines,
         $expectedResult3Files
     ) {
-        static::executeCommand(implode(' && ', array_merge(
+        self::executeScript(array_merge(
             array(
                 "git checkout -b ${branchName} -q",
             ),
             $caseCommands
-        )));
+        ));
 
-        $integrationScript = explode("\n", str_replace('vendor/bin/', './../../../', file_get_contents(__DIR__.'/../dev-tools/ci-integration.sh')));
+        $integrationScript = explode("\n", str_replace('vendor/bin/', './../../../', file_get_contents(__DIR__.'/../../dev-tools/ci-integration.sh')));
         $steps = array(
             "COMMIT_RANGE=\"master..${branchName}\"",
             $integrationScript[3],
@@ -114,15 +99,15 @@ final class CiIntegrationTest extends TestCase
             $integrationScript[5],
         );
 
-        $result1 = static::executeScript(array(
+        $result1 = self::executeScript(array(
             $steps[0],
             $steps[1],
             'echo "$CHANGED_FILES"',
         ));
 
-        $this->assertSame($expectedResult1Lines, explode("\n", rtrim($result1['output'])));
+        $this->assertSame(implode("\n", $expectedResult1Lines)."\n", $result1->getOutput());
 
-        $result2 = static::executeScript(array(
+        $result2 = self::executeScript(array(
             $steps[0],
             $steps[1],
             $steps[2],
@@ -134,9 +119,9 @@ final class CiIntegrationTest extends TestCase
             'echo "${EXTRA_ARGS[3]}"',
         ));
 
-        $this->assertSame($expectedResult2Lines, explode("\n", rtrim($result2['output'])));
+        $this->assertSame(implode("\n", $expectedResult2Lines), $result2->getOutput());
 
-        $result3 = static::executeScript(array(
+        $result3 = self::executeScript(array(
             $steps[0],
             $steps[1],
             $steps[2],
@@ -162,13 +147,13 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                 preg_quote($optionalXdebugWarning, '/'),
                 preg_quote($executionDetails, '/')
             ),
-            trim($result3['stderr'])
+            $result3->getError()
         );
+
         $this->assertRegExp(
-            '/^Checked all files in \d+\.\d+ seconds, \d+\.\d+ MB memory used$/',
-            trim($result3['output'])
+            '/^\s*Checked all files in \d+\.\d+ seconds, \d+\.\d+ MB memory used\s*$/',
+            $result3->getOutput()
         );
-        $this->assertSame(0, $result3['code']);
     }
 
     public function provideIntegrationCases()
@@ -195,6 +180,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '--',
                     'dir a/file.php',
                     'dir b/file b.php',
+                    '',
                 ),
                 'S.',
             ),
@@ -213,7 +199,15 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '.php_cs.dist',
                     'dir b/file b.php',
                 ),
-                array('0'),
+                array(
+                    '0',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                ),
                 '...',
             ),
             array(
@@ -229,7 +223,15 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '.php_cs',
                     'dir b/file b.php',
                 ),
-                array('0'),
+                array(
+                    '0',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                ),
                 '...',
             ),
             array(
@@ -245,7 +247,15 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'composer.lock',
                     'dir b/file b.php',
                 ),
-                array('0'),
+                array(
+                    '0',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                    '',
+                ),
                 '...',
             ),
         );
@@ -253,36 +263,11 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
 
     private static function executeCommand($command)
     {
-        $process = new Process($command, static::$fixtureDir);
-        $process->run();
-
-        $result = array(
-            'code' => $process->getExitCode(),
-            'output' => $process->getOutput(),
-            'stderr' => $process->getErrorOutput(),
-        );
-
-        if (0 !== $result['code']) {
-            throw new \RuntimeException(sprintf(
-                "Cannot execute `%s`:\n%s\nCode: %s\nExit text: %s\nError output: %s\nDetails:\n%s",
-                $command,
-                './'.static::$tmpFileName === $command
-                    ? implode('', array_map(function ($line) { return "$ ${line}"; }, file(static::$tmpFilePath)))."\n"
-                    : '',
-                $result['code'],
-                $process->getExitCodeText(),
-                $process->getErrorOutput(),
-                $result['output']
-            ));
-        }
-
-        return $result;
+        return CommandExecutor::create($command, self::$fixtureDir)->getResult();
     }
 
     private static function executeScript(array $scriptParts)
     {
-        file_put_contents(static::$tmpFilePath, implode("\n", array_merge(array('#!/usr/bin/env bash', 'set -e', ''), $scriptParts)));
-
-        return static::executeCommand('./'.static::$tmpFileName);
+        return BashScriptExecutor::create($scriptParts, self::$fixtureDir)->getResult();
     }
 }

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Smoke;
+
+use Keradus\CliExecutor\CommandExecutor;
+use PhpCsFixer\Console\Application;
+use PhpCsFixer\Console\Command\DescribeCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @coversNothing
+ * @large
+ */
+final class PharTest extends TestCase
+{
+    private static $pharCwd;
+    private static $pharName;
+    private static $pharPath;
+
+    public static function setUpBeforeClass()
+    {
+        self::$pharCwd = __DIR__.'/../..';
+        self::$pharName = 'php-cs-fixer.phar';
+        self::$pharPath = self::$pharCwd.'/'.self::$pharName;
+
+        if (!file_exists(self::$pharPath)) {
+            static::markTestSkipped('No phar file available.');
+        }
+    }
+
+    public function testVersion()
+    {
+        $this->assertRegExp(
+            '/^.*version '.Application::VERSION.' .*$/',
+            self::executePharCommand('--version')->getOutput()
+        );
+    }
+
+    public function testReadme()
+    {
+        $this->assertStringEqualsFile(
+            __DIR__.'/../../README.rst',
+            self::executePharCommand('readme')->getOutput()
+        );
+    }
+
+    public function testDescribe()
+    {
+        $command = new DescribeCommand();
+
+        $application = new Application();
+        $application->add($command);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array(
+            'command' => $command->getName(),
+            'name' => 'header_comment',
+        ));
+
+        $this->assertSame(
+            $commandTester->getDisplay(),
+            self::executePharCommand('describe header_comment')->getOutput()
+        );
+    }
+
+    public function testFix()
+    {
+        $this->assertSame(
+            0,
+            self::executePharCommand('fix src/Config.php -vvv --dry-run --diff --using-cache=no 2>&1')->getCode()
+        );
+    }
+
+    /**
+     * @param string $params
+     *
+     * @return CliResult
+     */
+    private static function executePharCommand($params)
+    {
+        return CommandExecutor::create('php '.self::$pharName.' '.$params, self::$pharCwd)->getResult();
+    }
+}

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Tests\Smoke;
 use Keradus\CliExecutor\CommandExecutor;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\DescribeCommand;
+use PhpCsFixer\Console\Command\HelpCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -46,15 +47,19 @@ final class PharTest extends TestCase
     public function testVersion()
     {
         $this->assertRegExp(
-            '/^.*version '.Application::VERSION.' .*$/',
+            '/^.* '.Application::VERSION.' by .*$/',
             self::executePharCommand('--version')->getOutput()
         );
     }
 
     public function testReadme()
     {
-        $this->assertStringEqualsFile(
-            __DIR__.'/../../README.rst',
+        $this->assertSame(
+            str_replace(
+                HelpCOmmand::getLatestReleaseVersionFromChangeLog(),
+                Application::VERSION,
+                file_get_contents(__DIR__.'/../../README.rst')
+            ),
             self::executePharCommand('readme')->getOutput()
         );
     }

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Smoke;
+
+use Keradus\CliExecutor\CommandExecutor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ *
+ * @coversNothing
+ */
+final class StdinTest extends TestCase
+{
+    private static $cwd;
+
+    public static function setUpBeforeClass()
+    {
+        self::$cwd = __DIR__.'/../..';
+    }
+
+    public function testFixingStdin()
+    {
+        $command = 'php php-cs-fixer fix --rules=@PSR2 --dry-run --diff --using-cache=no';
+        $inputFile = 'tests/Fixtures/Integration/set/@PSR2.test-in.php';
+
+        $fileResult = CommandExecutor::create("${command} ${inputFile}", self::$cwd)->getResult(false);
+        $stdinResult = CommandExecutor::create("${command} - < ${inputFile}", self::$cwd)->getResult(false);
+
+        $this->assertSame(
+            array(
+                'code' => $fileResult->getCode(),
+                'error' => str_replace(
+                    'Paths from configuration file have been overridden by paths provided as command arguments.'."\n",
+                    '',
+                    $fileResult->getError()
+                ),
+                'output' => str_replace(
+                    'PHP-CS-Fixer/tests/Fixtures/Integration/set/@PSR2.test-in.php',
+                    'php://stdin',
+                    $this->unifyFooter($fileResult->getOutput())
+                ),
+            ),
+            array(
+                'code' => $stdinResult->getCode(),
+                'error' => $stdinResult->getError(),
+                'output' => $this->unifyFooter($stdinResult->getOutput()),
+            )
+        );
+    }
+
+    /**
+     * @param string $output
+     *
+     * @return string
+     */
+    private function unifyFooter($output)
+    {
+        return preg_replace(
+            '/Checked all files in \d+\.\d+ seconds, \d+\.\d+ MB memory used/',
+            'Footer',
+            $output
+        );
+    }
+}

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -47,8 +47,8 @@ final class StdinTest extends TestCase
                     '',
                     $fileResult->getError()
                 ),
-                'output' => str_replace(
-                    'PHP-CS-Fixer/tests/Fixtures/Integration/set/@PSR2.test-in.php',
+                'output' => str_ireplace(
+                    str_replace('/', DIRECTORY_SEPARATOR, 'PHP-CS-Fixer/tests/Fixtures/Integration/set/@PSR2.test-in.php'),
                     'php://stdin',
                     $this->unifyFooter($fileResult->getOutput())
                 ),

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
  * @internal
  *
  * @coversNothing
+ * @requires OS Linux|Darwin
  */
 final class StdinTest extends TestCase
 {


### PR DESCRIPTION
fixing stdin is not working as filtering / linting processes are consuming the content of stdin, which is readable **once**

```
ker@dus:~/github/PHP-CS-Fixer$ vendor/bin/phpunit tests/Smoke/StdinTest.php 
PHPUnit 5.7.26 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.0-2+ubuntu17.04.1+deb.sury.org+2
Configuration: /home/keradus/github/PHP-CS-Fixer/phpunit.xml.dist

Testing PhpCsFixer\Tests\Smoke\StdinTest
F                                                                                                                                                                                                                                                                      1 / 1 (100%)

You should really fix these slow tests (>100ms)...
 1. 143ms to run PhpCsFixer\Tests\Smoke\StdinTest:testFixingStdin


Time: 165 ms, Memory: 4.00MB

There was 1 failure:

1) PhpCsFixer\Tests\Smoke\StdinTest::testFixingStdin
Failed asserting that Array &0 (
    'code' => 0
    'error' => 'Loaded config default from "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist".
'
    'output' => '
Checked all files in 0.001 seconds, 8.000 MB memory used
'
) is identical to Array &0 (
    'code' => 8
    'error' => 'Loaded config default from "/home/keradus/github/PHP-CS-Fixer/.php_cs.dist".
Paths from configuration file have been overridden by paths provided as command arguments.
'
    'output' => '   1) PHP-CS-Fixer/tests/Fixtures/Integration/set/@PSR2.test-in.php
      ---------- begin diff ----------
--- Original
+++ New
@@ @@
-<?
+<?php
 namespace Vendor\Package;
-use FooInterface, FooInterfaceB;
+
+use FooInterface;
+use FooInterfaceB;
 use BarClass as Bar;
 use OtherVendor\OtherPackage\BazClass;
-class Foo extends Bar implements FooInterface{
-    var $aaa = 1, $bbb = 2;

+class Foo extends Bar implements FooInterface
+{
+    public $aaa = 1;
+    public $bbb = 2;
+
     public function sampleFunction($a, $b = null)
     {
         if ($a === $b) {
             bar();
-        } else if ($a > $b) {
+        } elseif ($a > $b) {
             $foo->bar($arg1);
         } else {
-                BazClass::bar($arg2, $arg3);
+            BazClass::bar($arg2, $arg3);
         }
     }

-    static public  final function bar() {
-    // method body
+    final public static function bar()
+    {
+        // method body
     }
 }

 class Aaa implements
-    Bbb, Ccc,
+    Bbb,
+    Ccc,
     Ddd
-    {
-    }
-?>
+{
+}
      ----------- end diff -----------


Checked all files in 0.009 seconds, 8.000 MB memory used
'
).

/home/keradus/github/PHP-CS-Fixer/tests/Smoke/StdinTest.php:52

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```


Deps:
- [x] #3345
- [x] #3346

Broken since:
- #722