### PR TITLE
MultilineWhitespaceBeforeSemicolonsFixer - chained call for a return fix

### DIFF
--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -247,7 +247,7 @@ function foo () {
             }
 
             // must be the variable of the first call in the chain
-            if ($tokens[$index]->isGivenKind(T_VARIABLE) && 0 === $closingBrackets) {
+            if ($tokens[$index]->isGivenKind([T_VARIABLE, T_RETURN]) && 0 === $closingBrackets) {
                 if ($tokens[--$index]->isGivenKind(T_WHITESPACE)
                     || $tokens[$index]->isGivenKind(T_OPEN_TAG)) {
                     return $this->getIndentAt($tokens, $index);

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -424,6 +424,62 @@ $this
                         ->method2();
                 ?>',
             ],
+            [
+                '<?php
+
+                    function foo($bar)
+                    {
+                        if ($bar === 1) {
+                            $baz
+                                ->bar()
+                            ;
+                        }
+
+                        return (new Foo($bar))
+                            ->baz()
+                        ;
+                    }
+                ?>',
+                '<?php
+
+                    function foo($bar)
+                    {
+                        if ($bar === 1) {
+                            $baz
+                                ->bar();
+                        }
+
+                        return (new Foo($bar))
+                            ->baz();
+                    }
+                ?>',
+            ],
+            [
+                '<?php
+
+                    $foo = (new Foo($bar))
+                        ->baz()
+                    ;
+
+                    function foo($bar)
+                    {
+                        $foo = (new Foo($bar))
+                            ->baz()
+                        ;
+                    }
+                ?>',
+                '<?php
+
+                    $foo = (new Foo($bar))
+                        ->baz();
+
+                    function foo($bar)
+                    {
+                        $foo = (new Foo($bar))
+                            ->baz();
+                    }
+                ?>',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes the case when the chained call is on a instantiated object within the return statement.

```php
return (new Foo($bar))
    ->baz();

return (new Foo($bar))
    ->baz()
;
````