### PR TITLE
Add MagicMethodCasingFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -789,6 +789,10 @@ Choose from the list of available rules:
 
   Magic constants should be referred to using the correct casing.
 
+* **magic_method_casing** [@Symfony]
+
+  Magic method definitions and calls must be using the correct casing.
+
 * **mb_str_functions**
 
   Replace non multibyte-safe functions with corresponding mb function.

--- a/src/Fixer/Casing/MagicMethodCasingFixer.php
+++ b/src/Fixer/Casing/MagicMethodCasingFixer.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class MagicMethodCasingFixer extends AbstractFixer
+{
+    private static $magicNames = [
+        '__call' => '__call',
+        '__callstatic' => '__callStatic',
+        '__clone' => '__clone',
+        '__construct' => '__construct',
+        '__debuginfo' => '__debugInfo',
+        '__destruct' => '__destruct',
+        '__get' => '__get',
+        '__invoke' => '__invoke',
+        '__isset' => '__isset',
+        '__set' => '__set',
+        '__set_state' => '__set_state',
+        '__sleep' => '__sleep',
+        '__tostring' => '__toString',
+        '__unset' => '__unset',
+        '__wakeup' => '__wakeup',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Magic method definitions and calls must be using the correct casing.',
+            [
+                new CodeSample(
+'<?php
+class Foo
+{
+    public function __Sleep()
+    {
+    }
+}
+'
+                ),
+                new CodeSample(
+'<?php
+$foo->__INVOKE(1);
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_STRING) && $tokens->isAnyTokenKindsFound([T_FUNCTION, T_OBJECT_OPERATOR, T_DOUBLE_COLON]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $inClass = 0;
+        $tokenCount = \count($tokens);
+
+        for ($index = 1; $index < $tokenCount - 2; ++$index) {
+            if (0 === $inClass && $tokens[$index]->isClassy()) {
+                $inClass = 1;
+                $index = $tokens->getNextTokenOfKind($index, ['{']);
+
+                continue;
+            }
+
+            if (0 !== $inClass) {
+                if ($tokens[$index]->equals('{')) {
+                    ++$inClass;
+
+                    continue;
+                }
+
+                if ($tokens[$index]->equals('}')) {
+                    --$inClass;
+
+                    continue;
+                }
+            }
+
+            if (!$tokens[$index]->isGivenKind(T_STRING)) {
+                continue; // wrong type
+            }
+
+            $content = $tokens[$index]->getContent();
+            if ('__' !== substr($content, 0, 2)) {
+                continue; // cheap look ahead
+            }
+
+            $name = strtolower($content);
+
+            if (!$this->isMagicMethodName($name)) {
+                continue; // method name is not one of the magic ones we can fix
+            }
+
+            $nameInCorrectCasing = $this->getMagicMethodNameInCorrectCasing($name);
+            if ($nameInCorrectCasing === $content) {
+                continue; // method name is already in the correct casing, no fix needed
+            }
+
+            if ($this->isFunctionSignature($tokens, $index)) {
+                if (0 !== $inClass) {
+                    // this is a method definition we want to fix
+                    $this->setTokenToCorrectCasing($tokens, $index, $nameInCorrectCasing);
+                }
+
+                continue;
+            }
+
+            if ($this->isMethodCall($tokens, $index)) {
+                $this->setTokenToCorrectCasing($tokens, $index, $nameInCorrectCasing);
+
+                continue;
+            }
+
+            if (
+                ('__callstatic' === $name || '__set_state' === $name)
+                && $this->isStaticMethodCall($tokens, $index)
+            ) {
+                $this->setTokenToCorrectCasing($tokens, $index, $nameInCorrectCasing);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isFunctionSignature(Tokens $tokens, $index)
+    {
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+        if (!$tokens[$prevIndex]->isGivenKind(T_FUNCTION)) {
+            return false; // not a method signature
+        }
+
+        return $tokens[$tokens->getNextMeaningfulToken($index)]->equals('(');
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isMethodCall(Tokens $tokens, $index)
+    {
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+        if (!$tokens[$prevIndex]->equals([T_OBJECT_OPERATOR, '->'])) {
+            return false; // not a "simple" method call
+        }
+
+        return $tokens[$tokens->getNextMeaningfulToken($index)]->equals('(');
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function isStaticMethodCall(Tokens $tokens, $index)
+    {
+        $prevIndex = $tokens->getPrevMeaningfulToken($index);
+        if (!$tokens[$prevIndex]->isGivenKind(T_DOUBLE_COLON)) {
+            return false; // not a "simple" static method call
+        }
+
+        return $tokens[$tokens->getNextMeaningfulToken($index)]->equals('(');
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    private function isMagicMethodName($name)
+    {
+        return isset(self::$magicNames[$name]);
+    }
+
+    /**
+     * @param string $name name of a magic method
+     *
+     * @return string
+     */
+    private function getMagicMethodNameInCorrectCasing($name)
+    {
+        return self::$magicNames[$name];
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     * @param string $nameInCorrectCasing
+     */
+    private function setTokenToCorrectCasing(Tokens $tokens, $index, $nameInCorrectCasing)
+    {
+        $tokens[$index] = new Token([T_STRING, $nameInCorrectCasing]);
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -77,6 +77,7 @@ final class RuleSet implements RuleSetInterface
             'lowercase_cast' => true,
             'lowercase_static_reference' => true,
             'magic_constant_casing' => true,
+            'magic_method_casing' => true,
             'method_argument_space' => true,
             'native_function_casing' => true,
             'new_with_braces' => true,

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer
+ */
+final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        $fixerReflection = new \ReflectionClass(MagicMethodCasingFixer::class);
+        $property = $fixerReflection->getProperty('magicNames');
+        $property->setAccessible(true);
+        $allMethodNames = $property->getValue();
+
+        // '__callStatic'
+        yield 'method declaration for "__callstatic".' => [
+            '<?php class Foo {public static function __callStatic($a, $b){}}',
+            '<?php class Foo {public static function __CALLStatic($a, $b){}}',
+        ];
+
+        yield 'static call to "__callstatic".' => [
+            '<?php Foo::__callStatic() ?>',
+            '<?php Foo::__callstatic() ?>',
+        ];
+
+        unset($allMethodNames['__callstatic']);
+
+        // static version of '__set_state'
+        yield 'method declaration for "__set_state".' => [
+            '<?php class Foo {public static function __set_state($a, $b){}}',
+            '<?php class Foo {public static function __set_STATE($a, $b){}}',
+        ];
+
+        yield 'static call to "__set_state".' => [
+            '<?php Foo::__set_state() ?>',
+            '<?php Foo::__set_STATE() ?>',
+        ];
+
+        // '__clone'
+        yield 'method declaration for "__clone".' => [
+            '<?php class Foo {public function __clone(){}}',
+            '<?php class Foo {public function __CLONE(){}}',
+        ];
+
+        unset($allMethodNames['__clone']);
+
+        // two arguments
+        $methodNames = ['__call', '__set'];
+
+        foreach ($methodNames as $i => $name) {
+            unset($allMethodNames[$name]);
+
+            yield sprintf('method declaration for "%s".', $name) => [
+                sprintf('<?php class Foo {public function %s($a, $b){}}', $name),
+                sprintf('<?php class Foo {public function %s($a, $b){}}', strtoupper($name)),
+            ];
+        }
+
+        foreach ($methodNames as $i => $name) {
+            yield sprintf('method call "%s".', $name) => [
+                sprintf('<?php $a->%s($a, $b);', $name),
+                sprintf('<?php $a->%s($a, $b);', strtoupper($name)),
+            ];
+        }
+
+        // single argument
+        $methodNames = ['__get', '__isset', '__unset'];
+
+        foreach ($methodNames as $i => $name) {
+            unset($allMethodNames[$name]);
+
+            yield sprintf('method declaration for "%s".', $name) => [
+                sprintf('<?php class Foo {public function %s($a){}}', $name),
+                sprintf('<?php class Foo {public function %s($a){}}', strtoupper($name)),
+            ];
+        }
+
+        foreach ($methodNames as $i => $name) {
+            yield sprintf('method call "%s".', $name) => [
+                sprintf('<?php $a->%s($a);', $name),
+                sprintf('<?php $a->%s($a);', strtoupper($name)),
+            ];
+        }
+
+        // no argument
+
+        foreach ($allMethodNames as $i => $name) {
+            yield sprintf('method declaration for "%s".', $name) => [
+                sprintf('<?php class Foo {public function %s(){}}', $name),
+                sprintf('<?php class Foo {public function %s(){}}', strtoupper($name)),
+            ];
+        }
+
+        foreach ($allMethodNames as $i => $name) {
+            yield sprintf('method call "%s".', $name) => [
+                sprintf('<?php $a->%s();', $name),
+                sprintf('<?php $a->%s();', strtoupper($name)),
+            ];
+        }
+
+        yield 'method declaration in interface' => [
+            '<?php interface Foo {public function __toString();}',
+            '<?php interface Foo {public function __tostring();}',
+        ];
+
+        yield 'method declaration in interface' => [
+            '<?php trait Foo {public function __toString(){}}',
+            '<?php trait Foo {public function __tostring(){}}',
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideDoNotFixCases
+     */
+    public function testDoNotFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideDoNotFixCases()
+    {
+        return [
+            [
+                '<?php
+__Tostring();',
+            ],
+            [
+                '<?php
+function __Tostring() {}',
+            ],
+            [
+                '<?php
+                    #->__sleep()
+                    /** ->__sleep() */
+                    echo $a->__sleep;
+                ',
+            ],
+            [
+                '<?php
+                    class B
+                    {
+                        public function _not_magic()
+                        {
+                        }
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    function __alsoNotMagic()
+                    {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    function __()
+                    {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    function a()
+                    {
+                    }
+                ',
+            ],
+            [
+                '<?php
+                    $a->__not_magic();
+                ',
+            ],
+            [
+                '<?php
+                    $a->a();
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testFixPHP7()
+    {
+        $this->doTest(
+            '<?php
+            function __TOSTRING(){} // do not fix
+
+            trait FooTrait
+            {
+                public function __invoke($a){} // fix
+            }
+
+            function __GET($a){} // do not fix
+
+            interface Foo
+            {
+                public function __sleep(); // fix
+            }
+
+            final class Foo
+            {
+                private function __construct($a, $b, $c, $d = null, $e = 1) // fix
+                {
+                }
+
+                public function __isset($a) // fix
+                {
+                    return $b->__isset($b); // fix
+                }
+
+                private function bar()
+                {
+                    new class {
+                        public function __unset($a) // fix
+                        {
+                            $b = null === $a
+                                ? $b->__unset($a) // fix
+                                : $a->__unset($a) // fix
+                            ;
+
+                            return $b;
+                        }
+                    };
+                }
+            }
+
+            function __ISSET($bar){} // do not fix
+
+            $a->__unset($foo); // fix
+            ',
+            '<?php
+            function __TOSTRING(){} // do not fix
+
+            trait FooTrait
+            {
+                public function __INVOKE($a){} // fix
+            }
+
+            function __GET($a){} // do not fix
+
+            interface Foo
+            {
+                public function __SlEeP(); // fix
+            }
+
+            final class Foo
+            {
+                private function __consTRUCT($a, $b, $c, $d = null, $e = 1) // fix
+                {
+                }
+
+                public function __ISSET($a) // fix
+                {
+                    return $b->__IsseT($b); // fix
+                }
+
+                private function bar()
+                {
+                    new class {
+                        public function __UnSet($a) // fix
+                        {
+                            $b = null === $a
+                                ? $b->__UnSet($a) // fix
+                                : $a->__UnSet($a) // fix
+                            ;
+
+                            return $b;
+                        }
+                    };
+                }
+            }
+
+            function __ISSET($bar){} // do not fix
+
+            $a->__UnSet($foo); // fix
+            '
+        );
+    }
+}


### PR DESCRIPTION
```
$ php php-cs-fixer describe magic_method_casing
Description of magic_method_casing rule.
Magic method definitions and calls must be using the correct casing.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,7 +1,7 @@
    <?php
    class Foo
    {
   -    public function __Sleep()
   +    public function __sleep()
        {
        }
    }
   
   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$foo->__INVOKE(1);
   +$foo->__invoke(1);
   
   ----------- end diff -----------

```