### PR TITLE
Add LowercaseStaticReferenceFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -747,6 +747,11 @@ Choose from the list of available rules:
 
   PHP keywords MUST be in lower case.
 
+* **lowercase_static_reference** [@Symfony]
+
+  Class static references ``self``, ``static`` and ``parent`` MUST be in lower
+  case.
+
 * **magic_constant_casing** [@Symfony]
 
   Magic constants should be referred to using the correct casing.

--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ */
+final class LowercaseStaticReferenceFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Class static references `self`, `static` and `parent` MUST be in lower case.',
+            [
+                new CodeSample('<?php
+class Foo extends Bar
+{
+    public function baz1()
+    {
+        return STATIC::baz2();
+    }
+
+    public function baz2($x)
+    {
+        return $x instanceof Self;
+    }
+
+    public function baz3(PaRent $x)
+    {
+        return true;
+    }
+}
+'),
+                new VersionSpecificCodeSample(
+                    '<?php
+class Foo extends Bar
+{
+    public function baz(?self $x) : SELF
+    {
+        return false;
+    }
+}
+',
+                    new VersionSpecification(71000)
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound([T_STATIC, T_STRING]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->equalsAny([[T_STRING, 'self'], [T_STATIC, 'static'], [T_STRING, 'parent']], false)) {
+                continue;
+            }
+
+            $newContent = strtolower($token->getContent());
+            if ($token->getContent() === $newContent) {
+                continue; // case is already correct
+            }
+
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+            if ($tokens[$prevIndex]->isGivenKind([T_DOUBLE_COLON, T_FUNCTION, T_OBJECT_OPERATOR, T_PRIVATE, T_PROTECTED, T_PUBLIC])) {
+                continue;
+            }
+
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            if ($tokens[$nextIndex]->isGivenKind([T_FUNCTION, T_NS_SEPARATOR, T_PRIVATE, T_PROTECTED, T_PUBLIC])) {
+                continue;
+            }
+
+            if ('static' === $newContent && $tokens[$nextIndex]->isGivenKind([T_VARIABLE])) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([$token->getId(), $newContent]);
+        }
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -74,6 +74,7 @@ final class RuleSet implements RuleSetInterface
             'include' => true,
             'increment_style' => true,
             'lowercase_cast' => true,
+            'lowercase_static_reference' => true,
             'magic_constant_casing' => true,
             'method_argument_space' => true,
             'native_function_casing' => true,

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer
+ *
+ * @internal
+ */
+final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php class Foo extends Bar { public function baz() { self::qux(); } }',
+                '<?php class Foo extends Bar { public function baz() { SELF::qux(); } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { static::qux(); } }',
+                '<?php class Foo extends Bar { public function baz() { STATIC::qux(); } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { parent::baz(); } }',
+                '<?php class Foo extends Bar { public function baz() { PARENT::baz(); } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { parent::baz(); } }',
+                '<?php class Foo extends Bar { public function baz() { Parent::baz(); } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { return new self(); } }',
+                '<?php class Foo extends Bar { public function baz() { return new Self(); } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { return SelfFoo::FOO; } }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() { return FooSelf::FOO; } }',
+            ],
+            [
+                '<?php class Foo extends Bar { private STATIC $baz; }',
+            ],
+            [
+                '<?php class Foo extends Bar { STATIC private $baz; }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function paRent() {} }',
+            ],
+            [
+                '<?php $foo->Self();',
+            ],
+            [
+                '<?php Foo::Self();',
+            ],
+            [
+                '<?php if ($foo instanceof self) { return true; }',
+                '<?php if ($foo instanceof Self) { return true; }',
+            ],
+            [
+                '<?php if ($foo instanceof static) { return true; }',
+                '<?php if ($foo instanceof Static) { return true; }',
+            ],
+            [
+                '<?php if ($foo instanceof parent) { return true; }',
+                '<?php if ($foo instanceof Parent) { return true; }',
+            ],
+            [
+                '<?php if ($foo instanceof Self\Bar) { return true; }',
+            ],
+            [
+                '<?php if ($foo instanceof MySelf) { return true; }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz(self $x) {} }',
+                '<?php class Foo extends Bar { public function baz(Self $x) {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz(parent $x) {} }',
+                '<?php class Foo extends Bar { public function baz(Parent $x) {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz(MySelf $x) {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz(Self\Qux $x) {} }',
+            ],
+            [
+                '<?php $a = STATIC function() {};',
+            ],
+            [
+                '<?php class A { public function B() { STATIC $a; echo $a; }}',
+            ],
+            [
+                '<?php class A { public function B() { $collection = $static ? new static($b) : new self(); } }',
+                '<?php class A { public function B() { $collection = $static ? new STATIC($b) : new self(); } }',
+            ],
+            [
+                '<?php class A { STATIC public function B() {} }',
+            ],
+            [
+                '<?php
+                    $a = function () {
+                        STATIC $B = false;
+                        if ($B) {
+                            echo 1;
+                        }
+                        $B = true;
+                    };
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.0
+     * @dataProvider provideFix70Cases
+     */
+    public function testFix70($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix70Cases()
+    {
+        return [
+            [
+                '<?php class Foo extends Bar { public function baz() : self {} }',
+                '<?php class Foo extends Bar { public function baz() : Self {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : parent {} }',
+                '<?php class Foo extends Bar { public function baz() : Parent {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : MySelf {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : Self\Qux {} }',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.1
+     * @dataProvider provideFix71Cases
+     */
+    public function testFix71($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix71Cases()
+    {
+        return [
+            [
+                '<?php class Foo extends Bar { public function baz(?self $x) {} }',
+                '<?php class Foo extends Bar { public function baz(?Self $x) {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz(?parent $x) {} }',
+                '<?php class Foo extends Bar { public function baz(?Parent $x) {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : ?self {} }',
+                '<?php class Foo extends Bar { public function baz() : ?Self {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : ?parent {} }',
+                '<?php class Foo extends Bar { public function baz() : ?Parent {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : ?MySelf {} }',
+            ],
+            [
+                '<?php class Foo extends Bar { public function baz() : ?Self\Qux {} }',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
```diff
<?php
class Foo extends Bar
{
    public function baz()
    {
        return 42;
    }

    public function qux()
    {
-        return SELF::baz();
+        return self::baz();
    }

    public function quux()
    {
-        return STATIC::baz();
+        return static::baz();
    }

    public function quuz()
    {
-        return PARENT::baz();
+        return parent::baz();
    }
}
```

I've added it to `@Symfony` rule set as it seems to fit other lowercasing fixers and is not violated anywhere there, so won't make any problems.