### PR TITLE
PhpdocTypesOrderFixer - Fix ordering of nested generics

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -152,7 +152,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
     private function sortTypes(array $types)
     {
         foreach ($types as $index => $type) {
-            $types[$index] = Preg::replaceCallback('/^([^<]+)<(?:(.+?)(,\s*))?(.*)>$/', function (array $matches) {
+            $types[$index] = Preg::replaceCallback('/^([^<]+)<(?:([\w\|]+?)(,\s*))?(.*)>$/', function (array $matches) {
                 return $matches[1].'<'.$this->sortJoinedTypes($matches[2]).$matches[3].$this->sortJoinedTypes($matches[4]).'>';
             }, $type);
         }

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -485,6 +485,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
                 '<?php /** @var null|Foo|Foo[]|Foo\Bar|Foo_Bar */',
                 '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
             ],
+            [
+                '<?php /** @return array<array<string, int>> */',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #3636.