### PR TITLE
RunnerTest - workaround for failing Symfony v2.8.37

### DIFF
--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -106,7 +106,7 @@ final class RunnerTest extends TestCase
     {
         $errorsManager = new ErrorsManager();
 
-        $path = __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid';
+        $path = realpath(__DIR__.DIRECTORY_SEPARATOR.'..').DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'FixerTest'.DIRECTORY_SEPARATOR.'invalid';
         $runner = new Runner(
             Finder::create()->in($path),
             array(


### PR DESCRIPTION
[This](https://github.com/symfony/symfony/pull/26337/files) change was released with Symfony v2.8.37 today.