### PR TITLE
MultilineWhitespaceBeforeSemicolonsFixer: static call bug

### DIFF
--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -424,6 +424,17 @@ $this
                         ->method2();
                 ?>',
             ],
+            [
+                '<?php
+Foo::bar()
+    ->baz()
+;
+',
+                '<?php
+Foo::bar()
+    ->baz();
+',
+            ],
         ];
     }
 


### PR DESCRIPTION
Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3327

Ping @egircys 

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 Foo::bar()
-    ->baz()
-;
+    ->baz();
```