### PR TITLE
undefined order of files (tppka patch 4), fixes #3171

### DIFF
--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -136,17 +136,19 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
 If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, we will help you!
 ';
 
-        $executionDetails = "Loaded config default from \".php_cs.dist\".
-${expectedResult3Files}
-Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error";
+        $executionDetails = 'Loaded config default from ".php_cs.dist".
+@@@
+Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error';
 
+        $patternBuffer = sprintf(
+            '/^(?:%s)?(?:%s)?%s$/',
+            preg_quote($optionalIncompatibilityWarning, '/'),
+            preg_quote($optionalXdebugWarning, '/'),
+            preg_quote($executionDetails, '/')
+        );
+        $patternBuffer = strtr($patternBuffer, array('@@@' => $expectedResult3Files));
         $this->assertRegExp(
-            sprintf(
-                '/^(%s)?(%s)?%s$/',
-                preg_quote($optionalIncompatibilityWarning, '/'),
-                preg_quote($optionalXdebugWarning, '/'),
-                preg_quote($executionDetails, '/')
-            ),
+            $patternBuffer,
             $result3->getError()
         );
 
@@ -180,7 +182,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     'dir b/file b.php',
                     '',
                 ),
-                'S.',
+                '(?:S[.]|[.]S)',
             ),
             array(
                 'changes-including-dist-config-file',
@@ -201,7 +203,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '',
                     '',
                 ),
-                '...',
+                '\Q...\E',
             ),
             array(
                 'changes-including-custom-config-file-creation',
@@ -220,7 +222,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '',
                     '',
                 ),
-                '...',
+                '\Q...\E',
             ),
             array(
                 'changes-including-composer-lock',
@@ -239,7 +241,7 @@ Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes,
                     '',
                     '',
                 ),
-                '...',
+                '\Q...\E',
             ),
         );
     }


### PR DESCRIPTION
non invasive fix to deal w/ an inconsistency which is to adopt test
fixtures for undefined order of file result display on standard output
created by the file fixing iteration within the integration test.

props @keradus comment [1] to not rely on the order of fixing and earlier
[2] to not align iterator's flow just for that.

note: there is a similar approach to this in #3660.

refs:

- [1] https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3171#issuecomment-374572917

- [2] https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3617#discussion_r175851429

- #3171

- #3608

- #3660