### PR TITLE
Move classmap config to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,10 @@
         "sort-packages": true
     },
     "autoload": {
-        "psr-4": { "PhpCsFixer\\": "src/" },
+        "psr-4": { "PhpCsFixer\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "PhpCsFixer\\Tests\\": "tests/" },
         "classmap": [
             "tests/Test/AbstractFixerTestCase.php",
             "tests/Test/AbstractIntegrationTestCase.php",
@@ -63,9 +66,6 @@
             "tests/Test/IntegrationCaseFactory.php",
             "tests/TestCase.php"
         ]
-    },
-    "autoload-dev": {
-        "psr-4": { "PhpCsFixer\\Tests\\": "tests/" }
     },
     "bin": ["php-cs-fixer"]
 }


### PR DESCRIPTION
We use PHP CS Fixer as a library in [API Platform's Schema Generator](https://github.com/api-platform/schema-generator) and we use [PHP Scoper](https://github.com/humbug/php-scoper) to prevent conflicts in the generated PHAR.
PHP Scoper breaks because of the following config, moving it in the `autoload-dev` section fixes the issue. /cc @theofidry