### PR TITLE
Fix the default value of the doctrine_annotation_array_assignment rule

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -428,7 +428,7 @@ Choose from the list of available rules:
     'runInSeparateProcess', 'small', 'test', 'testdox', 'ticket', 'uses',
     'SuppressWarnings', 'noinspection', 'package_version', 'enduml',
     'startuml', 'fix', 'FIXME', 'fixme', 'override']``
-  - ``operator`` (``':'``, ``'='``): the operator to use; defaults to ``'='``
+  - ``operator`` (``':'``, ``'='``): the operator to use; defaults to ``':'``
 
 * **doctrine_annotation_braces** [@DoctrineAnnotation]
 


### PR DESCRIPTION
Default value should be `:` in the `README.rst` file according to: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/8f726d0f9abd5694433afdcbd2e7b1ebf4be8133/src/RuleSet.php#L178-L181