### PR TITLE
FileFilterIterator - input checks and utests

### DIFF
--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|string[]|\Traversable
+     * @return iterable|\Traversable
      */
     public function getFinder();
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -54,7 +54,6 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\PharChecker',
         'PhpCsFixer\Report\ReportSummary',
         'PhpCsFixer\Runner\FileCachingLintingIterator',
-        'PhpCsFixer\Runner\FileFilterIterator',
         'PhpCsFixer\Runner\FileLintingIterator',
         'PhpCsFixer\StdinFileInfo',
         'PhpCsFixer\Tokenizer\Transformers',

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -12,13 +12,14 @@
 
 namespace PhpCsFixer\Tests\Runner;
 
-use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\FixerFileProcessedEvent;
 use PhpCsFixer\Runner\FileFilterIterator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
+ * @author SpacePossum
+ *
  * @internal
  *
  * @covers \PhpCsFixer\Runner\FileFilterIterator
@@ -41,12 +42,12 @@ final class FileFilterIteratorTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addListener(
             FixerFileProcessedEvent::NAME,
-            static function ($event) use (&$events) {
+            function ($event) use (&$events) {
                 $events[] = $event;
             }
         );
 
-        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache = $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface');
         $cache->needFixing($file, $content)->willReturn(true);
 
         $fileInfo = new \SplFileInfo($file);
@@ -79,7 +80,7 @@ final class FileFilterIteratorTest extends TestCase
             }
         );
 
-        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache = $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface');
         $cache->needFixing($file, $content)->willReturn(false);
 
         $filter = new FileFilterIterator(
@@ -94,7 +95,7 @@ final class FileFilterIteratorTest extends TestCase
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        $this->assertInstanceOf(FixerFileProcessedEvent::class, $event);
+        $this->assertInstanceOf('PhpCsFixer\FixerFileProcessedEvent', $event);
         $this->assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 
@@ -112,7 +113,7 @@ final class FileFilterIteratorTest extends TestCase
             }
         );
 
-        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache = $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface');
         $cache->needFixing($file, $content)->willReturn(true);
 
         $filter = new FileFilterIterator(
@@ -127,7 +128,7 @@ final class FileFilterIteratorTest extends TestCase
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        $this->assertInstanceOf(FixerFileProcessedEvent::class, $event);
+        $this->assertInstanceOf('PhpCsFixer\FixerFileProcessedEvent', $event);
         $this->assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 
@@ -147,7 +148,7 @@ final class FileFilterIteratorTest extends TestCase
                 new \SplFileInfo('__INVALID__'),
             )),
             $eventDispatcher,
-            $this->prophesize(CacheManagerInterface::class)->reveal()
+            $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface')->reveal()
         );
 
         $this->assertCount(0, $filter);
@@ -158,7 +159,7 @@ final class FileFilterIteratorTest extends TestCase
         $file = __FILE__;
         $content = file_get_contents($file);
 
-        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache = $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface');
         $cache->needFixing($file, $content)->willReturn(false);
 
         $filter = new FileFilterIterator(
@@ -175,11 +176,11 @@ final class FileFilterIteratorTest extends TestCase
         $filter = new FileFilterIterator(
             new \ArrayIterator(array(__FILE__)),
             null,
-            $this->prophesize(CacheManagerInterface::class)->reveal()
+            $this->prophesize('PhpCsFixer\Cache\CacheManagerInterface')->reveal()
         );
 
         $this->setExpectedExceptionRegExp(
-            \RuntimeException::class,
+            'RuntimeException',
             '#^Expected instance of "\\\SplFileInfo", got "string"\.$#'
         );
 

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Runner;
+
+use PhpCsFixer\Cache\CacheManagerInterface;
+use PhpCsFixer\FixerFileProcessedEvent;
+use PhpCsFixer\Runner\FileFilterIterator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Runner\FileFilterIterator
+ */
+final class FileFilterIteratorTest extends TestCase
+{
+    /**
+     * @param int $repeat
+     *
+     * @testWith [1]
+     *           [2]
+     *           [3]
+     */
+    public function testAccept($repeat)
+    {
+        $file = __FILE__;
+        $content = file_get_contents($file);
+        $events = array();
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            FixerFileProcessedEvent::NAME,
+            static function ($event) use (&$events) {
+                $events[] = $event;
+            }
+        );
+
+        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache->needFixing($file, $content)->willReturn(true);
+
+        $fileInfo = new \SplFileInfo($file);
+
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array_fill(0, $repeat, $fileInfo)),
+            $eventDispatcher,
+            $cache->reveal()
+        );
+
+        $this->assertCount(0, $events);
+
+        $files = iterator_to_array($filter);
+
+        $this->assertCount(1, $files);
+        $this->assertSame($fileInfo, reset($files));
+    }
+
+    public function testEmitSkipEventWhenCacheNeedFixingFalse()
+    {
+        $file = __FILE__;
+        $content = file_get_contents($file);
+        $events = array();
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            FixerFileProcessedEvent::NAME,
+            static function ($event) use (&$events) {
+                $events[] = $event;
+            }
+        );
+
+        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache->needFixing($file, $content)->willReturn(false);
+
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array(new \SplFileInfo($file))),
+            $eventDispatcher,
+            $cache->reveal()
+        );
+
+        $this->assertCount(0, $filter);
+        $this->assertCount(1, $events);
+
+        /** @var FixerFileProcessedEvent $event */
+        $event = reset($events);
+
+        $this->assertInstanceOf(FixerFileProcessedEvent::class, $event);
+        $this->assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
+    }
+
+    public function testIgnoreEmptyFile()
+    {
+        $file = __DIR__.'/../Fixtures/empty.php';
+        $content = file_get_contents($file);
+        $events = array();
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            FixerFileProcessedEvent::NAME,
+            static function ($event) use (&$events) {
+                $events[] = $event;
+            }
+        );
+
+        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache->needFixing($file, $content)->willReturn(true);
+
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array(new \SplFileInfo($file))),
+            $eventDispatcher,
+            $cache->reveal()
+        );
+
+        $this->assertCount(0, $filter);
+        $this->assertCount(1, $events);
+
+        /** @var FixerFileProcessedEvent $event */
+        $event = reset($events);
+
+        $this->assertInstanceOf(FixerFileProcessedEvent::class, $event);
+        $this->assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
+    }
+
+    public function testIgnore()
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            FixerFileProcessedEvent::NAME,
+            function () {
+                throw new \Exception('No event expected.');
+            }
+        );
+
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array(
+                new \SplFileInfo(__DIR__),
+                new \SplFileInfo('__INVALID__'),
+            )),
+            $eventDispatcher,
+            $this->prophesize(CacheManagerInterface::class)->reveal()
+        );
+
+        $this->assertCount(0, $filter);
+    }
+
+    public function testWithoutDispatcher()
+    {
+        $file = __FILE__;
+        $content = file_get_contents($file);
+
+        $cache = $this->prophesize(CacheManagerInterface::class);
+        $cache->needFixing($file, $content)->willReturn(false);
+
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array(new \SplFileInfo($file))),
+            null,
+            $cache->reveal()
+        );
+
+        $this->assertCount(0, $filter);
+    }
+
+    public function testInvalidIterator()
+    {
+        $filter = new FileFilterIterator(
+            new \ArrayIterator(array(__FILE__)),
+            null,
+            $this->prophesize(CacheManagerInterface::class)->reveal()
+        );
+
+        $this->setExpectedExceptionRegExp(
+            \RuntimeException::class,
+            '#^Expected instance of "\\\SplFileInfo", got "string"\.$#'
+        );
+
+        iterator_to_array($filter);
+    }
+}

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @internal
  *
  * @covers \PhpCsFixer\Runner\FileFilterIterator
+ * @requires PHP 5.4
  */
 final class FileFilterIteratorTest extends TestCase
 {

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -23,7 +23,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  * @internal
  *
  * @covers \PhpCsFixer\Runner\FileFilterIterator
- * @requires PHP 5.4
  */
 final class FileFilterIteratorTest extends TestCase
 {
@@ -76,7 +75,7 @@ final class FileFilterIteratorTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addListener(
             FixerFileProcessedEvent::NAME,
-            static function ($event) use (&$events) {
+            function ($event) use (&$events) {
                 $events[] = $event;
             }
         );
@@ -109,7 +108,7 @@ final class FileFilterIteratorTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addListener(
             FixerFileProcessedEvent::NAME,
-            static function ($event) use (&$events) {
+            function ($event) use (&$events) {
                 $events[] = $event;
             }
         );


### PR DESCRIPTION
Tree shake of https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3364 ,
removing `string[]` support even more will be done in a follow up PR.
  