### PR TITLE
make phar extension optional

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -41,11 +41,17 @@ set_error_handler(function ($severity, $message, $file, $line) {
     }
 });
 
-try {
+$require = true;
+if (class_exists('Phar')) {
     // Maybe this file is used as phar-stub? Let's try!
-    Phar::mapPhar('php-cs-fixer.phar');
-    require_once 'phar://php-cs-fixer.phar/vendor/autoload.php';
-} catch (PharException $e) {
+    try {
+        Phar::mapPhar('php-cs-fixer.phar');
+        require_once 'phar://php-cs-fixer.phar/vendor/autoload.php';
+        $require = false;
+    } catch (PharException $e) {
+    }
+}
+if ($require) {
     // OK, it's not, let give Composer autoloader a try!
     if (file_exists($a = __DIR__.'/../../autoload.php')) {
         require_once $a;
@@ -53,6 +59,7 @@ try {
         require_once __DIR__.'/vendor/autoload.php';
     }
 }
+unset($require);
 
 use PhpCsFixer\Console\Application;
 


### PR DESCRIPTION
the utility itself does not need the phar extension if used in the source
version but it previously crashed when invoked w/o the phar extension b/c
there was an unchecked use while trying to map the phar.

fix is to check for the phar class and only if it exists try with phar
mapping. otherwise just take the source version as it is not a phar
anyway.