### PR TITLE
BlankLineBeforeStatementFixer - Add case and default as options

### DIFF
--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -36,8 +36,10 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
      */
     private static $tokenMap = [
         'break' => T_BREAK,
+        'case' => T_CASE,
         'continue' => T_CONTINUE,
         'declare' => T_DECLARE,
+        'default' => T_DEFAULT,
         'die' => T_EXIT,
         'do' => T_DO,
         'exit' => T_EXIT,
@@ -251,8 +253,8 @@ if (true) {
      */
     public function getPriority()
     {
-        // should be run after NoUselessReturnFixer
-        return -19;
+        // should be run after NoUselessReturnFixer and NoExtraBlankLinesFixer
+        return -21;
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -116,6 +116,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_empty_statement'], $fixers['no_whitespace_in_blank_line']],
             [$fixers['no_empty_statement'], $fixers['space_after_semicolon']],
             [$fixers['no_empty_statement'], $fixers['switch_case_semicolon_to_colon']],
+            [$fixers['no_extra_blank_lines'], $fixers['blank_line_before_statement']],
             [$fixers['no_leading_import_slash'], $fixers['ordered_imports']],
             [$fixers['no_multiline_whitespace_around_double_arrow'], $fixers['binary_operator_spaces']],
             [$fixers['no_multiline_whitespace_around_double_arrow'], $fixers['trailing_comma_in_multiline_array']],

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -166,6 +166,47 @@ while (true) {
     }
 
     /**
+     * @dataProvider provideFixWithCaseCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithCase($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['case'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFixWithCaseCases()
+    {
+        return [
+            [
+                '<?php
+switch ($a) {
+    case 1:
+        return 1;
+
+    case 2:
+        return 2;
+}',
+                '<?php
+switch ($a) {
+    case 1:
+        return 1;
+    case 2:
+        return 2;
+}',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideFixWithContinueCases
      *
      * @param string      $expected
@@ -302,6 +343,47 @@ do {
 } while (true);
 $foo = "bar";
 declare(ticks=1);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithDefaultCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithDefault($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'statements' => ['default'],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFixWithDefaultCases()
+    {
+        return [
+            [
+                '<?php
+switch ($a) {
+    case 1:
+        return 1;
+
+    default:
+        return 2;
+}',
+                '<?php
+switch ($a) {
+    case 1:
+        return 1;
+    default:
+        return 2;
+}',
             ],
         ];
     }
@@ -1228,7 +1310,7 @@ function foo() {
 
     public function provideFixWithMultipleConfigStatementsCases()
     {
-        $allStatements = [
+        $statementsWithoutCaseOrDefault = [
             'break',
             'continue',
             'declare',
@@ -1247,9 +1329,11 @@ function foo() {
             'while',
         ];
 
+        $allStatements = array_merge($statementsWithoutCaseOrDefault, ['case', 'default']);
+
         return [
             [
-                $allStatements,
+                $statementsWithoutCaseOrDefault,
                 '<?php
                     while($a) {
                         if ($c) {
@@ -1260,6 +1344,30 @@ function foo() {
                                     break;
                                 case 5:
                                     return 1;
+                                default:
+                                    return 0;
+                            }
+                        }
+                    }
+                ',
+            ],
+            [
+                $allStatements,
+                '<?php
+                    while($a) {
+                        if ($c) {
+                            switch ($d) {
+                                case $e:
+                                    continue 2;
+
+                                case 4:
+                                    break;
+
+                                case 5:
+                                    return 1;
+
+                                default:
+                                    return 0;
                             }
                         }
                     }

--- a/tests/Fixtures/Integration/priority/no_extra_blank_lines,blank_line_before_statement.test
+++ b/tests/Fixtures/Integration/priority/no_extra_blank_lines,blank_line_before_statement.test
@@ -1,0 +1,39 @@
+--TEST--
+Integration of fixers: no_extra_blank_lines,blank_line_before_statement.
+--RULESET--
+{"no_extra_blank_lines": {"tokens": ["return"]}, "blank_line_before_statement": {"statements": ["case", "default"]}}
+--EXPECT--
+<?php
+function a($a) {
+    switch ($a) {
+        case 1:
+            return 'a';
+
+        case 2:
+            return 'b';
+
+        case 3:
+            return 'c';
+
+        default:
+            return "{$a}";
+    }
+}
+
+--INPUT--
+<?php
+function a($a) {
+    switch ($a) {
+        case 1:
+            return 'a';
+
+        case 2:
+            return 'b';
+        case 3:
+            return 'c';
+
+        default:
+            return "{$a}";
+
+    }
+}


### PR DESCRIPTION
Includes testcases. Also lower priority, because now it needs to run after NoExtraBlankLinesFixer as that removes possible whitespace this fixer tries to add. Which is the reason these additions are wanted.