### PR TITLE
Add PhpUnitSetUpTearDownVisibilityFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -44,6 +44,7 @@ $config = PhpCsFixer\Config::create()
         'no_useless_return' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => true,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => true,

--- a/README.rst
+++ b/README.rst
@@ -1125,6 +1125,11 @@ Choose from the list of available rules:
     ``'newest'``
   - ``use_class_const`` (``bool``): use ::class notation; defaults to ``true``
 
+* **php_unit_set_up_tear_down_visibility**
+
+  Changes the visibility of the setUp and tearDown functions of phpunit to
+  protected, to match its parent.
+
 * **php_unit_strict**
 
   PHPUnit methods like ``assertSame`` should be used instead of

--- a/README.rst
+++ b/README.rst
@@ -1128,7 +1128,7 @@ Choose from the list of available rules:
 * **php_unit_set_up_tear_down_visibility**
 
   Changes the visibility of the setUp and tearDown functions of phpunit to
-  protected, to match its parent.
+  protected, to match the PHPUnit TestCase.
 
 * **php_unit_strict**
 

--- a/README.rst
+++ b/README.rst
@@ -1130,6 +1130,8 @@ Choose from the list of available rules:
   Changes the visibility of the setUp and tearDown functions of phpunit to
   protected, to match the PHPUnit TestCase.
 
+  *Risky rule: this fixer may change functions named setUp or tearDown outside of PHPUnit tests, when a class is wrongly seen as a PHPUnit test.*
+
 * **php_unit_strict**
 
   PHPUnit methods like ``assertSame`` should be used instead of

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -50,8 +50,19 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 }
 '
                 ),
-            ]
+            ],
+            null,
+            'This fixer may change functions named setUp or tearDown outside of PHPUnit tests, '.
+            'when a class is wrongly seen as a PHPUnit test.'
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -97,7 +97,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     private function fixSetUpAndTearDown(Tokens $tokens, $startIndex, $endIndex)
     {
-
         $counter = 0;
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * @author Gert de Pagter
+ */
+final class PhpUnitSetUpTearDownVisibilityFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Changes the visibility of the setUp and tearDown functions of phpunit to protected, to match its parent.',
+            [
+                new CodeSample(
+                    '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    private $hello;
+    public function setUp()
+    {
+        $this->hello = "hello";
+    }
+
+    public function tearDown()
+    {
+        $this->hello = null;
+    }
+}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_FUNCTION]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach (array_reverse($this->findPhpUnitClasses($tokens)) as $indexes) {
+            $this->fixSetUpAndTearDown($tokens, $indexes[0], $indexes[1]);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     *
+     * @return int[][] array of [start, end] indexes from sooner to later classes
+     */
+    private function findPhpUnitClasses(Tokens $tokens)
+    {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+        $phpunitClasses = [];
+
+        for ($index = 0, $limit = $tokens->count() - 1; $index < $limit; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_CLASS) && $phpUnitTestCaseIndicator->isPhpUnitClass($tokens, $index)) {
+                $index = $tokens->getNextTokenOfKind($index, ['{']);
+                $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+                $phpunitClasses[] = [$index, $endIndex];
+                $index = $endIndex;
+            }
+        }
+
+        return $phpunitClasses;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startIndex
+     * @param int    $endIndex
+     */
+    private function fixSetUpAndTearDown(Tokens $tokens, $startIndex, $endIndex)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        for ($i = $endIndex - 1; $i > $startIndex; --$i) {
+            if (!$this->isMethod($tokens, $i)) {
+                continue;
+            }
+            if (!$this->isMethodSetUpOrTearDown($tokens, $i)) {
+                continue;
+            }
+
+            $visibility = $tokensAnalyzer->getMethodAttributes($i)['visibility'];
+
+            if (T_PROTECTED === $visibility) {
+                continue;
+            }
+
+            if (T_PUBLIC === $visibility) {
+                do {
+                    $i = $tokens->getPrevMeaningfulToken($i);
+                } while (!$tokens[$i]->isGivenKind(T_PUBLIC));
+
+                $tokens[$i] = new Token([T_PROTECTED, 'protected']);
+
+                continue;
+            }
+
+            if (null === $visibility) {
+                $tokens->insertAt($i, [new Token([T_PROTECTED, 'protected']), new Token([T_WHITESPACE, ' '])]);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isMethod(Tokens $tokens, $index)
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        return $tokens[$index]->isGivenKind(T_FUNCTION) && !$tokensAnalyzer->isLambda($index);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isMethodSetUpOrTearDown(Tokens $tokens, $index)
+    {
+        $functionNameIndex = $tokens->getNextMeaningfulToken($index);
+        $functionName = \strtolower($tokens[$functionNameIndex]->getContent());
+
+        if ('setup' !== $functionName && 'teardown' !== $functionName) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -60,17 +60,17 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function isRisky()
+    public function isCandidate(Tokens $tokens)
     {
-        return true;
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_FUNCTION]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isCandidate(Tokens $tokens)
+    public function isRisky()
     {
-        return $tokens->isAllTokenKindsFound([T_CLASS, T_FUNCTION]);
+        return true;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -86,7 +86,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * @param Tokens $tokens
      *
-     * @return \Generator
+     * @return int[]
      */
     private function findPhpUnitClasses(Tokens $tokens)
     {

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -112,21 +112,16 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 
         for ($i = $endIndex - 1; $i > $startIndex; --$i) {
-            if ($counter >= 2) {
-                break;
+            if (2 === $counter) {
+                break; // we've seen both method we are interested in, so stop analyzing this class
             }
 
-            if (!$this->isMethodSetUpOrTearDown($tokens, $i)) {
+            if (!$this->isSetupOrTearDownMethod($tokens, $i)) {
                 continue;
             }
 
             ++$counter;
-
             $visibility = $tokensAnalyzer->getMethodAttributes($i)['visibility'];
-
-            if (T_PROTECTED === $visibility || T_PRIVATE === $visibility) {
-                continue;
-            }
 
             if (T_PUBLIC === $visibility) {
                 $index = $tokens->getPrevTokenOfKind($i, [[T_PUBLIC]]);
@@ -147,7 +142,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      *
      * @return bool
      */
-    private function isMethodSetUpOrTearDown(Tokens $tokens, $index)
+    private function isSetupOrTearDownMethod(Tokens $tokens, $index)
     {
         $tokensAnalyzer = new TokensAnalyzer($tokens);
 

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer
+ */
+final class PhpUnitSetUpTearDownVisibilityFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param mixed      $expected
+     * @param null|mixed $input
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFixCases()
+    {
+        return [
+            'setUp and tearDown are made protected if they are public' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public function setUp() {}
+
+    public function tearDown() {}
+}
+',
+            ],
+            'setUp and tearDown stay protected if they are' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+}
+',
+            ],
+            'Other functions are ignored' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+    public function hello() {}
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+
+    public function testWork() {}
+
+    protected function testProtectedFunction() {}
+
+    private function privateHelperFunction() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+    public function hello() {}
+
+    public function setUp() {}
+
+    public function tearDown() {}
+
+    public function testWork() {}
+
+    protected function testProtectedFunction() {}
+
+    private function privateHelperFunction() {}
+}
+',
+            ],
+            'It works when setUp and tearDown are final' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected final function setUp() {}
+
+    final protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public final function setUp() {}
+
+    final public function tearDown() {}
+}
+',
+            ],
+            'It works when setUp and tearDown do not have visibility defined' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    function setUp() {}
+
+    function tearDown() {}
+}
+',
+            ],
+            'It works when setUp and tearDown do not have visibility defined and are final' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    final protected function setUp() {}
+
+    final protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    final function setUp() {}
+
+    final function tearDown() {}
+}
+',
+            ],
+            'Functions outside a test class do not get changed' => [
+                '<?php
+class Fixer extends OtherClass
+{
+    public function hello() {}
+
+    public function setUp() {}
+
+    public function tearDown() {}
+
+    public function testWork() {}
+
+    protected function testProtectedFunction() {}
+
+    private function privateHelperFunction() {}
+}
+',
+            ],
+            'It works even when setup and teardown have improper casing' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function sEtUp() {}
+
+    protected function TeArDoWn() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public function sEtUp() {}
+
+    public function TeArDoWn() {}
+}
+',
+            ],
+            'It works even with messy comments' => [
+                    '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected /** foo */ function setUp() {}
+
+    /** foo */protected function tearDown() {}
+}
+',
+                    '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public /** foo */ function setUp() {}
+
+    /** foo */public function tearDown() {}
+}
+',
+            ],
+            'It works even with messy comments and no defined visibility' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    /** foo */protected function setUp() {}
+
+    /** bar */protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    /** foo */function setUp() {}
+
+    /** bar */function tearDown() {}
+}
+',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -15,6 +15,8 @@ namespace PhpCsFixer\Tests\Fixer\PhpUnit;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
+ * @author Gert de Pagter
+ *
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer
@@ -42,7 +44,6 @@ final class PhpUnitSetUpTearDownVisibilityFixerTest extends AbstractFixerTestCas
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected function setUp() {}
 
     protected function tearDown() {}
@@ -51,7 +52,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public function setUp() {}
 
     public function tearDown() {}
@@ -96,7 +96,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected final function setUp() {}
 
     final protected function tearDown() {}
@@ -105,7 +104,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public final function setUp() {}
 
     final public function tearDown() {}
@@ -116,7 +114,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected function setUp() {}
 
     protected function tearDown() {}
@@ -125,7 +122,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     function setUp() {}
 
     function tearDown() {}
@@ -136,7 +132,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     final protected function setUp() {}
 
     final protected function tearDown() {}
@@ -145,7 +140,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     final function setUp() {}
 
     final function tearDown() {}
@@ -174,7 +168,6 @@ class Fixer extends OtherClass
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected function sEtUp() {}
 
     protected function TeArDoWn() {}
@@ -183,7 +176,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public function sEtUp() {}
 
     public function TeArDoWn() {}
@@ -194,7 +186,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                     '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected /** foo */ function setUp() {}
 
     /** foo */protected function tearDown() {}
@@ -203,7 +194,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                     '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public /** foo */ function setUp() {}
 
     /** foo */public function tearDown() {}
@@ -214,7 +204,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     /** foo */protected function setUp() {}
 
     /** bar */protected function tearDown() {}
@@ -223,7 +212,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     /** foo */function setUp() {}
 
     /** bar */function tearDown() {}
@@ -234,7 +222,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     private function setUp() {}
 
     private function tearDown() {}
@@ -245,7 +232,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected function setUp() {}
 
     protected function tearDown() {}
@@ -253,7 +239,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
 
 class OtherTest extends \PhpUnit\FrameWork\TestCase
 {
-
     protected function setUp() {}
 
     protected function tearDown() {}
@@ -262,7 +247,6 @@ class OtherTest extends \PhpUnit\FrameWork\TestCase
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public function setUp() {}
 
     public function tearDown() {}
@@ -270,7 +254,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
 
 class OtherTest extends \PhpUnit\FrameWork\TestCase
 {
-
     public function setUp() {}
 
     public function tearDown() {}

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -24,8 +24,8 @@ final class PhpUnitSetUpTearDownVisibilityFixerTest extends AbstractFixerTestCas
     /**
      * @dataProvider provideFixCases
      *
-     * @param mixed      $expected
-     * @param null|mixed $input
+     * @param mixed       $expected
+     * @param null|string $input
      */
     public function testFix($expected, $input = null)
     {

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -241,6 +241,42 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
 }
 ',
             ],
+            'It works when there are multiple classes in one file' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+}
+
+class OtherTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    protected function setUp() {}
+
+    protected function tearDown() {}
+}
+',
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public function setUp() {}
+
+    public function tearDown() {}
+}
+
+class OtherTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    public function setUp() {}
+
+    public function tearDown() {}
+}
+',
+            ],
         ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -58,17 +58,6 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
 }
 ',
             ],
-            'setUp and tearDown stay protected if they are' => [
-                '<?php
-class FixerTest extends \PhpUnit\FrameWork\TestCase
-{
-
-    protected function setUp() {}
-
-    protected function tearDown() {}
-}
-',
-            ],
             'Other functions are ignored' => [
                 '<?php
 class FixerTest extends \PhpUnit\FrameWork\TestCase

--- a/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
@@ -241,6 +241,17 @@ class FixerTest extends \PhpUnit\FrameWork\TestCase
 }
 ',
             ],
+            'Nothing changes if setUp or tearDown are private' => [
+                '<?php
+class FixerTest extends \PhpUnit\FrameWork\TestCase
+{
+
+    private function setUp() {}
+
+    private function tearDown() {}
+}
+',
+            ],
         ];
     }
 }

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -56,7 +56,7 @@ final class CiIntegrationTest extends TestCase
         self::executeCommand('rm -rf .git');
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         parent::tearDown();
 


### PR DESCRIPTION
This fixer changes the setup and teardown function of phpunit classes to protected, to match its parent.

As talked about in #2538

This is ready for review