### PR TITLE
Add PregWrapper

### DIFF
--- a/src/AbstractPsrAutoloadingFixer.php
+++ b/src/AbstractPsrAutoloadingFixer.php
@@ -64,7 +64,7 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
             // ignore file with extension other than php
             (!isset($filenameParts[1]) || 'php' !== $filenameParts[1])
             // ignore file with name that cannot be a class name
-            || 0 === PregWrapper::match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $filenameParts[0])
+            || 0 === Preg::match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $filenameParts[0])
             // ignore filename that will halt compiler (and cannot be properly tokenized under PHP 5.3)
             || '__halt_compiler' === $filenameParts[0]
         ) {
@@ -84,6 +84,6 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
         }
 
         // ignore stubs/fixtures, since they are typically containing invalid files for various reasons
-        return !PregWrapper::match('{[/\\\\](stub|fixture)s?[/\\\\]}i', $file->getRealPath());
+        return !Preg::match('{[/\\\\](stub|fixture)s?[/\\\\]}i', $file->getRealPath());
     }
 }

--- a/src/AbstractPsrAutoloadingFixer.php
+++ b/src/AbstractPsrAutoloadingFixer.php
@@ -64,7 +64,7 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
             // ignore file with extension other than php
             (!isset($filenameParts[1]) || 'php' !== $filenameParts[1])
             // ignore file with name that cannot be a class name
-            || 0 === preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $filenameParts[0])
+            || 0 === PregWrapper::match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $filenameParts[0])
             // ignore filename that will halt compiler (and cannot be properly tokenized under PHP 5.3)
             || '__halt_compiler' === $filenameParts[0]
         ) {
@@ -84,6 +84,6 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
         }
 
         // ignore stubs/fixtures, since they are typically containing invalid files for various reasons
-        return !preg_match('{[/\\\\](stub|fixture)s?[/\\\\]}i', $file->getRealPath());
+        return !PregWrapper::match('{[/\\\\](stub|fixture)s?[/\\\\]}i', $file->getRealPath());
     }
 }

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -24,7 +24,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
 use PhpCsFixer\FixerFactory;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\RuleSet;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -182,8 +182,8 @@ final class DescribeCommand extends Command
                     $line .= ' (<comment>'.implode('</comment>, <comment>', $allowed).'</comment>)';
                 }
 
-                $description = PregWrapper::replace('/(`.+?`)/', '<info>$1</info>', $option->getDescription());
-                $line .= ': '.lcfirst(PregWrapper::replace('/\.$/', '', $description)).'; ';
+                $description = Preg::replace('/(`.+?`)/', '<info>$1</info>', $option->getDescription());
+                $line .= ': '.lcfirst(Preg::replace('/\.$/', '', $description)).'; ';
                 if ($option->hasDefault()) {
                     $line .= sprintf(
                         'defaults to <comment>%s</comment>',

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -24,6 +24,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\RuleSet;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -181,8 +182,8 @@ final class DescribeCommand extends Command
                     $line .= ' (<comment>'.implode('</comment>, <comment>', $allowed).'</comment>)';
                 }
 
-                $description = preg_replace('/(`.+?`)/', '<info>$1</info>', $option->getDescription());
-                $line .= ': '.lcfirst(preg_replace('/\.$/', '', $description)).'; ';
+                $description = PregWrapper::replace('/(`.+?`)/', '<info>$1</info>', $option->getDescription());
+                $line .= ': '.lcfirst(PregWrapper::replace('/\.$/', '', $description)).'; ';
                 if ($option->hasDefault()) {
                     $line .= sprintf(
                         'defaults to <comment>%s</comment>',

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -19,7 +19,7 @@ use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerFactory;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\RuleSet;
 use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -289,7 +289,7 @@ EOF
 
             $str = var_export($value, true);
             do {
-                $strNew = PregWrapper::replace(
+                $strNew = Preg::replace(
                     $replaces[0],
                     $replaces[1],
                     $str
@@ -305,7 +305,7 @@ EOF
             $str = var_export($value, true);
         }
 
-        return PregWrapper::replace('/\bNULL\b/', 'null', $str);
+        return Preg::replace('/\bNULL\b/', 'null', $str);
     }
 
     /**
@@ -371,7 +371,7 @@ EOF
         }
 
         for ($i = (int) Application::VERSION; $i > 0; --$i) {
-            if (1 === PregWrapper::match('/Changelog for v('.$i.'.\d+.\d+)/', $changelog, $matches)) {
+            if (1 === Preg::match('/Changelog for v('.$i.'.\d+.\d+)/', $changelog, $matches)) {
                 $version = $matches[1];
 
                 break;
@@ -448,7 +448,7 @@ EOF
             }
 
             $description = implode("\n   | ", self::wordwrap(
-                PregWrapper::replace('/(`.+?`)/', '<info>$1</info>', $description),
+                Preg::replace('/(`.+?`)/', '<info>$1</info>', $description),
                 72
             ));
 
@@ -461,10 +461,10 @@ EOF
             if ($fixer->isRisky()) {
                 $help .= sprintf(
                     "   | *Risky rule: %s.*\n",
-                    PregWrapper::replace(
+                    Preg::replace(
                         '/(`.+?`)/',
                         '<info>$1</info>',
-                        lcfirst(PregWrapper::replace('/\.$/', '', $fixer->getDefinition()->getRiskyDescription()))
+                        lcfirst(Preg::replace('/\.$/', '', $fixer->getDefinition()->getRiskyDescription()))
                     )
                 );
             }
@@ -498,10 +498,10 @@ EOF
                             $line .= ' (<comment>'.implode('</comment>, <comment>', $allowed).'</comment>)';
                         }
 
-                        $line .= ': '.PregWrapper::replace(
+                        $line .= ': '.Preg::replace(
                             '/(`.+?`)/',
                             '<info>$1</info>',
-                            lcfirst(PregWrapper::replace('/\.$/', '', $option->getDescription()))
+                            lcfirst(Preg::replace('/\.$/', '', $option->getDescription()))
                         ).'; ';
                         if ($option->hasDefault()) {
                             $line .= 'defaults to <comment>'.self::toString($option->getDefault()).'</comment>';
@@ -524,7 +524,7 @@ EOF
         }
 
         // prevent "\</foo>" from being rendered as an escaped literal style tag
-        return PregWrapper::replace('#\\\\(</.*?>)#', '<<$1', $help);
+        return Preg::replace('#\\\\(</.*?>)#', '<<$1', $help);
     }
 
     /**
@@ -541,7 +541,7 @@ EOF
         $currentLine = 0;
         $lineLength = 0;
         foreach (explode(' ', $string) as $word) {
-            $wordLength = strlen(PregWrapper::replace('~</?(\w+)>~', '', $word));
+            $wordLength = strlen(Preg::replace('~</?(\w+)>~', '', $word));
             if (0 !== $lineLength) {
                 ++$wordLength; // space before word
             }

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\RuleSet;
 use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -288,7 +289,7 @@ EOF
 
             $str = var_export($value, true);
             do {
-                $strNew = preg_replace(
+                $strNew = PregWrapper::replace(
                     $replaces[0],
                     $replaces[1],
                     $str
@@ -304,7 +305,7 @@ EOF
             $str = var_export($value, true);
         }
 
-        return preg_replace('/\bNULL\b/', 'null', $str);
+        return PregWrapper::replace('/\bNULL\b/', 'null', $str);
     }
 
     /**
@@ -370,7 +371,7 @@ EOF
         }
 
         for ($i = (int) Application::VERSION; $i > 0; --$i) {
-            if (1 === preg_match('/Changelog for v('.$i.'.\d+.\d+)/', $changelog, $matches)) {
+            if (1 === PregWrapper::match('/Changelog for v('.$i.'.\d+.\d+)/', $changelog, $matches)) {
                 $version = $matches[1];
 
                 break;
@@ -447,7 +448,7 @@ EOF
             }
 
             $description = implode("\n   | ", self::wordwrap(
-                preg_replace('/(`.+?`)/', '<info>$1</info>', $description),
+                PregWrapper::replace('/(`.+?`)/', '<info>$1</info>', $description),
                 72
             ));
 
@@ -460,10 +461,10 @@ EOF
             if ($fixer->isRisky()) {
                 $help .= sprintf(
                     "   | *Risky rule: %s.*\n",
-                    preg_replace(
+                    PregWrapper::replace(
                         '/(`.+?`)/',
                         '<info>$1</info>',
-                        lcfirst(preg_replace('/\.$/', '', $fixer->getDefinition()->getRiskyDescription()))
+                        lcfirst(PregWrapper::replace('/\.$/', '', $fixer->getDefinition()->getRiskyDescription()))
                     )
                 );
             }
@@ -497,10 +498,10 @@ EOF
                             $line .= ' (<comment>'.implode('</comment>, <comment>', $allowed).'</comment>)';
                         }
 
-                        $line .= ': '.preg_replace(
+                        $line .= ': '.PregWrapper::replace(
                             '/(`.+?`)/',
                             '<info>$1</info>',
-                            lcfirst(preg_replace('/\.$/', '', $option->getDescription()))
+                            lcfirst(PregWrapper::replace('/\.$/', '', $option->getDescription()))
                         ).'; ';
                         if ($option->hasDefault()) {
                             $line .= 'defaults to <comment>'.self::toString($option->getDefault()).'</comment>';
@@ -523,7 +524,7 @@ EOF
         }
 
         // prevent "\</foo>" from being rendered as an escaped literal style tag
-        return preg_replace('#\\\\(</.*?>)#', '<<$1', $help);
+        return PregWrapper::replace('#\\\\(</.*?>)#', '<<$1', $help);
     }
 
     /**
@@ -540,7 +541,7 @@ EOF
         $currentLine = 0;
         $lineLength = 0;
         foreach (explode(' ', $string) as $word) {
-            $wordLength = strlen(preg_replace('~</?(\w+)>~', '', $word));
+            $wordLength = strlen(PregWrapper::replace('~</?(\w+)>~', '', $word));
             if (0 !== $lineLength) {
                 ++$wordLength; // space before word
             }

--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Console\Command;
 
+use PhpCsFixer\PregWrapper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -225,26 +226,26 @@ EOF;
         $help = $command->getHelp();
         $help = str_replace('%command.full_name%', 'php-cs-fixer.phar '.$command->getName(), $help);
         $help = str_replace('%command.name%', $command->getName(), $help);
-        $help = preg_replace('#</?(comment|info)>#', '``', $help);
-        $help = preg_replace('#`(``.+?``)`#', '$1', $help);
-        $help = preg_replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
-        $help = preg_replace('#^ \* ``(.+)``(.*?\n)#m', "* **$1**$2\n", $help);
-        $help = preg_replace('#^   \\| #m', '  ', $help);
-        $help = preg_replace('#^   \\|#m', '', $help);
-        $help = preg_replace('#^(?=  \\*Risky rule: )#m', "\n", $help);
-        $help = preg_replace("#^(  Configuration options:\n)(  - )#m", "$1\n$2", $help);
-        $help = preg_replace("#^\n( +\\$ )#m", "\n.. code-block:: bash\n\n$1", $help);
-        $help = preg_replace("#^\n( +<\\?php)#m", "\n.. code-block:: php\n\n$1", $help);
-        $help = preg_replace_callback(
+        $help = PregWrapper::replace('#</?(comment|info)>#', '``', $help);
+        $help = PregWrapper::replace('#`(``.+?``)`#', '$1', $help);
+        $help = PregWrapper::replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
+        $help = PregWrapper::replace('#^ \* ``(.+)``(.*?\n)#m', "* **$1**$2\n", $help);
+        $help = PregWrapper::replace('#^   \\| #m', '  ', $help);
+        $help = PregWrapper::replace('#^   \\|#m', '', $help);
+        $help = PregWrapper::replace('#^(?=  \\*Risky rule: )#m', "\n", $help);
+        $help = PregWrapper::replace("#^(  Configuration options:\n)(  - )#m", "$1\n$2", $help);
+        $help = PregWrapper::replace("#^\n( +\\$ )#m", "\n.. code-block:: bash\n\n$1", $help);
+        $help = PregWrapper::replace("#^\n( +<\\?php)#m", "\n.. code-block:: php\n\n$1", $help);
+        $help = PregWrapper::replaceCallback(
             '#^\\s*<\\?(\\w+).*?\\?>#ms',
             function ($matches) {
-                $result = preg_replace("#^\\.\\. code-block:: bash\n\n#m", '', $matches[0]);
+                $result = PregWrapper::replace("#^\\.\\. code-block:: bash\n\n#m", '', $matches[0]);
 
                 if ('php' !== $matches[1]) {
-                    $result = preg_replace("#<\\?{$matches[1]}\\s*#", '', $result);
+                    $result = PregWrapper::replace("#<\\?{$matches[1]}\\s*#", '', $result);
                 }
 
-                $result = preg_replace("#\n\n +\\?>#", '', $result);
+                $result = PregWrapper::replace("#\n\n +\\?>#", '', $result);
 
                 return $result;
             },
@@ -257,7 +258,7 @@ EOF;
         // Make to RST http://www.sphinx-doc.org/en/stable/rest.html#hyperlinks
         //      `description <http://...>`_
 
-        $help = preg_replace_callback(
+        $help = PregWrapper::replaceCallback(
            '#`(.+)`\s?\(<url>(.+)<\/url>\)#',
             function (array $matches) {
                 return sprintf('`%s <%s>`_', str_replace('\\', '\\\\', $matches[1]), $matches[2]);
@@ -265,8 +266,8 @@ EOF;
             $help
         );
 
-        $help = preg_replace('#^                        #m', '  ', $help);
-        $help = preg_replace('#\*\* +\[#', '** [', $help);
+        $help = PregWrapper::replace('#^                        #m', '  ', $help);
+        $help = PregWrapper::replace('#\*\* +\[#', '** [', $help);
 
         $downloadLatestUrl = sprintf('https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v%s/php-cs-fixer.phar', HelpCommand::getLatestReleaseVersionFromChangeLog());
         $downloadUrl = 'http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar';

--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Console\Command;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -226,26 +226,26 @@ EOF;
         $help = $command->getHelp();
         $help = str_replace('%command.full_name%', 'php-cs-fixer.phar '.$command->getName(), $help);
         $help = str_replace('%command.name%', $command->getName(), $help);
-        $help = PregWrapper::replace('#</?(comment|info)>#', '``', $help);
-        $help = PregWrapper::replace('#`(``.+?``)`#', '$1', $help);
-        $help = PregWrapper::replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
-        $help = PregWrapper::replace('#^ \* ``(.+)``(.*?\n)#m', "* **$1**$2\n", $help);
-        $help = PregWrapper::replace('#^   \\| #m', '  ', $help);
-        $help = PregWrapper::replace('#^   \\|#m', '', $help);
-        $help = PregWrapper::replace('#^(?=  \\*Risky rule: )#m', "\n", $help);
-        $help = PregWrapper::replace("#^(  Configuration options:\n)(  - )#m", "$1\n$2", $help);
-        $help = PregWrapper::replace("#^\n( +\\$ )#m", "\n.. code-block:: bash\n\n$1", $help);
-        $help = PregWrapper::replace("#^\n( +<\\?php)#m", "\n.. code-block:: php\n\n$1", $help);
-        $help = PregWrapper::replaceCallback(
+        $help = Preg::replace('#</?(comment|info)>#', '``', $help);
+        $help = Preg::replace('#`(``.+?``)`#', '$1', $help);
+        $help = Preg::replace('#^(\s+)``(.+)``$#m', '$1$2', $help);
+        $help = Preg::replace('#^ \* ``(.+)``(.*?\n)#m', "* **$1**$2\n", $help);
+        $help = Preg::replace('#^   \\| #m', '  ', $help);
+        $help = Preg::replace('#^   \\|#m', '', $help);
+        $help = Preg::replace('#^(?=  \\*Risky rule: )#m', "\n", $help);
+        $help = Preg::replace("#^(  Configuration options:\n)(  - )#m", "$1\n$2", $help);
+        $help = Preg::replace("#^\n( +\\$ )#m", "\n.. code-block:: bash\n\n$1", $help);
+        $help = Preg::replace("#^\n( +<\\?php)#m", "\n.. code-block:: php\n\n$1", $help);
+        $help = Preg::replaceCallback(
             '#^\\s*<\\?(\\w+).*?\\?>#ms',
             function ($matches) {
-                $result = PregWrapper::replace("#^\\.\\. code-block:: bash\n\n#m", '', $matches[0]);
+                $result = Preg::replace("#^\\.\\. code-block:: bash\n\n#m", '', $matches[0]);
 
                 if ('php' !== $matches[1]) {
-                    $result = PregWrapper::replace("#<\\?{$matches[1]}\\s*#", '', $result);
+                    $result = Preg::replace("#<\\?{$matches[1]}\\s*#", '', $result);
                 }
 
-                $result = PregWrapper::replace("#\n\n +\\?>#", '', $result);
+                $result = Preg::replace("#\n\n +\\?>#", '', $result);
 
                 return $result;
             },
@@ -258,7 +258,7 @@ EOF;
         // Make to RST http://www.sphinx-doc.org/en/stable/rest.html#hyperlinks
         //      `description <http://...>`_
 
-        $help = PregWrapper::replaceCallback(
+        $help = Preg::replaceCallback(
            '#`(.+)`\s?\(<url>(.+)<\/url>\)#',
             function (array $matches) {
                 return sprintf('`%s <%s>`_', str_replace('\\', '\\\\', $matches[1]), $matches[2]);
@@ -266,8 +266,8 @@ EOF;
             $help
         );
 
-        $help = PregWrapper::replace('#^                        #m', '  ', $help);
-        $help = PregWrapper::replace('#\*\* +\[#', '** [', $help);
+        $help = Preg::replace('#^                        #m', '  ', $help);
+        $help = Preg::replace('#\*\* +\[#', '** [', $help);
 
         $downloadLatestUrl = sprintf('https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v%s/php-cs-fixer.phar', HelpCommand::getLatestReleaseVersionFromChangeLog());
         $downloadUrl = 'http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar';

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -14,7 +14,7 @@ namespace PhpCsFixer\Console\Command;
 
 use PhpCsFixer\Console\SelfUpdate\NewVersionCheckerInterface;
 use PhpCsFixer\PharCheckerInterface;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\ToolInfoInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -100,7 +100,7 @@ EOT
         }
 
         $currentVersion = $this->getApplication()->getVersion();
-        PregWrapper::match('/^v?(?<major>\d+)\./', $currentVersion, $matches);
+        Preg::match('/^v?(?<major>\d+)\./', $currentVersion, $matches);
         $currentMajor = (int) $matches['major'];
 
         try {

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Console\Command;
 
 use PhpCsFixer\Console\SelfUpdate\NewVersionCheckerInterface;
 use PhpCsFixer\PharCheckerInterface;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\ToolInfoInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -99,7 +100,7 @@ EOT
         }
 
         $currentVersion = $this->getApplication()->getVersion();
-        preg_match('/^v?(?<major>\d+)\./', $currentVersion, $matches);
+        PregWrapper::match('/^v?(?<major>\d+)\./', $currentVersion, $matches);
         $currentMajor = (int) $matches['major'];
 
         try {

--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Differ;
 
+use PhpCsFixer\PregWrapper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
@@ -53,7 +54,7 @@ final class DiffConsoleFormatter
 
         $template = $isDecorated
             ? $this->template
-            : preg_replace('/<[^<>]+>/', '', $this->template)
+            : PregWrapper::replace('/<[^<>]+>/', '', $this->template)
         ;
 
         return sprintf(
@@ -63,7 +64,7 @@ final class DiffConsoleFormatter
                 array_map(
                     function ($string) use ($isDecorated, $lineTemplate) {
                         if ($isDecorated) {
-                            $string = preg_replace_callback(
+                            $string = PregWrapper::replaceCallback(
                                 array(
                                     '/^(\+.*)/',
                                     '/^(\-.*)/',
@@ -86,7 +87,7 @@ final class DiffConsoleFormatter
 
                         return sprintf($lineTemplate, $string);
                     },
-                    preg_split('#\R#u', $diff)
+                    PregWrapper::split('#\R#u', $diff)
                 )
             )
         );

--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Differ;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
@@ -54,7 +54,7 @@ final class DiffConsoleFormatter
 
         $template = $isDecorated
             ? $this->template
-            : PregWrapper::replace('/<[^<>]+>/', '', $this->template)
+            : Preg::replace('/<[^<>]+>/', '', $this->template)
         ;
 
         return sprintf(
@@ -64,7 +64,7 @@ final class DiffConsoleFormatter
                 array_map(
                     function ($string) use ($isDecorated, $lineTemplate) {
                         if ($isDecorated) {
-                            $string = PregWrapper::replaceCallback(
+                            $string = Preg::replaceCallback(
                                 array(
                                     '/^(\+.*)/',
                                     '/^(\-.*)/',
@@ -87,7 +87,7 @@ final class DiffConsoleFormatter
 
                         return sprintf($lineTemplate, $string);
                     },
-                    PregWrapper::split('#\R#u', $diff)
+                    Preg::split('#\R#u', $diff)
                 )
             )
         );

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\DocBlock;
 
+use PhpCsFixer\PregWrapper;
+
 /**
  * This represents an entire annotation from a docblock.
  *
@@ -196,7 +198,7 @@ class Annotation
             $content = $this->getTypesContent();
 
             while ('' !== $content && false !== $content) {
-                preg_match(
+                PregWrapper::match(
                     '{^'.self::REGEX_TYPES.'$}x',
                     $content,
                     $matches
@@ -219,7 +221,7 @@ class Annotation
     {
         $pattern = '/'.preg_quote($this->getTypesContent(), '/').'/';
 
-        $this->lines[0]->setContent(preg_replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
+        $this->lines[0]->setContent(PregWrapper::replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
 
         $this->clearCache();
     }
@@ -267,7 +269,7 @@ class Annotation
                 throw new \RuntimeException('This tag does not support types.');
             }
 
-            $matchingResult = preg_match(
+            $matchingResult = PregWrapper::match(
                 '{^(?:\s*\*|/\*\*)\s*@'.$name.'\s+'.self::REGEX_TYPES.'(?:[ \t].*)?$}sx',
                 $this->lines[0]->getContent(),
                 $matches

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\DocBlock;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 /**
  * This represents an entire annotation from a docblock.
@@ -198,7 +198,7 @@ class Annotation
             $content = $this->getTypesContent();
 
             while ('' !== $content && false !== $content) {
-                PregWrapper::match(
+                Preg::match(
                     '{^'.self::REGEX_TYPES.'$}x',
                     $content,
                     $matches
@@ -221,7 +221,7 @@ class Annotation
     {
         $pattern = '/'.preg_quote($this->getTypesContent(), '/').'/';
 
-        $this->lines[0]->setContent(PregWrapper::replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
+        $this->lines[0]->setContent(Preg::replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
 
         $this->clearCache();
     }
@@ -269,7 +269,7 @@ class Annotation
                 throw new \RuntimeException('This tag does not support types.');
             }
 
-            $matchingResult = PregWrapper::match(
+            $matchingResult = Preg::match(
                 '{^(?:\s*\*|/\*\*)\s*@'.$name.'\s+'.self::REGEX_TYPES.'(?:[ \t].*)?$}sx',
                 $this->lines[0]->getContent(),
                 $matches

--- a/src/DocBlock/Line.php
+++ b/src/DocBlock/Line.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\DocBlock;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 /**
  * This represents a line of a docblock.
@@ -67,7 +67,7 @@ class Line
      */
     public function containsUsefulContent()
     {
-        return 0 !== PregWrapper::match('/\\*\s*\S+/', $this->content) && !$this->isTheStart() && !$this->isTheEnd();
+        return 0 !== Preg::match('/\\*\s*\S+/', $this->content) && !$this->isTheStart() && !$this->isTheEnd();
     }
 
     /**
@@ -79,7 +79,7 @@ class Line
      */
     public function containsATag()
     {
-        return 0 !== PregWrapper::match('/\\*\s*@/', $this->content);
+        return 0 !== Preg::match('/\\*\s*@/', $this->content);
     }
 
     /**
@@ -133,7 +133,7 @@ class Line
      */
     public function addBlank()
     {
-        $matched = PregWrapper::match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
+        $matched = Preg::match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
 
         if (1 !== $matched) {
             return;

--- a/src/DocBlock/Line.php
+++ b/src/DocBlock/Line.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\DocBlock;
 
+use PhpCsFixer\PregWrapper;
+
 /**
  * This represents a line of a docblock.
  *
@@ -65,7 +67,7 @@ class Line
      */
     public function containsUsefulContent()
     {
-        return 0 !== preg_match('/\\*\s*\S+/', $this->content) && !$this->isTheStart() && !$this->isTheEnd();
+        return 0 !== PregWrapper::match('/\\*\s*\S+/', $this->content) && !$this->isTheStart() && !$this->isTheEnd();
     }
 
     /**
@@ -77,7 +79,7 @@ class Line
      */
     public function containsATag()
     {
-        return 0 !== preg_match('/\\*\s*@/', $this->content);
+        return 0 !== PregWrapper::match('/\\*\s*@/', $this->content);
     }
 
     /**
@@ -131,7 +133,7 @@ class Line
      */
     public function addBlank()
     {
-        $matched = preg_match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
+        $matched = PregWrapper::match('/^([ \t]*\*)[^\r\n]*(\r?\n)$/', $this->content, $matches);
 
         if (1 !== $matched) {
             return;

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\DocBlock;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 /**
  * This represents a tag, as defined by the proposed PSR PHPDoc standard.
@@ -67,7 +67,7 @@ class Tag
     public function getName()
     {
         if (null === $this->name) {
-            PregWrapper::matchAll('/@[a-zA-Z0-9_-]+(?=\s|$)/', $this->line->getContent(), $matches);
+            Preg::matchAll('/@[a-zA-Z0-9_-]+(?=\s|$)/', $this->line->getContent(), $matches);
 
             if (isset($matches[0][0])) {
                 $this->name = ltrim($matches[0][0], '@');
@@ -94,7 +94,7 @@ class Tag
             throw new \RuntimeException('Cannot set name on unknown tag.');
         }
 
-        $this->line->setContent(PregWrapper::replace("/@${current}/", "@${name}", $this->line->getContent(), 1));
+        $this->line->setContent(Preg::replace("/@${current}/", "@${name}", $this->line->getContent(), 1));
 
         $this->name = $name;
     }

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\DocBlock;
 
+use PhpCsFixer\PregWrapper;
+
 /**
  * This represents a tag, as defined by the proposed PSR PHPDoc standard.
  *
@@ -65,7 +67,7 @@ class Tag
     public function getName()
     {
         if (null === $this->name) {
-            preg_match_all('/@[a-zA-Z0-9_-]+(?=\s|$)/', $this->line->getContent(), $matches);
+            PregWrapper::matchAll('/@[a-zA-Z0-9_-]+(?=\s|$)/', $this->line->getContent(), $matches);
 
             if (isset($matches[0][0])) {
                 $this->name = ltrim($matches[0][0], '@');
@@ -92,7 +94,7 @@ class Tag
             throw new \RuntimeException('Cannot set name on unknown tag.');
         }
 
-        $this->line->setContent(preg_replace("/@${current}/", "@${name}", $this->line->getContent(), 1));
+        $this->line->setContent(PregWrapper::replace("/@${current}/", "@${name}", $this->line->getContent(), 1));
 
         $this->name = $name;
     }

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Doctrine\Annotation;
 
 use Doctrine\Common\Annotations\DocLexer;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token as PhpToken;
 
 /**
@@ -42,7 +43,7 @@ final class Tokens extends \SplFixedArray
         $ignoredTextPosition = 0;
         $currentPosition = 0;
         while (false !== $nextAtPosition = strpos($content, '@', $currentPosition)) {
-            if (0 !== $nextAtPosition && !preg_match('/\s/', $content[$nextAtPosition - 1])) {
+            if (0 !== $nextAtPosition && !PregWrapper::match('/\s/', $content[$nextAtPosition - 1])) {
                 $currentPosition = $nextAtPosition + 1;
 
                 continue;
@@ -197,7 +198,7 @@ final class Tokens extends \SplFixedArray
                 isset($this[$index + 3])
                 && $this[$index + 2]->isType(DocLexer::T_NONE)
                 && $this[$index + 3]->isType(DocLexer::T_OPEN_PARENTHESIS)
-                && preg_match('/^(\R\s*\*\s*)*\s*$/', $this[$index + 2]->getContent())
+                && PregWrapper::match('/^(\R\s*\*\s*)*\s*$/', $this[$index + 2]->getContent())
             ) {
                 $currentIndex = $index + 3;
             }

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -13,7 +13,7 @@
 namespace PhpCsFixer\Doctrine\Annotation;
 
 use Doctrine\Common\Annotations\DocLexer;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token as PhpToken;
 
 /**
@@ -43,7 +43,7 @@ final class Tokens extends \SplFixedArray
         $ignoredTextPosition = 0;
         $currentPosition = 0;
         while (false !== $nextAtPosition = strpos($content, '@', $currentPosition)) {
-            if (0 !== $nextAtPosition && !PregWrapper::match('/\s/', $content[$nextAtPosition - 1])) {
+            if (0 !== $nextAtPosition && !Preg::match('/\s/', $content[$nextAtPosition - 1])) {
                 $currentPosition = $nextAtPosition + 1;
 
                 continue;
@@ -198,7 +198,7 @@ final class Tokens extends \SplFixedArray
                 isset($this[$index + 3])
                 && $this[$index + 2]->isType(DocLexer::T_NONE)
                 && $this[$index + 3]->isType(DocLexer::T_OPEN_PARENTHESIS)
-                && PregWrapper::match('/^(\R\s*\*\s*)*\s*$/', $this[$index + 2]->getContent())
+                && Preg::match('/^(\R\s*\*\s*)*\s*$/', $this[$index + 2]->getContent())
             ) {
                 $currentIndex = $index + 3;
             }

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Alias;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -142,7 +142,7 @@ final class EregToPregFixer extends AbstractFixer
     private function checkPreg($pattern)
     {
         try {
-            PregWrapper::match($pattern, '');
+            Preg::match($pattern, '');
 
             return true;
         } catch (\RuntimeException $e) {

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Preg;
+use PhpCsFixer\PregException;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -145,7 +146,7 @@ final class EregToPregFixer extends AbstractFixer
             Preg::match($pattern, '');
 
             return true;
-        } catch (\RuntimeException $e) {
+        } catch (PregException $e) {
             return false;
         }
     }

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Alias;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -140,7 +141,13 @@ final class EregToPregFixer extends AbstractFixer
      */
     private function checkPreg($pattern)
     {
-        return false !== @preg_match($pattern, '');
+        try {
+            PregWrapper::match($pattern, '');
+
+            return true;
+        } catch (\RuntimeException $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -19,7 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -383,7 +383,7 @@ class Foo
 
                         if ($nextLineCanBeIndented || $i === $startBraceIndex) {
                             $nextToken = $tokens[$nestIndex + 1];
-                            $nextLineCanBeIndented = $nextToken->isWhitespace() && 1 === PregWrapper::match('/\R/', $nextToken->getContent());
+                            $nextLineCanBeIndented = $nextToken->isWhitespace() && 1 === Preg::match('/\R/', $nextToken->getContent());
                         }
                     }
 
@@ -398,7 +398,7 @@ class Foo
                         // next Token is not a comment on its own line
                         !($nextNonWhitespaceNestToken->isComment() && (
                             !$tokens[$nextNonWhitespaceNestIndex - 1]->isWhitespace()
-                            || !PregWrapper::match('/\R/', $tokens[$nextNonWhitespaceNestIndex - 1]->getContent())
+                            || !Preg::match('/\R/', $tokens[$nextNonWhitespaceNestIndex - 1]->getContent())
                         )) &&
                         // and it is not a `$foo = function () {};` situation
                         !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equalsAny(array(';', ',', ']', array(CT::T_ARRAY_SQUARE_BRACE_CLOSE)))) &&
@@ -429,7 +429,7 @@ class Foo
                                 $nextWhitespace = rtrim($nextToken->getContent(), " \t");
 
                                 if ('' !== $nextWhitespace) {
-                                    $nextWhitespace = PregWrapper::replace(
+                                    $nextWhitespace = Preg::replace(
                                         sprintf('/%s$/', $this->whitespacesConfig->getLineEnding()),
                                         '',
                                         $nextWhitespace,
@@ -891,15 +891,15 @@ class Foo
             // do not indent inline comments used to comment out unused code
             if (
                 (0 === strpos($nextToken->getContent(), '//'.$this->whitespacesConfig->getIndent()) || '//' === $nextToken->getContent())
-                && $previousToken->isWhitespace() && 1 === PregWrapper::match('/\R$/', $previousToken->getContent())
+                && $previousToken->isWhitespace() && 1 === Preg::match('/\R$/', $previousToken->getContent())
             ) {
                 return;
             }
             $tokens[$nextTokenIndex] = new Token(array(
                 $nextToken->getId(),
-                PregWrapper::replace(
+                Preg::replace(
                     '/(\R)'.$this->detectIndent($tokens, $nextTokenIndex).'/',
-                    '$1'.PregWrapper::replace('/^.*\R([ \t]*)$/s', '$1', $whitespace),
+                    '$1'.Preg::replace('/^.*\R([ \t]*)$/s', '$1', $whitespace),
                     $nextToken->getContent()
                 ),
             ));
@@ -1006,8 +1006,8 @@ class Foo
 
         $newLines = 0;
         for ($i = min($siblingIndex, $index) + 1, $max = max($siblingIndex, $index); $i < $max; ++$i) {
-            if ($tokens[$i]->isWhitespace() && PregWrapper::match('/\R/', $tokens[$i]->getContent())) {
-                if (1 === $newLines || PregWrapper::match('/\R.*\R/', $tokens[$i]->getContent())) {
+            if ($tokens[$i]->isWhitespace() && Preg::match('/\R/', $tokens[$i]->getContent())) {
+                if (1 === $newLines || Preg::match('/\R.*\R/', $tokens[$i]->getContent())) {
                     return null;
                 }
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -382,7 +383,7 @@ class Foo
 
                         if ($nextLineCanBeIndented || $i === $startBraceIndex) {
                             $nextToken = $tokens[$nestIndex + 1];
-                            $nextLineCanBeIndented = $nextToken->isWhitespace() && 1 === preg_match('/\R/', $nextToken->getContent());
+                            $nextLineCanBeIndented = $nextToken->isWhitespace() && 1 === PregWrapper::match('/\R/', $nextToken->getContent());
                         }
                     }
 
@@ -397,7 +398,7 @@ class Foo
                         // next Token is not a comment on its own line
                         !($nextNonWhitespaceNestToken->isComment() && (
                             !$tokens[$nextNonWhitespaceNestIndex - 1]->isWhitespace()
-                            || !preg_match('/\R/', $tokens[$nextNonWhitespaceNestIndex - 1]->getContent())
+                            || !PregWrapper::match('/\R/', $tokens[$nextNonWhitespaceNestIndex - 1]->getContent())
                         )) &&
                         // and it is not a `$foo = function () {};` situation
                         !($nestToken->equals('}') && $nextNonWhitespaceNestToken->equalsAny(array(';', ',', ']', array(CT::T_ARRAY_SQUARE_BRACE_CLOSE)))) &&
@@ -428,7 +429,7 @@ class Foo
                                 $nextWhitespace = rtrim($nextToken->getContent(), " \t");
 
                                 if ('' !== $nextWhitespace) {
-                                    $nextWhitespace = preg_replace(
+                                    $nextWhitespace = PregWrapper::replace(
                                         sprintf('/%s$/', $this->whitespacesConfig->getLineEnding()),
                                         '',
                                         $nextWhitespace,
@@ -890,15 +891,15 @@ class Foo
             // do not indent inline comments used to comment out unused code
             if (
                 (0 === strpos($nextToken->getContent(), '//'.$this->whitespacesConfig->getIndent()) || '//' === $nextToken->getContent())
-                && $previousToken->isWhitespace() && 1 === preg_match('/\R$/', $previousToken->getContent())
+                && $previousToken->isWhitespace() && 1 === PregWrapper::match('/\R$/', $previousToken->getContent())
             ) {
                 return;
             }
             $tokens[$nextTokenIndex] = new Token(array(
                 $nextToken->getId(),
-                preg_replace(
+                PregWrapper::replace(
                     '/(\R)'.$this->detectIndent($tokens, $nextTokenIndex).'/',
-                    '$1'.preg_replace('/^.*\R([ \t]*)$/s', '$1', $whitespace),
+                    '$1'.PregWrapper::replace('/^.*\R([ \t]*)$/s', '$1', $whitespace),
                     $nextToken->getContent()
                 ),
             ));
@@ -1005,8 +1006,8 @@ class Foo
 
         $newLines = 0;
         for ($i = min($siblingIndex, $index) + 1, $max = max($siblingIndex, $index); $i < $max; ++$i) {
-            if ($tokens[$i]->isWhitespace() && preg_match('/\R/', $tokens[$i]->getContent())) {
-                if (1 === $newLines || preg_match('/\R.*\R/', $tokens[$i]->getContent())) {
+            if ($tokens[$i]->isWhitespace() && PregWrapper::match('/\R/', $tokens[$i]->getContent())) {
+                if (1 === $newLines || PregWrapper::match('/\R.*\R/', $tokens[$i]->getContent())) {
                     return null;
                 }
 

--- a/src/Fixer/ClassNotation/MethodSeparationFixer.php
+++ b/src/Fixer/ClassNotation/MethodSeparationFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -267,7 +268,7 @@ final class Sample
         if (1 === $numbOfWhiteTokens) {
             $tokens[$startIndex] = new Token(array(
                 T_WHITESPACE,
-                preg_replace('/\r\n|\n/', '', $tokens[$startIndex]->getContent(), $lineBreakCount - $reqLineCount),
+                PregWrapper::replace('/\r\n|\n/', '', $tokens[$startIndex]->getContent(), $lineBreakCount - $reqLineCount),
             ));
 
             return;
@@ -280,7 +281,7 @@ final class Sample
             if ($tokenLineCount > 0) {
                 $tokens[$i] = new Token(array(
                     T_WHITESPACE,
-                    preg_replace('/\r\n|\n/', '', $tokens[$i]->getContent(), min($toReplaceCount, $tokenLineCount)),
+                    PregWrapper::replace('/\r\n|\n/', '', $tokens[$i]->getContent(), min($toReplaceCount, $tokenLineCount)),
                 ));
                 $toReplaceCount -= $tokenLineCount;
             }

--- a/src/Fixer/ClassNotation/MethodSeparationFixer.php
+++ b/src/Fixer/ClassNotation/MethodSeparationFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -268,7 +268,7 @@ final class Sample
         if (1 === $numbOfWhiteTokens) {
             $tokens[$startIndex] = new Token(array(
                 T_WHITESPACE,
-                PregWrapper::replace('/\r\n|\n/', '', $tokens[$startIndex]->getContent(), $lineBreakCount - $reqLineCount),
+                Preg::replace('/\r\n|\n/', '', $tokens[$startIndex]->getContent(), $lineBreakCount - $reqLineCount),
             ));
 
             return;
@@ -281,7 +281,7 @@ final class Sample
             if ($tokenLineCount > 0) {
                 $tokens[$i] = new Token(array(
                     T_WHITESPACE,
-                    PregWrapper::replace('/\r\n|\n/', '', $tokens[$i]->getContent(), min($toReplaceCount, $tokenLineCount)),
+                    Preg::replace('/\r\n|\n/', '', $tokens[$i]->getContent(), min($toReplaceCount, $tokenLineCount)),
                 ));
                 $toReplaceCount -= $tokenLineCount;
             }

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -20,7 +20,7 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerConfiguration\FixerOptionValidatorGenerator;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -164,7 +164,7 @@ final class Example
         $divisionContent = null;
         if ($tokens[$startIndex - 1]->isWhitespace()) {
             $divisionContent = $tokens[$startIndex - 1]->getContent();
-            if (PregWrapper::match('#(\n|\r\n)#', $divisionContent, $matches)) {
+            if (Preg::match('#(\n|\r\n)#', $divisionContent, $matches)) {
                 $divisionContent = $matches[0].trim($divisionContent, "\r\n");
             }
         }

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -20,6 +20,7 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerConfiguration\FixerOptionValidatorGenerator;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -163,7 +164,7 @@ final class Example
         $divisionContent = null;
         if ($tokens[$startIndex - 1]->isWhitespace()) {
             $divisionContent = $tokens[$startIndex - 1]->getContent();
-            if (preg_match('#(\n|\r\n)#', $divisionContent, $matches)) {
+            if (PregWrapper::match('#(\n|\r\n)#', $divisionContent, $matches)) {
                 $divisionContent = $matches[0].trim($divisionContent, "\r\n");
             }
         }

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Options;
@@ -304,8 +305,8 @@ echo 1;
         $prev = $tokens->getPrevNonWhitespace($headerIndex);
 
         $regex = '/[\t ]$/';
-        if ($tokens[$prev]->isGivenKind(T_OPEN_TAG) && preg_match($regex, $tokens[$prev]->getContent())) {
-            $tokens[$prev] = new Token(array(T_OPEN_TAG, preg_replace($regex, $lineEnding, $tokens[$prev]->getContent())));
+        if ($tokens[$prev]->isGivenKind(T_OPEN_TAG) && PregWrapper::match($regex, $tokens[$prev]->getContent())) {
+            $tokens[$prev] = new Token(array(T_OPEN_TAG, PregWrapper::replace($regex, $lineEnding, $tokens[$prev]->getContent())));
         }
 
         $lineBreakCount = $this->getLineBreakCount($tokens, $prev, $headerIndex);

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -19,7 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Options;
@@ -305,8 +305,8 @@ echo 1;
         $prev = $tokens->getPrevNonWhitespace($headerIndex);
 
         $regex = '/[\t ]$/';
-        if ($tokens[$prev]->isGivenKind(T_OPEN_TAG) && PregWrapper::match($regex, $tokens[$prev]->getContent())) {
-            $tokens[$prev] = new Token(array(T_OPEN_TAG, PregWrapper::replace($regex, $lineEnding, $tokens[$prev]->getContent())));
+        if ($tokens[$prev]->isGivenKind(T_OPEN_TAG) && Preg::match($regex, $tokens[$prev]->getContent())) {
+            $tokens[$prev] = new Token(array(T_OPEN_TAG, Preg::replace($regex, $lineEnding, $tokens[$prev]->getContent())));
         }
 
         $lineBreakCount = $this->getLineBreakCount($tokens, $prev, $headerIndex);

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Comment;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -141,7 +142,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
     {
         $lineCount = 0;
         for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
-            $lineCount += preg_match_all('/\R/u', $tokens[$i]->getContent(), $matches);
+            $lineCount += PregWrapper::matchAll('/\R/u', $tokens[$i]->getContent(), $matches);
         }
 
         return $lineCount;
@@ -162,6 +163,6 @@ final class NoEmptyCommentFixer extends AbstractFixer
 
         $type = $this->getCommentType($content);
 
-        return 1 === preg_match($mapper[$type], $content);
+        return 1 === PregWrapper::match($mapper[$type], $content);
     }
 }

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Comment;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -142,7 +142,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
     {
         $lineCount = 0;
         for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
-            $lineCount += PregWrapper::matchAll('/\R/u', $tokens[$i]->getContent(), $matches);
+            $lineCount += Preg::matchAll('/\R/u', $tokens[$i]->getContent(), $matches);
         }
 
         return $lineCount;
@@ -163,6 +163,6 @@ final class NoEmptyCommentFixer extends AbstractFixer
 
         $type = $this->getCommentType($content);
 
-        return 1 === PregWrapper::match($mapper[$type], $content);
+        return 1 === Preg::match($mapper[$type], $content);
     }
 }

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Comment;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -52,14 +53,14 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
-                $tokens[$index] = new Token(array(T_DOC_COMMENT, preg_replace('/[ \t]+$/m', '', $token->getContent())));
+                $tokens[$index] = new Token(array(T_DOC_COMMENT, PregWrapper::replace('/[ \t]+$/m', '', $token->getContent())));
 
                 continue;
             }
 
             if ($token->isGivenKind(T_COMMENT)) {
                 if ('/*' === substr($token->getContent(), 0, 2)) {
-                    $tokens[$index] = new Token(array(T_COMMENT, preg_replace('/[ \t]+$/m', '', $token->getContent())));
+                    $tokens[$index] = new Token(array(T_COMMENT, PregWrapper::replace('/[ \t]+$/m', '', $token->getContent())));
                 } elseif (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
                     $trimmedContent = ltrim($tokens[$index + 1]->getContent(), " \t");
                     if ('' !== $trimmedContent) {

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Comment;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -53,14 +53,14 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
-                $tokens[$index] = new Token(array(T_DOC_COMMENT, PregWrapper::replace('/[ \t]+$/m', '', $token->getContent())));
+                $tokens[$index] = new Token(array(T_DOC_COMMENT, Preg::replace('/[ \t]+$/m', '', $token->getContent())));
 
                 continue;
             }
 
             if ($token->isGivenKind(T_COMMENT)) {
                 if ('/*' === substr($token->getContent(), 0, 2)) {
-                    $tokens[$index] = new Token(array(T_COMMENT, PregWrapper::replace('/[ \t]+$/m', '', $token->getContent())));
+                    $tokens[$index] = new Token(array(T_COMMENT, Preg::replace('/[ \t]+$/m', '', $token->getContent())));
                 } elseif (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
                     $trimmedContent = ltrim($tokens[$index + 1]->getContent(), " \t");
                     if ('' !== $trimmedContent) {

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
@@ -17,7 +17,7 @@ use PhpCsFixer\AbstractDoctrineAnnotationFixer;
 use PhpCsFixer\Doctrine\Annotation\Tokens;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotationFixer
 {
@@ -76,7 +76,7 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
 
             $previousLineBracesDelta = $currentLineDelta;
 
-            $token->setContent(PregWrapper::replace(
+            $token->setContent(Preg::replace(
                 '/(\n( +\*)?) *$/',
                 '$1'.str_repeat(' ', 4 * $indentLevel + 1),
                 $token->getContent()

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
@@ -17,6 +17,7 @@ use PhpCsFixer\AbstractDoctrineAnnotationFixer;
 use PhpCsFixer\Doctrine\Annotation\Tokens;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 
 final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotationFixer
 {
@@ -75,7 +76,7 @@ final class DoctrineAnnotationIndentationFixer extends AbstractDoctrineAnnotatio
 
             $previousLineBracesDelta = $currentLineDelta;
 
-            $token->setContent(preg_replace(
+            $token->setContent(PregWrapper::replace(
                 '/(\n( +\*)?) *$/',
                 '$1'.str_repeat(' ', 4 * $indentLevel + 1),
                 $token->getContent()

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
@@ -21,7 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 /**
  * Fixes spaces around commas and assignment operators in Doctrine annotations.
@@ -205,7 +205,7 @@ final class DoctrineAnnotationSpacesFixer extends AbstractDoctrineAnnotationFixe
                 $token->clear();
             }
 
-            if ($index < count($tokens) - 1 && !PregWrapper::match('/^\s/', $tokens[$index + 1]->getContent())) {
+            if ($index < count($tokens) - 1 && !Preg::match('/^\s/', $tokens[$index + 1]->getContent())) {
                 $tokens->insertAt($index + 1, new Token(DocLexer::T_NONE, ' '));
             }
         }

--- a/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+++ b/src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 
 /**
  * Fixes spaces around commas and assignment operators in Doctrine annotations.
@@ -204,7 +205,7 @@ final class DoctrineAnnotationSpacesFixer extends AbstractDoctrineAnnotationFixe
                 $token->clear();
             }
 
-            if ($index < count($tokens) - 1 && !preg_match('/^\s/', $tokens[$index + 1]->getContent())) {
+            if ($index < count($tokens) - 1 && !PregWrapper::match('/^\s/', $tokens[$index + 1]->getContent())) {
                 $tokens->insertAt($index + 1, new Token(DocLexer::T_NONE, ' '));
             }
         }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -18,7 +18,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -159,7 +159,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         //  2) no space after comma
         if ($nextToken->isWhitespace()) {
             if (
-                ($this->configuration['keep_multiple_spaces_after_comma'] && !PregWrapper::match('/\R/', $nextToken->getContent()))
+                ($this->configuration['keep_multiple_spaces_after_comma'] && !Preg::match('/\R/', $nextToken->getContent()))
                 || $this->isCommentLastLineToken($tokens, $index + 2)
             ) {
                 return;

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -158,7 +159,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
         //  2) no space after comma
         if ($nextToken->isWhitespace()) {
             if (
-                ($this->configuration['keep_multiple_spaces_after_comma'] && !preg_match('/\R/', $nextToken->getContent()))
+                ($this->configuration['keep_multiple_spaces_after_comma'] && !PregWrapper::match('/\R/', $nextToken->getContent()))
                 || $this->isCommentLastLineToken($tokens, $index + 2)
             ) {
                 return;

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Import;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -105,7 +106,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $usages = array();
 
         foreach ($useDeclarations as $shortName => $useDeclaration) {
-            $usages[$shortName] = (bool) preg_match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
+            $usages[$shortName] = (bool) PregWrapper::match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
         }
 
         return $usages;
@@ -289,7 +290,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $nextToken = $tokens[$nextIndex];
 
         if ($nextToken->isWhitespace()) {
-            $content = preg_replace(
+            $content = PregWrapper::replace(
                 "#^\r\n|^\n#",
                 '',
                 ltrim($nextToken->getContent(), " \t"),

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Import;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -106,7 +106,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $usages = array();
 
         foreach ($useDeclarations as $shortName => $useDeclaration) {
-            $usages[$shortName] = (bool) PregWrapper::match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
+            $usages[$shortName] = (bool) Preg::match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
         }
 
         return $usages;
@@ -290,7 +290,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $nextToken = $tokens[$nextIndex];
 
         if ($nextToken->isWhitespace()) {
-            $content = PregWrapper::replace(
+            $content = Preg::replace(
                 "#^\r\n|^\n#",
                 '',
                 ltrim($nextToken->getContent(), " \t"),

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -21,7 +21,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -300,7 +300,7 @@ use function CCC\AA;
      */
     private function prepareNamespace($namespace)
     {
-        return trim(PregWrapper::replace('%/\*(.*)\*/%s', '', $namespace));
+        return trim(Preg::replace('%/\*(.*)\*/%s', '', $namespace));
     }
 
     private function getNewOrder(array $uses, Tokens $tokens)

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -299,7 +300,7 @@ use function CCC\AA;
      */
     private function prepareNamespace($namespace)
     {
-        return trim(preg_replace('%/\*(.*)\*/%s', '', $namespace));
+        return trim(PregWrapper::replace('%/\*(.*)\*/%s', '', $namespace));
     }
 
     private function getNewOrder(array $uses, Tokens $tokens)

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\PhpTag;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -68,7 +69,7 @@ echo "Hello!";
         $content = $tokensOrg->generateCode();
 
         // replace all <? with <?php to replace all short open tags even without short_open_tag option enabled
-        $newContent = preg_replace('/<\?(?:phP|pHp|pHP|Php|PhP|PHp|PHP)?(\s|$)/', '<?php$1', $content, -1, $count);
+        $newContent = PregWrapper::replace('/<\?(?:phP|pHp|pHP|Php|PhP|PHp|PHP)?(\s|$)/', '<?php$1', $content, -1, $count);
 
         if (!$count) {
             return;

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\PhpTag;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -69,7 +69,7 @@ echo "Hello!";
         $content = $tokensOrg->generateCode();
 
         // replace all <? with <?php to replace all short open tags even without short_open_tag option enabled
-        $newContent = PregWrapper::replace('/<\?(?:phP|pHp|pHP|Php|PhP|PHp|PHP)?(\s|$)/', '<?php$1', $content, -1, $count);
+        $newContent = Preg::replace('/<\?(?:phP|pHp|pHP|Php|PhP|PHp|PHP)?(\s|$)/', '<?php$1', $content, -1, $count);
 
         if (!$count) {
             return;

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\PhpUnit;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -74,7 +74,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
-                $tokens[$index] = new Token(array(T_DOC_COMMENT, PregWrapper::replace(
+                $tokens[$index] = new Token(array(T_DOC_COMMENT, Preg::replace(
                     '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m',
                     '$1\\\\$2',
                     $token->getContent()

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\PhpUnit;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -73,7 +74,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
-                $tokens[$index] = new Token(array(T_DOC_COMMENT, preg_replace(
+                $tokens[$index] = new Token(array(T_DOC_COMMENT, PregWrapper::replace(
                     '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m',
                     '$1\\\\$2',
                     $token->getContent()

--- a/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -62,7 +62,7 @@ final class NoEmptyPhpdocFixer extends AbstractFixer
                 continue;
             }
 
-            if (PregWrapper::match('#^/\*\*[\s\*]*\*/$#', $token->getContent())) {
+            if (Preg::match('#^/\*\*[\s\*]*\*/$#', $token->getContent())) {
                 $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             }
         }

--- a/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -61,7 +62,7 @@ final class NoEmptyPhpdocFixer extends AbstractFixer
                 continue;
             }
 
-            if (preg_match('#^/\*\*[\s\*]*\*/$#', $token->getContent())) {
+            if (PregWrapper::match('#^/\*\*[\s\*]*\*/$#', $token->getContent())) {
                 $tokens->clearTokenAndMergeSurroundingWhitespace($index);
             }
         }

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -21,7 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -166,7 +166,7 @@ function f9(string $foo, $bar, $baz) {}',
             $lastParamLine = null;
 
             foreach ($doc->getAnnotationsOfType('param') as $annotation) {
-                $pregMatched = PregWrapper::match('/^[^$]+(\$\w+).*$/s', $annotation->getContent(), $matches);
+                $pregMatched = Preg::match('/^[^$]+(\$\w+).*$/s', $annotation->getContent(), $matches);
 
                 if (1 === $pregMatched) {
                     unset($arguments[$matches[1]]);
@@ -182,7 +182,7 @@ function f9(string $foo, $bar, $baz) {}',
             $lines = $doc->getLines();
             $linesCount = count($lines);
 
-            PregWrapper::match('/^(\s*).*$/', $lines[$linesCount - 1]->getContent(), $matches);
+            Preg::match('/^(\s*).*$/', $lines[$linesCount - 1]->getContent(), $matches);
             $indent = $matches[1];
 
             $newLines = array();

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -21,6 +21,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -165,7 +166,7 @@ function f9(string $foo, $bar, $baz) {}',
             $lastParamLine = null;
 
             foreach ($doc->getAnnotationsOfType('param') as $annotation) {
-                $pregMatched = preg_match('/^[^$]+(\$\w+).*$/s', $annotation->getContent(), $matches);
+                $pregMatched = PregWrapper::match('/^[^$]+(\$\w+).*$/s', $annotation->getContent(), $matches);
 
                 if (1 === $pregMatched) {
                     unset($arguments[$matches[1]]);
@@ -181,7 +182,7 @@ function f9(string $foo, $bar, $baz) {}',
             $lines = $doc->getLines();
             $linesCount = count($lines);
 
-            preg_match('/^(\s*).*$/', $lines[$linesCount - 1]->getContent(), $matches);
+            PregWrapper::match('/^(\s*).*$/', $lines[$linesCount - 1]->getContent(), $matches);
             $indent = $matches[1];
 
             $newLines = array();

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -219,7 +219,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
      */
     private function getMatches($line, $matchCommentOnly = false)
     {
-        if (PregWrapper::match($this->regex, $line, $matches)) {
+        if (Preg::match($this->regex, $line, $matches)) {
             if (!empty($matches['tag2'])) {
                 $matches['tag'] = $matches['tag2'];
                 $matches['hint'] = $matches['hint2'];
@@ -229,7 +229,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
             return $matches;
         }
 
-        if ($matchCommentOnly && PregWrapper::match($this->regexCommentLine, $line, $matches)) {
+        if ($matchCommentOnly && Preg::match($this->regexCommentLine, $line, $matches)) {
             $matches['tag'] = null;
             $matches['var'] = '';
             $matches['hint'] = '';

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -218,7 +219,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
      */
     private function getMatches($line, $matchCommentOnly = false)
     {
-        if (preg_match($this->regex, $line, $matches)) {
+        if (PregWrapper::match($this->regex, $line, $matches)) {
             if (!empty($matches['tag2'])) {
                 $matches['tag'] = $matches['tag2'];
                 $matches['hint'] = $matches['hint2'];
@@ -228,7 +229,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
             return $matches;
         }
 
-        if ($matchCommentOnly && preg_match($this->regexCommentLine, $line, $matches)) {
+        if ($matchCommentOnly && PregWrapper::match($this->regexCommentLine, $line, $matches)) {
             $matches['tag'] = null;
             $matches['var'] = '';
             $matches['hint'] = '';

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -77,20 +78,20 @@ function foo ($bar) {}
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== preg_match('/[.。]$/u', $content)
-                    || 0 !== preg_match('/[.。](?!$)/u', $content, $matches)
+                    1 !== PregWrapper::match('/[.。]$/u', $content)
+                    || 0 !== PregWrapper::match('/[.。](?!$)/u', $content, $matches)
                 ) {
                     continue;
                 }
 
                 $endLine = $doc->getLine($annotation->getEnd());
-                $endLine->setContent(preg_replace('/(?<![.。])[.。](\s+)$/u', '\1', $endLine->getContent()));
+                $endLine->setContent(PregWrapper::replace('/(?<![.。])[.。](\s+)$/u', '\1', $endLine->getContent()));
 
                 $startLine = $doc->getLine($annotation->getStart());
                 $optionalTypeRegEx = $annotation->supportTypes()
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes()), '/'))
                     : '';
-                $content = preg_replace_callback(
+                $content = PregWrapper::replaceCallback(
                     '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     function (array $matches) {
                         return $matches[1].strtolower($matches[2]).$matches[3];

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -78,20 +78,20 @@ function foo ($bar) {}
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== PregWrapper::match('/[.。]$/u', $content)
-                    || 0 !== PregWrapper::match('/[.。](?!$)/u', $content, $matches)
+                    1 !== Preg::match('/[.。]$/u', $content)
+                    || 0 !== Preg::match('/[.。](?!$)/u', $content, $matches)
                 ) {
                     continue;
                 }
 
                 $endLine = $doc->getLine($annotation->getEnd());
-                $endLine->setContent(PregWrapper::replace('/(?<![.。])[.。](\s+)$/u', '\1', $endLine->getContent()));
+                $endLine->setContent(Preg::replace('/(?<![.。])[.。](\s+)$/u', '\1', $endLine->getContent()));
 
                 $startLine = $doc->getLine($annotation->getStart());
                 $optionalTypeRegEx = $annotation->supportTypes()
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes()), '/'))
                     : '';
-                $content = PregWrapper::replaceCallback(
+                $content = Preg::replaceCallback(
                     '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     function (array $matches) {
                         return $matches[1].strtolower($matches[2]).$matches[3];

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -124,7 +124,7 @@ class DocBlocks
      */
     private function fixDocBlock($content, $indent)
     {
-        return ltrim(PregWrapper::replace('/^[ \t]*\*/m', $indent.' *', $content));
+        return ltrim(Preg::replace('/^[ \t]*\*/m', $indent.' *', $content));
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
@@ -123,7 +124,7 @@ class DocBlocks
      */
     private function fixDocBlock($content, $indent)
     {
-        return ltrim(preg_replace('/^[ \t]*\*/m', $indent.' *', $content));
+        return ltrim(PregWrapper::replace('/^[ \t]*\*/m', $indent.' *', $content));
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -67,7 +68,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
             // remove spaces between '{' and '@', remove 's' at the end of tag.
             // Make sure the tags are written in lower case, remove white space between end
             // of text and closing bracket and between the tag and inline comment.
-            $content = preg_replace_callback(
+            $content = PregWrapper::replaceCallback(
                 '#(?:@{+|{+[ \t]*@)[ \t]*(example|id|internal|inheritdoc|link|source|toc|tutorial)s?([^}]*)(?:}+)#i',
                 function (array $matches) {
                     $doc = trim($matches[2]);
@@ -83,7 +84,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
 
             // Always make inheritdoc inline using with '{' '}' when needed,
             // make sure lowercase.
-            $content = preg_replace(
+            $content = PregWrapper::replace(
                 '#(?<!{)@inheritdocs?(?!})#i',
                 '{@inheritdoc}',
                 $content

--- a/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -68,7 +68,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
             // remove spaces between '{' and '@', remove 's' at the end of tag.
             // Make sure the tags are written in lower case, remove white space between end
             // of text and closing bracket and between the tag and inline comment.
-            $content = PregWrapper::replaceCallback(
+            $content = Preg::replaceCallback(
                 '#(?:@{+|{+[ \t]*@)[ \t]*(example|id|internal|inheritdoc|link|source|toc|tutorial)s?([^}]*)(?:}+)#i',
                 function (array $matches) {
                     $doc = trim($matches[2]);
@@ -84,7 +84,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
 
             // Always make inheritdoc inline using with '{' '}' when needed,
             // make sure lowercase.
-            $content = PregWrapper::replace(
+            $content = Preg::replace(
                 '#(?<!{)@inheritdocs?(?!})#i',
                 '{@inheritdoc}',
                 $content

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverRootless;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
@@ -130,7 +131,7 @@ final class Example
                         ));
                     }
 
-                    if (1 !== preg_match('#^\S+$#', $to) || false !== strpos($to, '*/')) {
+                    if (1 !== PregWrapper::match('#^\S+$#', $to) || false !== strpos($to, '*/')) {
                         throw new InvalidOptionsException(sprintf(
                             'Tag "%s" cannot be replaced by invalid tag "%s".',
                             $from,

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -19,7 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverRootless;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
@@ -131,7 +131,7 @@ final class Example
                         ));
                     }
 
-                    if (1 !== PregWrapper::match('#^\S+$#', $to) || false !== strpos($to, '*/')) {
+                    if (1 !== Preg::match('#^\S+$#', $to) || false !== strpos($to, '*/')) {
                         throw new InvalidOptionsException(sprintf(
                             'Tag "%s" cannot be replaced by invalid tag "%s".',
                             $from,

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -17,7 +17,7 @@ use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -104,7 +104,7 @@ function foo() {}
      */
     private function fixAnnotation(DocBlock $doc, Annotation $annotation)
     {
-        if (1 === PregWrapper::match('/@return\s+(void|null)(?!\|)/', $doc->getLine($annotation->getStart())->getContent())) {
+        if (1 === Preg::match('/@return\s+(void|null)(?!\|)/', $doc->getLine($annotation->getStart())->getContent())) {
             $annotation->remove();
         }
     }

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -17,6 +17,7 @@ use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -103,7 +104,7 @@ function foo() {}
      */
     private function fixAnnotation(DocBlock $doc, Annotation $annotation)
     {
-        if (1 === preg_match('/@return\s+(void|null)(?!\|)/', $doc->getLine($annotation->getStart())->getContent())) {
+        if (1 === PregWrapper::match('/@return\s+(void|null)(?!\|)/', $doc->getLine($annotation->getStart())->getContent())) {
             $annotation->remove();
         }
     }

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -139,7 +140,7 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
     private function fixToken(Tokens $tokens, $tokenIndex)
     {
         $count = 0;
-        $content = preg_replace_callback(
+        $content = PregWrapper::replaceCallback(
             '#(\h*(?:@{*|{*\h*@)\h*inheritdoc\h*)([^}]*)((?:}*)\h*)#i',
             function ($matches) {
                 return ' '.$matches[2];

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -140,7 +140,7 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
     private function fixToken(Tokens $tokens, $tokenIndex)
     {
         $count = 0;
-        $content = PregWrapper::replaceCallback(
+        $content = Preg::replaceCallback(
             '#(\h*(?:@{*|{*\h*@)\h*inheritdoc\h*)([^}]*)((?:}*)\h*)#i',
             function ($matches) {
                 return ' '.$matches[2];

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -86,7 +86,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
      */
     private function fixTokenContent($content)
     {
-        return PregWrapper::replaceCallback(
+        return Preg::replaceCallback(
             '#^/\*\*[ \t]*@var[ \t]+(\S+)[ \t]*(\$\S+)?[ \t]*([^\n]*)\*/$#',
             function (array $matches) {
                 $content = '/** @var';

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -85,7 +86,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
      */
     private function fixTokenContent($content)
     {
-        return preg_replace_callback(
+        return PregWrapper::replaceCallback(
             '#^/\*\*[ \t]*@var[ \t]+(\S+)[ \t]*(\$\S+)?[ \t]*([^\n]*)\*/$#',
             function (array $matches) {
                 $content = '/** @var';

--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -92,7 +92,7 @@ final class Foo {}
      */
     private function fixStart($content)
     {
-        return PregWrapper::replace(
+        return Preg::replace(
             '~
                 (^/\*\*)                  # DocComment begin
                 (?:
@@ -115,7 +115,7 @@ final class Foo {}
      */
     private function fixEnd($content)
     {
-        return PregWrapper::replace(
+        return Preg::replace(
             '~
                 (\R[ \t]*(?:\*[ \t]*)?\S.*?) # last line with useful content
                 (?:

--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -91,7 +92,7 @@ final class Foo {}
      */
     private function fixStart($content)
     {
-        return preg_replace(
+        return PregWrapper::replace(
             '~
                 (^/\*\*)                  # DocComment begin
                 (?:
@@ -114,7 +115,7 @@ final class Foo {}
      */
     private function fixEnd($content)
     {
-        return preg_replace(
+        return PregWrapper::replace(
             '~
                 (\R[ \t]*(?:\*[ \t]*)?\S.*?) # last line with useful content
                 (?:

--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -17,6 +17,7 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\DocBlock\Line;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -92,7 +93,7 @@ final class Foo
     {
         $content = $line->getContent();
 
-        preg_match_all('/ \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $content, $matches);
+        PregWrapper::matchAll('/ \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $content, $matches);
 
         if (isset($matches[0][0])) {
             $line->setContent(str_replace($matches[0][0], '', $content));

--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -17,7 +17,7 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\DocBlock\Line;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -93,7 +93,7 @@ final class Foo
     {
         $content = $line->getContent();
 
-        PregWrapper::matchAll('/ \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $content, $matches);
+        Preg::matchAll('/ \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/', $content, $matches);
 
         if (isset($matches[0][0])) {
             $line->setContent(str_replace($matches[0][0], '', $content));

--- a/src/Fixer/StringNotation/HeredocToNowdocFixer.php
+++ b/src/Fixer/StringNotation/HeredocToNowdocFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\StringNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -77,7 +77,7 @@ EOF
 
             $content = $tokens[$index + 1]->getContent();
             // regex: odd number of backslashes, not followed by dollar
-            if (PregWrapper::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?![$\\\\])/', $content)) {
+            if (Preg::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?![$\\\\])/', $content)) {
                 continue;
             }
 
@@ -101,7 +101,7 @@ EOF
     {
         return new Token(array(
             $token->getId(),
-            PregWrapper::replace('/(?<=^<<<)([ \t]*)"?([^\s"]+)"?/', '$1\'$2\'', $token->getContent()),
+            Preg::replace('/(?<=^<<<)([ \t]*)"?([^\s"]+)"?/', '$1\'$2\'', $token->getContent()),
         ));
     }
 }

--- a/src/Fixer/StringNotation/HeredocToNowdocFixer.php
+++ b/src/Fixer/StringNotation/HeredocToNowdocFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\StringNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -76,7 +77,7 @@ EOF
 
             $content = $tokens[$index + 1]->getContent();
             // regex: odd number of backslashes, not followed by dollar
-            if (preg_match('/(?<!\\\\)(?:\\\\{2})*\\\\(?![$\\\\])/', $content)) {
+            if (PregWrapper::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?![$\\\\])/', $content)) {
                 continue;
             }
 
@@ -100,7 +101,7 @@ EOF
     {
         return new Token(array(
             $token->getId(),
-            preg_replace('/(?<=^<<<)([ \t]*)"?([^\s"]+)"?/', '$1\'$2\'', $token->getContent()),
+            PregWrapper::replace('/(?<=^<<<)([ \t]*)"?([^\s"]+)"?/', '$1\'$2\'', $token->getContent()),
         ));
     }
 }

--- a/src/Fixer/StringNotation/SingleQuoteFixer.php
+++ b/src/Fixer/StringNotation/SingleQuoteFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\StringNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -59,7 +59,7 @@ final class SingleQuoteFixer extends AbstractFixer
                 '"' === $content[0] &&
                 false === strpos($content, "'") &&
                 // regex: odd number of backslashes, not followed by double quote or dollar
-                !PregWrapper::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["$\\\\])/', $content)
+                !Preg::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["$\\\\])/', $content)
             ) {
                 $content = substr($content, 1, -1);
                 $content = str_replace(array('\\"', '\\$'), array('"', '$'), $content);

--- a/src/Fixer/StringNotation/SingleQuoteFixer.php
+++ b/src/Fixer/StringNotation/SingleQuoteFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\StringNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -58,7 +59,7 @@ final class SingleQuoteFixer extends AbstractFixer
                 '"' === $content[0] &&
                 false === strpos($content, "'") &&
                 // regex: odd number of backslashes, not followed by double quote or dollar
-                !preg_match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["$\\\\])/', $content)
+                !PregWrapper::match('/(?<!\\\\)(?:\\\\{2})*\\\\(?!["$\\\\])/', $content)
             ) {
                 $content = substr($content, 1, -1);
                 $content = str_replace(array('\\"', '\\$'), array('"', '$'), $content);

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -91,17 +91,17 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
      */
     private function fixIndentInComment(Tokens $tokens, $index)
     {
-        $content = PregWrapper::replace('/^(?:(?<! ) {1,3})?\t/m', '\1    ', $tokens[$index]->getContent(), -1, $count);
+        $content = Preg::replace('/^(?:(?<! ) {1,3})?\t/m', '\1    ', $tokens[$index]->getContent(), -1, $count);
 
         // Also check for more tabs.
         while (0 !== $count) {
-            $content = PregWrapper::replace('/^(\ +)?\t/m', '\1    ', $content, -1, $count);
+            $content = Preg::replace('/^(\ +)?\t/m', '\1    ', $content, -1, $count);
         }
 
         $indent = $this->indent;
 
         // change indent to expected one
-        $content = PregWrapper::replaceCallback('/^(?:    )+/m', function ($matches) use ($indent) {
+        $content = Preg::replaceCallback('/^(?:    )+/m', function ($matches) use ($indent) {
             return str_replace('    ', $indent, $matches[0]);
         }, $content);
 
@@ -126,11 +126,11 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
         }
 
         $indent = $this->indent;
-        $newContent = PregWrapper::replaceCallback(
+        $newContent = Preg::replaceCallback(
             '/(\R)(\h+)/', // find indent
             function (array $matches) use ($indent) {
                 // normalize mixed indent
-                $content = PregWrapper::replace('/(?:(?<! ) {1,3})?\t/', '    ', $matches[2]);
+                $content = Preg::replace('/(?:(?<! ) {1,3})?\t/', '    ', $matches[2]);
 
                 // change indent to expected one
                 return $matches[1].str_replace('    ', $indent, $content);

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -90,17 +91,17 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
      */
     private function fixIndentInComment(Tokens $tokens, $index)
     {
-        $content = preg_replace('/^(?:(?<! ) {1,3})?\t/m', '\1    ', $tokens[$index]->getContent(), -1, $count);
+        $content = PregWrapper::replace('/^(?:(?<! ) {1,3})?\t/m', '\1    ', $tokens[$index]->getContent(), -1, $count);
 
         // Also check for more tabs.
         while (0 !== $count) {
-            $content = preg_replace('/^(\ +)?\t/m', '\1    ', $content, -1, $count);
+            $content = PregWrapper::replace('/^(\ +)?\t/m', '\1    ', $content, -1, $count);
         }
 
         $indent = $this->indent;
 
         // change indent to expected one
-        $content = preg_replace_callback('/^(?:    )+/m', function ($matches) use ($indent) {
+        $content = PregWrapper::replaceCallback('/^(?:    )+/m', function ($matches) use ($indent) {
             return str_replace('    ', $indent, $matches[0]);
         }, $content);
 
@@ -125,11 +126,11 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
         }
 
         $indent = $this->indent;
-        $newContent = preg_replace_callback(
+        $newContent = PregWrapper::replaceCallback(
             '/(\R)(\h+)/', // find indent
             function (array $matches) use ($indent) {
                 // normalize mixed indent
-                $content = preg_replace('/(?:(?<! ) {1,3})?\t/', '    ', $matches[2]);
+                $content = PregWrapper::replace('/(?:(?<! ) {1,3})?\t/', '    ', $matches[2]);
 
                 // change indent to expected one
                 return $matches[1].str_replace('    ', $indent, $content);

--- a/src/Fixer/Whitespace/LineEndingFixer.php
+++ b/src/Fixer/Whitespace/LineEndingFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -65,7 +66,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
                 if ($tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_END_HEREDOC)) {
                     $tokens[$index] = new Token(array(
                         $token->getId(),
-                        preg_replace(
+                        PregWrapper::replace(
                             "#\r\n|\n#",
                             $ending,
                             $token->getContent()
@@ -79,7 +80,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
             if ($token->isGivenKind(array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_START_HEREDOC))) {
                 $tokens[$index] = new Token(array(
                     $token->getId(),
-                    preg_replace(
+                    PregWrapper::replace(
                         "#\r\n|\n#",
                         $ending,
                         $token->getContent()

--- a/src/Fixer/Whitespace/LineEndingFixer.php
+++ b/src/Fixer/Whitespace/LineEndingFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -66,7 +66,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
                 if ($tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_END_HEREDOC)) {
                     $tokens[$index] = new Token(array(
                         $token->getId(),
-                        PregWrapper::replace(
+                        Preg::replace(
                             "#\r\n|\n#",
                             $ending,
                             $token->getContent()
@@ -80,7 +80,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
             if ($token->isGivenKind(array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_START_HEREDOC))) {
                 $tokens[$index] = new Token(array(
                     $token->getId(),
-                    PregWrapper::replace(
+                    Preg::replace(
                         "#\r\n|\n#",
                         $ending,
                         $token->getContent()

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Whitespace;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -66,7 +67,7 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
                 continue;
             }
 
-            $lines = preg_split("/([\r\n]+)/", $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+            $lines = PregWrapper::split("/([\r\n]+)/", $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
             $linesSize = count($lines);
 
             // fix only multiline whitespaces or singleline whitespaces at the end of file

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -15,7 +15,7 @@ namespace PhpCsFixer\Fixer\Whitespace;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -67,7 +67,7 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
                 continue;
             }
 
-            $lines = PregWrapper::split("/([\r\n]+)/", $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+            $lines = Preg::split("/([\r\n]+)/", $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
             $linesSize = count($lines);
 
             // fix only multiline whitespaces or singleline whitespaces at the end of file

--- a/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+++ b/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
@@ -16,7 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -73,7 +73,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
     private function fixWhitespaceToken(Tokens $tokens, $index)
     {
         $content = $tokens[$index]->getContent();
-        $lines = PregWrapper::split("/(\r\n|\n)/", $content);
+        $lines = Preg::split("/(\r\n|\n)/", $content);
         $lineCount = count($lines);
 
         if (
@@ -90,7 +90,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
             }
 
             for ($l = $lStart; $l < $lMax; ++$l) {
-                $lines[$l] = PregWrapper::replace('/^\h+$/', '', $lines[$l]);
+                $lines[$l] = Preg::replace('/^\h+$/', '', $lines[$l]);
             }
             $content = implode($this->whitespacesConfig->getLineEnding(), $lines);
             if ('' !== $content) {

--- a/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+++ b/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -72,7 +73,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
     private function fixWhitespaceToken(Tokens $tokens, $index)
     {
         $content = $tokens[$index]->getContent();
-        $lines = preg_split("/(\r\n|\n)/", $content);
+        $lines = PregWrapper::split("/(\r\n|\n)/", $content);
         $lineCount = count($lines);
 
         if (
@@ -89,7 +90,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
             }
 
             for ($l = $lStart; $l < $lMax; ++$l) {
-                $lines[$l] = preg_replace('/^\h+$/', '', $lines[$l]);
+                $lines[$l] = PregWrapper::replace('/^\h+$/', '', $lines[$l]);
             }
             $content = implode($this->whitespacesConfig->getLineEnding(), $lines);
             if ('' !== $content) {

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -28,9 +28,9 @@ final class FixerNameValidator
     public function isValid($name, $isCustom)
     {
         if (!$isCustom) {
-            return 1 === PregWrapper::match('/^[a-z][a-z0-9_]*$/', $name);
+            return 1 === Preg::match('/^[a-z][a-z0-9_]*$/', $name);
         }
 
-        return 1 === PregWrapper::match('/^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/', $name);
+        return 1 === Preg::match('/^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/', $name);
     }
 }

--- a/src/FixerNameValidator.php
+++ b/src/FixerNameValidator.php
@@ -28,9 +28,9 @@ final class FixerNameValidator
     public function isValid($name, $isCustom)
     {
         if (!$isCustom) {
-            return 1 === preg_match('/^[a-z][a-z0-9_]*$/', $name);
+            return 1 === PregWrapper::match('/^[a-z][a-z0-9_]*$/', $name);
         }
 
-        return 1 === preg_match('/^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/', $name);
+        return 1 === PregWrapper::match('/^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/', $name);
     }
 }

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -20,11 +20,11 @@ namespace PhpCsFixer;
 final class Preg
 {
     /**
-     * @param string   $pattern
-     * @param string   $subject
-     * @param string[] &$matches
-     * @param int      $flags
-     * @param int      $offset
+     * @param string        $pattern
+     * @param string        $subject
+     * @param null|string[] &$matches
+     * @param int           $flags
+     * @param int           $offset
      *
      * @throws \RuntimeException
      *
@@ -46,11 +46,11 @@ final class Preg
     }
 
     /**
-     * @param string   $pattern
-     * @param string   $subject
-     * @param string[] &$matches
-     * @param int      $flags
-     * @param int      $offset
+     * @param string        $pattern
+     * @param string        $subject
+     * @param null|string[] &$matches
+     * @param int           $flags
+     * @param int           $offset
      *
      * @throws \RuntimeException
      *
@@ -76,7 +76,7 @@ final class Preg
      * @param string|string[] $replacement
      * @param string|string[] $subject
      * @param int             $limit
-     * @param int             $count
+     * @param null|int        &$count
      *
      * @throws \RuntimeException
      *
@@ -102,7 +102,7 @@ final class Preg
      * @param callable        $callback
      * @param string|string[] $subject
      * @param int             $limit
-     * @param int             $count
+     * @param null|int        &$count
      *
      * @throws \RuntimeException
      *

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -13,6 +13,8 @@
 namespace PhpCsFixer;
 
 /**
+ * This class replaces preg_* functions to better handle UTF8 strings.
+ *
  * @author Kuba Werłos <werlos@gmail.com>
  *
  * @internal

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -40,7 +40,7 @@ final class Preg
             return $result;
         }
 
-        $result = preg_match(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        $result = @preg_match(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
         if (false !== $result) {
             return $result;
         }
@@ -66,7 +66,7 @@ final class Preg
             return $result;
         }
 
-        $result = preg_match_all(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        $result = @preg_match_all(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
         if (false !== $result) {
             return $result;
         }
@@ -92,7 +92,7 @@ final class Preg
             return $result;
         }
 
-        $result = preg_replace(self::removeUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
+        $result = @preg_replace(self::removeUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
         if (null !== $result) {
             return $result;
         }
@@ -118,7 +118,7 @@ final class Preg
             return $result;
         }
 
-        $result = preg_replace_callback(self::removeUtf8Modifier($pattern), $callback, $subject, $limit, $count);
+        $result = @preg_replace_callback(self::removeUtf8Modifier($pattern), $callback, $subject, $limit, $count);
         if (null !== $result) {
             return $result;
         }
@@ -132,6 +132,8 @@ final class Preg
      * @param int    $limit
      * @param int    $flags
      *
+     * @throws PregException
+     *
      * @return string[]
      */
     public static function split($pattern, $subject, $limit = -1, $flags = 0)
@@ -141,7 +143,12 @@ final class Preg
             return $result;
         }
 
-        return preg_split(self::removeUtf8Modifier($pattern), $subject, $limit, $flags);
+        $result = @preg_split(self::removeUtf8Modifier($pattern), $subject, $limit, $flags);
+        if (false !== $result) {
+            return $result;
+        }
+
+        throw new PregException('Error occurred when calling preg_split.', preg_last_error());
     }
 
     /**

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -176,7 +176,11 @@ final class Preg
             return array_map(__METHOD__, $pattern);
         }
 
-        $delimiter = $pattern[0];
+        if ('' === $pattern) {
+            return '';
+        }
+
+        $delimiter = substr($pattern, 0, 1);
 
         $endDelimiterPosition = strrpos($pattern, $delimiter);
 

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -13,7 +13,8 @@
 namespace PhpCsFixer;
 
 /**
- * This class replaces preg_* functions to better handle UTF8 strings.
+ * This class replaces preg_* functions to better handling UTF8 strings,
+ * ensuring no matter "u" modifier is present or absent subject will be handled correctly.
  *
  * @author Kuba Werłos <werlos@gmail.com>
  *

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -26,7 +26,7 @@ final class Preg
      * @param int           $flags
      * @param int           $offset
      *
-     * @throws \RuntimeException
+     * @throws PregException
      *
      * @return int
      */
@@ -42,7 +42,7 @@ final class Preg
             return $result;
         }
 
-        throw new \RuntimeException('Error occurred when calling preg_match.', preg_last_error());
+        throw new PregException('Error occurred when calling preg_match.', preg_last_error());
     }
 
     /**
@@ -52,7 +52,7 @@ final class Preg
      * @param int           $flags
      * @param int           $offset
      *
-     * @throws \RuntimeException
+     * @throws PregException
      *
      * @return int
      */
@@ -68,7 +68,7 @@ final class Preg
             return $result;
         }
 
-        throw new \RuntimeException('Error occurred when calling preg_match_all.', preg_last_error());
+        throw new PregException('Error occurred when calling preg_match_all.', preg_last_error());
     }
 
     /**
@@ -78,7 +78,7 @@ final class Preg
      * @param int             $limit
      * @param null|int        &$count
      *
-     * @throws \RuntimeException
+     * @throws PregException
      *
      * @return string|string[]
      */
@@ -94,7 +94,7 @@ final class Preg
             return $result;
         }
 
-        throw new \RuntimeException('Error occurred when calling preg_replace.', preg_last_error());
+        throw new PregException('Error occurred when calling preg_replace.', preg_last_error());
     }
 
     /**
@@ -104,7 +104,7 @@ final class Preg
      * @param int             $limit
      * @param null|int        &$count
      *
-     * @throws \RuntimeException
+     * @throws PregException
      *
      * @return string|string[]
      */
@@ -120,7 +120,7 @@ final class Preg
             return $result;
         }
 
-        throw new \RuntimeException('Error occurred when calling preg_replace_callback.', preg_last_error());
+        throw new PregException('Error occurred when calling preg_replace_callback.', preg_last_error());
     }
 
     /**

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -17,7 +17,7 @@ namespace PhpCsFixer;
  *
  * @internal
  */
-final class PregWrapper
+final class Preg
 {
     /**
      * @param string   $pattern

--- a/src/PregException.php
+++ b/src/PregException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * Exception that is thrown when PCRE function encounters an error.
+ *
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+class PregException extends \RuntimeException
+{
+}

--- a/src/PregException.php
+++ b/src/PregException.php
@@ -19,6 +19,6 @@ namespace PhpCsFixer;
  *
  * @internal
  */
-class PregException extends \RuntimeException
+final class PregException extends \RuntimeException
 {
 }

--- a/src/PregWrapper.php
+++ b/src/PregWrapper.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class PregWrapper
+{
+    /**
+     * @param string   $pattern
+     * @param string   $subject
+     * @param string[] &$matches
+     * @param int      $flags
+     * @param int      $offset
+     *
+     * @throws \RuntimeException
+     *
+     * @return int
+     */
+    public static function match($pattern, $subject, &$matches = null, $flags = 0, $offset = 0)
+    {
+        $result = @preg_match(self::addUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        if (false !== $result) {
+            return $result;
+        }
+
+        $result = preg_match(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        if (false !== $result) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Error occurred when calling preg_match.', preg_last_error());
+    }
+
+    /**
+     * @param string   $pattern
+     * @param string   $subject
+     * @param string[] &$matches
+     * @param int      $flags
+     * @param int      $offset
+     *
+     * @throws \RuntimeException
+     *
+     * @return int
+     */
+    public static function matchAll($pattern, $subject, &$matches = null, $flags = PREG_PATTERN_ORDER, $offset = 0)
+    {
+        $result = @preg_match_all(self::addUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        if (false !== $result) {
+            return $result;
+        }
+
+        $result = preg_match_all(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
+        if (false !== $result) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Error occurred when calling preg_match_all.', preg_last_error());
+    }
+
+    /**
+     * @param string|string[] $pattern
+     * @param string|string[] $replacement
+     * @param string|string[] $subject
+     * @param int             $limit
+     * @param int             $count
+     *
+     * @throws \RuntimeException
+     *
+     * @return string|string[]
+     */
+    public static function replace($pattern, $replacement, $subject, $limit = -1, &$count = null)
+    {
+        $result = @preg_replace(self::addUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
+        if (null !== $result) {
+            return $result;
+        }
+
+        $result = preg_replace(self::removeUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
+        if (null !== $result) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Error occurred when calling preg_replace.', preg_last_error());
+    }
+
+    /**
+     * @param string|string[] $pattern
+     * @param callable        $callback
+     * @param string|string[] $subject
+     * @param int             $limit
+     * @param int             $count
+     *
+     * @throws \RuntimeException
+     *
+     * @return string|string[]
+     */
+    public static function replaceCallback($pattern, $callback, $subject, $limit = -1, &$count = null)
+    {
+        $result = @preg_replace_callback(self::addUtf8Modifier($pattern), $callback, $subject, $limit, $count);
+        if (null !== $result) {
+            return $result;
+        }
+
+        $result = preg_replace_callback(self::removeUtf8Modifier($pattern), $callback, $subject, $limit, $count);
+        if (null !== $result) {
+            return $result;
+        }
+
+        throw new \RuntimeException('Error occurred when calling preg_replace_callback.', preg_last_error());
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     * @param int    $limit
+     * @param int    $flags
+     *
+     * @return string[]
+     */
+    public static function split($pattern, $subject, $limit = -1, $flags = 0)
+    {
+        $result = @preg_split(self::addUtf8Modifier($pattern), $subject, $limit, $flags);
+        if (false !== $result) {
+            return $result;
+        }
+
+        return preg_split(self::removeUtf8Modifier($pattern), $subject, $limit, $flags);
+    }
+
+    /**
+     * @param string|string[] $pattern
+     *
+     * @return string|string[]
+     */
+    private static function addUtf8Modifier($pattern)
+    {
+        if (is_array($pattern)) {
+            return array_map(__METHOD__, $pattern);
+        }
+
+        return $pattern.'u';
+    }
+
+    /**
+     * @param string|string[] $pattern
+     *
+     * @return string|string[]
+     */
+    private static function removeUtf8Modifier($pattern)
+    {
+        if (is_array($pattern)) {
+            return array_map(__METHOD__, $pattern);
+        }
+
+        $delimiter = $pattern[0];
+
+        $endDelimiterPosition = strrpos($pattern, $delimiter);
+
+        return substr($pattern, 0, $endDelimiterPosition).str_replace('u', '', substr($pattern, $endDelimiterPosition));
+    }
+}

--- a/src/Report/JunitReporter.php
+++ b/src/Report/JunitReporter.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Report;
 
+use PhpCsFixer\PregWrapper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
@@ -115,7 +116,7 @@ final class JunitReporter implements ReporterInterface
     {
         $appliedFixersCount = count($fixResult['appliedFixers']);
 
-        $testName = str_replace('.', '_DOT_', preg_replace('@\.'.pathinfo($file, PATHINFO_EXTENSION).'$@', '', $file));
+        $testName = str_replace('.', '_DOT_', PregWrapper::replace('@\.'.pathinfo($file, PATHINFO_EXTENSION).'$@', '', $file));
 
         $testcase = $dom->createElement('testcase');
         $testcase->setAttribute('name', $testName);

--- a/src/Report/JunitReporter.php
+++ b/src/Report/JunitReporter.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Report;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 
 /**
@@ -116,7 +116,7 @@ final class JunitReporter implements ReporterInterface
     {
         $appliedFixersCount = count($fixResult['appliedFixers']);
 
-        $testName = str_replace('.', '_DOT_', PregWrapper::replace('@\.'.pathinfo($file, PATHINFO_EXTENSION).'$@', '', $file));
+        $testName = str_replace('.', '_DOT_', Preg::replace('@\.'.pathinfo($file, PATHINFO_EXTENSION).'$@', '', $file));
 
         $testcase = $dom->createElement('testcase');
         $testcase->setAttribute('name', $testName);

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tokenizer;
 
+use PhpCsFixer\PregWrapper;
 use PhpCsFixer\Utils;
 
 /**
@@ -914,7 +915,7 @@ class Tokens extends \SplFixedArray
 
             // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
             if (isset($this[$index - 2]) && $this[$index - 2]->isComment() && '/*' !== substr($this[$index - 2]->getContent(), 0, 2)) {
-                list($emptyString, $newContent, $whitespacesToCheck) = preg_split('/^(\R)/', $this[$index - 1]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+                list($emptyString, $newContent, $whitespacesToCheck) = PregWrapper::split('/^(\R)/', $this[$index - 1]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
                 if ('' === $whitespacesToCheck) {
                     return;
                 }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Tokenizer;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Utils;
 
 /**
@@ -915,7 +915,7 @@ class Tokens extends \SplFixedArray
 
             // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
             if (isset($this[$index - 2]) && $this[$index - 2]->isComment() && '/*' !== substr($this[$index - 2]->getContent(), 0, 2)) {
-                list($emptyString, $newContent, $whitespacesToCheck) = PregWrapper::split('/^(\R)/', $this[$index - 1]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$index - 1]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
                 if ('' === $whitespacesToCheck) {
                     return;
                 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -52,7 +52,7 @@ final class Utils
      */
     public static function camelCaseToUnderscore($string)
     {
-        return PregWrapper::replaceCallback(
+        return Preg::replaceCallback(
             '/(^|[a-z0-9])([A-Z])/',
             function (array $matches) {
                 return strtolower('' !== $matches[1] ? $matches[1].'_'.$matches[2] : $matches[2]);
@@ -95,7 +95,7 @@ final class Utils
      */
     public static function splitLines($content)
     {
-        PregWrapper::matchAll("/[^\n\r]+[\r\n]*/", $content, $matches);
+        Preg::matchAll("/[^\n\r]+[\r\n]*/", $content, $matches);
 
         return $matches[0];
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -52,7 +52,7 @@ final class Utils
      */
     public static function camelCaseToUnderscore($string)
     {
-        return preg_replace_callback(
+        return PregWrapper::replaceCallback(
             '/(^|[a-z0-9])([A-Z])/',
             function (array $matches) {
                 return strtolower('' !== $matches[1] ? $matches[1].'_'.$matches[2] : $matches[2]);
@@ -95,7 +95,7 @@ final class Utils
      */
     public static function splitLines($content)
     {
-        preg_match_all("/[^\n\r]+[\r\n]*/", $content, $matches);
+        PregWrapper::matchAll("/[^\n\r]+[\r\n]*/", $content, $matches);
 
         return $matches[0];
     }

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -407,7 +407,7 @@ final class ProjectCodeTest extends TestCase
             array_filter(
                 $this->getSrcClasses(),
                 function ($className) {
-                    return 'PhpCsFixer\\PregWrapper' !== $className;
+                    return 'PhpCsFixer\\Preg' !== $className;
                 }
             )
         );

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -260,6 +260,10 @@ final class ProjectCodeTest extends TestCase
      */
     public function testThereIsNoPregFunctionUsedDirectly($className)
     {
+        if (extension_loaded('xdebug') && false === getenv('CI')) {
+            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
+        }
+
         $rc = new \ReflectionClass($className);
         $tokens = Tokens::fromCode(file_get_contents($rc->getFileName()));
         $stringTokens = array_filter(
@@ -396,10 +400,6 @@ final class ProjectCodeTest extends TestCase
 
     public function provideClassesWherePregFunctionsAreForbiddenCases()
     {
-        if (extension_loaded('xdebug') && false === getenv('CI')) {
-            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
-        }
-
         return array_map(
             function ($item) {
                 return array($item);

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -260,10 +260,6 @@ final class ProjectCodeTest extends TestCase
      */
     public function testThereIsNoPregFunctionUsedDirectly($className)
     {
-        if (extension_loaded('xdebug') && false === getenv('CI')) {
-            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
-        }
-
         $rc = new \ReflectionClass($className);
         $tokens = Tokens::fromCode(file_get_contents($rc->getFileName()));
         $stringTokens = array_filter(
@@ -400,6 +396,10 @@ final class ProjectCodeTest extends TestCase
 
     public function provideClassesWherePregFunctionsAreForbiddenCases()
     {
+        if (extension_loaded('xdebug') && false === getenv('CI')) {
+            $this->markTestSkipped('Test too slow when Xdebug is loaded.');
+        }
+
         return array_map(
             function ($item) {
                 return array($item);

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Tests\AutoReview;
 
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -252,6 +253,38 @@ final class ProjectCodeTest extends TestCase
         ));
     }
 
+    /**
+     * @dataProvider provideClassesWherePregFunctionsAreForbiddenCases
+     *
+     * @param string $className
+     */
+    public function testThereIsNoPregFunctionUsedDirectly($className)
+    {
+        $rc = new \ReflectionClass($className);
+        $tokens = Tokens::fromCode(file_get_contents($rc->getFileName()));
+        $stringTokens = array_filter(
+            $tokens->toArray(),
+            function (Token $token) {
+                return $token->isGivenKind(T_STRING);
+            }
+        );
+        $strings = array_map(
+            function (Token $token) {
+                return $token->getContent();
+            },
+            $stringTokens
+        );
+        $strings = array_unique($strings);
+        $message = sprintf('Tested file: %s', $rc->getFileName());
+        $this->assertNotContains('preg_filter', $strings, $message);
+        $this->assertNotContains('preg_grep', $strings, $message);
+        $this->assertNotContains('preg_match', $strings, $message);
+        $this->assertNotContains('preg_match_all', $strings, $message);
+        $this->assertNotContains('preg_replace', $strings, $message);
+        $this->assertNotContains('preg_replace_callback', $strings, $message);
+        $this->assertNotContains('preg_split', $strings, $message);
+    }
+
     public function provideSrcClassCases()
     {
         return array_map(
@@ -359,6 +392,25 @@ final class ProjectCodeTest extends TestCase
         }
 
         return $data;
+    }
+
+    public function provideClassesWherePregFunctionsAreForbiddenCases()
+    {
+        if (extension_loaded('xdebug') && false === getenv('CI')) {
+            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
+        }
+
+        return array_map(
+            function ($item) {
+                return array($item);
+            },
+            array_filter(
+                $this->getSrcClasses(),
+                function ($className) {
+                    return 'PhpCsFixer\\PregWrapper' !== $className;
+                }
+            )
+        );
     }
 
     private function getSrcClasses()

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -275,7 +275,7 @@ final class ProjectCodeTest extends TestCase
             $stringTokens
         );
         $strings = array_unique($strings);
-        $message = sprintf('Tested file: %s', $rc->getFileName());
+        $message = sprintf('Class %s must not use preg_*, it shall use Preg::* instead.', $className);
         $this->assertNotContains('preg_filter', $strings, $message);
         $this->assertNotContains('preg_grep', $strings, $message);
         $this->assertNotContains('preg_match', $strings, $message);

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -93,6 +93,11 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
                 // invalid char inside line won't crash the fixer
                 '<?php
     /**
+     * @var string this: '.chr(174).' is an odd character
+     * @var string This: '.chr(174).' is an odd character 2nd time。
+     */',
+                '<?php
+    /**
      * @var string This: '.chr(174).' is an odd character.
      * @var string This: '.chr(174).' is an odd character 2nd time。
      */',

--- a/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimFixerTest.php
@@ -59,6 +59,15 @@ function deactivateCompleted()
     return 0;
 }',
             ),
+            array(
+                mb_convert_encoding('
+<?php
+/**
+ * Test à
+ */
+function foo(){}
+', 'Windows-1252', 'UTF-8'),
+            ),
         );
     }
 

--- a/tests/PregExceptionTest.php
+++ b/tests/PregExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests;
+
+use PhpCsFixer\PregException;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\PregException
+ */
+final class PregExceptionTest extends TestCase
+{
+    public function testIsRuntimeException()
+    {
+        $exception = new PregException();
+
+        $this->assertInstanceOf('\\RuntimeException', $exception);
+    }
+}

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -30,7 +30,7 @@ final class PregTest extends TestCase
             'Error occurred when calling preg_match.'
         );
 
-        Preg::match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+        Preg::match('', 'foo', $matches);
     }
 
     /**
@@ -55,7 +55,7 @@ final class PregTest extends TestCase
             'Error occurred when calling preg_match_all.'
         );
 
-        Preg::matchAll('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+        Preg::matchAll('', 'foo', $matches);
     }
 
     /**
@@ -80,7 +80,7 @@ final class PregTest extends TestCase
             'Error occurred when calling preg_replace.'
         );
 
-        Preg::replace('/(?:\D+|<\d+>)*[!?]/', 'foo', 'foobar foobar foobar');
+        Preg::replace('', 'foo', 'bar');
     }
 
     /**
@@ -105,7 +105,7 @@ final class PregTest extends TestCase
             'Error occurred when calling preg_replace_callback.'
         );
 
-        Preg::replaceCallback('/(?:\D+|<\d+>)*[!?]/', 'sort', 'foobar foobar foobar');
+        Preg::replaceCallback('', 'sort', 'foo');
     }
 
     /**
@@ -144,20 +144,27 @@ final class PregTest extends TestCase
         );
     }
 
-    public function testSplitUtf8Pattern()
+    public function testSplitFailing()
     {
-        $expectedResult = preg_split('/à/u', 'àbc');
-        $actual = Preg::split('/à/u', 'àbc');
+        $this->setExpectedException(
+            'PhpCsFixer\\PregException',
+            'Error occurred when calling preg_split.'
+        );
 
-        $this->assertSame($expectedResult, $actual);
+        Preg::split('', 'foo');
     }
 
-    public function testSplitNonUtf8Pattern()
+    /**
+     * @param string $pattern
+     *
+     * @dataProvider provideCommonCases
+     */
+    public function testSplit($pattern)
     {
-        $expectedResult = preg_split('/'.chr(224).'|í/', 'àbc');
-        $actual = Preg::split('/'.chr(224).'|í/', 'àbc');
+        $expectedResult = preg_split($pattern, 'foo');
+        $actualResult = Preg::split($pattern, 'foo');
 
-        $this->assertSame($expectedResult, $actual);
+        $this->assertSame($expectedResult, $actualResult);
     }
 
     public function testCorrectnessForUtf8String()

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -12,16 +12,16 @@
 
 namespace PhpCsFixer\Tests;
 
-use PhpCsFixer\PregWrapper;
+use PhpCsFixer\Preg;
 
 /**
  * @author Kuba Werłos <werlos@gmail.com>
  *
- * @covers \PhpCsFixer\PregWrapper
+ * @covers \PhpCsFixer\Preg
  *
  * @internal
  */
-final class PregWrapperTest extends TestCase
+final class PregTest extends TestCase
 {
     public function testMatchFailing()
     {
@@ -30,7 +30,7 @@ final class PregWrapperTest extends TestCase
             'Error occurred when calling preg_match.'
         );
 
-        PregWrapper::match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+        Preg::match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
     }
 
     /**
@@ -42,7 +42,7 @@ final class PregWrapperTest extends TestCase
     public function testMatch($pattern, $subject)
     {
         $expectedResult = preg_match($pattern, $subject, $expectedMatches);
-        $actualResult = PregWrapper::match($pattern, $subject, $actualMatches);
+        $actualResult = Preg::match($pattern, $subject, $actualMatches);
 
         $this->assertSame($expectedResult, $actualResult);
         $this->assertSame($expectedMatches, $actualMatches);
@@ -55,7 +55,7 @@ final class PregWrapperTest extends TestCase
             'Error occurred when calling preg_match_all.'
         );
 
-        PregWrapper::matchAll('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+        Preg::matchAll('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
     }
 
     /**
@@ -67,7 +67,7 @@ final class PregWrapperTest extends TestCase
     public function testMatchAll($pattern, $subject)
     {
         $expectedResult = preg_match_all($pattern, $subject, $expectedMatches);
-        $actualResult = PregWrapper::matchAll($pattern, $subject, $actualMatches);
+        $actualResult = Preg::matchAll($pattern, $subject, $actualMatches);
 
         $this->assertSame($expectedResult, $actualResult);
         $this->assertSame($expectedMatches, $actualMatches);
@@ -80,7 +80,7 @@ final class PregWrapperTest extends TestCase
             'Error occurred when calling preg_replace.'
         );
 
-        PregWrapper::replace('/(?:\D+|<\d+>)*[!?]/', 'foo', 'foobar foobar foobar');
+        Preg::replace('/(?:\D+|<\d+>)*[!?]/', 'foo', 'foobar foobar foobar');
     }
 
     /**
@@ -93,7 +93,7 @@ final class PregWrapperTest extends TestCase
     public function testReplace($pattern, $subject)
     {
         $expectedResult = preg_replace($pattern, 'foo', $subject);
-        $actualResult = PregWrapper::replace($pattern, 'foo', $subject);
+        $actualResult = Preg::replace($pattern, 'foo', $subject);
 
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -105,7 +105,7 @@ final class PregWrapperTest extends TestCase
             'Error occurred when calling preg_replace_callback.'
         );
 
-        PregWrapper::replaceCallback('/(?:\D+|<\d+>)*[!?]/', 'sort', 'foobar foobar foobar');
+        Preg::replaceCallback('/(?:\D+|<\d+>)*[!?]/', 'sort', 'foobar foobar foobar');
     }
 
     /**
@@ -120,7 +120,7 @@ final class PregWrapperTest extends TestCase
         $callback = function (array $x) { return implode('-', $x); };
 
         $expectedResult = preg_replace_callback($pattern, $callback, $subject);
-        $actualResult = PregWrapper::replaceCallback($pattern, $callback, $subject);
+        $actualResult = Preg::replaceCallback($pattern, $callback, $subject);
 
         $this->assertSame($expectedResult, $actualResult);
     }
@@ -147,7 +147,7 @@ final class PregWrapperTest extends TestCase
     public function testSplitUtf8Pattern()
     {
         $expectedResult = preg_split('/à/u', 'àbc');
-        $actual = PregWrapper::split('/à/u', 'àbc');
+        $actual = Preg::split('/à/u', 'àbc');
 
         $this->assertSame($expectedResult, $actual);
     }
@@ -155,7 +155,7 @@ final class PregWrapperTest extends TestCase
     public function testSplitNonUtf8Pattern()
     {
         $expectedResult = preg_split('/'.chr(224).'|í/', 'àbc');
-        $actual = PregWrapper::split('/'.chr(224).'|í/', 'àbc');
+        $actual = Preg::split('/'.chr(224).'|í/', 'àbc');
 
         $this->assertSame($expectedResult, $actual);
     }

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -159,4 +159,22 @@ final class PregTest extends TestCase
 
         $this->assertSame($expectedResult, $actual);
     }
+
+    public function testCorrectnessForUtf8String()
+    {
+        Preg::match('/./', 'àbc', $methodMatches);
+        preg_match('/./', 'àbc', $functionMatches);
+
+        $this->assertSame(array('à'), $methodMatches);
+        $this->assertNotSame(array('à'), $functionMatches);
+    }
+
+    public function testCorrectnessForNonUtf8String()
+    {
+        Preg::match('/./u', chr(224).'bc', $methodMatches);
+        preg_match('/./u', chr(224).'bc', $functionMatches);
+
+        $this->assertSame(array(chr(224)), $methodMatches);
+        $this->assertNotSame(array(chr(224)), $functionMatches);
+    }
 }

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -26,7 +26,7 @@ final class PregTest extends TestCase
     public function testMatchFailing()
     {
         $this->setExpectedException(
-            'RuntimeException',
+            'PhpCsFixer\\PregException',
             'Error occurred when calling preg_match.'
         );
 
@@ -51,7 +51,7 @@ final class PregTest extends TestCase
     public function testMatchAllFailing()
     {
         $this->setExpectedException(
-            'RuntimeException',
+            'PhpCsFixer\\PregException',
             'Error occurred when calling preg_match_all.'
         );
 
@@ -76,7 +76,7 @@ final class PregTest extends TestCase
     public function testReplaceFailing()
     {
         $this->setExpectedException(
-            'RuntimeException',
+            'PhpCsFixer\\PregException',
             'Error occurred when calling preg_replace.'
         );
 
@@ -101,7 +101,7 @@ final class PregTest extends TestCase
     public function testReplaceCallbackFailing()
     {
         $this->setExpectedException(
-            'RuntimeException',
+            'PhpCsFixer\\PregException',
             'Error occurred when calling preg_replace_callback.'
         );
 

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -162,8 +162,11 @@ final class PregTest extends TestCase
 
     public function testCorrectnessForUtf8String()
     {
-        Preg::match('/./', 'àbc', $methodMatches);
-        preg_match('/./', 'àbc', $functionMatches);
+        $pattern = '/./';
+        $subject = 'àbc';
+
+        Preg::match($pattern, $subject, $methodMatches);
+        preg_match($pattern, $subject, $functionMatches);
 
         $this->assertSame(array('à'), $methodMatches);
         $this->assertNotSame(array('à'), $functionMatches);
@@ -171,8 +174,11 @@ final class PregTest extends TestCase
 
     public function testCorrectnessForNonUtf8String()
     {
-        Preg::match('/./u', chr(224).'bc', $methodMatches);
-        preg_match('/./u', chr(224).'bc', $functionMatches);
+        $pattern = '/./u';
+        $subject = chr(224).'bc';
+
+        Preg::match($pattern, $subject, $methodMatches);
+        preg_match($pattern, $subject, $functionMatches);
 
         $this->assertSame(array(chr(224)), $methodMatches);
         $this->assertNotSame(array(chr(224)), $functionMatches);

--- a/tests/PregWrapperTest.php
+++ b/tests/PregWrapperTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests;
+
+use PhpCsFixer\PregWrapper;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @covers \PhpCsFixer\PregWrapper
+ *
+ * @internal
+ */
+final class PregWrapperTest extends TestCase
+{
+    public function testMatchFailing()
+    {
+        $this->setExpectedException(
+            'RuntimeException',
+            'Error occurred when calling preg_match.'
+        );
+
+        PregWrapper::match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @dataProvider provideCommonCases
+     */
+    public function testMatch($pattern, $subject)
+    {
+        $expectedResult = preg_match($pattern, $subject, $expectedMatches);
+        $actualResult = PregWrapper::match($pattern, $subject, $actualMatches);
+
+        $this->assertSame($expectedResult, $actualResult);
+        $this->assertSame($expectedMatches, $actualMatches);
+    }
+
+    public function testMatchAllFailing()
+    {
+        $this->setExpectedException(
+            'RuntimeException',
+            'Error occurred when calling preg_match_all.'
+        );
+
+        PregWrapper::matchAll('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', $matches);
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @dataProvider provideCommonCases
+     */
+    public function testMatchAll($pattern, $subject)
+    {
+        $expectedResult = preg_match_all($pattern, $subject, $expectedMatches);
+        $actualResult = PregWrapper::matchAll($pattern, $subject, $actualMatches);
+
+        $this->assertSame($expectedResult, $actualResult);
+        $this->assertSame($expectedMatches, $actualMatches);
+    }
+
+    public function testReplaceFailing()
+    {
+        $this->setExpectedException(
+            'RuntimeException',
+            'Error occurred when calling preg_replace.'
+        );
+
+        PregWrapper::replace('/(?:\D+|<\d+>)*[!?]/', 'foo', 'foobar foobar foobar');
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @dataProvider provideCommonCases
+     * @dataProvider provideArrayOfPatternsCases
+     */
+    public function testReplace($pattern, $subject)
+    {
+        $expectedResult = preg_replace($pattern, 'foo', $subject);
+        $actualResult = PregWrapper::replace($pattern, 'foo', $subject);
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    public function testReplaceCallbackFailing()
+    {
+        $this->setExpectedException(
+            'RuntimeException',
+            'Error occurred when calling preg_replace_callback.'
+        );
+
+        PregWrapper::replaceCallback('/(?:\D+|<\d+>)*[!?]/', 'sort', 'foobar foobar foobar');
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @dataProvider provideCommonCases
+     * @dataProvider provideArrayOfPatternsCases
+     */
+    public function testReplaceCallback($pattern, $subject)
+    {
+        $callback = function (array $x) { return implode('-', $x); };
+
+        $expectedResult = preg_replace_callback($pattern, $callback, $subject);
+        $actualResult = PregWrapper::replaceCallback($pattern, $callback, $subject);
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    public function provideCommonCases()
+    {
+        return array(
+            array('/u/u', 'u'),
+            array('/u/u', 'u/u'),
+            array('/./', chr(224).'bc'),
+            array('/à/', 'àbc'),
+            array('/'.chr(224).'|í/', 'àbc'),
+        );
+    }
+
+    public function provideArrayOfPatternsCases()
+    {
+        return array(
+            array(array('/à/', '/í/'), 'Tàíl'),
+            array(array('/'.chr(174).'/', '/'.chr(224).'/'), 'foo'),
+        );
+    }
+
+    public function testSplitUtf8Pattern()
+    {
+        $expectedResult = preg_split('/à/u', 'àbc');
+        $actual = PregWrapper::split('/à/u', 'àbc');
+
+        $this->assertSame($expectedResult, $actual);
+    }
+
+    public function testSplitNonUtf8Pattern()
+    {
+        $expectedResult = preg_split('/'.chr(224).'|í/', 'àbc');
+        $actual = PregWrapper::split('/'.chr(224).'|í/', 'àbc');
+
+        $this->assertSame($expectedResult, $actual);
+    }
+}


### PR DESCRIPTION
Solution for https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3309 and idea how to handle non-UTF8 strings.

Of course, as @Slamdunk already [mendioned](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3309#issuecomment-351030840), with `AutoReview` class to check if all `preg_*` functions are wrapped.