### PR TITLE
Update readme for homebrew-php deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,16 +78,14 @@ Then make sure you have the global Composer binaries directory in your ``PATH``.
 
     $ export PATH="$PATH:$HOME/.composer/vendor/bin"
 
-Globally (homebrew)
+Globally (Homebrew)
 ~~~~~~~~~~~~~~~~~~~
 
-PHP-CS-Fixer is part of the homebrew-php project. Follow the installation
-instructions at https://github.com/homebrew/homebrew-php if you don't
-already have it.
+PHP-CS-Fixer can be installed via `Homebrew <https://brew.sh>`_:
 
 .. code-block:: bash
 
-    $ brew install homebrew/php/php-cs-fixer
+    $ brew install php-cs-fixer
 
 Update
 ------
@@ -119,7 +117,7 @@ You can update ``php-cs-fixer`` through this command:
 
     $ ./composer.phar global update friendsofphp/php-cs-fixer
 
-Globally (homebrew)
+Globally (Homebrew)
 ~~~~~~~~~~~~~~~~~~~
 
 You can update ``php-cs-fixer`` through this command:


### PR DESCRIPTION
The homebrew-php tap has been removed, but the php-cs-fixer formula was moved to homebrew-core. This PR addresses the change.