### PR TITLE
Add PhpdocTrimAfterDescriptionFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -64,6 +64,7 @@ $config = PhpCsFixer\Config::create()
         'php_unit_test_class_requires_covers' => true,
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
+        'phpdoc_trim_after_description' => true,
         'phpdoc_types_order' => true,
         'return_assignment' => true,
         'semicolon_after_instruction' => true,

--- a/README.rst
+++ b/README.rst
@@ -1358,6 +1358,10 @@ Choose from the list of available rules:
   PHPDoc should start and end with content, excluding the very first and
   last line of the docblocks.
 
+* **phpdoc_trim_after_description**
+
+  Removes extra blank lines after summary and after description in PHPDoc.
+
 * **phpdoc_types** [@Symfony]
 
   The correct case must be used for standard PHP types in PHPDoc.

--- a/src/DocBlock/ShortDescription.php
+++ b/src/DocBlock/ShortDescription.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\DocBlock;
+
+/**
+ * This class represents a short description (aka summary) of a docblock.
+ *
+ * @internal
+ */
+final class ShortDescription
+{
+    /**
+     * The docblock containing the short description.
+     *
+     * @var DocBlock
+     */
+    private $doc;
+
+    public function __construct(DocBlock $doc)
+    {
+        $this->doc = $doc;
+    }
+
+    /**
+     * Get the line index of the line containing the end of the short
+     * description, if present.
+     *
+     * @return null|int
+     */
+    public function getEnd()
+    {
+        $reachedContent = false;
+
+        foreach ($this->doc->getLines() as $index => $line) {
+            // we went past a description, then hit a tag or blank line, so
+            // the last line of the description must be the one before this one
+            if ($reachedContent && ($line->containsATag() || !$line->containsUsefulContent())) {
+                return $index - 1;
+            }
+
+            // no short description was found
+            if ($line->containsATag()) {
+                return null;
+            }
+
+            // we've reached content, but need to check the next lines too
+            // in case the short description is multi-line
+            if ($line->containsUsefulContent()) {
+                $reachedContent = true;
+            }
+        }
+    }
+}

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\DocBlock\ShortDescription;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
@@ -61,7 +62,7 @@ function foo () {}
             }
 
             $doc = new DocBlock($token->getContent());
-            $end = $this->findShortDescriptionEnd($doc->getLines());
+            $end = (new ShortDescription($doc))->getEnd();
 
             if (null !== $end) {
                 $line = $doc->getLine($end);
@@ -71,38 +72,6 @@ function foo () {}
                     $line->setContent($content.'.'.$this->whitespacesConfig->getLineEnding());
                     $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
                 }
-            }
-        }
-    }
-
-    /**
-     * Find the line number of the line containing the end of the short
-     * description, if present.
-     *
-     * @param Line[] $lines
-     *
-     * @return null|int
-     */
-    private function findShortDescriptionEnd(array $lines)
-    {
-        $reachedContent = false;
-
-        foreach ($lines as $index => $line) {
-            // we went past a description, then hit a tag or blank line, so
-            // the last line of the description must be the one before this one
-            if ($reachedContent && ($line->containsATag() || !$line->containsUsefulContent())) {
-                return $index - 1;
-            }
-
-            // no short description was found
-            if ($line->containsATag()) {
-                return null;
-            }
-
-            // we've reached content, but need to check the next lines too
-            // in case the short description is multi-line
-            if ($line->containsUsefulContent()) {
-                $reachedContent = true;
             }
         }
     }

--- a/src/Fixer/Phpdoc/PhpdocTrimAfterDescriptionFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimAfterDescriptionFixer.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Phpdoc;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\DocBlock\ShortDescription;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Nobu Funaki <nobu.funaki@gmail.com>
+ */
+final class PhpdocTrimAfterDescriptionFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Removes extra blank lines after summary and after description in PHPDoc.',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * Summary.
+ *
+ *
+ * Description.
+ *
+ *
+ * @param string $foo
+ */
+function fnc($foo) {}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $doc = new DocBlock($token->getContent());
+            $summaryEnd = (new ShortDescription($doc))->getEnd();
+
+            if (null === $summaryEnd) {
+                continue;
+            }
+
+            $this->fixSummary($doc, $summaryEnd);
+            $this->fixDescription($doc, $summaryEnd);
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+        }
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param int      $summaryEnd
+     */
+    private function fixSummary(DocBlock $doc, $summaryEnd)
+    {
+        $nonBlankLineAfterSummary = $this->findNonBlankLine($doc, $summaryEnd);
+
+        $this->removeExtraBlankLinesBetween($doc, $summaryEnd, $nonBlankLineAfterSummary);
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param int      $summaryEnd
+     */
+    private function fixDescription(DocBlock $doc, $summaryEnd)
+    {
+        $annotationStart = $this->findFirstAnnotation($doc);
+        // assuming the end of the Description appears before the first Annotation
+        $descriptionEnd = $this->reverseFindLastUsefulContent($doc, $annotationStart);
+
+        if (null === $descriptionEnd || $summaryEnd === $descriptionEnd) {
+            return; // no Description
+        }
+
+        $this->removeExtraBlankLinesBetween($doc, $descriptionEnd, $annotationStart);
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param int      $from
+     * @param int      $to
+     */
+    private function removeExtraBlankLinesBetween(DocBlock $doc, $from, $to)
+    {
+        for ($index = $from + 1; $index < $to; ++$index) {
+            $line = $doc->getLine($index);
+            $next = $doc->getLine($index + 1);
+            $this->removeExtraBlankLine($line, $next);
+        }
+    }
+
+    /**
+     * @param Line $current
+     * @param Line $next
+     */
+    private function removeExtraBlankLine(Line $current, Line $next)
+    {
+        if (!$current->isTheEnd() && !$current->containsUsefulContent()
+            && !$next->isTheEnd() && !$next->containsUsefulContent()) {
+            $current->remove();
+        }
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param int      $after
+     *
+     * @return null|int
+     */
+    private function findNonBlankLine(DocBlock $doc, $after)
+    {
+        foreach ($doc->getLines() as $index => $line) {
+            if ($index <= $after) {
+                continue;
+            }
+
+            if ($line->containsATag() || $line->containsUsefulContent() || $line->isTheEnd()) {
+                return $index;
+            }
+        }
+    }
+
+    /**
+     * @param DocBlock $doc
+     *
+     * @return null|int
+     */
+    private function findFirstAnnotation(DocBlock $doc)
+    {
+        $index = null;
+        foreach ($doc->getLines() as $index => $line) {
+            if ($line->containsATag()) {
+                return $index;
+            }
+        }
+
+        return $index; // no Annotation, return the last line
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param int      $from
+     *
+     * @return null|int
+     */
+    private function reverseFindLastUsefulContent(DocBlock $doc, $from)
+    {
+        for ($index = $from - 1; $index >= 0; --$index) {
+            if ($doc->getLine($index)->containsUsefulContent()) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/DocBlock/ShortDescriptionTest.php
+++ b/tests/DocBlock/ShortDescriptionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\DocBlock;
+
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\ShortDescription;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\DocBlock\ShortDescription
+ */
+final class ShortDescriptionTest extends TestCase
+{
+    /**
+     * @param mixed      $expected
+     * @param null|mixed $input
+     *
+     * @dataProvider provideGetEndCases
+     */
+    public function testGetEnd($expected, $input = null)
+    {
+        $doc = new DocBlock($input);
+        $shortDescription = new ShortDescription($doc);
+
+        $this->assertSame($expected, $shortDescription->getEnd());
+    }
+
+    public function provideGetEndCases()
+    {
+        return [
+            [null, '/** */'],
+            [1, '/**
+     * Test docblock.
+     *
+     * @param string $hello
+     * @param bool $test Description
+     *        extends over many lines
+     *
+     * @param adkjbadjasbdand $asdnjkasd
+     *
+     * @throws \Exception asdnjkasd
+     * asdasdasdasdasdasdasdasd
+     * kasdkasdkbasdasdasdjhbasdhbasjdbjasbdjhb
+     *
+     * @return void
+     */'],
+            [2, '/**
+                  * This is a multi-line
+                  * short description.
+                  */'],
+            [3, '/**
+                  *
+                  *
+                  * There might be extra blank lines.
+                  *
+                  */'],
+        ];
+    }
+}

--- a/tests/Fixer/Phpdoc/PhpdocTrimAfterDescriptionFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTrimAfterDescriptionFixerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Phpdoc;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Nobu Funaki <nobu.funaki@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Phpdoc\PhpdocTrimAfterDescriptionFixer
+ */
+final class PhpdocTrimAfterDescriptionFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'basic' => [
+                <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     * Description.
+                     *
+                     * @var int
+                     *
+                     *
+                     * @return int
+                     *
+                     *
+                     * foo
+                     */
+
+EOF
+                , <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     *
+                     * Description.
+                     *
+                     *
+                     * @var int
+                     *
+                     *
+                     * @return int
+                     *
+                     *
+                     * foo
+                     */
+
+EOF
+            ],
+            'multiple extra blank lines' => [
+                <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     * Description.
+                     *
+                     * @var int
+                     */
+
+EOF
+                , <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     *
+                     *
+                     * Description.
+                     *
+                     *
+                     *
+                     * @var int
+                     */
+
+EOF
+            ],
+            'extra blank lines after summary' => [
+                <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     */
+
+EOF
+                , <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     *
+                     *
+                     */
+
+EOF
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideNoChangeCases
+     */
+    public function testNoChange($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideNoChangeCases()
+    {
+        return [
+            'summary only' => [<<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     */
+
+EOF
+            ],
+            'inline doc' => [<<<'EOF'
+                <?php
+                    /** Summary. */
+
+EOF
+            ],
+            'extra blank lines in description' => [
+                <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     * Description has multiple blank lines:
+                     *
+                     *
+                     * End.
+                     *
+                     * @var int
+                     */
+
+EOF
+            ],
+            'extra blank lines after annotation' => [
+                <<<'EOF'
+                <?php
+                    /**
+                     * Summary.
+                     *
+                     * Description.
+                     *
+                     * @var int
+                     *
+                     * Ignore the below blank lines:
+                     *
+                     *
+                     * End.
+                     */
+
+EOF
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Implements https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1686; a new fixer to remove extra blank lines after Summary and after Description in phpdocs.

```diff
 <?php

 /**
  * Description.
  *
- *
  * @var int
  */
 $foo = 1;
```

It expects to be used with phpdoc_trim, phpdoc_separation.

First pull request here :)