### PR TITLE
Fix no unused imports fixer

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -106,7 +106,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         $usages = [];
 
         foreach ($useDeclarations as $shortName => $useDeclaration) {
-            $usages[$shortName] = (bool) Preg::match('/(?<![\$\\\\])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
+            $usages[$shortName] = (bool) Preg::match('/(?<![\$\\\\"\'])(?<!->)\b'.preg_quote($shortName, '/').'\b/i', $content);
         }
 
         return $usages;

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -48,6 +48,7 @@ class AnnotatedClass
     {
         $bar = $foo->toArray();
         /** @var ArrayInterface $bar */
+        $baz = 'baz';
     }
 }
 EOF;
@@ -80,6 +81,7 @@ class AnnotatedClass
     {
         $bar = $foo->toArray();
         /** @var ArrayInterface $bar */
+        $baz = 'baz';
     }
 }
 EOF;


### PR DESCRIPTION
This bugfix prevents finding false position usages of use statements that are quoted (either single or double quotes).

Maybe related to #2480