### PR TITLE
Make shell scripts POSIX-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ git:
 cache:
     directories:
         - $HOME/.composer
+        - $HOME/bin
 
 env:
     global:
@@ -33,6 +34,9 @@ jobs:
 
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
+
+                - wget --no-clobber --output-document=$HOME/bin/checkbashisms https://sourceforge.net/projects/checkbaskisms/files/2.0.0.2/checkbashisms/download || true
+                - chmod +x $HOME/bin/checkbashisms
             before_script:
                 - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then COMMIT_RANGE=$TRAVIS_COMMIT_RANGE; else COMMIT_RANGE="HEAD~..HEAD"; fi;
                 - export COMMIT_SCA_FILES=`git diff --name-only --diff-filter=ACMRTUXB $COMMIT_RANGE`
@@ -55,6 +59,7 @@ jobs:
                 - if [ -n "$COMMIT_SCA_FILES" ]; then ./dev-tools/vendor/bin/phpmd `echo "$COMMIT_SCA_FILES" | grep -Ev "^tests/Fixtures" | xargs | sed 's/ /,/g'` text phpmd.xml || travis_terminate 1; fi
                 - ./dev-tools/vendor/bin/composer-require-checker check composer.json --config-file=.composer-require-checker.json || travis_terminate 1
                 - composer normalize -d ./dev-tools ./../composer.json --dry-run
+                - ./dev-tools/check-shell-scripts.sh
 
         - &STANDARD_TEST_JOB
             stage: Fast Test

--- a/README.rst
+++ b/README.rst
@@ -1237,9 +1237,11 @@ Then, add the following command to your CI:
 
 .. code-block:: bash
 
+    $ IFS='
+    $ '
     $ CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
-    $ if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
-    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no "${EXTRA_ARGS[@]}"
+    $ if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
+    $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
 
 Where ``$COMMIT_RANGE`` is your range of commits, eg ``$TRAVIS_COMMIT_RANGE`` or ``HEAD~..HEAD``.
 

--- a/README.rst
+++ b/README.rst
@@ -1241,7 +1241,6 @@ Then, add the following command to your CI:
     $ '
     $ CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
     $ if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
-    $ # shellcheck disable=SC2086
     $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
 
 Where ``$COMMIT_RANGE`` is your range of commits, eg ``$TRAVIS_COMMIT_RANGE`` or ``HEAD~..HEAD``.

--- a/README.rst
+++ b/README.rst
@@ -1241,6 +1241,7 @@ Then, add the following command to your CI:
     $ '
     $ CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
     $ if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
+    $ # shellcheck disable=SC2086
     $ vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
 
 Where ``$COMMIT_RANGE`` is your range of commits, eg ``$TRAVIS_COMMIT_RANGE`` or ``HEAD~..HEAD``.

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-command -v php >/dev/null 2>&1 || { echo "I require `php` but it's not available. Aborting." >&2; exit 255; }
-command -v grep >/dev/null 2>&1 || { echo "I require `grep` but it's not available. Aborting." >&2; exit 255; }
-command -v awk >/dev/null 2>&1 || { echo "I require `awk` but it's not available. Aborting." >&2; exit 255; }
+command -v php >/dev/null 2>&1 || { echo "I require \`php\` but it's not available. Aborting." >&2; exit 255; }
+command -v grep >/dev/null 2>&1 || { echo "I require \`grep\` but it's not available. Aborting." >&2; exit 255; }
+command -v awk >/dev/null 2>&1 || { echo "I require \`awk\` but it's not available. Aborting." >&2; exit 255; }
 
 if [ "" = "$1" ] || [ "" = "$2" ];
 then
@@ -10,12 +10,12 @@ then
     exit 1;
 fi
 
-for BRANCH in $@
+for BRANCH in "$@"
 do
-    git checkout $BRANCH > /dev/null 2>&1 &&
+    git checkout "$BRANCH" > /dev/null 2>&1 &&
     git reset --hard > /dev/null 2>&1 &&
-    printf '%s' $BRANCH
-    (for i in $(seq 1 10); do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
+    printf '%s' "$BRANCH"
+    (for _ in $(seq 1 10); do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
     {
         total += $5;
         ++count;

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 command -v php >/dev/null 2>&1 || { echo "I require `php` but it's not available. Aborting." >&2; exit 255; }
 command -v grep >/dev/null 2>&1 || { echo "I require `grep` but it's not available. Aborting." >&2; exit 255; }
 command -v awk >/dev/null 2>&1 || { echo "I require `awk` but it's not available. Aborting." >&2; exit 255; }
 
-if [ "" == "$1" ] || [ "" == "$2" ];
+if [ "" = "$1" ] || [ "" = "$2" ];
 then
     echo "Usage: bash benchmark.sh BRANCH1 BRANCH2 ...BRANCHN"
     exit 1;
@@ -12,10 +12,10 @@ fi
 
 for BRANCH in $@
 do
-    git checkout $BRANCH &> /dev/null &&
-    git reset --hard &> /dev/null &&
-    echo -n $BRANCH
-    (for i in {1..10}; do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
+    git checkout $BRANCH > /dev/null 2>&1 &&
+    git reset --hard > /dev/null 2>&1 &&
+    printf '%s' $BRANCH
+    (for i in $(seq 1 10); do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
     {
         total += $5;
         ++count;

--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -15,7 +15,7 @@ if [ "$files_with_trailing_spaces" ]
 then
     printf '\033[97;41mTrailing whitespaces detected:\033[0m\n'
     e=$(printf '\033')
-    echo "${files_with_trailing_spaces}" | sed -E "s/^\\.\\/([^:]+):([0-9]+):(.*[^\t ])?([\t ]+)$/${e}[0;31m - in ${e}[0;33m\\1${e}[0;31m at line ${e}[0;33m\\2\\n   ${e}[0;31m>${e}[0m \\3${e}[41;1m\\4${e}[0m/"
+    echo "${files_with_trailing_spaces}" | sed -E "s/^\\.\\/([^:]+):([0-9]+):(.*[^\\t ])?([\\t ]+)$/${e}[0;31m - in ${e}[0;33m\\1${e}[0;31m at line ${e}[0;33m\\2\\n   ${e}[0;31m>${e}[0m \\3${e}[41;1m\\4${e}[0m/"
 
     exit 3
 fi

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 # ensure that deps will work on lowest supported PHP version

--- a/dev-tools/build.sh
+++ b/dev-tools/build.sh
@@ -15,7 +15,7 @@ composer info -D | sort
 composer global show kherge/box -q || composer global require --no-interaction --no-progress kherge/box:^2.7
 
 # build phar file
-php -d phar.readonly=false $(composer config home)/vendor/bin/box build
+php -d phar.readonly=false "$(composer config home)/vendor/bin/box" build
 
 # revert changes to composer
 git checkout composer.json

--- a/dev-tools/check-shell-scripts.sh
+++ b/dev-tools/check-shell-scripts.sh
@@ -5,10 +5,18 @@ set -eu
 IFS='
 '
 
-SHELL_SCRIPTS=$(find ./ -type f -not -path '*/vendor/*' -iname '*.sh')
+SHELL_SCRIPTS=$(
+    find ./ \
+    -type f \
+    -not -path '*/vendor/*' \
+    -not -path './dev-tools/ci-integration.sh' \
+    -iname '*.sh'
+)
 
 # shellcheck disable=SC2086
 checkbashisms $SHELL_SCRIPTS
 
 # shellcheck disable=SC2086
 shellcheck $SHELL_SCRIPTS
+
+shellcheck --exclude=SC2086 ./dev-tools/ci-integration.sh

--- a/dev-tools/check-shell-scripts.sh
+++ b/dev-tools/check-shell-scripts.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+IFS='
+'
+
+SHELL_SCRIPTS=$(find ./ -type f -not -path '*/vendor/*' -iname '*.sh')
+
+# shellcheck disable=SC2086
+checkbashisms $SHELL_SCRIPTS

--- a/dev-tools/check-shell-scripts.sh
+++ b/dev-tools/check-shell-scripts.sh
@@ -9,3 +9,6 @@ SHELL_SCRIPTS=$(find ./ -type f -not -path '*/vendor/*' -iname '*.sh')
 
 # shellcheck disable=SC2086
 checkbashisms $SHELL_SCRIPTS
+
+# shellcheck disable=SC2086
+shellcheck $SHELL_SCRIPTS

--- a/dev-tools/ci-integration.sh
+++ b/dev-tools/ci-integration.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
+IFS='
+'
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
-if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then IFS=$'\n' EXTRA_ARGS=('--path-mode=intersection' '--' ${CHANGED_FILES[@]}); fi
-vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no "${EXTRA_ARGS[@]}"
+if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
+vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}

--- a/dev-tools/ci-integration.sh
+++ b/dev-tools/ci-integration.sh
@@ -5,5 +5,4 @@ IFS='
 '
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
 if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
-# shellcheck disable=SC2086
 vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}

--- a/dev-tools/ci-integration.sh
+++ b/dev-tools/ci-integration.sh
@@ -5,4 +5,5 @@ IFS='
 '
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
 if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); fi
+# shellcheck disable=SC2086
 vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}

--- a/dev-tools/trigger-website.sh
+++ b/dev-tools/trigger-website.sh
@@ -4,7 +4,7 @@ set -e
 TOKEN=$1
 MSG_SUFFIX=$2
 
-if [ ! -z $MSG_SUFFIX ]
+if [ ! -z "$MSG_SUFFIX" ]
 then
     MSG_SUFFIX=" for ${MSG_SUFFIX}"
 fi
@@ -25,4 +25,4 @@ curl -s -X POST \
     -H "User-Agent: API Explorer" \
     -H "Authorization: token ${TOKEN}" \
     -d "${body}" \
-    https://api.travis-ci.org/repo/${REPO}/requests
+    "https://api.travis-ci.org/repo/${REPO}/requests"

--- a/dev-tools/trigger-website.sh
+++ b/dev-tools/trigger-website.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 TOKEN=$1
@@ -9,7 +9,7 @@ then
     MSG_SUFFIX=" for ${MSG_SUFFIX}"
 fi
 
-REPO=$(sed "s@/@%2F@g" <<< "PHP-CS-Fixer/PHP-CS-Fixer.github.io")
+REPO=$(echo "PHP-CS-Fixer/PHP-CS-Fixer.github.io" | sed "s@/@%2F@g")
 
 body="{
     \"request\": {

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -95,14 +95,16 @@ final class CiIntegrationTest extends TestCase
         $integrationScript = explode("\n", str_replace('vendor/bin/', './../../../', file_get_contents(__DIR__.'/../../dev-tools/ci-integration.sh')));
         $steps = array(
             "COMMIT_RANGE=\"master..${branchName}\"",
-            $integrationScript[3],
-            $integrationScript[4],
+            "{$integrationScript[3]}\n{$integrationScript[4]}",
             $integrationScript[5],
+            $integrationScript[6],
+            $integrationScript[7],
         );
 
         $result1 = self::executeScript(array(
             $steps[0],
             $steps[1],
+            $steps[2],
             'echo "$CHANGED_FILES"',
         ));
 
@@ -112,12 +114,8 @@ final class CiIntegrationTest extends TestCase
             $steps[0],
             $steps[1],
             $steps[2],
-            'echo "${#EXTRA_ARGS[@]}"',
-            'echo "${EXTRA_ARGS[@]}"',
-            'echo "${EXTRA_ARGS[0]}"',
-            'echo "${EXTRA_ARGS[1]}"',
-            'echo "${EXTRA_ARGS[2]}"',
-            'echo "${EXTRA_ARGS[3]}"',
+            $steps[3],
+            'echo "${EXTRA_ARGS}"',
         ));
 
         $this->assertSame(implode("\n", $expectedResult2Lines), $result2->getOutput());
@@ -127,6 +125,7 @@ final class CiIntegrationTest extends TestCase
             $steps[1],
             $steps[2],
             $steps[3],
+            $steps[4],
         ));
 
         $optionalIncompatibilityWarning = 'PHP needs to be a minimum version of PHP 5.3.6 and maximum version of PHP 7.2.*.
@@ -175,8 +174,6 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'dir b/file b.php',
                 ),
                 array(
-                    '4',
-                    '--path-mode=intersection -- dir a/file.php dir b/file b.php',
                     '--path-mode=intersection',
                     '--',
                     'dir a/file.php',
@@ -201,11 +198,6 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'dir b/file b.php',
                 ),
                 array(
-                    '0',
-                    '',
-                    '',
-                    '',
-                    '',
                     '',
                     '',
                 ),
@@ -225,11 +217,6 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'dir b/file b.php',
                 ),
                 array(
-                    '0',
-                    '',
-                    '',
-                    '',
-                    '',
                     '',
                     '',
                 ),
@@ -249,11 +236,6 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'dir b/file b.php',
                 ),
                 array(
-                    '0',
-                    '',
-                    '',
-                    '',
-                    '',
                     '',
                     '',
                 ),

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -98,7 +98,7 @@ final class CiIntegrationTest extends TestCase
             "{$integrationScript[3]}\n{$integrationScript[4]}",
             $integrationScript[5],
             $integrationScript[6],
-            $integrationScript[8],
+            $integrationScript[7],
         );
 
         $result1 = self::executeScript(array(

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -98,7 +98,7 @@ final class CiIntegrationTest extends TestCase
             "{$integrationScript[3]}\n{$integrationScript[4]}",
             $integrationScript[5],
             $integrationScript[6],
-            $integrationScript[7],
+            $integrationScript[8],
         );
 
         $result1 = self::executeScript(array(


### PR DESCRIPTION
I used ShellCheck and checkbashisms to find and get rid of Bash-specific syntax and features in shell scripts.

This PR is not about refactoring or fixing the scripts. The intention of this PR is to make the scripts work in any POSIX-compliant shell.

This will allow developers to contribute to PHP-CS-Fixer using environments that don't have Bash, e. g. Alpine Linux.

Fixes #3544.
Fixes #3613.
Closes #3609.