### PR TITLE
NoEmptyCommentFixer - comment block detection for line ending different than LF

### DIFF
--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -141,7 +141,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
     {
         $lineCount = 0;
         for ($i = $whiteStart; $i < $whiteEnd; ++$i) {
-            $lineCount += substr_count($tokens[$i]->getContent(), "\n");
+            $lineCount += preg_match_all('/\R/u', $tokens[$i]->getContent(), $matches);
         }
 
         return $lineCount;

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -287,6 +287,18 @@ echo 1;
                 true,
             ),
             array(
+                str_replace("\n", "\r", '<?php
+//
+//
+
+//
+//
+'),
+                1,
+                3,
+                true,
+            ),
+            array(
                 '<?php
 //
 

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -143,18 +143,20 @@ echo 1;
                 */',
             ),
             array(
-                '<?php
-                    '.'
-                    '.'
-                    '.'
-                    '.'
-                ',
-                '<?php
-                    //
-                    //
-                    //
-                    /**///
-                ',
+                "<?php\n                    \n                    \n                    \n                    \n                ",
+                "<?php\n                    //\n                    //\n                    //\n                    /**///\n                ",
+            ),
+            array(
+                "<?php\r                    \r                    \r                    \r                    \r                ",
+                "<?php\r                    //\r                    //\r                    //\r                    /**///\r                ",
+            ),
+            array(
+                "<?php\r\n                    \r\n                    \r\n                    \r\n                    \r\n                ",
+                "<?php\r\n                    //\r\n                    //\r\n                    //\r\n                    /**///\r\n                ",
+            ),
+            array(
+                "<?php\necho 1;\r\recho 2;",
+                "<?php\necho 1;\r//\recho 2;",
             ),
             // do not fix cases
             array(
@@ -287,13 +289,13 @@ echo 1;
                 true,
             ),
             array(
-                str_replace("\n", "\r", '<?php
-//
-//
-
-//
-//
-'),
+                str_replace("\n", "\r", "<?php\n//\n//\n\n//\n//\n"),
+                1,
+                3,
+                true,
+            ),
+            array(
+                str_replace("\n", "\r\n", "<?php\n//\n//\n\n//\n//\n"),
                 1,
                 3,
                 true,


### PR DESCRIPTION
When line ending was different than LF the end of comment block was calculated incorrectly.