### PR TITLE
DX: Fix PHPUnit warnings

### DIFF
--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1111,6 +1111,7 @@ final class ConfigurationResolverTest extends TestCase
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Fixer `Vendor4/foo` is deprecated, use `testA` and `testB` instead.
      */

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -719,6 +719,7 @@ INPUT
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer::fixSpace is deprecated and will be removed in 3.0.
      */

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -769,6 +769,7 @@ $b;
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'align', '=>' => 'single_space']] as replacement for ['align_equals' => true, 'align_double_arrow' => false].
      */
@@ -781,6 +782,7 @@ $b;
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'align']] as replacement for ['align_equals' => true, 'align_double_arrow' => null].
      */
@@ -793,6 +795,7 @@ $b;
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=>' => 'align']] as replacement for ['align_equals' => null, 'align_double_arrow' => true].
      */
@@ -805,6 +808,7 @@ $b;
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Given configuration is deprecated and will be removed in 3.0. Use configuration ['operators' => ['=' => 'single_space', '=>' => 'align']] as replacement for ['align_equals' => false, 'align_double_arrow' => true].
      */

--- a/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
@@ -34,6 +34,7 @@ final class FixerConfigurationResolverRootlessTest extends TestCase
     }
 
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation Passing "foo" at the root of the configuration is deprecated and will not be supported in 3.0, use "foo" => array(...) option instead.
      */

--- a/tests/Test/IntegrationCaseTest.php
+++ b/tests/Test/IntegrationCaseTest.php
@@ -24,6 +24,7 @@ use PhpCsFixer\Tests\TestCase;
 final class IntegrationCaseTest extends TestCase
 {
     /**
+     * @doesNotPerformAssertions
      * @group legacy
      * @expectedDeprecation The "PhpCsFixer\Test\IntegrationCase::shouldCheckPriority" method is deprecated. You should stop using it, as it will be removed in 3.0 version.
      */


### PR DESCRIPTION
```
There were 8 risky tests:

1) PhpCsFixer\Tests\Console\ConfigurationResolverTest::testDeprecatedFixerConfigured
This test did not perform any assertions

2) PhpCsFixer\Tests\Fixer\FunctionNotation\MethodArgumentSpaceFixerTest::testLegacyFixSpace
This test did not perform any assertions

3) PhpCsFixer\Tests\Fixer\Operator\BinaryOperatorSpacesFixerTest::testWrongConfigOldDeprecated
This test did not perform any assertions

4) PhpCsFixer\Tests\Fixer\Operator\BinaryOperatorSpacesFixerTest::testWrongConfigOldDeprecated2
This test did not perform any assertions

5) PhpCsFixer\Tests\Fixer\Operator\BinaryOperatorSpacesFixerTest::testWrongConfigOldDeprecated3
This test did not perform any assertions

6) PhpCsFixer\Tests\Fixer\Operator\BinaryOperatorSpacesFixerTest::testWrongConfigOldDeprecated4
This test did not perform any assertions

7) PhpCsFixer\Tests\FixerConfiguration\FixerConfigurationResolverRootlessTest::testResolveWithMappedRoot
This test did not perform any assertions

8) PhpCsFixer\Tests\Test\IntegrationCaseTest::testLegacyShouldCheckPriority
This test did not perform any assertions

```