### PR TITLE
Add PhpUnitOrderedCoversFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -45,6 +45,7 @@ $config = PhpCsFixer\Config::create()
         'no_useless_return' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
+        'php_unit_ordered_covers' => true,
         'php_unit_strict' => true,
         'php_unit_test_annotation' => true,
         'php_unit_test_class_requires_covers' => true,

--- a/README.rst
+++ b/README.rst
@@ -1125,6 +1125,10 @@ Choose from the list of available rules:
     ``'newest'``
   - ``use_class_const`` (``bool``): use ::class notation; defaults to ``true``
 
+* **php_unit_ordered_covers**
+
+  Order ``@covers`` annotation of PHPUnit tests.
+
 * **php_unit_strict**
 
   PHPUnit methods like ``assertSame`` should be used instead of

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -61,7 +61,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         for ($index = $tokens->count() - 1; $index > 0; --$index) {
-            if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT) || false === strpos($tokens[$index]->getContent(), '@covers')) {
+            if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT) || 0 === preg_match('/@covers\s.+@covers\s/s', $tokens[$index]->getContent())) {
                 continue;
             }
 
@@ -76,7 +76,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 }
 
                 $linesToUpdate[] = $line;
-                $comparableContent = preg_replace('/\*\s*@covers\s+(.+)/', '\1', trim($rawContent));
+                $comparableContent = preg_replace('/\*\s*@covers\s+(.+)/', '\1', strtolower(trim($rawContent)));
                 $coversMap[$comparableContent] = $rawContent;
             }
             ksort($coversMap, SORT_STRING);

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class PhpUnitOrderedCoversFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Order `@covers` annotation of PHPUnit tests.',
+            [
+                new CodeSample(
+'<?php
+/**
+ * @covers Foo
+ * @covers Bar
+ */
+final class MyTest extends \PHPUnit_Framework_TestCase
+{}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
+            if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT) || false === strpos($tokens[$index]->getContent(), '@covers')) {
+                continue;
+            }
+
+            $docBlock = new DocBlock($tokens[$index]->getContent());
+
+            $coversMap = [];
+            $linesToUpdate = [];
+            foreach ($docBlock->getLines() as $line) {
+                $rawContent = $line->getContent();
+                if (false === strpos($rawContent, '@covers')) {
+                    continue;
+                }
+
+                $linesToUpdate[] = $line;
+                $comparableContent = preg_replace('/\*\s*@covers\s+(.+)/', '\1', trim($rawContent));
+                $coversMap[$comparableContent] = $rawContent;
+            }
+            ksort($coversMap, SORT_STRING);
+
+            foreach ($linesToUpdate as $line) {
+                $newContent = array_shift($coversMap);
+                $line->setContent($newContent);
+            }
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $docBlock->getContent()]);
+        }
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -50,6 +50,15 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // should be run after PhpUnitFqcnAnnotationFixer
+        return -10;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isCandidate(Tokens $tokens)
     {
         return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT]);

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -79,10 +79,14 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 $comparableContent = preg_replace('/\*\s*@covers\s+(.+)/', '\1', strtolower(trim($rawContent)));
                 $coversMap[$comparableContent] = $rawContent;
             }
-            ksort($coversMap, SORT_STRING);
+            $orderedCoversMap = $coversMap;
+            ksort($orderedCoversMap, SORT_STRING);
+            if ($orderedCoversMap === $coversMap) {
+                continue;
+            }
 
             foreach ($linesToUpdate as $line) {
-                $newContent = array_shift($coversMap);
+                $newContent = array_shift($orderedCoversMap);
                 $line->setContent($newContent);
             }
 

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -144,6 +144,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['ordered_class_elements'], $fixers['no_blank_lines_after_class_opening']],
             [$fixers['ordered_class_elements'], $fixers['space_after_semicolon']],
             [$fixers['php_unit_fqcn_annotation'], $fixers['no_unused_imports']],
+            [$fixers['php_unit_fqcn_annotation'], $fixers['php_unit_ordered_covers']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['no_empty_phpdoc']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['php_unit_expectation']],
             [$fixers['php_unit_strict'], $fixers['php_unit_construct']],

--- a/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
@@ -111,6 +111,30 @@ final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
             ],
+            'data provider' => [
+                '<?php
+                    class FooTest extends \PHPUnit_Framework_TestCase
+                    {
+                        /**
+                         * @covers Bar
+                         * @dataProvider provide
+                         * @covers Foo
+                         */
+                        public function testMe() {}
+                    }
+                ',
+                '<?php
+                    class FooTest extends \PHPUnit_Framework_TestCase
+                    {
+                        /**
+                         * @covers Foo
+                         * @dataProvider provide
+                         * @covers Bar
+                         */
+                        public function testMe() {}
+                    }
+                ',
+            ],
         ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
@@ -37,7 +37,25 @@ final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
     public function provideFixCases()
     {
         return [
-            [
+            'skip on 1 or 0 occurrences' => [
+                '<?php
+                    class FooTest extends \PHPUnit_Framework_TestCase {
+                        /**
+                         * @covers Foo
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function testMe() {}
+
+                        /**
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function testMe2() {}
+                    }
+                ',
+            ],
+            'base case' => [
                 '<?php
                     /**
                      * @covers Bar
@@ -53,7 +71,7 @@ final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
             ],
-            [
+            'preserve positions if other docblock parts are present' => [
                 '<?php
                     /**
                      * @covers Bar
@@ -69,6 +87,26 @@ final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
                      *
                      *  MyComment
                      * @covers Bar
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            'case-insensitive' => [
+                '<?php
+                    /**
+                     * @covers A
+                     * @covers c
+                     * @covers D
+                     * @covers E
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+                    /**
+                     * @covers A
+                     * @covers E
+                     * @covers c
+                     * @covers D
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',

--- a/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
@@ -74,19 +74,21 @@ final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
             'preserve positions if other docblock parts are present' => [
                 '<?php
                     /**
+                     * Comment 1
                      * @covers Bar
-                     *
-                     *  MyComment
+                     * Comment 3
                      * @covers Foo
+                     * Comment 2
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',
                 '<?php
                     /**
+                     * Comment 1
                      * @covers Foo
-                     *
-                     *  MyComment
+                     * Comment 2
                      * @covers Bar
+                     * Comment 3
                      */
                     class FooTest extends \PHPUnit_Framework_TestCase {}
                 ',

--- a/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitOrderedCoversFixerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitOrderedCoversFixer
+ */
+final class PhpUnitOrderedCoversFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+                    /**
+                     * @covers Bar
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+                    /**
+                     * @covers Foo
+                     * @covers Bar
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+            [
+                '<?php
+                    /**
+                     * @covers Bar
+                     *
+                     *  MyComment
+                     * @covers Foo
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+                '<?php
+                    /**
+                     * @covers Foo
+                     *
+                     *  MyComment
+                     * @covers Bar
+                     */
+                    class FooTest extends \PHPUnit_Framework_TestCase {}
+                ',
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,php_unit_ordered_covers.test
+++ b/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,php_unit_ordered_covers.test
@@ -1,0 +1,21 @@
+--TEST--
+Integration of fixers: php_unit_fqcn_annotation,php_unit_ordered_covers.
+--RULESET--
+{"php_unit_fqcn_annotation": true, "php_unit_ordered_covers": true}
+--EXPECT--
+<?php
+/**
+ * @covers \A
+ * @covers \B
+ * @covers \C
+ */
+class FooTest extends \PHPUnit_Framework_TestCase {}
+
+--INPUT--
+<?php
+/**
+ * @covers A
+ * @covers C
+ * @covers \B
+ */
+class FooTest extends \PHPUnit_Framework_TestCase {}


### PR DESCRIPTION
```diff
 /**
+ * @covers Bar
  * @covers Foo
- * @covers Bar
  */
 class MyTest extends \PHPUnit_Framework_TestCase
 {}
```

- [x] Implement base logic
- [x] Run after `PhpUnitFqcnAnnotationFixer`