### PR TITLE
Add SetTypeToCastFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1390,6 +1390,12 @@ Choose from the list of available rules:
 
   Instructions must be terminated with a semicolon.
 
+* **set_type_to_cast**
+
+  Cast shall be used, not ``settype``.
+
+  *Risky rule: risky when the ``settype`` function is overridden or when used as the 2nd or 3rd expression in a ``for`` loop .*
+
 * **short_scalar_cast** [@Symfony]
 
   Cast ``(boolean)`` and ``(integer)`` should be written as ``(bool)`` and

--- a/src/Fixer/Alias/SetTypeToCastFixer.php
+++ b/src/Fixer/Alias/SetTypeToCastFixer.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Alias;
+
+use PhpCsFixer\AbstractFunctionReferenceFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class SetTypeToCastFixer extends AbstractFunctionReferenceFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Cast shall be used, not `settype`.',
+            [
+                new CodeSample(
+                    '<?php
+settype($foo, "integer");
+settype($bar, "string");
+settype($bar, "null");
+'
+                ),
+            ],
+            null,
+            'Risky when the `settype` function is overridden or when used as the 2nd or 3rd expression in a `for` loop .'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_CONSTANT_ENCAPSED_STRING, T_STRING, T_VARIABLE]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $map = [
+            'array' => [T_ARRAY_CAST, '(array)'],
+            'bool' => [T_BOOL_CAST, '(bool)'],
+            'boolean' => [T_BOOL_CAST, '(bool)'],
+            'double' => [T_DOUBLE_CAST, '(float)'],
+            'float' => [T_DOUBLE_CAST, '(float)'],
+            'int' => [T_INT_CAST, '(int)'],
+            'integer' => [T_INT_CAST, '(int)'],
+            'object' => [T_OBJECT_CAST, '(object)'],
+            'string' => [T_STRING_CAST, '(string)'],
+            // note: `'null' is dealt with later on
+        ];
+
+        $argumentsAnalyzer = new ArgumentsAnalyzer();
+
+        foreach (array_reverse($this->findSettypeCalls($tokens)) as $candidate) {
+            $functionNameIndex = $candidate[0];
+
+            $arguments = $argumentsAnalyzer->getArguments($tokens, $candidate[1], $candidate[2]);
+            if (2 !== count($arguments)) {
+                continue; // function must be overridden or used incorrectly
+            }
+
+            $prev = $tokens->getPrevMeaningfulToken($functionNameIndex);
+            if (!$tokens[$prev]->isGivenKind(T_OPEN_TAG) && !$tokens[$prev]->equalsAny([';', '{'])) {
+                continue; // return value of the function is used
+            }
+
+            reset($arguments);
+
+            // --- Test first argument --------------------
+
+            $firstArgumentStart = key($arguments);
+            if ($tokens[$firstArgumentStart]->isComment() || $tokens[$firstArgumentStart]->isWhitespace()) {
+                $firstArgumentStart = $tokens->getNextMeaningfulToken($firstArgumentStart);
+            }
+
+            if (!$tokens[$firstArgumentStart]->isGivenKind(T_VARIABLE)) {
+                continue; // settype only works with variables pass by reference, function must be overridden
+            }
+
+            $commaIndex = $tokens->getNextMeaningfulToken($firstArgumentStart);
+
+            if (null === $commaIndex || !$tokens[$commaIndex]->equals(',')) {
+                continue; // first argument is complex statement; function must be overridden
+            }
+
+            // --- Test second argument -------------------
+
+            next($arguments);
+            $secondArgumentStart = key($arguments);
+            $secondArgumentEnd = $arguments[$secondArgumentStart];
+
+            if ($tokens[$secondArgumentStart]->isComment() || $tokens[$secondArgumentStart]->isWhitespace()) {
+                $secondArgumentStart = $tokens->getNextMeaningfulToken($secondArgumentStart);
+            }
+
+            if (
+                !$tokens[$secondArgumentStart]->isGivenKind(T_CONSTANT_ENCAPSED_STRING)
+                || $tokens->getNextMeaningfulToken($secondArgumentStart) < $secondArgumentEnd
+            ) {
+                continue; // second argument is of the wrong type or is a (complex) statement of some sort (function is overridden)
+            }
+
+            // --- Test type ------------------------------
+
+            $type = strtolower(trim($tokens[$secondArgumentStart]->getContent(), '"\'"'));
+
+            if ('null' !== $type && !isset($map[$type])) {
+                continue; // we don't know how to map
+            }
+
+            // --- Fixing ---------------------------------
+
+            $argumentToken = $tokens[$firstArgumentStart];
+
+            $this->removeSettypeCall(
+                $tokens,
+                $functionNameIndex,
+                $candidate[1],
+                $firstArgumentStart,
+                $commaIndex,
+                $secondArgumentStart,
+                $candidate[2]
+            );
+
+            if ('null' === $type) {
+                $this->findSettypeNullCall($tokens, $functionNameIndex, $argumentToken);
+            } else {
+                $this->fixSettypeCall($tokens, $functionNameIndex, $argumentToken, new Token($map[$type]));
+            }
+        }
+    }
+
+    private function findSettypeCalls(Tokens $tokens)
+    {
+        $candidates = [];
+
+        $end = count($tokens);
+        for ($i = 1; $i < $end; ++$i) {
+            $candidate = $this->find('settype', $tokens, $i, $end);
+            if (null === $candidate) {
+                break;
+            }
+
+            $i = $candidate[1]; // proceed to openParenthesisIndex
+            $candidates[] = $candidate;
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $functionNameIndex
+     * @param int    $openParenthesisIndex
+     * @param int    $firstArgumentStart
+     * @param int    $commaIndex
+     * @param int    $secondArgumentStart
+     * @param int    $closeParenthesisIndex
+     */
+    private function removeSettypeCall(
+        Tokens $tokens,
+        $functionNameIndex,
+        $openParenthesisIndex,
+        $firstArgumentStart,
+        $commaIndex,
+        $secondArgumentStart,
+        $closeParenthesisIndex
+    ) {
+        $tokens->clearTokenAndMergeSurroundingWhitespace($closeParenthesisIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($secondArgumentStart);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($commaIndex);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($firstArgumentStart);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($openParenthesisIndex);
+        $tokens->clearAt($functionNameIndex); // we'll be inserting here so no need to merge the space tokens
+        $tokens->clearEmptyTokens();
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param Token  $castToken
+     * @param int    $functionNameIndex
+     * @param Token  $argumentToken
+     */
+    private function fixSettypeCall(
+        Tokens $tokens,
+        $functionNameIndex,
+        Token $argumentToken,
+        Token $castToken
+    ) {
+        $tokens->insertAt(
+            $functionNameIndex,
+            [
+                clone $argumentToken,
+                new Token([T_WHITESPACE, ' ']),
+                new Token('='),
+                new Token([T_WHITESPACE, ' ']),
+                $castToken,
+                new Token([T_WHITESPACE, ' ']),
+                clone $argumentToken,
+            ]
+        );
+
+        $tokens->removeTrailingWhitespace($functionNameIndex + 6); // 6 = number of inserted tokens -1 for offset correction
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $functionNameIndex
+     * @param Token  $argumentToken
+     */
+    private function findSettypeNullCall(
+        Tokens $tokens,
+        $functionNameIndex,
+        Token $argumentToken
+    ) {
+        $tokens->insertAt(
+            $functionNameIndex,
+            [
+                clone $argumentToken,
+                new Token([T_WHITESPACE, ' ']),
+                new Token('='),
+                new Token([T_WHITESPACE, ' ']),
+                new Token([T_STRING, 'null']),
+            ]
+        );
+
+        $tokens->removeTrailingWhitespace($functionNameIndex + 4); // 4 = number of inserted tokens -1 for offset correction
+    }
+}

--- a/tests/Fixer/Alias/SetTypeToCastFixerTest.php
+++ b/tests/Fixer/Alias/SetTypeToCastFixerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Alias;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Alias\SetTypeToCastFixer
+ */
+final class SetTypeToCastFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'null cast' => [
+                '<?php $foo = null;',
+                '<?php settype($foo, "null");',
+            ],
+            'null cast comments' => [
+                '<?php
+# 0
+$foo = null# 1
+# 2
+# 3
+# 4
+# 5
+# 6
+# 7
+# 8
+# 9
+# 10
+;',
+                '<?php
+# 0
+settype# 1
+# 2
+(# 3
+# 4
+$foo# 5
+# 6
+,# 7
+# 8
+"null"# 9
+)# 10
+;',
+            ],
+            'array + spacing' => [
+                '<?php $foo = (array) $foo;',
+                '<?php settype  (  $foo  , \'array\');',
+            ],
+            'bool + casing' => [
+                '<?php $foo = (bool) $foo;',
+                '<?php settype  (  $foo  , "Bool");',
+            ],
+            'boolean' => [
+                '<?php $foo = (bool) $foo;',
+                '<?php settype  (  $foo  , "boolean");',
+            ],
+            'double' => [
+                '<?php $foo = (float) $foo;',
+                '<?php settype($foo, "double");',
+            ],
+            'float' => [
+                '<?php $foo = (float) $foo;',
+                '<?php settype($foo, "float");',
+            ],
+            'float in loop' => [
+                '<?php while(a()){$foo = (float) $foo;}',
+                '<?php while(a()){settype($foo, "float");}',
+            ],
+            'int full caps' => [
+                '<?php $foo = (int) $foo;',
+                '<?php settype($foo, "INT");',
+            ],
+            'integer (simple)' => [
+                '<?php $foo = (int) $foo;',
+                '<?php settype($foo, "integer");',
+            ],
+            'object' => [
+                '<?php echo 1; $foo = (object) $foo;',
+                '<?php echo 1; settype($foo, "object");',
+            ],
+            'string' => [
+                '<?php $foo = (string) $foo;',
+                '<?php settype($foo, "string");',
+            ],
+            'string in function body' => [
+                '<?php function A(){ $foo = (string) $foo; return $foo; }',
+                '<?php function A(){ settype($foo, "string"); return $foo; }',
+            ],
+            'integer + no space' => [
+                '<?php $foo = (int) $foo;',
+                '<?php settype($foo,"integer");',
+            ],
+            'no space comments' => [
+                '<?php /*0*//*1*/$foo = (int) $foo/*2*//*3*//*4*//*5*//*6*//*7*/;/*8*/',
+                '<?php /*0*//*1*/settype/*2*/(/*3*/$foo/*4*/,/*5*/"integer"/*6*/)/*7*/;/*8*/',
+            ],
+            'comments with line breaks' => [
+                '<?php #0
+#1
+$foo = (int) $foo#2
+#3
+#4
+#5
+#6
+#7
+#8
+;#9',
+                '<?php #0
+#1
+settype#2
+#3
+(#4
+$foo#5
+,#6
+"integer"#7
+)#8
+;#9',
+            ],
+            // do not fix cases
+            'first argument is not a variable' => [
+                '<?php
+                    namespace A\B;             // needed to keep the linter happy on PHP5.6
+                    function settype($a, $b){} // "
+
+                    settype(1, "double");
+                ',
+            ],
+            'first argument is variable followed by operation' => [
+                '<?php
+                    namespace A\B;                // needed to keep the linter happy on PHP5.6
+                    function settype($a, $b){}    // "
+
+                    settype($foo + 1, "integer"); // function must be overridden, so do not fix it
+                ',
+            ],
+            'wrong numbers of arguments' => [
+                '<?php settype($foo, "integer", $a);',
+            ],
+            'other namespace I' => [
+                '<?php a\b\settype($foo, "integer", $a);',
+            ],
+            'other namespace II' => [
+                '<?php \b\settype($foo, "integer", $a);',
+            ],
+            'static call' => [
+                '<?php A::settype($foo, "integer");',
+            ],
+            'member call' => [
+                '<?php $a->settype($foo, "integer");',
+            ],
+            'unknown type' => [
+                '<?php $a->settype($foo, "foo");',
+            ],
+            'return value used I' => [
+                '<?php $a = settype($foo, "integer");',
+            ],
+            'return value used II' => [
+                '<?php a(settype($foo, "integer"));',
+            ],
+            'return value used III' => [
+                '<?php $a = "123"; $b = [settype($a, "integer")];',
+            ],
+            'return value used IV' => [
+                '<?php $a = "123"; $b = [3 => settype($a, "integer")];',
+            ],
+            'wrapped statements, fixable after removing the useless parenthesis brace' => [
+                '<?php
+                    settype(/*1*//*2*/($a), \'int\');
+                    settype($b, (\'int\'));
+                    settype(($c), (\'int\'));
+                    settype((($d)), ((\'int\')));
+                ',
+            ],
+            'wrapped statements, not-fixable, even after removing the useless parenthesis brace' => [
+                '<?php
+                    namespace A\B;                // needed to keep the linter happy on PHP5.6
+                    function settype($a, $b){}    // "
+
+                    settype($foo1, (("integer")."1"));
+                    settype($foo2, ("1".("integer")));
+                    settype($foo3, ((("integer")."1")));
+                    settype((($foo)+1), "integer");
+                ',
+            ],
+            'nested is not an issue for this fixer, as these non may be fixed' => [
+                '<?php
+                    settype($foo, settype($foo, "double"));
+                    settype(settype($foo, "double"), "double");
+                ',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
```
$ php php-cs-fixer describe set_type_to_cast
Description of set_type_to_cast rule.
Cast shall be used, not `settype`.

Fixer applying this rule is risky.
Risky when the `settype` function is overridden.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,3 +1,3 @@
    <?php
   -settype($foo, "integer");
   -settype($bar, "string");
   -settype($bar, "null");
   +$foo = (int) $foo;
   +$bar = (string) $bar;
   +$bar = null;
   
   ----------- end diff -----------
```

might require some priority tweaking with other rules