### PR TITLE
Fix Doctrine Annotation test cases merging

### DIFF
--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -39,18 +39,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixWithBracesCases()
     {
-        $edgeCases = array(
-            array(
-                '<?php
-
-/**
- * @see \User getId()
- */
-',
-            ),
-        );
-
-        return $edgeCases + $this->createTestCases(array(
+        $cases = $this->createTestCases(array(
             array('
 /**
  * @Foo()
@@ -273,6 +262,17 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  * @todo: foo
  */'),
         ));
+
+        $cases[] = array(
+            '<?php
+
+/**
+* @see \User getId()
+*/
+',
+        );
+
+        return $cases;
     }
 
     /**
@@ -294,18 +294,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixWithoutBracesCases()
     {
-        $edgeCases = array(
-            array(
-                '<?php
-
-/**
- * @see \User getId()
- */
-',
-            ),
-        );
-
-        return $edgeCases + $this->createTestCases(array(
+        $cases = $this->createTestCases(array(
             array('
 /**
  * Foo.
@@ -545,6 +534,17 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  * @todo: foo()
  */'),
         ));
+
+        $cases[] = array(
+            '<?php
+
+/**
+* @see \User getId()
+*/
+',
+        );
+
+        return $cases;
     }
 
     /**

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
@@ -38,18 +38,7 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
      */
     public function provideFixCases()
     {
-        $edgeCases = array(
-            array(
-                '<?php
-
-/**
- * @see \User getId()
- */
-',
-            ),
-        );
-
-        return $edgeCases + $this->createTestCases(array(
+        $cases = $this->createTestCases(array(
             array('
 /**
  * Foo.
@@ -304,5 +293,16 @@ final class DoctrineAnnotationIndentationFixerTest extends AbstractDoctrineAnnot
  */
 '),
         ));
+
+        $cases[] = array(
+            '<?php
+
+/**
+* @see \User getId()
+*/
+',
+        );
+
+        return $cases;
     }
 }

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
@@ -62,18 +62,7 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
      */
     public function provideFixAllCases()
     {
-        $edgeCases = array(
-            array(
-                '<?php
-
-/**
- * @see \User getId()
- */
-',
-            ),
-        );
-
-        return $edgeCases + $this->createTestCases(array(
+        $cases = $this->createTestCases(array(
             array('
 /**
  * @Foo
@@ -330,6 +319,17 @@ final class DoctrineAnnotationSpacesFixerTest extends AbstractDoctrineAnnotation
  * @Transform /^(\d+)$/
  */'),
         ));
+
+        $cases[] = array(
+            '<?php
+
+/**
+* @see \User getId()
+*/
+',
+        );
+
+        return $cases;
     }
 
     /**


### PR DESCRIPTION
Didn't notice that in #3557:
```php
['a'] + ['b', 'c'] // = ['a', 'c']
```