### PR TITLE
DX: Tokens - removeLeadingWhitespace and removeTrailingWhitespace must act in same way

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -909,28 +909,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeLeadingWhitespace($index, $whitespaces = null)
     {
-        if (isset($this[$index - 1]) && $this[$index - 1]->isWhitespace()) {
-            $newContent = '';
-            $tokenToCheck = $this[$index - 1];
-
-            // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
-            if (isset($this[$index - 2]) && $this[$index - 2]->isComment() && '/*' !== substr($this[$index - 2]->getContent(), 0, 2)) {
-                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$index - 1]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
-                if ('' === $whitespacesToCheck) {
-                    return;
-                }
-                $tokenToCheck = new Token(array(T_WHITESPACE, $whitespacesToCheck));
-            }
-
-            if (!$tokenToCheck->isWhitespace($whitespaces)) {
-                return;
-            }
-
-            $this->clearAt($index - 1);
-            if ('' !== $newContent) {
-                $this->insertAt($index - 1, new Token(array(T_WHITESPACE, $newContent)));
-            }
-        }
+        $this->saveRemoveSpace($index, 1, $whitespaces);
     }
 
     /**
@@ -939,9 +918,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeTrailingWhitespace($index, $whitespaces = null)
     {
-        if (isset($this[$index + 1]) && $this[$index + 1]->isWhitespace($whitespaces)) {
-            $this->clearAt($index + 1);
-        }
+        $this->saveRemoveSpace($index, -1, $whitespaces);
     }
 
     /**
@@ -1153,6 +1130,32 @@ class Tokens extends \SplFixedArray
         }
 
         $this->clearAt($nextIndex);
+    }
+
+    private function saveRemoveSpace($index, $offset, $whitespaces = null)
+    {
+        if (isset($this[$index - $offset]) && $this[$index - $offset]->isWhitespace()) {
+            $newContent = '';
+            $tokenToCheck = $this[$index - $offset];
+
+            // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
+            if (isset($this[$index - $offset - 1]) && $this[$index - $offset - 1]->isComment() && '/*' !== substr($this[$index - $offset - 1]->getContent(), 0, 2)) {
+                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$index - $offset]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+                if ('' === $whitespacesToCheck) {
+                    return;
+                }
+                $tokenToCheck = new Token(array(T_WHITESPACE, $whitespacesToCheck));
+            }
+
+            if (!$tokenToCheck->isWhitespace($whitespaces)) {
+                return;
+            }
+
+            $this->clearAt($index - $offset);
+            if ('' !== $newContent) {
+                $this->insertAt($index - $offset, new Token(array(T_WHITESPACE, $newContent)));
+            }
+        }
     }
 
     /**

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1118,6 +1118,36 @@ echo $a;',
     }
 
     /**
+     * @dataProvider provideRemoveTrailingWhitespaceCases
+     *
+     * @param int         $index
+     * @param null|string $whitespaces
+     * @param string      $expected
+     * @param string      $input
+     */
+    public function testRemoveTrailingWhitespace($index, $whitespaces, $expected, $input = null)
+    {
+        Tokens::clearCache();
+
+        $tokens = Tokens::fromCode(null === $input ? $expected : $input);
+        $tokens->removeTrailingWhitespace($index, $whitespaces);
+
+        $this->assertSame($expected, $tokens->generateCode());
+    }
+
+    public function provideRemoveTrailingWhitespaceCases()
+    {
+        $cases = array();
+        $leadingCases = $this->provideRemoveLeadingWhitespaceCases();
+        foreach ($leadingCases as $leadingCase) {
+            $leadingCase[0] -= 2;
+            $cases[] = $leadingCase;
+        }
+
+        return $cases;
+    }
+
+    /**
      * @param null|Token[] $expected
      * @param null|Token[] $input
      */


### PR DESCRIPTION
The difference in (not) taking multi line comments into account when clearing the space makes it very confusing.