### PR TITLE
Add CommentToPhpdocFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -22,6 +22,7 @@ $config = PhpCsFixer\Config::create()
         'blank_line_before_statement' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
+        'comment_to_phpdoc' => true,
         'compact_nullable_typehint' => true,
         'escape_implicit_backslashes' => true,
         'explicit_indirect_variable' => true,

--- a/README.rst
+++ b/README.rst
@@ -365,6 +365,10 @@ Choose from the list of available rules:
 
   Calling ``unset`` on multiple items should be done in one call.
 
+* **comment_to_phpdoc**
+
+  Comments with annotation should be docblock.
+
 * **compact_nullable_typehint**
 
   Remove extra spaces in a nullable typehint.

--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,8 @@ Choose from the list of available rules:
 
   Comments with annotation should be docblock.
 
+  *Risky rule: risky as new docblocks might began mean more, e.g. Doctrine's entity might have a new column in database.*
+
 * **compact_nullable_typehint**
 
   Remove extra spaces in a nullable typehint.

--- a/src/Console/WarningsDetector.php
+++ b/src/Console/WarningsDetector.php
@@ -39,8 +39,10 @@ final class WarningsDetector
 
     public function detectOldMajor()
     {
-        // @TODO 3.0 to be activated with new MAJOR release
-        // $this->warnings[] = 'You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.';
+        /*
+         * @TODO 3.0 to be activated with new MAJOR release
+         * $this->warnings[] = 'You are running PHP CS Fixer v2, which is not maintained anymore. Please update to v3.';
+         */
     }
 
     public function detectOldVendor()

--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -37,6 +37,14 @@ final class CommentToPhpdocFixer extends AbstractFixer implements WhitespacesAwa
     /**
      * {@inheritdoc}
      */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getPriority()
     {
         // Should be run before PhpdocToCommentFixer
@@ -50,11 +58,9 @@ final class CommentToPhpdocFixer extends AbstractFixer implements WhitespacesAwa
     {
         return new FixerDefinition(
             'Comments with annotation should be docblock.',
-            [
-                new CodeSample(
-                    "<?php /* @var bool \$isFoo */\n"
-                ),
-            ]
+            [new CodeSample("<?php /* @var bool \$isFoo */\n")],
+            null,
+            "Risky as new docblocks might began mean more, e.g. Doctrine's entity might have a new column in database"
         );
     }
 

--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Comment;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ */
+final class CommentToPhpdocFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // Should be run before PhpdocToCommentFixer
+        return 26;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Comments with annotation should be docblock.',
+            [
+                new CodeSample(
+                    "<?php /* @var bool \$isFoo */\n"
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_COMMENT)) {
+                continue;
+            }
+
+            if (1 === preg_match('~(#|//|/\*+|\R(\s*\*)?)\s*\@[a-zA-Z0-9_\\\\-]+(?=\s|\(|$)~', $token->getContent())) {
+                $tokens[$index] = new Token([T_DOC_COMMENT, $this->fixContent($token->getContent())]);
+            }
+        }
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return string
+     */
+    private function fixContent($content)
+    {
+        if (0 === strpos($content, '#')) {
+            $content = substr($content, 1);
+        } elseif (0 === strpos($content, '//')) {
+            $content = substr($content, 2);
+        } else {
+            $content = ltrim($content, '/*');
+            $content = rtrim($content, '*/');
+        }
+
+        if ('' !== trim(substr($content, 0, 1))) {
+            $content = ' '.$content;
+        }
+
+        if ('' !== trim(substr($content, -1))) {
+            $content .= ' ';
+        }
+
+        return '/**'.$content.'*/';
+    }
+}

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -154,8 +154,10 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurationDefin
             ->setAllowedValues([
                 $generator->allowedValueIsSubsetOf(self::$alignableTags),
             ])
-            // By default, all tags apart from @property and @method will be aligned for backwards compatibility
-            // @TODO 3.0 Align all available tags by default
+            /*
+             * By default, all tags apart from @property and @method will be aligned for backwards compatibility
+             * @TODO 3.0 Align all available tags by default
+             */
             ->setDefault([
                 'param',
                 'return',

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class CommentsAnalyzer
+{
+    const TYPE_HASH = 1;
+    const TYPE_DOUBLE_SLASH = 2;
+    const TYPE_SLASH_ASTERISK = 3;
+
+    /**
+     * Return array of indices that are part of a comment started at given index.
+     *
+     * @param Tokens $tokens
+     * @param int    $index  T_COMMENT index
+     *
+     * @return null|array
+     */
+    public function getCommentBlockIndices(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index]->isGivenKind(T_COMMENT)) {
+            throw new \InvalidArgumentException('Given index must point to a comment.');
+        }
+
+        $commentType = $this->getCommentType($tokens[$index]->getContent());
+        $indices = [$index];
+
+        if (self::TYPE_SLASH_ASTERISK === $commentType) {
+            return $indices;
+        }
+
+        $count = count($tokens);
+        ++$index;
+
+        for (; $index < $count; ++$index) {
+            if ($tokens[$index]->isComment()) {
+                if ($commentType === $this->getCommentType($tokens[$index]->getContent())) {
+                    $indices[] = $index;
+
+                    continue;
+                }
+
+                break;
+            }
+
+            if (!$tokens[$index]->isWhitespace() || $this->getLineBreakCount($tokens, $index, $index + 1) > 1) {
+                break;
+            }
+        }
+
+        return $indices;
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return int
+     */
+    private function getCommentType($content)
+    {
+        if ('#' === $content[0]) {
+            return self::TYPE_HASH;
+        }
+
+        if ('*' === $content[1]) {
+            return self::TYPE_SLASH_ASTERISK;
+        }
+
+        return self::TYPE_DOUBLE_SLASH;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $whiteStart
+     * @param int    $whiteEnd
+     *
+     * @return int
+     */
+    private function getLineBreakCount(Tokens $tokens, $whiteStart, $whiteEnd)
+    {
+        $lineCount = 0;
+        for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
+            $lineCount += preg_match_all('/\R/u', $tokens[$i]->getContent());
+        }
+
+        return $lineCount;
+    }
+}

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -206,11 +206,13 @@ final class FixerFactoryTest extends TestCase
         $cases = [];
 
         // prepare bulk tests for phpdoc fixers to test that:
-        // * `phpdoc_to_comment` is first
-        // * `phpdoc_indent` is second
-        // * `phpdoc_types` is third
-        // * `phpdoc_scalar` is fourth
+        // * `comment_to_phpdoc` is first
+        // * `phpdoc_to_comment` is second
+        // * `phpdoc_indent` is third
+        // * `phpdoc_types` is fourth
+        // * `phpdoc_scalar` is fifth
         // * `phpdoc_align` is last
+        $cases[] = [$fixers['comment_to_phpdoc'], $fixers['phpdoc_to_comment']];
         $cases[] = [$fixers['phpdoc_indent'], $fixers['phpdoc_types']];
         $cases[] = [$fixers['phpdoc_to_comment'], $fixers['phpdoc_indent']];
         $cases[] = [$fixers['phpdoc_types'], $fixers['phpdoc_scalar']];
@@ -223,7 +225,8 @@ final class FixerFactoryTest extends TestCase
         );
 
         foreach ($docFixerNames as $docFixerName) {
-            if (!in_array($docFixerName, ['phpdoc_to_comment', 'phpdoc_indent', 'phpdoc_types', 'phpdoc_scalar'], true)) {
+            if (!in_array($docFixerName, ['comment_to_phpdoc', 'phpdoc_to_comment', 'phpdoc_indent', 'phpdoc_types', 'phpdoc_scalar'], true)) {
+                $cases[] = [$fixers['comment_to_phpdoc'], $fixers[$docFixerName]];
                 $cases[] = [$fixers['phpdoc_indent'], $fixers[$docFixerName]];
                 $cases[] = [$fixers['phpdoc_scalar'], $fixers[$docFixerName]];
                 $cases[] = [$fixers['phpdoc_to_comment'], $fixers[$docFixerName]];

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -55,8 +55,10 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
                 print("test");
                 ',
             ],
-            // `echo` can take multiple parameters (although such usage is rare) while `print` can take only one argument,
-            // @see https://secure.php.net/manual/en/function.echo.php and @see https://secure.php.net/manual/en/function.print.php
+            /*
+             * `echo` can take multiple parameters (although such usage is rare) while `print` can take only one argument,
+             * @see https://secure.php.net/manual/en/function.echo.php and @see https://secure.php.net/manual/en/function.print.php
+             */
             [
                 '<?php
                 echo "This ", "string ", "was ", "made ", "with multiple parameters.";

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -52,6 +52,10 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php /** @var string $foo */',
+                '<?php /*@var string $foo */',
+            ],
+            [
+                '<?php /** @var string $foo */',
                 '<?php /*** @var string $foo */',
             ],
             [

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Comment;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Comment\CommentToPhpdocFixer
+ */
+final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestCases()
+    {
+        return [
+            [
+                '<?php /* string $foo */',
+            ],
+            [
+                '<?php /* $yoda string @var */',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php /* @var string $foo */',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php /*** @var string $foo */',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php // @var string $foo',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php //@var string $foo',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php # @var string $foo',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php #@var string $foo',
+            ],
+            [
+                '<?php /** @var string $foo */',
+                '<?php #@var string $foo',
+            ],
+            [
+                <<<'EOT'
+<?php
+
+/**
+ * @var string $foo
+ */
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+/*
+ * @var string $foo
+ */
+EOT
+                ,
+            ],
+            [
+                <<<'EOT'
+<?php
+
+/**
+ * @Column(type="string", length=32, unique=true, nullable=false)
+ */
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+/*
+ * @Column(type="string", length=32, unique=true, nullable=false)
+ */
+EOT
+                ,
+            ],
+            [
+                <<<'EOT'
+<?php
+
+/**
+ * @ORM\Column(name="id", type="integer")
+ */
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+/*
+ * @ORM\Column(name="id", type="integer")
+ */
+EOT
+                ,
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -44,6 +44,9 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
                 '<?php /* $yoda string @var */',
             ],
             [
+                '<?php /* $yoda @var string */',
+            ],
+            [
                 '<?php /** @var string $foo */',
                 '<?php /* @var string $foo */',
             ],
@@ -86,6 +89,78 @@ EOT
 /*
  * @var string $foo
  */
+EOT
+                ,
+            ],
+            [
+                <<<'EOT'
+<?php
+
+/**
+ * This is my var
+ * @var string $foo
+ * stop using it
+ * @deprecated since 1.2
+ */
+$foo = 1;
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+// This is my var
+// @var string $foo
+// stop using it
+// @deprecated since 1.2
+$foo = 1;
+EOT
+                ,
+            ],
+            [
+                <<<'EOT'
+<?php
+
+for (;;) {
+    /**
+     * This is my var
+     * @var string $foo
+     */
+    $foo++;
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+for (;;) {
+    // This is my var
+    // @var string $foo
+    $foo++;
+}
+EOT
+                ,
+            ],
+            [
+                <<<'EOT'
+<?php
+
+/**
+ * This is my var
+ * @var string $foo
+ * stop using it
+ * @deprecated since 1.3
+ */
+$foo = 1;
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+# This is my var
+# @var string $foo
+# stop using it
+# @deprecated since 1.3
+$foo = 1;
 EOT
                 ,
             ],

--- a/tests/Fixtures/Integration/priority/comment_to_phpdoc,phpdoc_to_comment.test
+++ b/tests/Fixtures/Integration/priority/comment_to_phpdoc,phpdoc_to_comment.test
@@ -1,0 +1,12 @@
+--TEST--
+Integration of fixers: comment_to_phpdoc,phpdoc_to_comment.
+--RULESET--
+{"comment_to_phpdoc": true, "phpdoc_to_comment": true}
+--EXPECT--
+<?php
+$first = true;// needed because by default first docblock is ignored by phpdoc_to_comment.
+
+/* @var string $notContent */
+while ($content = $this->getContent()) {
+    $name .= $content;
+}

--- a/tests/Fixtures/Integration/priority/comment_to_phpdoc,phpdoc_to_comment.test
+++ b/tests/Fixtures/Integration/priority/comment_to_phpdoc,phpdoc_to_comment.test
@@ -6,6 +6,25 @@ Integration of fixers: comment_to_phpdoc,phpdoc_to_comment.
 <?php
 $first = true;// needed because by default first docblock is ignored by phpdoc_to_comment.
 
+/** @var string $content */
+while ($content = $this->getContent()) {
+    $name .= $content;
+}
+
+/* @var string $notContent */
+while ($content = $this->getContent()) {
+    $name .= $content;
+}
+
+--INPUT--
+<?php
+$first = true;// needed because by default first docblock is ignored by phpdoc_to_comment.
+
+/* @var string $content */
+while ($content = $this->getContent()) {
+    $name .= $content;
+}
+
 /* @var string $notContent */
 while ($content = $this->getContent()) {
     $name .= $content;

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\CommentsAnalyzer;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\Analyzer\CommentsAnalyzer
+ */
+final class CommentsAnalyzerTest extends TestCase
+{
+    public function testWhenNotPointingToComment()
+    {
+        $analyzer = new CommentsAnalyzer();
+        $tokens = Tokens::fromCode('<?php $no; $comment; $here;');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Given index must point to a comment.');
+
+        $analyzer->getCommentBlockIndices($tokens, 4);
+    }
+
+    /**
+     * @param string     $code
+     * @param int        $index
+     * @param null|array $borders
+     *
+     * @dataProvider provideCommentsCases
+     */
+    public function testComments($code, $index, $borders)
+    {
+        $tokens = Tokens::fromCode($code);
+        $analyzer = new CommentsAnalyzer();
+
+        $this->assertSame($borders, $analyzer->getCommentBlockIndices($tokens, $index));
+    }
+
+    public function provideCommentsCases()
+    {
+        return [
+            'discover all 4 comments for the 1st comment with slash' => [
+                '<?php
+$foo;
+// one
+// two
+// three
+// four
+$bar;',
+                4,
+                [4, 6, 8, 10],
+            ],
+            'discover all 4 comments for the 1st comment with hash' => [
+                '<?php
+$foo;
+# one
+# two
+# three
+# four
+$bar;',
+                4,
+                [4, 6, 8, 10],
+            ],
+            'discover 3 comments out of 4 for the 2nd comment' => [
+                '<?php
+$foo;
+// one
+// two
+// three
+// four
+$bar;',
+                6,
+                [6, 8, 10],
+            ],
+            'discover 3 comments when empty line separates 4th' => [
+                '<?php
+$foo;
+// one
+// two
+// three
+
+// four
+$bar;',
+                4,
+                [4, 6, 8],
+            ],
+            'discover 3 comments when empty line of CR separates 4th' => [
+                str_replace("\n", "\r", '<?php
+$foo;
+// one
+// two
+// three
+
+// four
+$bar;'),
+                4,
+                [4, 6, 8],
+            ],
+            'discover correctly when mix of slash and hash' => [
+                '<?php
+$foo;
+// one
+// two
+# three
+// four
+$bar;',
+                4,
+                [4, 6],
+            ],
+            'do not group asterisk comments' => [
+                '<?php
+$foo;
+/* one */
+/* two */
+/* three */
+$bar;',
+                4,
+                [4],
+            ],
+            'handle fancy indent' => [
+                '<?php
+$foo;
+        // one
+       //  two
+      //   three
+     //    four
+$bar;',
+                4,
+                [4, 6, 8, 10],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
As mentioned by @Slamdunk in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3439#issuecomment-357189286 here is a proposition of fixer
```diff
-/*
+/**
 * @var string $foo
 */
```
when the comment contains annotation.