### PR TITLE
DescribeCommand: add fixer class when verbose

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -156,6 +156,10 @@ final class DescribeCommand extends Command
             $description .= sprintf(' <error>DEPRECATED</error>: %s.', $message);
         }
 
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+            $output->writeln(sprintf('Fixer class: <comment>%s</comment>.', get_class($fixer)));
+        }
+
         $output->writeln(sprintf('<info>Description of</info> %s <info>rule</info>.', $name));
         $output->writeln($description);
         if ($definition->getDescription()) {

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -156,11 +156,11 @@ final class DescribeCommand extends Command
             $description .= sprintf(' <error>DEPRECATED</error>: %s.', $message);
         }
 
+        $output->writeln(sprintf('<info>Description of</info> %s <info>rule</info>.', $name));
         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
             $output->writeln(sprintf('Fixer class: <comment>%s</comment>.', get_class($fixer)));
         }
 
-        $output->writeln(sprintf('<info>Description of</info> %s <info>rule</info>.', $name));
         $output->writeln($description);
         if ($definition->getDescription()) {
             $output->writeln($definition->getDescription());

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -23,6 +23,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Tokenizer\Token;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -179,6 +180,37 @@ EOT;
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageRegExp('#^Rule "Foo2/bar" not found\. Did you mean "Foo/bar"\?$#');
         $this->execute('Foo2/bar', false);
+    }
+
+    public function testFixerClassNameIsExposedWhenVerbose()
+    {
+        $fixerName = uniqid('Foo/bar_');
+
+        $fixer = $this->prophesize(\PhpCsFixer\Fixer\FixerInterface::class);
+        $fixer->getName()->willReturn($fixerName);
+        $fixer->getPriority()->willReturn(0);
+        $fixer->isRisky()->willReturn(true);
+        $mock = $fixer->reveal();
+
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerFixer($mock, true);
+
+        $this->application->add(new DescribeCommand($fixerFactory));
+
+        $command = $this->application->find('describe');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            [
+                'command' => $command->getName(),
+                'name' => $fixerName,
+            ],
+            [
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+            ]
+        );
+
+        $this->assertContains(get_class($mock), $commandTester->getDisplay(true));
     }
 
     /**


### PR DESCRIPTION
Following https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3413 as I have no idea why Github doesn't allow changing the branch back to master.

Also implemented https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3413#discussion_r160126392