### PR TITLE
Add the 'none' sort algorithm to OrderedImportsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1042,8 +1042,9 @@ Choose from the list of available rules:
 
   - ``importsOrder`` (``array``, ``null``): defines the order of import types; defaults
     to ``null``
-  - ``sortAlgorithm`` (``'alpha'``, ``'length'``): whether the statements should be
-    sorted alphabetically or by length; defaults to ``'alpha'``
+  - ``sortAlgorithm`` (``'alpha'``, ``'length'``, ``'none'``): whether the statements should
+    be sorted alphabetically or by length, or not sorted; defaults to
+    ``'alpha'``
 
 * **php_unit_construct** [@Symfony:risky]
 

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -814,7 +814,7 @@ use Foo\Bor\{
     {
         $this->expectException(\PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
-            '[ordered_imports] Invalid configuration: The option "sortAlgorithm" with value %s is invalid. Accepted values are: "alpha", "length".',
+            '[ordered_imports] Invalid configuration: The option "sortAlgorithm" with value %s is invalid. Accepted values are: "alpha", "length", "none".',
             $expectedValue
         ));
 
@@ -1701,6 +1701,77 @@ use function some\a\{fn_a, fn_b};
     }
 
     /**
+     * @dataProvider provideFix70TypesOrderAndNoneCases
+     * @requires PHP 7.0
+     *
+     * @param string      $expected
+     * @param null|string $input
+     * @param string[]    $importOrder
+     */
+    public function testFix70TypesOrderAndNone($expected, $input = null, array $importOrder = null)
+    {
+        $this->fixer->configure([
+            'sortAlgorithm' => OrderedImportsFixer::SORT_NONE,
+            'importsOrder' => $importOrder,
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix70TypesOrderAndNoneCases()
+    {
+        return [
+            [
+                '<?php
+use Aaa\Ccc;
+use Foo\Zar\Baz;
+use some\a\{ClassA};
+use some\b\{ClassD, ClassB, ClassC as C};
+use Bar\Biz\Boooz\Bum;
+use some\b\{
+    ClassF,
+    ClassG
+};
+use Some\Cloz;
+use Aaa\Bbb;
+use const some\a\{ConstD};
+use const some\a\{ConstA};
+use const some\a\{ConstB, ConstC as CC};
+use const some\b\{ConstE};
+use function some\f\{fn_g, fn_h, fn_i};
+use function some\c\{fn_f};
+use function some\a\{fn};
+use function some\b\{fn_c, fn_d, fn_e};
+use function some\a\{fn_a, fn_b};
+',
+                '<?php
+use Aaa\Ccc;
+use Foo\Zar\Baz;
+use function some\f\{fn_g, fn_h, fn_i};
+use some\a\{ClassA};
+use some\b\{ClassD, ClassB, ClassC as C};
+use Bar\Biz\Boooz\Bum;
+use function some\c\{fn_f};
+use some\b\{
+    ClassF,
+    ClassG
+};
+use const some\a\{ConstD};
+use Some\Cloz;
+use function some\a\{fn};
+use const some\a\{ConstA};
+use function some\b\{fn_c, fn_d, fn_e};
+use const some\a\{ConstB, ConstC as CC};
+use Aaa\Bbb;
+use const some\b\{ConstE};
+use function some\a\{fn_a, fn_b};
+',
+                [OrderedImportsFixer::IMPORT_TYPE_CLASS, OrderedImportsFixer::IMPORT_TYPE_CONST, OrderedImportsFixer::IMPORT_TYPE_FUNCTION],
+            ],
+        ];
+    }
+
+    /**
      * @param string      $expected
      * @param null|string $input
      * @param null|array  $config
@@ -1767,6 +1838,70 @@ use function some\a\{fn_a, fn_b, fn_c,};
                     'importsOrder' => [OrderedImportsFixer::IMPORT_TYPE_CLASS, OrderedImportsFixer::IMPORT_TYPE_CONST, OrderedImportsFixer::IMPORT_TYPE_FUNCTION],
                 ],
             ],
+            [
+                '<?php use A\{B,};
+use some\y\{ClassA, ClassB, ClassC as C,};
+use C\{D,E,};
+use const some\Z\{ConstAA,ConstBB,ConstCC,};
+use const some\X\{ConstA,ConstB,ConstC,ConstF};
+use function some\a\{fn_a, fn_b, fn_c,};
+',
+                $input,
+                [
+                    'sortAlgorithm' => OrderedImportsFixer::SORT_NONE,
+                    'importsOrder' => [OrderedImportsFixer::IMPORT_TYPE_CLASS, OrderedImportsFixer::IMPORT_TYPE_CONST, OrderedImportsFixer::IMPORT_TYPE_FUNCTION],
+                ],
+            ],
         ];
+    }
+
+    public function testFixByNone()
+    {
+        $this->fixer->configure([
+            'sortAlgorithm' => OrderedImportsFixer::SORT_NONE,
+            'importsOrder' => null,
+        ]);
+
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Bar as ZooBar;
+use Foo\Bar;
+use Foo\Zar\Baz;
+
+<?php
+
+use Foo\Bar\FooBar as FooBaz;
+use Zoo\Bar as ZooBar, Zoo\Tar;
+ use Foo\Bar;
+use Foo\Zar\Baz;
+use Symfony\Annotation\Template;
+   use Foo\Bar\Foo as Fooo, Foo\Bir as FBB;
+use SomeClass;
+
+$a = new Bar();
+$a = new FooBaz();
+$a = new someclass();
+
+use Symfony\Doctrine\Entities\Entity;
+
+class AnnotatedClass
+{
+    /**
+     * @Template(foobar=21)
+     * @param Entity $foo
+     */
+    public function doSomething($foo)
+    {
+        $bar = $foo->toArray();
+        /** @var ArrayInterface $bar */
+
+        return function () use ($bar, $foo) {};
+    }
+}
+EOF;
+
+        $this->doTest($expected);
     }
 }


### PR DESCRIPTION
I need some feedback on the following matter.

It is now possible to configure the fixer this way:

```php
'sortAlgorithm' => 'none',
'importsOrder' => null,
```

which basically disables the fixer.

Should it be allowed to use such configuration, or should I implement a check for it?


Closes #3543 