### PR TITLE
Use `strpos` instead of `substr` where possible

### DIFF
--- a/src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+++ b/src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
@@ -88,7 +88,7 @@ final class TrimArraySpacesFixer extends AbstractFixer
                 !$nextNonWhitespaceToken->isComment()
                 || $nextNonWhitespaceIndex === $prevNonWhitespaceIndex
                 || $tokenAfterNextNonWhitespaceToken->isWhitespace(" \t")
-                || '/*' === substr($nextNonWhitespaceToken->getContent(), 0, 2)
+                || 0 === strpos($nextNonWhitespaceToken->getContent(), '/*')
             )
         ) {
             $tokens->clearAt($nextIndex);

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -369,9 +369,9 @@ interface Bar extends
 
                 if ($tokens[$prevNonWhite]->isComment() || $tokens[$nextNonWhite]->isComment()) {
                     $content = $tokens[$prevNonWhite]->getContent();
-                    if (!('#' === $content || '//' === substr($content, 0, 2))) {
+                    if (!('#' === $content || 0 === strpos($content, '//'))) {
                         $content = $tokens[$nextNonWhite]->getContent();
-                        if (!('#' === $content || '//' === substr($content, 0, 2))) {
+                        if (!('#' === $content || 0 === strpos($content, '//'))) {
                             $tokens[$i] = new Token(array(T_WHITESPACE, ' '));
                         }
                     }

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -358,7 +358,7 @@ array('order' => array('method_private', 'method_public'))
             return array('phpunit', strtolower($nameToken->getContent()));
         }
 
-        if ('__' === substr($nameToken->getContent(), 0, 2)) {
+        if (0 === strpos($nameToken->getContent(), '__')) {
             return 'magic';
         }
 

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -58,7 +58,7 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
             }
 
             if ($token->isGivenKind(T_COMMENT)) {
-                if ('/*' === substr($token->getContent(), 0, 2)) {
+                if (0 === strpos($token->getContent(), '/*')) {
                     $tokens[$index] = new Token(array(T_COMMENT, preg_replace('/[ \t]+$/m', '', $token->getContent())));
                 } elseif (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
                     $trimmedContent = ltrim($tokens[$index + 1]->getContent(), " \t");

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -176,7 +176,7 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
                     $i += 2;
                 }
 
-                if ($token->isWhitespace(" \t") || '//' !== substr($tokens[$i - 1]->getContent(), 0, 2)) {
+                if ($token->isWhitespace(" \t") || 0 !== strpos($tokens[$i - 1]->getContent(), '//')) {
                     continue;
                 }
             }

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -82,7 +82,7 @@ final class ToolInfo implements ToolInfoInterface
 
     public function isInstalledAsPhar()
     {
-        return 'phar://' === substr(__DIR__, 0, 7);
+        return 0 === strpos(__DIR__, 'phar://');
     }
 
     public function isInstalledByComposer()


### PR DESCRIPTION
Some benefits:

- Less to maintain (only one value instead of two to change)
- Faster
- Less memory intensive
- Slightly less code 😉 