### PR TITLE
Disable Composer optimized autoloader by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ install:
 
 before_test:
     - cd C:\projects\php-cs-fixer
-    - php C:\tools\composer.phar update --no-interaction --no-progress --prefer-stable --no-ansi
+    - php C:\tools\composer.phar update --optimize-autoloader --no-interaction --no-progress --prefer-stable --no-ansi
 
 test_script:
     - cd C:\projects\php-cs-fixer

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 env:
     global:
-        - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-progress"
+        - DEFAULT_COMPOSER_FLAGS="--optimize-autoloader --no-interaction --no-progress"
         - COMPOSER_FLAGS=""
 
 before_install:

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
         - curl -sS https://getcomposer.org/installer | php
         - php composer.phar global show hirak/prestissimo -q || php composer.phar global require --no-interaction --no-progress --optimize-autoloader hirak/prestissimo
     override:
-        - php composer.phar install --no-interaction --no-progress --no-suggest
+        - php composer.phar install --optimize-autoloader --no-interaction --no-progress --no-suggest
 
 test:
     override:

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
     },
     "config": {
-        "optimize-autoloader": true,
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
Using the optimized autoloader of Composer in a dev environment has a drawback: if you rename or drop a class, you have to dump the autoloader again, which is a bit cumbersome. If you don't know that or forget about it, it becomes painful to debug.