### PR TITLE
Output warnings for deprecated rules and options

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -95,6 +95,7 @@ $xdebug->check();
 unset($xdebug);
 
 $application = new Application();
+$application->enableDeprecationWarnings();
 $application->run();
 
 __HALT_COMPILER();

--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -124,7 +124,7 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
                 throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
             }
 
-            @trigger_error($message, E_USER_DEPRECATED);
+            Application::triggerDeprecation($message);
 
             $configuration = [];
         }
@@ -148,7 +148,7 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
                     throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
                 }
 
-                @trigger_error($message, E_USER_DEPRECATED);
+                Application::triggerDeprecation($message);
             }
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Fixer\FixerInterface;
 
 /**
@@ -46,7 +47,7 @@ class Config implements ConfigInterface
      */
     public static function create()
     {
-        @trigger_error(__METHOD__.' is deprecated since 2.17 and will be removed in 3.0.', E_USER_DEPRECATED);
+        Application::triggerDeprecation(__METHOD__.' is deprecated since 2.17 and will be removed in 3.0.');
 
         return new static();
     }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -434,7 +434,7 @@ final class ConfigurationResolver
                         throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
                     }
 
-                    @trigger_error($message, E_USER_DEPRECATED);
+                    Application::triggerDeprecation($message);
                 }
 
                 $this->progress = $progressType;
@@ -771,7 +771,7 @@ final class ConfigurationResolver
                     throw new \RuntimeException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
                 }
 
-                @trigger_error($message, E_USER_DEPRECATED);
+                Application::triggerDeprecation($message);
             }
         }
     }
@@ -923,7 +923,7 @@ final class ConfigurationResolver
             throw new InvalidConfigurationException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
         }
 
-        @trigger_error($message, E_USER_DEPRECATED);
+        Application::triggerDeprecation($message);
 
         return false;
     }

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Fixer\ClassNotation;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -195,7 +196,7 @@ class Sample
                     $deprecated = array_intersect($values, self::SUPPORTED_TYPES);
                     if (\count($deprecated) > 0) {
                         $message = 'A list of elements is deprecated, use a dictionary of `const|method|property` => `none|one` instead.';
-                        @trigger_error($message, E_USER_DEPRECATED);
+                        Application::triggerDeprecation($message);
 
                         return array_fill_keys($deprecated, self::SPACING_ONE);
                     }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Fixer\Operator;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\HelpCommand;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -525,7 +526,7 @@ $foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
             throw new InvalidFixerConfigurationException($this->getName(), "{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
         }
 
-        @trigger_error($message, E_USER_DEPRECATED);
+        Application::triggerDeprecation($message);
 
         return $newConfig;
     }

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Fixer\Whitespace;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
@@ -88,7 +89,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
 
         foreach ($this->configuration['statements'] as $key) {
             if ('die' === $key) {
-                @trigger_error('Option "die" is deprecated, use "exit" instead.', E_USER_DEPRECATED);
+                Application::triggerDeprecation('Option "die" is deprecated, use "exit" instead.');
             }
 
             $this->fixTokenMap[$key] = self::$tokenMap[$key];

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Fixer\Whitespace;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
+use PhpCsFixer\Console\Application;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
@@ -325,7 +326,7 @@ switch($a) {
                                 throw new InvalidConfigurationException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
                             }
 
-                            @trigger_error($message, E_USER_DEPRECATED);
+                            Application::triggerDeprecation($message);
                             $token = 'use_trait';
 
                             break;

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\FixerConfiguration;
 
+use PhpCsFixer\Console\Application;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -67,7 +68,7 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
                         throw new InvalidOptionsException(sprintf('Aliased option %s/%s is passed multiple times.', $name, $alias));
                     }
 
-                    @trigger_error(sprintf('Option "%s" is deprecated, use "%s" instead.', $alias, $name), E_USER_DEPRECATED);
+                    Application::triggerDeprecation(sprintf('Option "%s" is deprecated, use "%s" instead.', $alias, $name));
 
                     $options[$name] = $options[$alias];
                     unset($options[$alias]);

--- a/src/FixerConfiguration/FixerConfigurationResolverRootless.php
+++ b/src/FixerConfiguration/FixerConfigurationResolverRootless.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\FixerConfiguration;
 
+use PhpCsFixer\Console\Application;
+
 /**
  * @internal
  *
@@ -88,7 +90,7 @@ final class FixerConfigurationResolverRootless implements FixerConfigurationReso
                     throw new \RuntimeException("{$message}. This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
                 }
 
-                @trigger_error($message, E_USER_DEPRECATED);
+                Application::triggerDeprecation($message);
 
                 $options = [$this->root => $options];
             }


### PR DESCRIPTION
This PR adds warnings in the `fix` command output when using deprecated rules or deprecated options.

```console
 $ ./php-cs-fixer fix --rules='{"is_null": {"use_yoda_style": true}, "method_separation": true}'       
Loaded config default from "/home/julien/Projects/php-cs-fixer/.php_cs.dist".
Option "use_yoda_style" for rule "is_null" is deprecated and will be removed in version 3.0. Use "yoda_style" fixer instead.
Rule "method_separation" is deprecated. Use "class_attributes_separation" instead.

Fixed all files in 3.532 seconds, 12.000 MB memory used
```