### PR TITLE
[WIP] Make shell scripts POSIX-compatible

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v php >/dev/null 2>&1 || { echo "I require `php` but it's not available. Aborting." >&2; exit 255; }
 command -v grep >/dev/null 2>&1 || { echo "I require `grep` but it's not available. Aborting." >&2; exit 255; }
 command -v awk >/dev/null 2>&1 || { echo "I require `awk` but it's not available. Aborting." >&2; exit 255; }
 
-if [ "" == "$1" ] || [ "" == "$2" ];
+if [ "" = "$1" ] || [ "" = "$2" ];
 then
     echo "Usage: bash benchmark.sh BRANCH1 BRANCH2 ...BRANCHN"
     exit 1;
@@ -12,10 +12,10 @@ fi
 
 for BRANCH in $@
 do
-    git checkout $BRANCH &> /dev/null &&
-    git reset --hard &> /dev/null &&
-    echo -n $BRANCH
-    (for i in {1..10}; do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
+    git checkout $BRANCH > /dev/null 2>&1 &&
+    git reset --hard > /dev/null 2>&1 &&
+    printf '%s' $BRANCH
+    (for i in $(seq 1 10); do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
     {
         total += $5;
         ++count;

--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -1,14 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 files_with_trailing_spaces=$(find . -type f -not -path "./.git/*" -not -path "./dev-tools/vendor/*" -not -path "./vendor/*" -not -path "./tests/Fixtures/*" -exec egrep -nH " $" {} \;)
 
-if [[ $files_with_trailing_spaces ]]
+if [ "$files_with_trailing_spaces" ]
 then
-    echo -e "\e[97;41mTrailing spaces detected:\e[0m"
+    printf '\033[97;41mTrailing spaces detected:\033[0m\n'
     e=$(printf '\033')
     echo "${files_with_trailing_spaces}" | sed -E "s/^\.\/([^:]+):([0-9]+):(.*[^ ])( +)$/${e}[0;31m - in ${e}[0;33m\1${e}[0;31m at line ${e}[0;33m\2\n   ${e}[0;31m>${e}[0m \3${e}[41m\4${e}[0m/"
 
     exit 1
 fi
 
-echo -e "\e[0;32mNo trailing spaces detected.\e[0m"
+printf '\033[0;32mNo trailing spaces detected.\033[0m\n'

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 # ensure that deps will work on lowest supported PHP version

--- a/dev-tools/trigger-website.sh
+++ b/dev-tools/trigger-website.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 TOKEN=$1
@@ -9,7 +9,7 @@ then
     MSG_SUFFIX=" for ${MSG_SUFFIX}"
 fi
 
-REPO=$(sed "s@/@%2F@g" <<< "PHP-CS-Fixer/PHP-CS-Fixer.github.io")
+REPO=$(echo "PHP-CS-Fixer/PHP-CS-Fixer.github.io" | sed "s@/@%2F@g")
 
 body="{
     \"request\": {


### PR DESCRIPTION
I used ShellCheck and checkbashisms to find and get rid of Bash-specific syntax and features in shell scripts.

This PR is not about refactoring or fixing the scripts. The intention of this PR is to make the scripts work in any POSIX-compliant shell.

This will allow developers to contribute to PHP-CS-Fixer using environments that don't have Bash, e. g. Alpine Linux.

Fixes #3544.