### PR TITLE
Make sure PHPUnit is cased correctly in fixers descriptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -456,7 +456,7 @@ Choose from the list of available rules:
 
 * **general_phpdoc_annotation_remove**
 
-  Configured annotations should be omitted from PHPDocs.
+  Configured annotations should be omitted from PHPDoc.
 
   Configuration options:
 
@@ -694,7 +694,7 @@ Choose from the list of available rules:
 
 * **no_trailing_whitespace_in_comment** [@PSR2, @Symfony]
 
-  There MUST be no trailing spaces inside comments and PHPDocs.
+  There MUST be no trailing spaces inside comment or PHPDoc.
 
 * **no_unneeded_control_parentheses** [@Symfony]
 
@@ -842,7 +842,7 @@ Choose from the list of available rules:
 
 * **phpdoc_annotation_without_dot** [@Symfony]
 
-  PHPDocs annotation descriptions should not be a sentence.
+  PHPDoc annotation descriptions should not be a sentence.
 
 * **phpdoc_indent** [@Symfony]
 
@@ -854,7 +854,7 @@ Choose from the list of available rules:
 
 * **phpdoc_no_access** [@Symfony]
 
-  ``@access`` annotations should be omitted from PHPDocs.
+  ``@access`` annotations should be omitted from PHPDoc.
 
 * **phpdoc_no_alias_tag** [@Symfony]
 
@@ -869,11 +869,11 @@ Choose from the list of available rules:
 * **phpdoc_no_empty_return** [@Symfony]
 
   ``@return`` void and ``@return null`` annotations should be omitted from
-  PHPDocs.
+  PHPDoc.
 
 * **phpdoc_no_package** [@Symfony]
 
-  ``@package`` and ``@subpackage`` annotations should be omitted from PHPDocs.
+  ``@package`` and ``@subpackage`` annotations should be omitted from PHPDoc.
 
 * **phpdoc_no_useless_inheritdoc** [@Symfony]
 
@@ -881,7 +881,7 @@ Choose from the list of available rules:
 
 * **phpdoc_order**
 
-  Annotations in PHPDocs should be ordered so that ``@param`` annotations
+  Annotations in PHPDoc should be ordered so that ``@param`` annotations
   come first, then ``@throws`` annotations, then ``@return`` annotations.
 
 * **phpdoc_return_self_reference** [@Symfony]
@@ -903,7 +903,7 @@ Choose from the list of available rules:
 
 * **phpdoc_separation** [@Symfony]
 
-  Annotations in PHPDocs should be grouped together so that annotations of
+  Annotations in PHPDoc should be grouped together so that annotations of
   the same type immediately follow each other, and annotations of a
   different type are separated by a single blank line.
 
@@ -913,7 +913,7 @@ Choose from the list of available rules:
 
 * **phpdoc_summary** [@Symfony]
 
-  PHPDocs summary should end in either a full stop, exclamation mark, or
+  PHPDoc summary should end in either a full stop, exclamation mark, or
   question mark.
 
 * **phpdoc_to_comment** [@Symfony]
@@ -922,7 +922,7 @@ Choose from the list of available rules:
 
 * **phpdoc_trim** [@Symfony]
 
-  PHPDocs should start and end with content, excluding the very first and
+  PHPDoc should start and end with content, excluding the very first and
   last line of the docblocks.
 
 * **phpdoc_types** [@Symfony]

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -30,7 +30,7 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'There MUST be no trailing spaces inside comments and PHPDocs.',
+            'There MUST be no trailing spaces inside comment or PHPDoc.',
             array(new CodeSample('<?php
 // This is '.'
 // a comment. '.'

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -34,7 +34,7 @@ final class GeneralPhpdocAnnotationRemoveFixer extends AbstractFixer implements 
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Configured annotations should be omitted from PHPDocs.',
+            'Configured annotations should be omitted from PHPDoc.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -33,7 +33,7 @@ final class PhpdocAnnotationWithoutDotFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPDocs annotation descriptions should not be a sentence.',
+            'PHPDoc annotation descriptions should not be a sentence.',
             array(new CodeSample('<?php
 /**
  * @param string $bar Some string.

--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -28,7 +28,7 @@ final class PhpdocNoAccessFixer extends AbstractProxyFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '`@access` annotations should be omitted from PHPDocs.',
+            '`@access` annotations should be omitted from PHPDoc.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -40,7 +40,7 @@ final class PhpdocNoEmptyReturnFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '`@return` void and `@return null` annotations should be omitted from PHPDocs.',
+            '`@return` void and `@return null` annotations should be omitted from PHPDoc.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -28,7 +28,7 @@ final class PhpdocNoPackageFixer extends AbstractProxyFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            '`@package` and `@subpackage` annotations should be omitted from PHPDocs.',
+            '`@package` and `@subpackage` annotations should be omitted from PHPDoc.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -38,7 +38,7 @@ final class PhpdocOrderFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Annotations in PHPDocs should be ordered so that `@param` annotations come first, then `@throws` annotations, then `@return` annotations.',
+            'Annotations in PHPDoc should be ordered so that `@param` annotations come first, then `@throws` annotations, then `@return` annotations.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -32,7 +32,7 @@ final class PhpdocSeparationFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Annotations in PHPDocs should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.',
+            'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.',
             array(
                 new CodeSample(
                     '<?php

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -32,7 +32,7 @@ final class PhpdocSummaryFixer extends AbstractFixer implements WhitespacesAware
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPDocs summary should end in either a full stop, exclamation mark, or question mark.',
+            'PHPDoc summary should end in either a full stop, exclamation mark, or question mark.',
             array(new CodeSample('<?php
 /**
  * Foo function is great

--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -30,7 +30,7 @@ final class PhpdocTrimFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPDocs should start and end with content, excluding the very first and last line of the docblocks.',
+            'PHPDoc should start and end with content, excluding the very first and last line of the docblocks.',
             array(new CodeSample('<?php
 /**
  *

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -58,6 +58,9 @@ final class FixerTest extends TestCase
         $fixerIsConfigurable = $fixer instanceof ConfigurationDefinitionFixerInterface;
 
         $this->assertRegExp('/^[A-Z`].*\.$/', $definition->getSummary(), sprintf('[%s] Description must start with capital letter or a ` and end with dot.', $fixerName));
+        $this->assertNotContains('phpdocs', $definition->getSummary(), sprintf('[%s] `PHPDoc` must not be in the plural in description.', $fixerName), true);
+        $this->assertCorrectCasing($definition->getSummary(), 'PHPDoc', sprintf('[%s] `PHPDoc` must be in correct casing in description.', $fixerName));
+        $this->assertCorrectCasing($definition->getSummary(), 'PHPUnit', sprintf('[%s] `PHPUnit` must be in correct casing in description.', $fixerName));
 
         $samples = $definition->getCodeSamples();
         $this->assertNotEmpty($samples, sprintf('[%s] Code samples are required.', $fixerName));
@@ -126,6 +129,9 @@ final class FixerTest extends TestCase
 
         if ($fixer->isRisky()) {
             $this->assertStringIsNotEmpty($definition->getRiskyDescription(), sprintf('[%s] Risky reasoning is required.', $fixerName));
+            $this->assertNotContains('phpdocs', $definition->getRiskyDescription(), sprintf('[%s] `PHPDoc` must not be in the plural in risky reasoning.', $fixerName), true);
+            $this->assertCorrectCasing($definition->getRiskyDescription(), 'PHPDoc', sprintf('[%s] `PHPDoc` must be in correct casing in risky reasoning.', $fixerName));
+            $this->assertCorrectCasing($definition->getRiskyDescription(), 'PHPUnit', sprintf('[%s] `PHPUnit` must be in correct casing in risky reasoning.', $fixerName));
         } else {
             $this->assertNull($definition->getRiskyDescription(), sprintf('[%s] Fixer is not risky so no description of it expected.', $fixerName));
         }
@@ -230,5 +236,15 @@ final class FixerTest extends TestCase
     {
         self::assertInternalType('string', $actual, $message);
         self::assertNotEmpty($actual, $message);
+    }
+
+    /**
+     * @param string $needle
+     * @param string $haystack
+     * @param string $message
+     */
+    private static function assertCorrectCasing($needle, $haystack, $message)
+    {
+        self::assertSame(substr_count(strtolower($haystack), strtolower($needle)), substr_count($haystack, $needle), $message);
     }
 }


### PR DESCRIPTION
With a special [dedication](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3745/files#diff-88b99bb28683bd5b7e3a204826ead112R1126) for @BackEndTea.