### PR TITLE
Configuration - finder string[]

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -767,7 +767,9 @@ final class ConfigurationResolver
             array_walk(
                 $currentFinder,
                 function (&$item) {
-                    $item = new \SplFileInfo($item);
+                    if (!($item instanceof \SplFileInfo)) { // do not use `is_string` to prevent reference mismatch
+                        $item = new \SplFileInfo($item);
+                    }
                 }
             );
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -761,7 +761,7 @@ final class ConfigurationResolver
             }
 
             if (!is_array($currentFinder)) {
-                return $this->iterableToTraversable($currentFinder);
+                return $currentFinder;
             }
 
             array_walk(

--- a/src/Runner/FileFilterIterator.php
+++ b/src/Runner/FileFilterIterator.php
@@ -52,7 +52,12 @@ final class FileFilterIterator extends \FilterIterator
 
     public function accept()
     {
+        /** @var \SplFileInfo $file */
         $file = $this->current();
+        if (!($file instanceof \SplFileInfo)) {
+            return false;
+        }
+
         $path = $file->getRealPath();
 
         if (isset($this->visitedElements[$path])) {
@@ -61,7 +66,7 @@ final class FileFilterIterator extends \FilterIterator
 
         $this->visitedElements[$path] = true;
 
-        if ($file->isDir() || $file->isLink()) {
+        if (!$file->isFile() || $file->isLink()) {
             return false;
         }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1040,7 +1040,7 @@ final class ConfigurationResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFinders
+     * @dataProvider provideFinderCases
      *
      * @param mixed $finder
      */
@@ -1063,7 +1063,7 @@ final class ConfigurationResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider provideFinders
+     * @dataProvider provideFinderCases
      *
      * @param mixed $finder
      */
@@ -1082,7 +1082,7 @@ final class ConfigurationResolverTest extends TestCase
         }
     }
 
-    public function provideFinders()
+    public function provideFinderCases()
     {
         $path = $this->getFixPath();
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1055,10 +1055,10 @@ final class ConfigurationResolverTest extends TestCase
         ), $config);
 
         $finder = $resolver->getFinder();
-        $this->assertInstanceOf(\Traversable::class, $finder);
+        $this->assertInstanceOf('Traversable', $finder);
 
         foreach ($finder as $file) {
-            $this->assertInstanceOf(\SplFileInfo::class, $file);
+            $this->assertInstanceOf('SplFileInfo', $file);
         }
     }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1075,10 +1075,10 @@ final class ConfigurationResolverTest extends TestCase
         $resolver = $this->createConfigurationResolver(array(), $config);
 
         $finder = $resolver->getFinder();
-        $this->assertInstanceOf(\Traversable::class, $finder);
+        $this->assertInstanceOf('Traversable', $finder);
 
         foreach ($finder as $file) {
-            $this->assertInstanceOf(\SplFileInfo::class, $file);
+            $this->assertInstanceOf('SplFileInfo', $file);
         }
     }
 

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -36,6 +36,8 @@ final class RunnerTest extends TestCase
      *
      * @covers \PhpCsFixer\Runner\Runner::fix
      * @covers \PhpCsFixer\Runner\Runner::fixFile
+     *
+     * @param mixed $finder
      */
     public function testThatFixSuccessfully($finder)
     {
@@ -153,10 +155,10 @@ final class RunnerTest extends TestCase
 
         $paths[] = new \SplFileInfo('__INVALID__');
 
-        return [
-            [Finder::create()->in($path)],
-            [new \ArrayIterator($paths)],
-        ];
+        return array(
+            array(Finder::create()->in($path)),
+            array(new \ArrayIterator($paths)),
+        );
     }
 
     private function getFixPath()

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\Finder\Finder;
 final class RunnerTest extends TestCase
 {
     /**
-     * @dataProvider provideFinders
+     * @dataProvider provideFinderCases
      *
      * @covers \PhpCsFixer\Runner\Runner::fix
      * @covers \PhpCsFixer\Runner\Runner::fixFile
@@ -140,7 +140,7 @@ final class RunnerTest extends TestCase
         $this->assertSame($pathToInvalidFile, $error->getFilePath());
     }
 
-    public function provideFinders()
+    public function provideFinderCases()
     {
         $path = $this->getFixPath();
 

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -32,10 +32,12 @@ use Symfony\Component\Finder\Finder;
 final class RunnerTest extends TestCase
 {
     /**
+     * @dataProvider provideFinders
+     *
      * @covers \PhpCsFixer\Runner\Runner::fix
      * @covers \PhpCsFixer\Runner\Runner::fixFile
      */
-    public function testThatFixSuccessfully()
+    public function testThatFixSuccessfully($finder)
     {
         $linterProphecy = $this->prophesize('PhpCsFixer\Linter\LinterInterface');
         $linterProphecy
@@ -58,9 +60,9 @@ final class RunnerTest extends TestCase
             'diff' => '',
         );
 
-        $path = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix';
+        $path = $this->getFixPath();
         $runner = new Runner(
-            Finder::create()->in($path),
+            $finder,
             $fixers,
             new NullDiffer(),
             null,
@@ -78,9 +80,9 @@ final class RunnerTest extends TestCase
         $this->assertArraySubset($expectedChangedInfo, array_pop($changed));
         $this->assertArraySubset($expectedChangedInfo, array_pop($changed));
 
-        $path = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix';
+        $path = $this->getFixPath();
         $runner = new Runner(
-            Finder::create()->in($path),
+            $finder,
             $fixers,
             new NullDiffer(),
             null,
@@ -120,6 +122,7 @@ final class RunnerTest extends TestCase
             true,
             new NullCacheManager()
         );
+
         $changed = $runner->fix();
         $pathToInvalidFile = $path.DIRECTORY_SEPARATOR.'somefile.php';
 
@@ -135,5 +138,29 @@ final class RunnerTest extends TestCase
 
         $this->assertSame(Error::TYPE_INVALID, $error->getType());
         $this->assertSame($pathToInvalidFile, $error->getFilePath());
+    }
+
+    public function provideFinders()
+    {
+        $path = $this->getFixPath();
+
+        $paths = array();
+        foreach (new \DirectoryIterator($path) as $file) {
+            if ($file->isFile()) {
+                $paths[] = new \SplFileInfo($file->getPathname());
+            }
+        }
+
+        $paths[] = new \SplFileInfo('__INVALID__');
+
+        return [
+            [Finder::create()->in($path)],
+            [new \ArrayIterator($paths)],
+        ];
+    }
+
+    private function getFixPath()
+    {
+        return __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'fix';
     }
 }


### PR DESCRIPTION
In the `ConfigInterface` we suggest it is OK to return `string[]` for the finder.
However both the `Runner` and the `ConfigurationResolver` do not like this.

Since we never suggested that the `Runner` accepts  the `string[]` I've only updated that one only to be more defensive.

The `ConfigurationResolver` now transforms the string array to an iterator providing `SplFileInfo` objects based on the strings in the array.

for ref.:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.2.13/src/ConfigInterface.php#L40
and:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3305#issuecomment-352557362