### PR TITLE
[WIP] MethodArgumentSpaceFixer identation in multiline affected by trailing whitespace

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -199,6 +199,12 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             ? ltrim($tokens[$prevWhitespaceTokenIndex]->getContent(), "\n\r")
             : '';
 
+        // " \r\n" may occur by a trailing whitespace in a previous line
+        // in which case it should be ignored
+        if (" \r\n" === $existingIndentation) {
+            $existingIndentation = '';
+        }
+
         $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();
         $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
         if (!$this->isNewline($tokens[$endFunctionIndex - 1])) {

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -241,6 +241,20 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
                     $c=30
                     );',
             ],
+            'multi line testing where previous whitespace token includes a trailing space' => [
+                '<?php '.
+'defraculate(
+    1,
+    2,
+    3
+);',
+                '<?php '.
+'defraculate(
+    1, 2, 3);',
+                [
+                    'ensure_fully_multiline' => true,
+                ],
+            ],
             'skip arrays but replace arg methods' => [
                 '<?php fnc(1, array(2, func2(6, 7) ,4), 5);',
                 '<?php fnc(1,array(2, func2(6,    7) ,4),    5);',


### PR DESCRIPTION
In `MethodArgumentSpaceFixer::ensureFunctionFullyMultiline` the `$existingIdentation` gets assigned the previous whitespace token.
When this has a trailing space the existing identation becomes `[space]\r\n` instead of empty string.
