### PR TITLE
DX: Tokens - fix naming

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -909,7 +909,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeLeadingWhitespace($index, $whitespaces = null)
     {
-        $this->saveRemoveSpace($index, 1, $whitespaces);
+        $this->removeWhitespaceSafely($index, 1, $whitespaces);
     }
 
     /**
@@ -918,7 +918,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeTrailingWhitespace($index, $whitespaces = null)
     {
-        $this->saveRemoveSpace($index, -1, $whitespaces);
+        $this->removeWhitespaceSafely($index, -1, $whitespaces);
     }
 
     /**
@@ -1132,7 +1132,7 @@ class Tokens extends \SplFixedArray
         $this->clearAt($nextIndex);
     }
 
-    private function saveRemoveSpace($index, $offset, $whitespaces = null)
+    private function removeWhitespaceSafely($index, $offset, $whitespaces = null)
     {
         if (isset($this[$index - $offset]) && $this[$index - $offset]->isWhitespace()) {
             $newContent = '';


### PR DESCRIPTION
appendix for #3680
`save` vs `safe`
