### PR TITLE
AbstractFixer: remove redundant FixerInterface

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -18,7 +18,6 @@ use PhpCsFixer\ConfigurationException\RequiredFixerConfigurationException;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
-use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
@@ -31,7 +30,7 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
  *
  * @internal
  */
-abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
+abstract class AbstractFixer implements DefinedFixerInterface
 {
     /**
      * @var null|array<string, mixed>


### PR DESCRIPTION
`FixerInterface` is a parent interface of `DefinedFixerInterface`