### PR TITLE
AbstractDoctrineAnnotationFixer: edge case bugfix

### DIFF
--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -207,6 +207,10 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
     {
         do {
             $index = $tokens->getNextMeaningfulToken($index);
+
+            if (null === $index) {
+                return false;
+            }
         } while ($tokens[$index]->isGivenKind(array(T_ABSTRACT, T_FINAL)));
 
         if ($tokens[$index]->isClassy()) {

--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -208,9 +208,9 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
         do {
             $index = $tokens->getNextMeaningfulToken($index);
 
-            if (null === $index) {
-                return false;
-            }
+//             if (null === $index) {
+//                 return false;
+//             }
         } while ($tokens[$index]->isGivenKind(array(T_ABSTRACT, T_FINAL)));
 
         if ($tokens[$index]->isClassy()) {

--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -208,9 +208,9 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
         do {
             $index = $tokens->getNextMeaningfulToken($index);
 
-//             if (null === $index) {
-//                 return false;
-//             }
+            if (null === $index) {
+                return false;
+            }
         } while ($tokens[$index]->isGivenKind(array(T_ABSTRACT, T_FINAL)));
 
         if ($tokens[$index]->isClassy()) {

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -39,7 +39,18 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixWithBracesCases()
     {
-        return $this->createTestCases(array(
+        $edgeCases = array(
+            array(
+                '<?php
+
+/**
+ * @see \User getId()
+ */
+',
+            ),
+        );
+
+        return $edgeCases + $this->createTestCases(array(
             array('
 /**
  * @Foo()
@@ -283,7 +294,18 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixWithoutBracesCases()
     {
-        return $this->createTestCases(array(
+        $edgeCases = array(
+            array(
+                '<?php
+
+/**
+ * @see \User getId()
+ */
+',
+            ),
+        );
+
+        return $edgeCases + $this->createTestCases(array(
             array('
 /**
  * Foo.

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -38,7 +38,18 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
      */
     public function provideFixCases()
     {
-        return $this->createTestCases(array(
+        $edgeCases = array(
+            array(
+                '<?php
+
+/**
+ * @see \User getId()
+ */
+',
+            ),
+        );
+
+        return $edgeCases + $this->createTestCases(array(
             array('
 /**
  * Foo.

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -62,7 +62,18 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixAllCases()
     {
-        return $this->createTestCases(array(
+        $edgeCases = array(
+            array(
+                '<?php
+
+/**
+ * @see \User getId()
+ */
+',
+            ),
+        );
+
+        return $edgeCases + $this->createTestCases(array(
             array('
 /**
  * @Foo


### PR DESCRIPTION
```
    [RuntimeException]
    Index invalid or out of range

  PhpCsFixer\AbstractDoctrineAnnotationFixer->nextElementAcceptsDoctrineAnnotations()
    in ./vendor/friendsofphp/php-cs-fixer/src/AbstractDoctrineAnnotationFixer.php at line 52
  PhpCsFixer\AbstractDoctrineAnnotationFixer->applyFix()
    in ./vendor/friendsofphp/php-cs-fixer/src/AbstractFixer.php at line 73
  PhpCsFixer\AbstractFixer->fix()
    in ./vendor/friendsofphp/php-cs-fixer/src/Runner/Runner.php at line 190
  PhpCsFixer\Runner\Runner->fixFile()
    in ./vendor/friendsofphp/php-cs-fixer/src/Runner/Runner.php at line 132
  PhpCsFixer\Runner\Runner->fix()
    in ./vendor/friendsofphp/php-cs-fixer/src/Console/Command/FixCommand.php at line 219
  PhpCsFixer\Console\Command\FixCommand->execute()
    in ./vendor/symfony/console/Command/Command.php at line 252
  [ ... ]
```