### PR TITLE
Fix Yoda when space between  and [ - issue 3754

### DIFF
--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -558,7 +558,7 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
             ) {
                 $index = $tokens->findBlockEnd(
                     $next->equals('[') ? Tokens::BLOCK_TYPE_INDEX_SQUARE_BRACE : Tokens::BLOCK_TYPE_ARRAY_INDEX_CURLY_BRACE,
-                    $index + 1
+                    $nextIndex
                 );
                 if ($index === $end) {
                     return true;

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -262,6 +262,10 @@ if ($a = $obj instanceof A === true) {
                 '<?php return $a[2] == null;',
             ],
             [
+                '<?php return "" === $this->myArray [$index];',
+                '<?php return $this->myArray [$index] === "";',
+            ],
+            [
                 '<?php return "" === $this->myArray[$index];',
                 '<?php return $this->myArray[$index] === "";',
             ],


### PR DESCRIPTION
Fixes issue #3754 

After a var name, like ``$this->myArray`` then there might be a white-space token before the ``[`` that introduces the array key. Make sure to skip over that white-space token before looking for the ``[`` and its ``]`` mate.