### PR TITLE
Use null|type instead of ?type in PHPDocs

### DIFF
--- a/src/FileReader.php
+++ b/src/FileReader.php
@@ -24,12 +24,12 @@ namespace PhpCsFixer;
 final class FileReader
 {
     /**
-     * @var ?self
+     * @var null|self
      */
     private static $instance;
 
     /**
-     * @var ?string
+     * @var null|string
      */
     private $stdinContent;
 


### PR DESCRIPTION
Keeps it consistent throughout the project