### PR TITLE
ArrayIndentationFixer: priority bug with BinaryOperatorSpacesFixer and MethodChainingIndentationFixer

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -212,8 +212,8 @@ $h = $i===  $j;
      */
     public function getPriority()
     {
-        // must run after ArraySyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer and StrictComparisonFixer.
-        return -1;
+        // must run after ArraySyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer and BinaryOperatorSpacesFixer.
+        return -31;
     }
 
     /**

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -212,7 +212,7 @@ $h = $i===  $j;
      */
     public function getPriority()
     {
-        // must run after ArraySyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer and BinaryOperatorSpacesFixer.
+        // must run after ArraySyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer and ArrayIndentationFixer.
         return -31;
     }
 

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -40,6 +40,15 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // must run after ArrayIndentationFixer
+        return -31;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isCandidate(Tokens $tokens)
     {
         return $tokens->isTokenKindFound(T_OBJECT_OPERATOR);

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -60,6 +60,7 @@ final class FixerFactoryTest extends TestCase
         return [
             [$fixers['array_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['array_syntax'], $fixers['ternary_operator_spaces']],
+            [$fixers['array_indentation'], $fixers['binary_operator_spaces']],
             [$fixers['backtick_to_shell_exec'], $fixers['escape_implicit_backslashes']],
             [$fixers['blank_line_after_opening_tag'], $fixers['no_blank_lines_before_namespace']],
             [$fixers['braces'], $fixers['array_indentation']],

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -58,9 +58,10 @@ final class FixerFactoryTest extends TestCase
         }
 
         return [
+            [$fixers['array_indentation'], $fixers['binary_operator_spaces']],
+            [$fixers['array_indentation'], $fixers['method_chaining_indentation']],
             [$fixers['array_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['array_syntax'], $fixers['ternary_operator_spaces']],
-            [$fixers['array_indentation'], $fixers['binary_operator_spaces']],
             [$fixers['backtick_to_shell_exec'], $fixers['escape_implicit_backslashes']],
             [$fixers['blank_line_after_opening_tag'], $fixers['no_blank_lines_before_namespace']],
             [$fixers['braces'], $fixers['array_indentation']],

--- a/tests/Fixtures/Integration/priority/binary_operator_spaces,array_indentation.test
+++ b/tests/Fixtures/Integration/priority/binary_operator_spaces,array_indentation.test
@@ -1,0 +1,17 @@
+--TEST--
+Integration of fixers: binary_operator_spaces,array_indentation.
+--RULESET--
+{"binary_operator_spaces": {"default": "align_single_space"}, "array_indentation": true}
+--EXPECT--
+<?php
+$foo = [
+    'bar'   => 1,
+    'baz'   => 2,
+];
+
+--INPUT--
+<?php
+$foo = [
+    'bar'   => 1,
+        'baz' => 2,
+];

--- a/tests/Fixtures/Integration/priority/method_chaining_indentation,array_indentation.test
+++ b/tests/Fixtures/Integration/priority/method_chaining_indentation,array_indentation.test
@@ -1,0 +1,17 @@
+--TEST--
+Integration of fixers: method_chaining_indentation,array_indentation.
+--RULESET--
+{"method_chaining_indentation": true, "array_indentation": true}
+--EXPECT--
+<?php
+Foo::bar([
+    'baz',
+])
+->call();
+
+--INPUT--
+<?php
+Foo::bar([
+		'baz',
+	])
+	->call();


### PR DESCRIPTION
Ping @julienfalque (ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3135)
```diff
--- Expected
+++ Actual
@@ @@
 '<?php
 $foo = [
-    'bar'   => 1,
-    'baz'   => 2,
+    'bar'     => 1,
+    'baz' => 2,
 ];
```
With config:
```json
{
   "array_indentation": true,
   "binary_operator_spaces": {
      "default": "align_single_space"
   }
}
```