### PR TITLE
Better type hinting for AbstractFixerTestCase::$fixer

### DIFF
--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Tests\Test;
 
 use GeckoPackages\PHPUnit\Constraints\SameStringsConstraint;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Linter\Linter;
@@ -37,7 +38,7 @@ abstract class AbstractFixerTestCase extends TestCase
     protected $linter;
 
     /**
-     * @var null|FixerInterface
+     * @var null|ConfigurableFixerInterface|FixerInterface
      */
     protected $fixer;
 


### PR DESCRIPTION
So IDE won't complain that `Method 'configure' not found in null|\PhpCsFixer\Fixer\FixerInterface`.