### PR TITLE
YodaStyleFixer - handle space between var name and index

### DIFF
--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -558,8 +558,9 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
             ) {
                 $index = $tokens->findBlockEnd(
                     $next->equals('[') ? Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE : Tokens::BLOCK_TYPE_ARRAY_INDEX_CURLY_BRACE,
-                    $index + 1
+                    $nextIndex
                 );
+
                 if ($index === $end) {
                     return true;
                 }

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -62,6 +62,10 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
     {
         return [
             [
+                '<?php return 1 !== $a [$b];',
+                '<?php return $a [$b] !== 1;',
+            ],
+            [
                 '<?= 1 === $a ? 5 : 7;',
                 '<?= $a === 1 ? 5 : 7;',
             ],


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3754