### PR TITLE
SingleLineCommentStyleFixer - fix 'strpos() expects parameter 1 to be string, boolean given'

### DIFF
--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -116,7 +116,8 @@ $c = 3;
             }
 
             $content = $token->getContent();
-            $commentContent = substr($content, 2, -2);
+            $commentContent = substr($content, 2, -2) ?: '';
+
             if ($this->hashEnabled && '#' === $content[0]) {
                 $tokens[$index] = new Token([$token->getId(), '//'.substr($content, 1)]);
 

--- a/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+++ b/tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
@@ -149,7 +149,14 @@ $a = 1; /* after code */
 s    *
      */',
             ],
-
+            'empty comment' => [
+                '<?php
+//
+',
+                '<?php
+/**/
+',
+            ],
             // Untouched cases
             [
                 '<?php


### PR DESCRIPTION


broken since #3318