### PR TITLE
README.rst - Format all code-like strings in fixer descriptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -425,7 +425,7 @@ Choose from the list of available rules:
 
 * **ereg_to_preg** [@Symfony:risky]
 
-  Replace deprecated ``ereg`` regular expression functions with preg.
+  Replace deprecated ``ereg`` regular expression functions with ``preg``.
 
   *Risky rule: risky if the ``ereg`` function is overridden.*
 
@@ -624,7 +624,7 @@ Choose from the list of available rules:
 
 * **no_leading_import_slash** [@Symfony]
 
-  Remove leading slashes in use clauses.
+  Remove leading slashes in ``use`` clauses.
 
 * **no_leading_namespace_whitespace** [@Symfony]
 
@@ -719,7 +719,7 @@ Choose from the list of available rules:
 
 * **no_unused_imports** [@Symfony]
 
-  Unused use statements must be removed.
+  Unused ``use`` statements must be removed.
 
 * **no_useless_else**
 
@@ -727,7 +727,8 @@ Choose from the list of available rules:
 
 * **no_useless_return**
 
-  There should not be an empty return statement at the end of a function.
+  There should not be an empty ``return`` statement at the end of a
+  function.
 
 * **no_whitespace_before_comma_in_array** [@Symfony]
 
@@ -776,7 +777,7 @@ Choose from the list of available rules:
 
 * **ordered_imports**
 
-  Ordering use statements.
+  Ordering ``use`` statements.
 
   Configuration options:
 
@@ -787,8 +788,8 @@ Choose from the list of available rules:
 
 * **php_unit_construct** [@Symfony:risky]
 
-  PHPUnit assertion method calls like "->assertSame(true, $foo)" should be
-  written with dedicated method like "->assertTrue($foo)".
+  PHPUnit assertion method calls like ``->assertSame(true, $foo)`` should be
+  written with dedicated method like ``->assertTrue($foo)``.
 
   *Risky rule: fixer could be risky if one is overriding PHPUnit's native methods.*
 
@@ -799,8 +800,8 @@ Choose from the list of available rules:
 
 * **php_unit_dedicate_assert** [@Symfony:risky]
 
-  PHPUnit assertions like "assertInternalType", "assertFileExists", should
-  be used over "assertTrue".
+  PHPUnit assertions like ``assertInternalType``, ``assertFileExists``, should
+  be used over ``assertTrue``.
 
   *Risky rule: fixer could be risky if one is overriding PHPUnit's native methods.*
 
@@ -831,7 +832,7 @@ Choose from the list of available rules:
 
 * **phpdoc_add_missing_param_annotation**
 
-  Phpdoc should contain @param for all params.
+  Phpdoc should contain ``@param`` for all params.
 
   Configuration options:
 
@@ -840,8 +841,8 @@ Choose from the list of available rules:
 
 * **phpdoc_align** [@Symfony]
 
-  All items of the @param, @throws, @return, @var, and @type phpdoc tags
-  must be aligned vertically.
+  All items of the ``@param``, ``@throws``, ``@return``, ``@var``, and ``@type``
+  phpdoc tags must be aligned vertically.
 
 * **phpdoc_annotation_without_dot** [@Symfony]
 
@@ -853,11 +854,11 @@ Choose from the list of available rules:
 
 * **phpdoc_inline_tag** [@Symfony]
 
-  Fix phpdoc inline tags, make inheritdoc always inline.
+  Fix phpdoc inline tags, make ``@inheritdoc`` always inline.
 
 * **phpdoc_no_access** [@Symfony]
 
-  @access annotations should be omitted from phpdocs.
+  ``@access`` annotations should be omitted from phpdocs.
 
 * **phpdoc_no_alias_tag** [@Symfony]
 
@@ -871,21 +872,21 @@ Choose from the list of available rules:
 
 * **phpdoc_no_empty_return** [@Symfony]
 
-  @return void and @return null annotations should be omitted from
+  ``@return`` void and ``@return null`` annotations should be omitted from
   phpdocs.
 
 * **phpdoc_no_package** [@Symfony]
 
-  @package and @subpackage annotations should be omitted from phpdocs.
+  ``@package`` and ``@subpackage`` annotations should be omitted from phpdocs.
 
 * **phpdoc_no_useless_inheritdoc** [@Symfony]
 
-  Classy that does not inherit must not have inheritdoc tags.
+  Classy that does not inherit must not have ``@inheritdoc`` tags.
 
 * **phpdoc_order**
 
-  Annotations in phpdocs should be ordered so that param annotations come
-  first, then throws annotations, then return annotations.
+  Annotations in phpdocs should be ordered so that ``@param`` annotations
+  come first, then ``@throws`` annotations, then ``@return`` annotations.
 
 * **phpdoc_return_self_reference** [@Symfony]
 
@@ -912,7 +913,7 @@ Choose from the list of available rules:
 
 * **phpdoc_single_line_var_spacing** [@Symfony]
 
-  Single line @var PHPDoc should have proper spacing.
+  Single line ``@var`` PHPDoc should have proper spacing.
 
 * **phpdoc_summary** [@Symfony]
 
@@ -934,7 +935,7 @@ Choose from the list of available rules:
 
 * **phpdoc_var_without_name** [@Symfony]
 
-  @var and @type annotations should not contain the variable name.
+  ``@var`` and ``@type`` annotations should not contain the variable name.
 
 * **pow_to_exponentiation** [@PHP56Migration:risky, @PHP70Migration:risky]
 
@@ -993,7 +994,7 @@ Choose from the list of available rules:
 
 * **self_accessor** [@Symfony:risky]
 
-  Inside class or interface element "self" should be preferred to the
+  Inside class or interface element ``self`` should be preferred to the
   class name itself.
 
   *Risky rule: risky when using dynamic calls like get_called_class() or late static binding.*
@@ -1100,9 +1101,9 @@ Choose from the list of available rules:
 
 * **visibility_required** [@PSR2, @Symfony, @PHP71Migration]
 
-  Visibility MUST be declared on all properties and methods; abstract and
-  final MUST be declared before the visibility; static MUST be declared
-  after the visibility.
+  Visibility MUST be declared on all properties and methods; ``abstract``
+  and ``final`` MUST be declared before the visibility; ``static`` MUST be
+  declared after the visibility.
 
   Configuration options:
 

--- a/src/Fixer/Alias/EregToPregFixer.php
+++ b/src/Fixer/Alias/EregToPregFixer.php
@@ -50,7 +50,7 @@ final class EregToPregFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Replace deprecated `ereg` regular expression functions with preg.',
+            'Replace deprecated `ereg` regular expression functions with `preg`.',
             array(new CodeSample('<?php $x = ereg(\'[A-Z]\');')),
             null,
             'Risky if the `ereg` function is overridden.'

--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -30,7 +30,7 @@ final class SelfAccessorFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Inside class or interface element "self" should be preferred to the class name itself.',
+            'Inside class or interface element `self` should be preferred to the class name itself.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -41,7 +41,7 @@ final class VisibilityRequiredFixer extends AbstractFixer implements Configurati
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.',
+            'Visibility MUST be declared on all properties and methods; `abstract` and `final` MUST be declared before the visibility; `static` MUST be declared after the visibility.',
             array(
                 new CodeSample(
 '<?php

--- a/src/Fixer/Import/NoLeadingImportSlashFixer.php
+++ b/src/Fixer/Import/NoLeadingImportSlashFixer.php
@@ -30,7 +30,7 @@ final class NoLeadingImportSlashFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Remove leading slashes in use clauses.',
+            'Remove leading slashes in `use` clauses.',
             array(new CodeSample("<?php\nnamespace Foo;\nuse \\Bar;"))
         );
     }

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -32,7 +32,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Unused use statements must be removed.',
+            'Unused `use` statements must be removed.',
             array(new CodeSample("<?php\nuse \\DateTime;\nuse \\Exception;\n\nnew DateTime();"))
         );
     }

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -67,7 +67,7 @@ final class OrderedImportsFixer extends AbstractFixer implements ConfigurationDe
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Ordering use statements.',
+            'Ordering `use` statements.',
             array(
                 new CodeSample("<?php\nuse Z; use A;"),
                 new CodeSample(

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -56,7 +56,7 @@ final class PhpUnitConstructFixer extends AbstractFixer implements Configuration
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPUnit assertion method calls like "->assertSame(true, $foo)" should be written with dedicated method like "->assertTrue($foo)".',
+            'PHPUnit assertion method calls like `->assertSame(true, $foo)` should be written with dedicated method like `->assertTrue($foo)`.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -72,7 +72,7 @@ final class PhpUnitDedicateAssertFixer extends AbstractFixer implements Configur
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPUnit assertions like "assertInternalType", "assertFileExists", should be used over "assertTrue".',
+            'PHPUnit assertions like `assertInternalType`, `assertFileExists`, should be used over `assertTrue`.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -37,7 +37,7 @@ final class PhpdocAddMissingParamAnnotationFixer extends AbstractFunctionReferen
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Phpdoc should contain @param for all params.',
+            'Phpdoc should contain `@param` for all params.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -55,7 +55,7 @@ final class PhpdocAlignFixer extends AbstractFixer implements WhitespacesAwareFi
     public function getDefinition()
     {
         return new FixerDefinition(
-            'All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically.',
+            'All items of the `@param`, `@throws`, `@return`, `@var`, and `@type` phpdoc tags must be aligned vertically.',
             array(new CodeSample('<?php
 /**
  * @param  EngineInterface $templating

--- a/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
@@ -30,7 +30,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Fix phpdoc inline tags, make inheritdoc always inline.',
+            'Fix phpdoc inline tags, make `@inheritdoc` always inline.',
             array(new CodeSample(
 '<?php
 /**

--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -28,7 +28,7 @@ final class PhpdocNoAccessFixer extends AbstractProxyFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '@access annotations should be omitted from phpdocs.',
+            '`@access` annotations should be omitted from phpdocs.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -40,7 +40,7 @@ final class PhpdocNoEmptyReturnFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '@return void and @return null annotations should be omitted from phpdocs.',
+            '`@return` void and `@return null` annotations should be omitted from phpdocs.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -28,7 +28,7 @@ final class PhpdocNoPackageFixer extends AbstractProxyFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '@package and @subpackage annotations should be omitted from phpdocs.',
+            '`@package` and `@subpackage` annotations should be omitted from phpdocs.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -33,7 +33,7 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Classy that does not inherit must not have inheritdoc tags.',
+            'Classy that does not inherit must not have `@inheritdoc` tags.',
             array(
                 new CodeSample("<?php\n/** {@inheritdoc} */\nclass Sample\n{\n}"),
                 new CodeSample("<?php\nclass Sample\n{\n    /**\n     * @inheritdoc\n     */\n    public function Test()\n    {\n    }\n}"),

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -38,7 +38,7 @@ final class PhpdocOrderFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Annotations in phpdocs should be ordered so that param annotations come first, then throws annotations, then return annotations.',
+            'Annotations in phpdocs should be ordered so that `@param` annotations come first, then `@throws` annotations, then `@return` annotations.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -32,7 +32,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Single line @var PHPDoc should have proper spacing.',
+            'Single line `@var` PHPDoc should have proper spacing.',
             array(new CodeSample("<?php /**@var   MyClass   \$a   */\n\$a = test();"))
         );
     }

--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -32,7 +32,7 @@ final class PhpdocVarWithoutNameFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '@var and @type annotations should not contain the variable name.',
+            '`@var` and `@type` annotations should not contain the variable name.',
             array(new CodeSample('<?php
 final class Foo
 {

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -36,7 +36,7 @@ final class NoUselessReturnFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'There should not be an empty return statement at the end of a function.',
+            'There should not be an empty `return` statement at the end of a function.',
             array(
                 new CodeSample(
                     '<?php

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -57,7 +57,7 @@ final class FixerTest extends TestCase
         $definition = $fixer->getDefinition();
         $fixerIsConfigurable = $fixer instanceof ConfigurationDefinitionFixerInterface;
 
-        $this->assertRegExp('/^[A-Z@].*\.$/', $definition->getSummary(), sprintf('[%s] Description must start with capital letter or an @ and end with dot.', $fixerName));
+        $this->assertRegExp('/^[A-Z`].*\.$/', $definition->getSummary(), sprintf('[%s] Description must start with capital letter or a ` and end with dot.', $fixerName));
 
         $samples = $definition->getCodeSamples();
         $this->assertNotEmpty($samples, sprintf('[%s] Code samples are required.', $fixerName));


### PR DESCRIPTION
Will do one for 2.11 if merged