### PR TITLE
Create Tokens::findBlockStart

### DIFF
--- a/src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+++ b/src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
@@ -91,11 +91,11 @@ final class NoWhitespaceBeforeCommaInArrayFixer extends AbstractFixer
     private function skipNonArrayElements($index, Tokens $tokens)
     {
         if ($tokens[$index]->equals('}')) {
-            return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index, false);
+            return $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
         }
 
         if ($tokens[$index]->equals(')')) {
-            $startIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index, false);
+            $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
             $startIndex = $tokens->getPrevMeaningfulToken($startIndex);
             if (!$tokens[$startIndex]->isGivenKind(array(T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN))) {
                 return $startIndex;

--- a/src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+++ b/src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
@@ -90,11 +90,11 @@ final class WhitespaceAfterCommaInArrayFixer extends AbstractFixer
     private function skipNonArrayElements($index, Tokens $tokens)
     {
         if ($tokens[$index]->equals('}')) {
-            return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index, false);
+            return $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
         }
 
         if ($tokens[$index]->equals(')')) {
-            $startIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index, false);
+            $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
             $startIndex = $tokens->getPrevMeaningfulToken($startIndex);
             if (!$tokens[$startIndex]->isGivenKind(array(T_ARRAY, CT::T_ARRAY_SQUARE_BRACE_OPEN))) {
                 return $startIndex;

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -173,13 +173,13 @@ final class Example
             $token = $tokens[$i];
 
             if ($token->equals(')')) {
-                $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $i, false);
+                $i = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $i);
 
                 continue;
             }
 
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
-                $i = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $i, false);
+                $i = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $i);
 
                 continue;
             }

--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -150,7 +150,7 @@ final class NoUselessElseFixer extends AbstractFixer
         $close = $previous = $tokens->getPrevMeaningfulToken($index);
         // short 'if' detection
         if ($tokens[$close]->equals('}')) {
-            $previous = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $close, false);
+            $previous = $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $close);
         }
 
         $open = $tokens->getPrevTokenOfKind($previous, array(array(T_IF), array(T_ELSE), array(T_ELSEIF)));
@@ -230,7 +230,7 @@ final class NoUselessElseFixer extends AbstractFixer
         // token is always ')' here.
         // If it is part of the condition the token is always in, return false.
         // If it is not it is a nested condition so return true
-        $open = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $candidateIndex, false);
+        $open = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $candidateIndex);
 
         return $tokens->getPrevMeaningfulToken($open) > $lowerLimitIndex;
     }
@@ -278,10 +278,9 @@ final class NoUselessElseFixer extends AbstractFixer
                     return false; // like `else {`
                 }
 
-                $index = $tokens->findBlockEnd(
+                $index = $tokens->findBlockStart(
                     Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
-                    $index,
-                    false
+                    $index
                 );
 
                 $index = $tokens->getPrevMeaningfulToken($index);
@@ -290,10 +289,9 @@ final class NoUselessElseFixer extends AbstractFixer
                 }
             } elseif ($token->equals(')')) {
                 $type = Tokens::detectBlockType($token);
-                $index = $tokens->findBlockEnd(
+                $index = $tokens->findBlockStart(
                     $type['type'],
-                    $index,
-                    false
+                    $index
                 );
 
                 $index = $tokens->getPrevMeaningfulToken($index);

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -116,13 +116,13 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
             $token = $tokens[$index];
 
             if ($token->equals(')')) {
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index, false);
+                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 
                 continue;
             }
 
             if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index, false);
+                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
 
                 continue;
             }

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -146,7 +146,7 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
             return $previousUnsetBraceEnd;
         }
 
-        $previousUnsetBraceStart = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $previousUnsetBraceEnd, false);
+        $previousUnsetBraceStart = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $previousUnsetBraceEnd);
         $previousUnset = $tokens->getPrevMeaningfulToken($previousUnsetBraceStart);
         if (null === $previousUnset) {
             return $index;

--- a/src/Fixer/Semicolon/NoEmptyStatementFixer.php
+++ b/src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -114,7 +114,7 @@ final class NoEmptyStatementFixer extends AbstractFixer
             }
         }
 
-        $curlyOpeningIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $curlyCloseIndex, false);
+        $curlyOpeningIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $curlyCloseIndex);
         $beforeCurlyOpening = $tokens->getPrevMeaningfulToken($curlyOpeningIndex);
         if ($tokens[$beforeCurlyOpening]->isGivenKind($beforeCurlyOpeningKinds) || $tokens[$beforeCurlyOpening]->equalsAny(array(';', '{', '}'))) {
             $tokens->clearTokenAndMergeSurroundingWhitespace($index);
@@ -146,7 +146,7 @@ final class NoEmptyStatementFixer extends AbstractFixer
             return;
         }
 
-        $openingBrace = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $beforeCurlyOpening, false);
+        $openingBrace = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $beforeCurlyOpening);
         $beforeOpeningBrace = $tokens->getPrevMeaningfulToken($openingBrace);
 
         if ($tokens[$beforeOpeningBrace]->isGivenKind(array(T_IF, T_ELSEIF, T_FOR, T_FOREACH, T_WHILE, T_SWITCH, T_CATCH, T_DECLARE))) {

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -446,8 +446,8 @@ class Tokens extends \SplFixedArray
     /**
      * Find block start.
      *
-     * @param int  $type        type of block, one of BLOCK_TYPE_*
-     * @param int  $searchIndex index of opening brace
+     * @param int $type        type of block, one of BLOCK_TYPE_*
+     * @param int $searchIndex index of opening brace
      *
      * @return int index of opening brace
      */

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -444,6 +444,19 @@ class Tokens extends \SplFixedArray
     }
 
     /**
+     * Find block start.
+     *
+     * @param int  $type        type of block, one of BLOCK_TYPE_*
+     * @param int  $searchIndex index of opening brace
+     *
+     * @return int index of opening brace
+     */
+    public function findBlockStart($type, $searchIndex)
+    {
+        return $this->findBlockEnd($type, $searchIndex, false);
+    }
+
+    /**
      * Find tokens of given kind.
      *
      * @param array|int $possibleKind kind or array of kind

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -447,7 +447,7 @@ class Tokens extends \SplFixedArray
      * Find block start.
      *
      * @param int $type        type of block, one of BLOCK_TYPE_*
-     * @param int $searchIndex index of opening brace
+     * @param int $searchIndex index of closing brace
      *
      * @return int index of opening brace
      */

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -529,7 +529,7 @@ final class TokensAnalyzer
             return false;
         }
 
-        $startIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $endIndex, false);
+        $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $endIndex);
         $beforeStartIndex = $tokens->getPrevMeaningfulToken($startIndex);
 
         return $tokens[$beforeStartIndex]->isGivenKind(T_DO);

--- a/src/Tokenizer/Transformer/CurlyBraceTransformer.php
+++ b/src/Tokenizer/Transformer/CurlyBraceTransformer.php
@@ -192,7 +192,7 @@ final class CurlyBraceTransformer extends AbstractTransformer
         if (
             $tokens[$prevIndex]->equals(')')
             && !$tokens[$tokens->getPrevMeaningfulToken(
-                $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $prevIndex, false)
+                $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $prevIndex)
             )]->isGivenKind(T_ARRAY)
         ) {
             return;

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -66,7 +66,7 @@ final class TypeColonTransformer extends AbstractTransformer
             return;
         }
 
-        $startIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $endIndex, false);
+        $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $endIndex);
         $prevIndex = $tokens->getPrevMeaningfulToken($startIndex);
         $prevToken = $tokens[$prevIndex];
 

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -894,6 +894,7 @@ PHP;
 
         $this->assertSame($expectedIndex, $tokens->findBlockEnd($type, $searchIndex, true));
         $this->assertSame($searchIndex, $tokens->findBlockEnd($type, $expectedIndex, false));
+        $this->assertSame($searchIndex, $tokens->findBlockStart($type, $expectedIndex));
 
         $detectedType = Tokens::detectBlockType($tokens[$searchIndex]);
         $this->assertInternalType('array', $detectedType);


### PR DESCRIPTION
Having `findBlockEnd` with a boolean flag to invert the behaviour is very confusing, makes the code harder to read. I propose we add a new `findBlockStart` method that replicates this behaviour in a more readable way.

Am I right in thinking I should target 2.2 with this, ~as this is an internal class~ it should be OK to add new features on patch releases?