### PR TITLE
PhpUnitTestAnnotationFixer: Do not prepend with test if method is test()

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -300,7 +300,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             return false;
         }
 
-        if  (strlen($functionName) === 4) {
+        if (4 === strlen($functionName)) {
             return true;
         }
 

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -300,7 +300,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             return false;
         }
 
-        if (4 === strlen($functionName)) {
+        if ('test' === $functionName) {
             return true;
         }
 

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -296,8 +296,12 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     private function hasTestPrefix($functionName)
     {
-        if (!$this->startsWith('test', $functionName) || strlen($functionName) < 5) {
+        if (!$this->startsWith('test', $functionName)) {
             return false;
+        }
+
+        if  (strlen($functionName) === 4) {
+            return true;
         }
 
         $nextCharacter = $functionName[4];

--- a/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
@@ -1037,6 +1037,25 @@ class Test extends \PhpUnit\FrameWork\TestCase
 }',
                 ['style' => 'prefix'],
             ],
+            'Annotation present, but method is test prefix' => [
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     *
+     */
+    public function test() {}
+}',
+                '<?php
+class Test extends \PhpUnit\FrameWork\TestCase
+{
+    /**
+     * @test
+     */
+    public function test() {}
+}',
+                ['style' => 'prefix'],
+            ],
             'Abstract test gets annotation added' => [
                 '<?php
 abstract class Test extends \PhpUnit\FrameWork\TestCase


### PR DESCRIPTION
This PR

* [x] adds a failing test case
* [x] fixes the edge case

Fixes #3437.