### PR TITLE
PhuUnit: migrate getMock to createPartialMock when arguments count is 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1025,7 +1025,7 @@ Choose from the list of available rules:
   - ``assertions`` (``array``): list of assertion methods to fix; defaults to
     ``['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']``
 
-* **php_unit_dedicate_assert** [@Symfony:risky, @PHPUnit30Migration:risky, @PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
+* **php_unit_dedicate_assert** [@Symfony:risky, @PHPUnit30Migration:risky, @PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   PHPUnit assertions like "assertInternalType", "assertFileExists", should
   be used over "assertTrue".
@@ -1039,7 +1039,7 @@ Choose from the list of available rules:
   - ``target`` (``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'``, ``'newest'``): target version of
     PHPUnit; defaults to ``'5.0'``
 
-* **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
+* **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   Usages of ``->setExpectedException*`` methods MUST be replaced by
   ``->expectException*`` methods.
@@ -1055,15 +1055,20 @@ Choose from the list of available rules:
 
   PHPUnit annotations should be a FQCNs including a root namespace.
 
-* **php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
+* **php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   Usages of ``->getMock`` and
   ``->getMockWithoutInvokingTheOriginalConstructor`` methods MUST be
-  replaced by ``->createMock`` method.
+  replaced by ``->createMock`` or ``->createPartialMock`` methods.
 
   *Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.*
 
-* **php_unit_namespaced** [@PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
+  Configuration options:
+
+  - ``target`` (``'5.4'``, ``'5.5'``, ``'newest'``): target version of PHPUnit; defaults to
+    ``'newest'``
+
+* **php_unit_namespaced** [@PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   PHPUnit classes MUST be used in namespaced version, eg
   ``\PHPUnit\Framework\TestCase`` instead of ``\PHPUnit_Framework_TestCase``.
@@ -1075,7 +1080,7 @@ Choose from the list of available rules:
   - ``target`` (``'4.8'``, ``'5.7'``, ``'6.0'``, ``'newest'``): target version of PHPUnit;
     defaults to ``'newest'``
 
-* **php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
+* **php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   Usages of ``@expectedException*`` annotations MUST be replaced by
   ``->setExpectedException*`` methods.

--- a/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
+++ b/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
@@ -29,6 +29,7 @@ final class PhpUnitTargetVersion
     const VERSION_5_0 = '5.0';
     const VERSION_5_2 = '5.2';
     const VERSION_5_4 = '5.4';
+    const VERSION_5_5 = '5.5';
     const VERSION_5_6 = '5.6';
     const VERSION_5_7 = '5.7';
     const VERSION_6_0 = '6.0';

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -233,10 +233,14 @@ final class RuleSet implements RuleSetInterface
         ],
         '@PHPUnit54Migration:risky' => [
             '@PHPUnit52Migration:risky' => true,
-            'php_unit_mock' => true,
+            'php_unit_mock' => ['target' => PhpUnitTargetVersion::VERSION_5_4],
+        ],
+        '@PHPUnit55Migration:risky' => [
+            '@PHPUnit54Migration:risky' => true,
+            'php_unit_mock' => ['target' => PhpUnitTargetVersion::VERSION_5_5],
         ],
         '@PHPUnit56Migration:risky' => [
-            '@PHPUnit54Migration:risky' => true,
+            '@PHPUnit55Migration:risky' => true,
             'php_unit_dedicate_assert' => ['target' => PhpUnitTargetVersion::VERSION_5_6],
             'php_unit_expectation' => ['target' => PhpUnitTargetVersion::VERSION_5_6],
         ],

--- a/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\PhpUnit;
 
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -26,11 +27,13 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
     /**
      * @param string      $expected
      * @param null|string $input
+     * @param array       $config
      *
      * @dataProvider provideTestFixCases
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -74,6 +77,31 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
             $this->getMock("Foo");
             $this->getMock($foo(1, 2));
             $this->getMock("Foo", ["aaa"]);
+        }
+    }',
+                ['target' => PhpUnitTargetVersion::VERSION_5_4],
+            ],
+            [
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        public function testFoo()
+        {
+            $this->createMock("Foo");
+            $this->createMock($foo(1, 2));
+            $this->createPartialMock("Foo", ["aaa"]);
+            $this->getMock("Foo", ["aaa"], ["argument"]);
+        }
+    }',
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        public function testFoo()
+        {
+            $this->getMock("Foo");
+            $this->getMock($foo(1, 2));
+            $this->getMock("Foo", ["aaa"]);
+            $this->getMock("Foo", ["aaa"], ["argument"]);
         }
     }',
             ],


### PR DESCRIPTION
PhpUnit 5.5 introduces `createMockPartial` that emulates `getMock` with the first 2 arguments only set.

Reference: https://github.com/sebastianbergmann/phpunit/blob/5.5/src/Framework/TestCase.php#L1548

- [x] Introduce `PhpUnitTargetVersion::VERSION_5_5`
- [x] Make `PhpUnitMockFixer` configurable for versions `5.4` and `5.5`
- [x] Add distinct test cases for `5.4` and `5.5`
- [x] Update `RuleSet` introducing new `@PHPUnit55Migration:risky`

Since this is a new feature, base branch is `master` instead of `2.9`.