### PR TITLE
Fix `fopen` mode

### DIFF
--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -40,7 +40,7 @@ final class ErrorOutputTest extends TestCase
     {
         $source = $error->getSource();
 
-        $output = new StreamOutput(fopen('php://memory', 'bw', false));
+        $output = new StreamOutput(fopen('php://memory', 'wb', false));
         $output->setDecorated(false);
         $output->setVerbosity($verbosityLevel);
 


### PR DESCRIPTION
From the [manual](http://php.net/manual/en/function.fopen.php):

> To use these flags, specify either 'b' or 't' as the last character of the mode parameter.