### PR TITLE
PhpdocAlignFixer - Fix removing of everything after @ when there is a space after the @

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -65,18 +65,25 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurationDefin
         $tagsWithNameToAlign = array_intersect($this->configuration['tags'], self::$tagsWithName);
         $tagsWithMethodSignatureToAlign = array_intersect($this->configuration['tags'], self::$tagsWithMethodSignature);
         $tagsWithoutNameToAlign = array_diff($this->configuration['tags'], $tagsWithNameToAlign, $tagsWithMethodSignatureToAlign);
+        $types = [];
 
         $indent = '(?P<indent>(?: {2}|\t)*)';
         // e.g. @param <hint> <$var>
-        $tagsWithName = '(?P<tag>'.implode('|', $tagsWithNameToAlign).')\s+(?P<hint>[^$]+?)\s+(?P<var>(?:&|\.{3})?\$[^\s]+)';
+        if (!empty($tagsWithNameToAlign)) {
+            $types[] = '(?P<tag>'.implode('|', $tagsWithNameToAlign).')\s+(?P<hint>[^$]+?)\s+(?P<var>(?:&|\.{3})?\$[^\s]+)';
+        }
         // e.g. @return <hint>
-        $tagsWithoutName = '(?P<tag2>'.implode('|', $tagsWithoutNameToAlign).')\s+(?P<hint2>[^\s]+?)';
+        if (!empty($tagsWithoutNameToAlign)) {
+            $types[] = '(?P<tag2>'.implode('|', $tagsWithoutNameToAlign).')\s+(?P<hint2>[^\s]+?)';
+        }
         // e.g. @method <hint> <signature>
-        $tagsWithMethodSignature = '(?P<tag3>'.implode('|', $tagsWithMethodSignatureToAlign).')(\s+(?P<hint3>[^\s(]+)|)\s+(?P<signature>.+\))';
+        if (!empty($tagsWithMethodSignatureToAlign)) {
+            $types[] = '(?P<tag3>'.implode('|', $tagsWithMethodSignatureToAlign).')(\s+(?P<hint3>[^\s(]+)|)\s+(?P<signature>.+\))';
+        }
         // optional <desc>
         $desc = '(?:\s+(?P<desc>\V*))';
 
-        $this->regex = '/^'.$indent.' \* @(?:'.$tagsWithName.'|'.$tagsWithoutName.'|'.$tagsWithMethodSignature.')'.$desc.'\s*$/u';
+        $this->regex = '/^'.$indent.' \* @(?:'.implode('|', $types).')'.$desc.'\s*$/u';
         $this->regexCommentLine = '/^'.$indent.' \*(?! @)(?:\s+(?P<desc>\V+))(?<!\*\/)$/u';
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -875,4 +875,14 @@ final class Sample
             ],
         ];
     }
+
+    public function testSpaceAfterAtIsNotCleared()
+    {
+        $input = '<?php
+/**
+ * @ Security("is_granted(\'CANCEL\', giftCard)")
+ */';
+
+        $this->doTest($input);
+    }
 }

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -876,13 +876,48 @@ final class Sample
         ];
     }
 
-    public function testSpaceAfterAtIsNotCleared()
+    /**
+     * @param array  $config
+     * @param string $input
+     *
+     * @dataProvider provideInvalidPhpdocCases
+     */
+    public function testInvalidPhpdocsAreUnchanged(array $config, $input)
     {
-        $input = '<?php
-/**
- * @ Security("is_granted(\'CANCEL\', giftCard)")
- */';
+        $this->fixer->configure($config);
 
         $this->doTest($input);
+    }
+
+    public function provideInvalidPhpdocCases()
+    {
+        return [
+            [
+                ['tags' => ['param', 'return', 'throws', 'type', 'var']],
+                '<?php
+/**
+ * @ Security("is_granted(\'CANCEL\', giftCard)")
+ */
+ ',
+            ],
+            [
+                ['tags' => ['param', 'return', 'throws', 'type', 'var', 'method']],
+                '<?php
+/**
+ * @ Security("is_granted(\'CANCEL\', giftCard)")
+ */
+ ',
+            ],
+            [
+                ['tags' => ['param', 'return', 'throws', 'type', 'var']],
+                '<?php
+/**
+ * @ Security("is_granted(\'CANCEL\', giftCard)")
+ * @     foo   bar
+ *   @ foo
+ */
+ ',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Fixes #3336

Because the default configuration doesn't align `@method`, the regex for detecting method signature tags was matching spaces