### PR TITLE
DX: allow for more phpunit-speedtrap versions to support more PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "hhvm": "<3.18"
     },
     "require-dev": {
-        "johnkary/phpunit-speedtrap": "^1.0.1",
+        "johnkary/phpunit-speedtrap": "^1.0.1 || ^2.0 || ^3.0",
         "justinrainbow/json-schema": "^5.0",
         "keradus/cli-executor": "^1.0",
         "mikey179/vfsStream": "^1.6",


### PR DESCRIPTION
basically newly released v3 added support for PHPUnit v7