### PR TITLE
Adding new configuration option 'position_after_multiline_functions_and_oop_constructs' for classy constructs with the argument list is split across multiple lines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -358,10 +358,11 @@ Choose from the list of available rules:
     the opening brace should be placed on "next" or "same" line after
     classy constructs (non-anonymous classes, interfaces, traits, methods
     and non-lambda functions); defaults to ``'next'``
-  - ``position_after_multiline_functions_and_oop_constructs`` (``'next'``, ``'same'``): whether
-    the opening brace should be placed on "next" or "same" line after
-    classy constructs with the argument list is split across multiple lines (non-anonymous classes, interfaces, traits, methods
-    and non-lambda functions); defaults to ``'same'``
+  - ``position_after_multiline_functions_and_oop_constructs`` (``'next'``, ``'same'``):
+    whether the opening brace should be placed on "next" or "same" line
+    after classy constructs with the argument list is split across multiple
+    lines (non-anonymous classes, interfaces, traits, methods and
+    non-lambda functions); defaults to ``'same'``
 
 * **cast_spaces** [@Symfony, @PhpCsFixer]
 

--- a/README.rst
+++ b/README.rst
@@ -358,6 +358,10 @@ Choose from the list of available rules:
     the opening brace should be placed on "next" or "same" line after
     classy constructs (non-anonymous classes, interfaces, traits, methods
     and non-lambda functions); defaults to ``'next'``
+  - ``position_after_multiline_functions_and_oop_constructs`` (``'next'``, ``'same'``): whether
+    the opening brace should be placed on "next" or "same" line after
+    classy constructs with the argument list is split across multiple lines (non-anonymous classes, interfaces, traits, methods
+    and non-lambda functions); defaults to ``'same'``
 
 * **cast_spaces** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -117,6 +117,37 @@ class Foo
 ',
                     ['position_after_functions_and_oop_constructs' => self::LINE_SAME]
                 ),
+                new CodeSample(
+                    '<?php
+
+class Foo
+{
+    public function bar($baz)
+    {
+        if ($baz = 900) echo "Hello!";
+
+        if ($baz = 9000)
+            echo "Wait!";
+
+        if ($baz == true)
+        {
+            echo "Why?";
+        }
+        else
+        {
+            echo "Ha?";
+        }
+
+        if (is_array($baz))
+            foreach ($baz as $b)
+            {
+                echo $b;
+            }
+    }
+}
+',
+                    ['position_after_multiline_functions_and_oop_constructs' => self::LINE_SAME]
+                ),
             ]
         );
     }
@@ -170,6 +201,10 @@ class Foo
             (new FixerOptionBuilder('position_after_functions_and_oop_constructs', 'whether the opening brace should be placed on "next" or "same" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).'))
                 ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
                 ->setDefault(self::LINE_NEXT)
+                ->getOption(),
+            (new FixerOptionBuilder('position_after_multiline_functions_and_oop_constructs', 'whether the opening brace should be placed on "next" or "same" line after classy constructs with the argument list is split across multiple lines (non-anonymous classes, interfaces, traits, methods and non-lambda functions).'))
+                ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
+                ->setDefault(self::LINE_SAME)
                 ->getOption(),
             (new FixerOptionBuilder('position_after_control_structures', 'whether the opening brace should be placed on "next" or "same" line after control structures.'))
                 ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
@@ -596,6 +631,7 @@ class Foo
                     !$isAnonymousClass
                     && $tokens[$closingParenthesisIndex - 1]->isWhitespace()
                     && false !== strpos($tokens[$closingParenthesisIndex - 1]->getContent(), "\n")
+                    && self::LINE_SAME === $this->configuration['position_after_multiline_functions_and_oop_constructs']
                 ) {
                     if (!$tokens[$startBraceIndex - 2]->isComment()) {
                         $tokens->ensureWhitespaceAtIndex($startBraceIndex - 1, 1, ' ');
@@ -613,7 +649,6 @@ class Foo
                     } else {
                         $ensuredWhitespace = $this->whitespacesConfig->getLineEnding().$indent;
                     }
-
                     $tokens->ensureWhitespaceAtIndex($startBraceIndex - 1, 1, $ensuredWhitespace);
                 }
             } else {

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -27,6 +27,8 @@ final class BracesFixerTest extends AbstractFixerTestCase
     private static $configurationOopPositionSameLine = ['position_after_functions_and_oop_constructs' => 'same'];
     private static $configurationCtrlStructPositionNextLine = ['position_after_control_structures' => 'next'];
     private static $configurationAnonymousPositionNextLine = ['position_after_anonymous_constructs' => 'next'];
+    private static $configurationOopPositionMultilineSameLine = ['position_after_multiline_functions_and_oop_constructs' => 'same'];
+    private static $configurationOopPositionMultilineNextLine = ['position_after_multiline_functions_and_oop_constructs' => 'next'];
 
     public function testInvalidConfigurationClassyConstructs()
     {
@@ -166,6 +168,204 @@ final class BracesFixerTest extends AbstractFixerTestCase
         ){
         }
     }',
+            ],
+            [
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        ) {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s)
+        {
+        }
+    }',
+                null,
+                self::$configurationOopPositionMultilineSameLine,
+            ],
+            [
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        ) {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s)
+        {
+        }
+    }',
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        )
+        {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s) {}
+    }',
+                self::$configurationOopPositionMultilineSameLine,
+            ],
+            [
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            ) {
+            }
+        };
+    }',
+                null,
+                self::$configurationOopPositionMultilineSameLine,
+            ],
+            [
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            ) {
+            }
+        };
+    }',
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            )
+            {
+            }
+        };
+    }',
+                self::$configurationOopPositionMultilineSameLine,
+            ],
+            [
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        )
+        {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s)
+        {
+        }
+    }',
+                null,
+                self::$configurationOopPositionMultilineNextLine,
+            ],
+            [
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        )
+        {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s)
+        {
+        }
+    }',
+                '<?php
+    class Foo
+    {
+        public function bar(
+            FooInterface $foo,
+            BarInterface $bar,
+            array $data = []
+        ) {
+        }
+    }
+
+    class Bar
+    {
+        public function foo(Something $s) {}
+    }',
+                self::$configurationOopPositionMultilineNextLine,
+            ],
+            [
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            )
+            {
+            }
+        };
+    }',
+                null,
+                self::$configurationOopPositionMultilineNextLine,
+            ],
+            [
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            )
+            {
+            }
+        };
+    }',
+                '<?php
+    function foo()
+    {
+        return new class {
+            public function __construct(
+                $multi,
+                $line
+            ) {
+            }
+        };
+    }',
+                self::$configurationOopPositionMultilineNextLine,
             ],
             [
                 '<?php


### PR DESCRIPTION
Closes #3637.