### PR TITLE
DX: Optimize tests

### DIFF
--- a/tests/AutoReview/ProjectFixerConfigurationTest.php
+++ b/tests/AutoReview/ProjectFixerConfigurationTest.php
@@ -28,26 +28,17 @@ use PhpCsFixer\ToolInfo;
  */
 final class ProjectFixerConfigurationTest extends TestCase
 {
-    /**
-     * @var Config
-     */
-    private $config;
-
-    protected function setUp()
-    {
-        $file = __DIR__.'/../../.php_cs.dist';
-        $this->config = require $file;
-    }
-
     public function testCreate()
     {
-        $this->assertInstanceOf('PhpCsFixer\Config', $this->config);
-        $this->assertEmpty($this->config->getCustomFixers());
-        $this->assertNotEmpty($this->config->getRules());
+        $config = $this->loadConfig();
+
+        $this->assertInstanceOf('PhpCsFixer\Config', $config);
+        $this->assertEmpty($config->getCustomFixers());
+        $this->assertNotEmpty($config->getRules());
 
         // call so the fixers get configured to reveal issue (like deprecated configuration used etc.)
         $resolver = new ConfigurationResolver(
-            $this->config,
+            $config,
             array(),
             __DIR__,
             new ToolInfo()
@@ -58,8 +49,16 @@ final class ProjectFixerConfigurationTest extends TestCase
 
     public function testRuleDefinedAlpha()
     {
-        $rules = $rulesSorted = array_keys($this->config->getRules());
+        $rules = $rulesSorted = array_keys($this->loadConfig()->getRules());
         sort($rulesSorted);
         $this->assertSame($rulesSorted, $rules, 'Please sort the "rules" in `.php_cs.dist` of this project.');
+    }
+
+    /**
+     * @return Config
+     */
+    private function loadConfig()
+    {
+        return require __DIR__.'/../../.php_cs.dist';
     }
 }

--- a/tests/Console/Command/DescribeCommandTest.php
+++ b/tests/Console/Command/DescribeCommandTest.php
@@ -32,18 +32,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class DescribeCommandTest extends TestCase
 {
-    /**
-     * @var Application
-     */
-    private $application;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->application = new Application();
-    }
-
     public function testExecuteOutput()
     {
         $expected =
@@ -134,9 +122,10 @@ Fixing examples:
 
     public function testExecuteWithUnknownRuleName()
     {
-        $this->application->add(new DescribeCommand(new FixerFactory()));
+        $application = new Application();
+        $application->add(new DescribeCommand(new FixerFactory()));
 
-        $command = $this->application->find('describe');
+        $command = $application->find('describe');
 
         $commandTester = new CommandTester($command);
 
@@ -149,9 +138,10 @@ Fixing examples:
 
     public function testExecuteWithUnknownSetName()
     {
-        $this->application->add(new DescribeCommand(new FixerFactory()));
+        $application = new Application();
+        $application->add(new DescribeCommand(new FixerFactory()));
 
-        $command = $this->application->find('describe');
+        $command = $application->find('describe');
 
         $commandTester = new CommandTester($command);
 
@@ -164,9 +154,10 @@ Fixing examples:
 
     public function testExecuteWithoutName()
     {
-        $this->application->add(new DescribeCommand(new FixerFactory()));
+        $application = new Application();
+        $application->add(new DescribeCommand(new FixerFactory()));
 
-        $command = $this->application->find('describe');
+        $command = $application->find('describe');
 
         $commandTester = new CommandTester($command);
 
@@ -248,9 +239,10 @@ Fixing examples:
         $fixerFactory = new FixerFactory();
         $fixerFactory->registerFixer($fixer->reveal(), true);
 
-        $this->application->add(new DescribeCommand($fixerFactory));
+        $application = new Application();
+        $application->add(new DescribeCommand($fixerFactory));
 
-        $command = $this->application->find('describe');
+        $command = $application->find('describe');
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -26,18 +26,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class FixCommandTest extends TestCase
 {
-    /**
-     * @var Application
-     */
-    private $application;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->application = new Application();
-    }
-
     public function testEmptyRulesValue()
     {
         $this->setExpectedExceptionRegExp(
@@ -73,9 +61,10 @@ final class FixCommandTest extends TestCase
      */
     private function doTestExecute(array $arguments)
     {
-        $this->application->add(new FixCommand(new ToolInfo()));
+        $application = new Application();
+        $application->add(new FixCommand(new ToolInfo()));
 
-        $command = $this->application->find('fix');
+        $command = $application->find('fix');
         $commandTester = new CommandTester($command);
 
         $commandTester->execute(

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -38,6 +38,8 @@ final class SelfUpdateCommandTest extends TestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->root = vfsStream::setup();
 
         file_put_contents($this->getToolPath(), 'Current PHP CS Fixer.');
@@ -48,7 +50,9 @@ final class SelfUpdateCommandTest extends TestCase
 
     protected function tearDown()
     {
-        unset($this->root);
+        parent::tearDown();
+
+        $this->root = null;
 
         try {
             vfsStreamWrapper::unregister();

--- a/tests/Report/AbstractReporterTestCase.php
+++ b/tests/Report/AbstractReporterTestCase.php
@@ -30,7 +30,16 @@ abstract class AbstractReporterTestCase extends TestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->reporter = $this->createReporter();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->reporter = null;
     }
 
     final public function testGetFormat()

--- a/tests/Report/JunitReporterTest.php
+++ b/tests/Report/JunitReporterTest.php
@@ -37,6 +37,8 @@ final class JunitReporterTest extends AbstractReporterTestCase
 
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+
         // @TODO 2.11 remove me
         if (!class_exists('PhpCsFixer\PhpunitConstraintXmlMatchesXsd\Constraint\XmlMatchesXsd')) {
             self::markTestSkipped('Cannot execute test, install `php-cs-fixer/phpunit-constraint-xmlmatchesxsd` first.');
@@ -47,6 +49,8 @@ final class JunitReporterTest extends AbstractReporterTestCase
 
     public static function tearDownAfterClass()
     {
+        parent::tearDownAfterClass();
+
         self::$xsd = null;
     }
 

--- a/tests/Report/XmlReporterTest.php
+++ b/tests/Report/XmlReporterTest.php
@@ -33,6 +33,8 @@ final class XmlReporterTest extends AbstractReporterTestCase
 
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+
         // @TODO 2.11 remove me
         if (!class_exists('PhpCsFixer\PhpunitConstraintXmlMatchesXsd\Constraint\XmlMatchesXsd')) {
             self::markTestSkipped('Cannot execute test, install `php-cs-fixer/phpunit-constraint-xmlmatchesxsd` first.');
@@ -43,6 +45,8 @@ final class XmlReporterTest extends AbstractReporterTestCase
 
     public static function tearDownAfterClass()
     {
+        parent::tearDownAfterClass();
+
         self::$xsd = null;
     }
 

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -32,15 +32,15 @@ final class PharTest extends TestCase
 {
     private static $pharCwd;
     private static $pharName;
-    private static $pharPath;
 
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+
         self::$pharCwd = __DIR__.'/../..';
         self::$pharName = 'php-cs-fixer.phar';
-        self::$pharPath = self::$pharCwd.'/'.self::$pharName;
 
-        if (!file_exists(self::$pharPath)) {
+        if (!file_exists(self::$pharCwd.'/'.self::$pharName)) {
             if (getenv('PHP_CS_FIXER_TEST_ALLOW_SKIPPING_PHAR_TESTS')) {
                 self::markTestSkipped('No phar file available.');
             }

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -26,20 +26,15 @@ use PHPUnit\Framework\TestCase;
  */
 final class StdinTest extends TestCase
 {
-    private static $cwd;
-
-    public static function setUpBeforeClass()
-    {
-        self::$cwd = __DIR__.'/../..';
-    }
-
     public function testFixingStdin()
     {
+        $cwd = __DIR__.'/../..';
+
         $command = 'php php-cs-fixer fix --rules=@PSR2 --dry-run --diff --using-cache=no';
         $inputFile = 'tests/Fixtures/Integration/set/@PSR2.test-in.php';
 
-        $fileResult = CommandExecutor::create("${command} ${inputFile}", self::$cwd)->getResult(false);
-        $stdinResult = CommandExecutor::create("${command} - < ${inputFile}", self::$cwd)->getResult(false);
+        $fileResult = CommandExecutor::create("${command} ${inputFile}", $cwd)->getResult(false);
+        $stdinResult = CommandExecutor::create("${command} - < ${inputFile}", $cwd)->getResult(false);
 
         $this->assertSame(
             array(

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -14,15 +14,12 @@ namespace PhpCsFixer\Tests\Test;
 
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Linter\CachingLinter;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
-use PhpCsFixer\RuleSet;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use PhpCsFixer\Utils;
 use Prophecy\Argument;
 
 /**
@@ -42,11 +39,6 @@ abstract class AbstractFixerTestCase extends TestCase
      */
     protected $fixer;
 
-    /**
-     * @var null|string
-     */
-    private $fixerClassName;
-
     protected function setUp()
     {
         parent::setUp();
@@ -55,36 +47,22 @@ abstract class AbstractFixerTestCase extends TestCase
         $this->fixer = $this->createFixer();
     }
 
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->linter = null;
+        $this->fixer = null;
+    }
+
     /**
      * @return FixerInterface
      */
     protected function createFixer()
     {
-        $fixerClassName = $this->getFixerClassName();
+        $fixerClassName = preg_replace('/^(PhpCsFixer)\\\\Tests(\\\\.+)Test$/', '$1$2', get_called_class());
 
         return new $fixerClassName();
-    }
-
-    /**
-     * Create fixer factory with all needed fixers registered.
-     *
-     * @return FixerFactory
-     */
-    protected function createFixerFactory()
-    {
-        return FixerFactory::create()->registerBuiltInFixers();
-    }
-
-    /**
-     * @return string
-     */
-    protected function getFixerName()
-    {
-        $reflection = new \ReflectionClass($this);
-
-        $name = preg_replace('/FixerTest$/', '', $reflection->getShortName());
-
-        return Utils::camelCaseToUnderscore($name);
     }
 
     /**
@@ -235,33 +213,6 @@ abstract class AbstractFixerTestCase extends TestCase
         }
 
         return $linter;
-    }
-
-    /**
-     * @return string
-     */
-    private function getFixerClassName()
-    {
-        if (null !== $this->fixerClassName) {
-            return $this->fixerClassName;
-        }
-
-        try {
-            $fixers = $this->createFixerFactory()
-                ->useRuleSet(new RuleSet(array($this->getFixerName() => true)))
-                ->getFixers()
-            ;
-        } catch (\UnexpectedValueException $e) {
-            throw new \UnexpectedValueException('Cannot determine fixer class, perhaps you forget to override `getFixerName` or `createFixerFactory` method?', 0, $e);
-        }
-
-        if (1 !== count($fixers)) {
-            throw new \UnexpectedValueException(sprintf('Determine fixer class should result in one fixer, got "%d". Perhaps you configured the fixer to "false" ?', count($fixers)));
-        }
-
-        $this->fixerClassName = get_class($fixers[0]);
-
-        return $this->fixerClassName;
     }
 
     /**

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -99,6 +99,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
         $tmpFile = static::getTempFile();
 
         self::$fileRemoval->delete($tmpFile);
+        self::$fileRemoval = null;
     }
 
     protected function setUp()
@@ -106,6 +107,13 @@ abstract class AbstractIntegrationTestCase extends TestCase
         parent::setUp();
 
         $this->linter = $this->getLinter();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->linter = null;
     }
 
     /**

--- a/tests/Test/AccessibleObjectTest.php
+++ b/tests/Test/AccessibleObjectTest.php
@@ -34,6 +34,13 @@ final class AccessibleObjectTest extends TestCase
         $this->accessibleObject = new AccessibleObject(new DummyClass());
     }
 
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->accessibleObject = null;
+    }
+
     public function testCreate()
     {
         $object = AccessibleObject::create(new \stdClass());


### PR DESCRIPTION
This PR reduces usage of properties in test classes or clean them after tests are run.

A few local tests gave the following results:

-- | Without changes | With changes | Delta
-- | ---- | ---- | ----
**Execution time** | ~23.5s | ~16.5s | -29.8%
**Memory usage** | 132.00MB | 124.00MB | -6.5%