### PR TITLE
Add PhpUnitInternalClassFixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -56,6 +56,7 @@ $config = PhpCsFixer\Config::create()
         'no_useless_return' => true,
         'ordered_class_elements' => true,
         'ordered_imports' => true,
+        'php_unit_internal_class' => true,
         'php_unit_ordered_covers' => true,
         'php_unit_set_up_tear_down_visibility' => true,
         'php_unit_strict' => true,

--- a/README.rst
+++ b/README.rst
@@ -1159,6 +1159,15 @@ Choose from the list of available rules:
 
   PHPUnit annotations should be a FQCNs including a root namespace.
 
+* **php_unit_internal_class**
+
+  All PHPUnit test classes should be marked as internal.
+
+  Configuration options:
+
+  - ``types`` (a subset of ``['normal', 'final', 'abstract']``): what types of
+    classes to mark as internal; defaults to ``['normal', 'final']``
+
 * **php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky]
 
   Usages of ``->getMock`` and

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Gert de Pagter <BackEndTea@gmail.com>
+ */
+final class PhpUnitInternalClassFixer extends AbstractFixer implements WhitespacesAwareFixerInterface, ConfigurationDefinitionFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'All PHPUnit test classes should be marked as internal.',
+            [new CodeSample("<?php\nclass MyTest extends TestCase {}\n")]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should be run before FinalInternalClassFixer
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        $types = ['normal', 'final', 'abstract'];
+
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('types', 'What types of classes to mark as internal'))
+                ->setAllowedValues([(new AllowedValueSubset($types))])
+                ->setAllowedTypes(['array'])
+                ->setDefault(['normal', 'final'])
+                ->getOption(),
+        ]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens, true) as $indexes) {
+            $this->markClassInternal($tokens, $indexes[0]);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startIndex
+     */
+    private function markClassInternal(Tokens $tokens, $startIndex)
+    {
+        $classIndex = $tokens->getPrevTokenOfKind($startIndex, [[T_CLASS]]);
+
+        if (!$this->isAllowedByConfiguration($tokens, $classIndex)) {
+            return;
+        }
+
+        $docBlockIndex = $this->getDocBlockIndex($tokens, $classIndex);
+
+        if ($this->hasDocBlock($tokens, $classIndex)) {
+            $this->updateDocBlockIfNeeded($tokens, $docBlockIndex);
+
+            return;
+        }
+
+        $this->createDocBlock($tokens, $docBlockIndex);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $i
+     *
+     * @return bool
+     */
+    private function isAllowedByConfiguration(Tokens $tokens, $i)
+    {
+        $typeIndex = $tokens->getPrevMeaningfulToken($i);
+        if ($tokens[$typeIndex]->isGivenKind([T_FINAL])) {
+            return in_array('final', $this->configuration['types'], true);
+        }
+
+        if ($tokens[$typeIndex]->isGivenKind([T_ABSTRACT])) {
+            return in_array('abstract', $this->configuration['types'], true);
+        }
+
+        return in_array('normal', $this->configuration['types'], true);
+    }
+
+    private function createDocBlock(Tokens $tokens, $docBlockIndex)
+    {
+        $lineEnd = $this->whitespacesConfig->getLineEnding();
+        $originalIndent = $this->detectIndent($tokens, $tokens->getNextNonWhitespace($docBlockIndex));
+        $toInsert = [
+            new Token([T_DOC_COMMENT, '/**'.$lineEnd."${originalIndent} * @internal".$lineEnd."${originalIndent} */"]),
+            new Token([T_WHITESPACE, $lineEnd.$originalIndent]),
+        ];
+        $index = $tokens->getNextMeaningfulToken($docBlockIndex);
+        $tokens->insertAt($index, $toInsert);
+    }
+
+    private function updateDocBlockIfNeeded(Tokens $tokens, $docBlockIndex)
+    {
+        $doc = new DocBlock($tokens[$docBlockIndex]->getContent());
+        if (!empty($doc->getAnnotationsOfType('internal'))) {
+            return;
+        }
+        $doc = $this->makeDocBlockMultiLineIfNeeded($doc, $tokens, $docBlockIndex);
+        $lines = $this->addInternalAnnotation($doc, $tokens, $docBlockIndex);
+        $lines = implode($lines);
+
+        $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return bool
+     */
+    private function hasDocBlock(Tokens $tokens, $index)
+    {
+        $docBlockIndex = $this->getDocBlockIndex($tokens, $index);
+
+        return $tokens[$docBlockIndex]->isGivenKind(T_DOC_COMMENT);
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return int
+     */
+    private function getDocBlockIndex(Tokens $tokens, $index)
+    {
+        do {
+            $index = $tokens->getPrevNonWhitespace($index);
+        } while ($tokens[$index]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_COMMENT]));
+
+        return $index;
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     *
+     * @return string
+     */
+    private function detectIndent(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index - 1]->isWhitespace()) {
+            return ''; // cannot detect indent
+        }
+
+        $explodedContent = explode($this->whitespacesConfig->getLineEnding(), $tokens[$index - 1]->getContent());
+
+        return end($explodedContent);
+    }
+
+    /**
+     * @param DocBlock $docBlock
+     * @param Tokens   $tokens
+     * @param int      $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function addInternalAnnotation(DocBlock $docBlock, Tokens $tokens, $docBlockIndex)
+    {
+        $lines = $docBlock->getLines();
+        $originalIndent = $this->detectIndent($tokens, $docBlockIndex);
+        $lineEnd = $this->whitespacesConfig->getLineEnding();
+        array_splice($lines, -1, 0, $originalIndent.' *'.$lineEnd.$originalIndent.' * @internal'.$lineEnd);
+
+        return $lines;
+    }
+
+    /**
+     * @param DocBlock $doc
+     * @param Tokens   $tokens
+     * @param int      $docBlockIndex
+     *
+     * @return DocBlock
+     */
+    private function makeDocBlockMultiLineIfNeeded(DocBlock $doc, Tokens $tokens, $docBlockIndex)
+    {
+        $lines = $doc->getLines();
+        if (1 === count($lines) && empty($doc->getAnnotationsOfType('internal'))) {
+            $lines = $this->splitUpDocBlock($lines, $tokens, $docBlockIndex);
+
+            return new DocBlock(implode($lines));
+        }
+
+        return $doc;
+    }
+
+    /**
+     * Take a one line doc block, and turn it into a multi line doc block.
+     *
+     * @param Line[] $lines
+     * @param Tokens $tokens
+     * @param int    $docBlockIndex
+     *
+     * @return Line[]
+     */
+    private function splitUpDocBlock($lines, Tokens $tokens, $docBlockIndex)
+    {
+        $lineContent = $this->getSingleLineDocBlockEntry($lines);
+        $lineEnd = $this->whitespacesConfig->getLineEnding();
+        $originalIndent = $this->detectIndent($tokens, $tokens->getNextNonWhitespace($docBlockIndex));
+
+        return [
+            new Line('/**'.$lineEnd),
+            new Line($originalIndent.' * '.$lineContent.$lineEnd),
+            new Line($originalIndent.' */'),
+        ];
+    }
+
+    /**
+     * @param Line []$line
+     *
+     * @return string
+     */
+    private function getSingleLineDocBlockEntry($line)
+    {
+        $line = $line[0];
+        $line = \str_replace('*/', '', $line);
+        $line = trim($line);
+        $line = \str_split($line);
+        $i = \count($line);
+        do {
+            --$i;
+        } while ('*' !== $line[$i] && '*' !== $line[$i - 1] && '/' !== $line[$i - 2]);
+        if (' ' === $line[$i]) {
+            ++$i;
+        }
+        $line = array_slice($line, $i);
+
+        return implode($line);
+    }
+}

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -149,6 +149,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['ordered_class_elements'], $fixers['space_after_semicolon']],
             [$fixers['php_unit_construct'], $fixers['php_unit_dedicate_assert']],
             [$fixers['php_unit_fqcn_annotation'], $fixers['no_unused_imports']],
+            [$fixers['php_unit_internal_class'], $fixers['final_internal_class']],
             [$fixers['php_unit_fqcn_annotation'], $fixers['php_unit_ordered_covers']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['no_empty_phpdoc']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['php_unit_expectation']],

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @author Gert de Pagter <BackEndTea@gmail.com>
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitInternalClassFixer
+ */
+final class PhpUnitInternalClassFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     *
+     * @param string     $expected
+     * @param null|mixed $input
+     * @param array      $config
+     */
+    public function testFix($expected, $input = null, $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'It does not change normal classes' => [
+                '<?php
+
+class Hello
+{
+}
+',
+            ],
+            'It marks a test class as internal' => [
+                '<?php
+
+/**
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+                '<?php
+
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It adds an internal tag to a class that already has a doc block' => [
+                '<?php
+
+/**
+ * @coversNothing
+ *
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+                '<?php
+
+/**
+ * @coversNothing
+ */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It does not change a class that is already internal' => [
+                '<?php
+
+/**
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It does not change a class that is already internal and has other annotations' => [
+                '<?php
+
+/**
+ * @author me
+ * @coversNothing
+ * @internal
+ * @group large
+ */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It works on other indentation levels' => [
+                '<?php
+
+if (class_exists("Foo\Bar")) {
+    /**
+     * @internal
+     */
+    class Test Extends TestCase
+    {
+    }
+}
+',
+                '<?php
+
+if (class_exists("Foo\Bar")) {
+    class Test Extends TestCase
+    {
+    }
+}
+',
+            ],
+            'It works on other indentation levels when the class has other annotations' => [
+                '<?php
+
+if (class_exists("Foo\Bar")) {
+    /**
+     * @author me again
+     *
+     *
+     * @covers \Other\Class
+     *
+     * @internal
+     */
+    class Test Extends TestCase
+    {
+    }
+}
+',
+                '<?php
+
+if (class_exists("Foo\Bar")) {
+    /**
+     * @author me again
+     *
+     *
+     * @covers \Other\Class
+     */
+    class Test Extends TestCase
+    {
+    }
+}
+',
+            ],
+            'It always adds @internal to the bottom of the doc block' => [
+                '<?php
+
+/**
+ * @coversNothing
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+                '<?php
+
+/**
+ * @coversNothing
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It does not change a class with a single line internal doc block' => [
+                '<?php
+
+/** @internal */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'It adds an internal tag to a class that already has a one linedoc block' => [
+                '<?php
+
+/**
+ * @coversNothing
+ *
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+                '<?php
+
+/** @coversNothing */
+class Test extends TestCase
+{
+}
+',
+            ],
+            'By default it will not mark an abstract class as internal' => [
+                '<?php
+
+abstract class Test
+{
+}
+',
+            ],
+            'If abstract is added as an option, abstract classes will be marked internal' => [
+                '<?php
+
+/**
+ * @internal
+ */
+abstract class Test
+{
+}
+',
+                '<?php
+
+abstract class Test
+{
+}
+',
+                [
+                    'types' => ['abstract'],
+                ],
+            ],
+            'If final is not added as an option, final classes will not be marked internal' => [
+                '<?php
+
+final class Test
+{
+}
+',
+                null,
+                [
+                    'types' => ['abstract'],
+                ],
+            ],
+            'If normal is not added as an option, normal classes will not be marked internal' => [
+                '<?php
+
+class Test
+{
+}
+',
+                null,
+                [
+                    'types' => ['abstract'],
+                ],
+            ],
+            'It works correctly with multiple classes in one file, even when one of them is not allowed' => [
+                '<?php
+
+/**
+ * @internal
+ */
+class Test
+{
+}
+
+abstract class Test
+{
+}
+
+class FooBar
+{
+}
+
+/**
+ * @internal
+ */
+class Test extends TestCase
+{
+}
+',
+                '<?php
+
+class Test
+{
+}
+
+abstract class Test
+{
+}
+
+class FooBar
+{
+}
+
+class Test extends TestCase
+{
+}
+',
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/php_unit_internal_class,final_internal_class.test
+++ b/tests/Fixtures/Integration/priority/php_unit_internal_class,final_internal_class.test
@@ -1,0 +1,26 @@
+--TEST--
+Integration of fixers: php_unit_internal_class, final_internal_class.
+--RULESET--
+{"php_unit_internal_class": true, "final_internal_class": true}
+--EXPECT--
+<?php
+/**
+ * @internal
+ */
+final class FooTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        foo();
+    }
+}
+
+--INPUT--
+<?php
+class FooTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        foo();
+    }
+}

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -133,10 +133,13 @@ class Foo implements TestInterface, SomethingElse
     {
         $tokens = Tokens::fromCode($code);
 
-        $classes = $this->indicator->findPhpUnitClasses($tokens);
-        $classes = iterator_to_array($classes);
+        $classesFromTop = $this->indicator->findPhpUnitClasses($tokens, false);
+        $classesFromTop = iterator_to_array($classesFromTop);
+        $classesFromBottom = $this->indicator->findPhpUnitClasses($tokens);
+        $classesFromBottom = iterator_to_array($classesFromBottom);
 
-        $this->assertSame($expectedIndexes, $classes);
+        $this->assertSame($expectedIndexes, $classesFromTop);
+        $this->assertSame(array_reverse($classesFromBottom), $classesFromTop);
     }
 
     public function provideFindPhpUnitClassesCases()


### PR DESCRIPTION
Fixes #3741 

Adds `@internal` annotation to phpunit test classes. This fixes #3741 if used in combination with the `final_internal_class` fixer.