### PR TITLE
Fix: Keep rules sorted

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -46,9 +46,10 @@ $config = PhpCsFixer\Config::create()
         'header_comment' => ['header' => $header],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],
-        'method_chaining_indentation' => true,
         'method_argument_space' => ['ensure_fully_multiline' => true],
+        'method_chaining_indentation' => true,
         'multiline_comment_opening_closing' => true,
+        'no_alternative_syntax' => true,
         'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
         'no_null_property_initialization' => true,
         'no_short_echo_tag' => true,
@@ -74,7 +75,6 @@ $config = PhpCsFixer\Config::create()
         'strict_param' => true,
         'string_line_ending' => true,
         'yoda_style' => true,
-        'no_alternative_syntax' => true,
     ])
     ->setFinder($finder)
 ;


### PR DESCRIPTION
This PR

* [x] keeps rules sorted in `.php_cs.dist`