### PR TITLE
ArrayIndentationFixer: missing handling of case when value starts on new line

### DIFF
--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -220,6 +220,42 @@ INPUT
                 <<<'EXPECTED'
 <?php
 $foo = [
+    'foo' =>
+        'My'
+        . ' very'
+        . ' long'
+        . ' string',
+    'bar' =>
+        'My'
+        . ' second'
+        . ' very'
+        . ' long'
+        . ' string',
+];
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+$foo = [
+    'foo' =>
+        'My'
+        . ' very'
+        . ' long'
+        . ' string',
+        'bar' =>
+            'My'
+            . ' second'
+            . ' very'
+            . ' long'
+            . ' string',
+];
+INPUT
+                ,
+            ],
+            [
+                <<<'EXPECTED'
+<?php
+$foo = [
     'foo' => ['bar' => [
         'baz',
     ]],


### PR DESCRIPTION
Ping @julienfalque (ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3135)

```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 $foo = [
     'foo' =>
-        'Value'
-        . ' on'
-        . ' new-line',
+    'Value'
+    . ' on'
+    . ' new-line',
 ];'
```