### PR TITLE
MultilineWhitespaceBeforeSemicolonsFixer - support static calls

### DIFF
--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -226,8 +226,8 @@ function foo () {
             return null;
         }
 
-        // ->
-        if (!$tokens[--$index]->isGivenKind(T_OBJECT_OPERATOR)) {
+        // -> or ::
+        if (!$tokens[--$index]->isGivenKind([T_OBJECT_OPERATOR, T_DOUBLE_COLON])) {
             return null;
         }
 
@@ -247,7 +247,7 @@ function foo () {
             }
 
             // must be the variable of the first call in the chain
-            if ($tokens[$index]->isGivenKind([T_VARIABLE, T_RETURN]) && 0 === $closingBrackets) {
+            if ($tokens[$index]->isGivenKind([T_VARIABLE, T_RETURN, T_STRING]) && 0 === $closingBrackets) {
                 if ($tokens[--$index]->isGivenKind(T_WHITESPACE)
                     || $tokens[$index]->isGivenKind(T_OPEN_TAG)) {
                     return $this->getIndentAt($tokens, $index);

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -124,6 +124,81 @@ $this
 
     ;',
             ],
+            [
+                '<?php
+                    Foo::bar() // test
+;',
+                '<?php
+                    Foo::bar() // test
+                    ;',
+            ],
+            [
+                '<?php
+                    Foo::bar() # test
+;',
+                '<?php
+                    Foo::bar() # test
+
+
+                ;',
+            ],
+            [
+                '<?php
+self
+    ::setName(\'readme1\')
+    ->setDescription(\'Generates the README\');
+',
+                '<?php
+self
+    ::setName(\'readme1\')
+    ->setDescription(\'Generates the README\')
+;
+',
+            ],
+            [
+                '<?php
+self
+    ::setName(\'readme2\')
+    ->setDescription(\'Generates the README\');
+',
+                '<?php
+self
+    ::setName(\'readme2\')
+    ->setDescription(\'Generates the README\')
+    ;
+',
+            ],
+            [
+                '<?php echo "self::foo(\'with param containing ;\') ;" ;',
+            ],
+            [
+                '<?php self::foo();',
+            ],
+            [
+                '<?php self::foo() ;',
+            ],
+            [
+                '<?php self::foo(\'with param containing ;\') ;',
+            ],
+            [
+                '<?php self::foo(\'with param containing ) ; \') ;',
+            ],
+            [
+                '<?php self::foo("with param containing ) ; ")  ; ?>',
+            ],
+            [
+                '<?php self::foo("with semicolon in string) ; "); ?>',
+            ],
+            [
+                '<?php
+self
+    ::example();',
+                '<?php
+self
+    ::example()
+
+    ;',
+            ],
         ];
     }
 
@@ -421,6 +496,265 @@ $this
                 '<?php
 $this
                         ->method1()
+                        ->method2();
+                ?>',
+            ],
+            [
+                '<?php
+
+                    self
+                        ::method1()
+                        ->method2()
+                    ;
+                ?>',
+                '<?php
+
+                    self
+                        ::method1()
+                        ->method2();
+                ?>',
+            ], [
+                '<?php
+
+                    self
+                        ::method1()
+                        ->method2() // comment
+                    ;
+
+
+',
+                '<?php
+
+                    self
+                        ::method1()
+                        ->method2(); // comment
+
+
+',
+            ], [
+                '<?php
+
+                    Service::method1()
+                        ->method2()
+                    ;
+
+                    Service::method3();
+                    $this
+                        ->method1()
+                        ->method2()
+                    ;',
+                '<?php
+
+                    Service::method1()
+                        ->method2()
+                    ;
+
+                    Service::method3();
+                    $this
+                        ->method1()
+                        ->method2();',
+            ], [
+                '<?php
+
+                    Service
+                        ::method2()
+                    ;
+                ?>',
+                '<?php
+
+                    Service
+                        ::method2();
+                ?>',
+            ], [
+                '<?php
+
+                    Service::method1()
+                        ->method2()
+                        ->method3()
+                        ->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    Service::method1()
+                        ->method2()
+                        ->method3()
+                        ->method4();
+                ?>',
+            ], [
+                '<?php
+
+                    self::method1()
+                        ->method2([1, 2])
+                        ->method3(
+                            "2",
+                            2,
+                            [1, 2]
+                        )
+                        ->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    self::method1()
+                        ->method2([1, 2])
+                        ->method3(
+                            "2",
+                            2,
+                            [1, 2]
+                        )
+                        ->method4();
+                ?>',
+            ], [
+                '<?php
+
+                    Service
+                        ::method1()
+                            ->method2()
+                        ->method3()
+                            ->method4()
+                    ;
+                ?>',
+                '<?php
+
+                    Service
+                        ::method1()
+                            ->method2()
+                        ->method3()
+                            ->method4();
+                ?>',
+            ], [
+                '<?php
+                    $f = "g";
+
+                    Service
+                        ::method1("a", true)
+                        ->method2(true, false)
+                        ->method3([1, 2, 3], ["a" => "b", "c" => 1, "d" => true])
+                        ->method4(1, "a", $f)
+                    ;
+                ?>',
+                '<?php
+                    $f = "g";
+
+                    Service
+                        ::method1("a", true)
+                        ->method2(true, false)
+                        ->method3([1, 2, 3], ["a" => "b", "c" => 1, "d" => true])
+                        ->method4(1, "a", $f);
+                ?>',
+            ], [
+                '<?php
+                    $f = "g";
+
+                    Service
+                        ::method1("a", true) // this is a comment
+                        /* ->method2(true, false) */
+                        ->method3([1, 2, 3], ["a" => "b", "c" => 1, "d" => true])
+                        ->method4(1, "a", $f) /* this is a comment */
+                    ;
+                ?>',
+                '<?php
+                    $f = "g";
+
+                    Service
+                        ::method1("a", true) // this is a comment
+                        /* ->method2(true, false) */
+                        ->method3([1, 2, 3], ["a" => "b", "c" => 1, "d" => true])
+                        ->method4(1, "a", $f); /* this is a comment */
+                ?>',
+            ], [
+                '<?php
+                    Service::method1();
+                    Service::method2()->method3();
+                ?>',
+            ], [
+                '<?php
+                    Service::method1() ;
+                    Service::method2()->method3() ;
+                ?>',
+            ], [
+                '<?php
+
+                    Service
+                        ::method2(function ($a) {
+                            $a->otherCall()
+                                ->a()
+                                ->b()
+                            ;
+                        })
+                    ;
+                ?>',
+                '<?php
+
+                    Service
+                        ::method2(function ($a) {
+                            $a->otherCall()
+                                ->a()
+                                ->b()
+                            ;
+                        });
+                ?>',
+            ], [
+                '<?php
+
+                    $data = Service
+                        ::method2(function () {
+                            Foo::otherCall()
+                                ->a()
+                                ->b(array_merge([
+                                        1 => 1,
+                                        2 => 2,
+                                    ], $this->getOtherArray()
+                                ))
+                            ;
+                        })
+                    ;
+                ?>',
+                '<?php
+
+                    $data = Service
+                        ::method2(function () {
+                            Foo::otherCall()
+                                ->a()
+                                ->b(array_merge([
+                                        1 => 1,
+                                        2 => 2,
+                                    ], $this->getOtherArray()
+                                ));
+                        });
+                ?>',
+            ], [
+                '<?php
+
+                    Service
+                        ::method1(null, null, [
+                            null => null,
+                            1 => $data->getId() > 0,
+                        ])
+                        ->method2(4, Type::class)
+                    ;
+',
+                '<?php
+
+                    Service
+                        ::method1(null, null, [
+                            null => null,
+                            1 => $data->getId() > 0,
+                        ])
+                        ->method2(4, Type::class);
+',
+            ],
+            [
+                '<?php
+Service
+                        ::method1()
+                        ->method2()
+;
+                ?>',
+                '<?php
+Service
+                        ::method1()
                         ->method2();
                 ?>',
             ],


### PR DESCRIPTION
Ref #3529 

Not really a bug as it was never supported, so targetting master

Just duplicated all the `$foo->` tests and changed them to `Foo::`, let me know if you want any other cases added