### PR TITLE
Add BacktickToShellExecFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,10 @@ Choose from the list of available rules:
   - ``syntax`` (``'long'``, ``'short'``): whether to use the ``long`` or ``short`` array
     syntax; defaults to ``'long'``
 
+* **backtick_to_shell_exec**
+
+  Converts backtick operators to shell_exec calls.
+
 * **binary_operator_spaces** [@Symfony]
 
   Binary operators should be surrounded by space as configured.

--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Alias;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class BacktickToShellExecFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound('`');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+           'Converts backtick operators to shell_exec calls.',
+            [
+                new CodeSample(
+<<<'EOT'
+<?php
+$plain = `ls -lah`;
+$withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;
+$withQuotes = `ls -lah a\"m\\\\z`;
+
+EOT
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $backtickStarted = false;
+        $backtickTokens = [];
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
+            $token = $tokens[$index];
+            if (!$token->equals('`')) {
+                if ($backtickStarted) {
+                    $backtickTokens[$index] = $token;
+                }
+
+                continue;
+            }
+
+            $backtickTokens[$index] = $token;
+            if ($backtickStarted) {
+                $this->fixBackticks($tokens, $backtickTokens);
+                $backtickTokens = [];
+            }
+            $backtickStarted = !$backtickStarted;
+        }
+    }
+
+    /**
+     * Override backtick code with corresponding double-quoted string.
+     *
+     * @param Tokens $tokens
+     * @param array  $backtickTokens
+     */
+    private function fixBackticks(Tokens $tokens, array $backtickTokens)
+    {
+        // Track indexes for final override
+        ksort($backtickTokens);
+        $openingBacktickIndex = key($backtickTokens);
+        end($backtickTokens);
+        $closingBacktickIndex = key($backtickTokens);
+
+        // Strip enclosing backticks
+        array_shift($backtickTokens);
+        array_pop($backtickTokens);
+
+        // Double-quoted strings are parsed differenly if they contains
+        // variables or not
+        $count = count($backtickTokens);
+
+        $newTokens = [
+            new Token([T_STRING, 'shell_exec']),
+            new Token('('),
+        ];
+        if (1 !== $count) {
+            $newTokens[] = new Token('"');
+        }
+        foreach ($backtickTokens as $token) {
+            if (!$token->isGivenKind(T_ENCAPSED_AND_WHITESPACE)) {
+                $newTokens[] = $token;
+
+                continue;
+            }
+            $content = str_replace('\\"', '\\\\\\"', $token->getContent());
+            $kind = T_ENCAPSED_AND_WHITESPACE;
+            if (1 === $count) {
+                $content = '"'.$content.'"';
+                $kind = T_CONSTANT_ENCAPSED_STRING;
+            }
+
+            $newTokens[] = new Token([$kind, $content]);
+        }
+        if (1 !== $count) {
+            $newTokens[] = new Token('"');
+        }
+        $newTokens[] = new Token(')');
+
+        $tokens->overrideRange($openingBacktickIndex, $closingBacktickIndex, $newTokens);
+    }
+}

--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -45,6 +45,7 @@ final class BacktickToShellExecFixer extends AbstractFixer
 $plain = `ls -lah`;
 $withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;
 $withQuotes = `ls -lah a\"m\\\\z`;
+$withBacktick = `ls -lah 'foo\`bar'`;
 
 EOT
                 ),
@@ -106,7 +107,7 @@ EOT
         array_pop($backtickTokens);
 
         // Double-quoted strings are parsed differenly if they contains
-        // variables or not
+        // variables or not, so we need to build the new token array accordingly
         $count = count($backtickTokens);
 
         $newTokens = [
@@ -122,7 +123,7 @@ EOT
 
                 continue;
             }
-            $content = str_replace('\\"', '\\\\\\"', $token->getContent());
+            $content = str_replace(['\\`', '\\"'], ['`', '\\\\\\"'], $token->getContent());
             $kind = T_ENCAPSED_AND_WHITESPACE;
             if (1 === $count) {
                 $content = '"'.$content.'"';

--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -105,7 +105,7 @@ EOT
         array_shift($backtickTokens);
         array_pop($backtickTokens);
 
-        // Double-quoted strings are parsed differenly if they contains
+        // Double-quoted strings are parsed differenly if they contain
         // variables or not, so we need to build the new token array accordingly
         $count = count($backtickTokens);
 

--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -55,6 +55,15 @@ EOT
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // Should run before escape_implicit_backslashes
+        return 2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $backtickStarted = false;

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -59,6 +59,7 @@ final class FixerFactoryTest extends TestCase
         $cases = [
             [$fixers['array_syntax'], $fixers['binary_operator_spaces']], // tested also in: array_syntax,binary_operator_spaces.test
             [$fixers['array_syntax'], $fixers['ternary_operator_spaces']], // tested also in: array_syntax,ternary_operator_spaces.test
+            [$fixers['backtick_to_shell_exec'], $fixers['escape_implicit_backslashes']], // tested also in: backtick_to_shell_exec,escape_implicit_backslashes.test
             [$fixers['blank_line_after_opening_tag'], $fixers['no_blank_lines_before_namespace']], // tested also in: blank_line_after_opening_tag,no_blank_lines_before_namespace.test
             [$fixers['class_attributes_separation'], $fixers['braces']],
             [$fixers['class_attributes_separation'], $fixers['indentation_type']],

--- a/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
+++ b/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
@@ -41,43 +41,31 @@ final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
                 '<?php shell_exec("ls -lah");',
                 '<?php `ls -lah`;',
             ],
-            'with double quote' => [
-<<<'EOT'
-<?php
-shell_exec("ls -lah a\\\"m\\\\z");
-EOT
-,
-<<<'EOT'
-<?php
-`ls -lah a\"m\\\\z`;
-EOT
-,
-            ],
             'with variables' => [
                 '<?php shell_exec("$var1 ls ${var2} -lah {$var3} file1.txt {$var4[0]} file2.txt {$var5->call()}");',
                 '<?php `$var1 ls ${var2} -lah {$var3} file1.txt {$var4[0]} file2.txt {$var5->call()}`;',
             ],
-            'with double quote and variable' => [
+            'with single quote' => [
 <<<'EOT'
 <?php
-shell_exec("ls -lah a\\\"m\\\\z $var");
+`echo a\'b`;
+`echo 'ab'`;
 EOT
 ,
+            ],
+            'with double quote' => [
 <<<'EOT'
 <?php
-`ls -lah a\"m\\\\z $var`;
+`echo a\"b`;
+`echo 'a"b'`;
 EOT
 ,
             ],
             'with backtick' => [
 <<<'EOT'
 <?php
-shell_exec("echo 'foo`bar'");
-EOT
-,
-<<<'EOT'
-<?php
-`echo 'foo\`bar'`;
+`echo 'a\`b'`;
+`echo a\\\`b`;
 EOT
 ,
             ],

--- a/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
+++ b/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Alias;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Alias\BacktickToShellExecFixer
+ */
+final class BacktickToShellExecFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'plain' => [
+                '<?php shell_exec("ls -lah");',
+                '<?php `ls -lah`;',
+            ],
+            'with double quote' => [
+<<<'EOT'
+<?php
+shell_exec("ls -lah a\\\"m\\\\z");
+EOT
+,
+<<<'EOT'
+<?php
+`ls -lah a\"m\\\\z`;
+EOT
+,
+            ],
+            'with variables' => [
+                '<?php shell_exec("$var1 ls ${var2} -lah {$var3} file1.txt {$var4[0]} file2.txt {$var5->call()}");',
+                '<?php `$var1 ls ${var2} -lah {$var3} file1.txt {$var4[0]} file2.txt {$var5->call()}`;',
+            ],
+            'with double quote and variable' => [
+<<<'EOT'
+<?php
+shell_exec("ls -lah a\\\"m\\\\z $var");
+EOT
+,
+<<<'EOT'
+<?php
+`ls -lah a\"m\\\\z $var`;
+EOT
+,
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
+++ b/tests/Fixer/Alias/BacktickToShellExecFixerTest.php
@@ -69,6 +69,18 @@ EOT
 EOT
 ,
             ],
+            'with backtick' => [
+<<<'EOT'
+<?php
+shell_exec("echo 'foo`bar'");
+EOT
+,
+<<<'EOT'
+<?php
+`echo 'foo\`bar'`;
+EOT
+,
+            ],
         ];
     }
 }

--- a/tests/Fixtures/Integration/priority/backtick_to_shell_exec,escape_implicit_backslashes.test
+++ b/tests/Fixtures/Integration/priority/backtick_to_shell_exec,escape_implicit_backslashes.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: backtick_to_shell_exec,escape_implicit_backslashes.
+--RULESET--
+{"backtick_to_shell_exec": true, "escape_implicit_backslashes": true}
+--EXPECT--
+<?php
+$var = shell_exec("ls a\\b");
+
+--INPUT--
+<?php
+$var = `ls a\b`;


### PR DESCRIPTION
```diff
-$plain = `ls -lah`;
+$plain = shell_exec("ls -lah");

-$withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;
+$withVar = shell_exec("ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}");
```

Reference: https://secure.php.net/manual/en/language.operators.execution.php
  
  