### PR TITLE
DX: Add CachingLinter for tests

### DIFF
--- a/src/Linter/CachingLinter.php
+++ b/src/Linter/CachingLinter.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Linter;
+
+/**
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @internal
+ */
+final class CachingLinter implements LinterInterface
+{
+    /**
+     * @var LinterInterface
+     */
+    private $sublinter;
+
+    /**
+     * @var array<string, LintingResultInterface>
+     */
+    private $cache = array();
+
+    /**
+     * @param LinterInterface $linter Linter instance
+     */
+    public function __construct(LinterInterface $linter)
+    {
+        $this->sublinter = $linter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAsync()
+    {
+        return $this->sublinter->isAsync();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lintFile($path)
+    {
+        $checksum = crc32(file_get_contents($path));
+
+        if (!isset($this->cache[$checksum])) {
+            $this->cache[$checksum] = $this->sublinter->lintFile($path);
+        }
+
+        return $this->cache[$checksum];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lintSource($source)
+    {
+        $checksum = crc32($source);
+
+        if (!isset($this->cache[$checksum])) {
+            $this->cache[$checksum] = $this->sublinter->lintSource($source);
+        }
+
+        return $this->cache[$checksum];
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -45,6 +45,7 @@ final class ProjectCodeTest extends TestCase
         'PhpCsFixer\FileRemoval',
         'PhpCsFixer\Fixer\Operator\AlignDoubleArrowFixerHelper',
         'PhpCsFixer\Fixer\Operator\AlignEqualsFixerHelper',
+        'PhpCsFixer\Linter\CachingLinter',
         'PhpCsFixer\Runner\FileCachingLintingIterator',
         'PhpCsFixer\Runner\FileLintingIterator',
         'PhpCsFixer\StdinFileInfo',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Tests\Test;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Linter\CachingLinter;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\RuleSet;
@@ -230,7 +231,7 @@ abstract class AbstractFixerTestCase extends TestCase
 
                 $linter = $linterProphecy->reveal();
             } else {
-                $linter = new Linter();
+                $linter = new CachingLinter(new Linter());
             }
         }
 

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\FileRemoval;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Linter\CachingLinter;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\Runner\Runner;
@@ -382,7 +383,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
 
                 $linter = $linterProphecy->reveal();
             } else {
-                $linter = new Linter();
+                $linter = new CachingLinter(new Linter());
             }
         }
 


### PR DESCRIPTION
before:
```
ker@dus:~/github/PHP-CS-Fixer λ vendor/bin/phpunit tests/Fixer/PhpUnit/
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.1-1+ubuntu17.04.1+deb.sury.org+1
Configuration: /home/keradus/github/PHP-CS-Fixer/phpunit.xml.dist

Testing tests/Fixer/PhpUnit/
..........................................................................................................................................................................                                                                                         170 / 170 (100%)

You should really fix these slow tests (>100ms)...
 1. 170ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #27
 2. 161ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #28
 3. 159ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testLegacyFix with data set #16
 4. 157ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #12
 5. 155ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testLegacyFix with data set #30
 6. 154ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #5
 7. 153ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #26
 8. 152ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testLegacyFix with data set #9
 9. 151ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testLegacyFix with data set #26
 10. 149ms to run PhpCsFixer\Tests\Fixer\PhpUnit\PhpUnitConstructFixerTest:testFix with data set #16
...and there are 57 more above your threshold hidden from view

Time: 15.4 seconds, Memory: 10.00MB

OK (170 tests, 11375 assertions)
```

---------------------------

after
```
ker@dus:~/github/PHP-CS-Fixer λ vendor/bin/phpunit tests/Fixer/PhpUnit/
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.1-1+ubuntu17.04.1+deb.sury.org+1
Configuration: /home/keradus/github/PHP-CS-Fixer/phpunit.xml.dist

Testing tests/Fixer/PhpUnit/
..........................................................................................................................................................................                                                                                         170 / 170 (100%)

Time: 4.39 seconds, Memory: 10.00MB

OK (170 tests, 11375 assertions)
```