### PR TITLE
ReturnAssignmentFixer description update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1377,8 +1377,8 @@ Choose from the list of available rules:
 
 * **return_assignment**
 
-  Non global, static or indirectly referenced variables should not be
-  assigned and directly returned by a function or method.
+  Local, dynamic and directly referenced variables should not be assigned
+  and directly returned by a function or method.
 
 * **return_type_declaration** [@Symfony]
 

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -30,7 +30,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Non global, static or indirectly referenced variables should not be assigned and directly returned by a function or method.',
+            'Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method.',
             [new CodeSample("<?php\nfunction a() {\n    \$a = 1;\n    return \$a;\n}\n")]
         );
     }


### PR DESCRIPTION
The original description gave me a little headache. I guess the intention of @SpacePossum was to read it as:
`Non (global, static or indirectly) referenced variables ...`
I understood it as:
`(Non global), static or indirectly referenced variables ...`
Wouldn't the new version be more readable?