### PR TITLE
Travis - allow for hhvm failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,3 +158,4 @@ jobs:
 
     allow_failures:
         - php: nightly
+        - php: hhvm


### PR DESCRIPTION
That's next time when hhvm is making troubles.
Just a quick fix to make hhvm non-blocking for Travis.
Probably lower version of hhvm is still working, while upper introduces more incompatibilities with PHP.
I won't put more effort into maintaining hhvm - it's already dropped since 2.3.

Yet, If anyone will be able and willing to investigate which hhvm version is working and which is not, put it down into composer&travis file - I will approve such change.