### PR TITLE
PhpUnitTestClassRequiresCoversFixer - Remove unneeded loop and use phpunit indicator class

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -66,90 +66,87 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
 
-        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
-            if (!$tokens[$index]->isGivenKind(T_CLASS)) {
-                continue;
-            }
-
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
-
-            // don't add `@covers` annotation for abstract base classes
-            if ($tokens[$prevIndex]->isGivenKind(T_ABSTRACT)) {
-                continue;
-            }
-
-            if (!$phpUnitTestCaseIndicator->isPhpUnitClass($tokens, $index)) {
-                continue;
-            }
-
-            $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            $index = $tokens[$prevIndex]->isGivenKind(T_FINAL) ? $prevIndex : $index;
-
-            $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
-                ? Preg::replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
-                : '';
-
-            $prevIndex = $tokens->getPrevNonWhitespace($index);
-            $doc = null;
-            $docIndex = null;
-
-            if ($tokens[$prevIndex]->isGivenKind(T_DOC_COMMENT)) {
-                $docIndex = $prevIndex;
-                $docContent = $tokens[$docIndex]->getContent();
-
-                // ignore one-line phpdocs like `/** foo */`, as there is no place to put new annotations
-                if (false === strpos($docContent, "\n")) {
-                    continue;
-                }
-
-                $doc = new DocBlock($docContent);
-
-                // skip if already has annotation
-                if (!empty($doc->getAnnotationsOfType([
-                    'covers',
-                    'coversDefaultClass',
-                    'coversNothing',
-                ]))) {
-                    continue;
-                }
-            } else {
-                $docIndex = $index;
-                $tokens->insertAt($docIndex, [
-                    new Token([T_DOC_COMMENT, sprintf('/**%s%s */', $this->whitespacesConfig->getLineEnding(), $indent)]),
-                    new Token([T_WHITESPACE, sprintf('%s%s', $this->whitespacesConfig->getLineEnding(), $indent)]),
-                ]);
-
-                if (!$tokens[$docIndex - 1]->isGivenKind(T_WHITESPACE)) {
-                    $extraNewLines = $this->whitespacesConfig->getLineEnding();
-
-                    if (!$tokens[$docIndex - 1]->isGivenKind(T_OPEN_TAG)) {
-                        $extraNewLines .= $this->whitespacesConfig->getLineEnding();
-                    }
-
-                    $tokens->insertAt($docIndex, [
-                        new Token([T_WHITESPACE, $extraNewLines.$indent]),
-                    ]);
-                    ++$docIndex;
-                }
-
-                $doc = new DocBlock($tokens[$docIndex]->getContent());
-            }
-
-            $lines = $doc->getLines();
-            array_splice(
-                $lines,
-                \count($lines) - 1,
-                0,
-                [
-                    new Line(sprintf(
-                        '%s * @coversNothing%s',
-                        $indent,
-                        $this->whitespacesConfig->getLineEnding()
-                    )),
-                ]
-            );
-
-            $tokens[$docIndex] = new Token([T_DOC_COMMENT, implode('', $lines)]);
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indexes) {
+            $this->addRequiresCover($tokens, $indexes[0]);
         }
+    }
+
+    private function addRequiresCover(Tokens $tokens, $startIndex)
+    {
+        $classIndex = $tokens->getPrevTokenOfKind($startIndex, [[T_CLASS]]);
+        $prevIndex = $tokens->getPrevMeaningfulToken($classIndex);
+
+        // don't add `@covers` annotation for abstract base classes
+        if ($tokens[$prevIndex]->isGivenKind(T_ABSTRACT)) {
+            return;
+        }
+
+        $index = $tokens[$prevIndex]->isGivenKind(T_FINAL) ? $prevIndex : $classIndex;
+
+        $indent = $tokens[$index - 1]->isGivenKind(T_WHITESPACE)
+            ? Preg::replace('/^.*\R*/', '', $tokens[$index - 1]->getContent())
+            : '';
+
+        $prevIndex = $tokens->getPrevNonWhitespace($index);
+        $doc = null;
+        $docIndex = null;
+
+        if ($tokens[$prevIndex]->isGivenKind(T_DOC_COMMENT)) {
+            $docIndex = $prevIndex;
+            $docContent = $tokens[$docIndex]->getContent();
+
+            // ignore one-line phpdocs like `/** foo */`, as there is no place to put new annotations
+            if (false === strpos($docContent, "\n")) {
+                return;
+            }
+
+            $doc = new DocBlock($docContent);
+
+            // skip if already has annotation
+            if (!empty($doc->getAnnotationsOfType([
+                'covers',
+                'coversDefaultClass',
+                'coversNothing',
+            ]))) {
+                return;
+            }
+        } else {
+            $docIndex = $index;
+            $tokens->insertAt($docIndex, [
+                new Token([T_DOC_COMMENT, sprintf('/**%s%s */', $this->whitespacesConfig->getLineEnding(), $indent)]),
+                new Token([T_WHITESPACE, sprintf('%s%s', $this->whitespacesConfig->getLineEnding(), $indent)]),
+            ]);
+
+            if (!$tokens[$docIndex - 1]->isGivenKind(T_WHITESPACE)) {
+                $extraNewLines = $this->whitespacesConfig->getLineEnding();
+
+                if (!$tokens[$docIndex - 1]->isGivenKind(T_OPEN_TAG)) {
+                    $extraNewLines .= $this->whitespacesConfig->getLineEnding();
+                }
+
+                $tokens->insertAt($docIndex, [
+                    new Token([T_WHITESPACE, $extraNewLines.$indent]),
+                ]);
+                ++$docIndex;
+            }
+
+            $doc = new DocBlock($tokens[$docIndex]->getContent());
+        }
+
+        $lines = $doc->getLines();
+        array_splice(
+            $lines,
+            \count($lines) - 1,
+            0,
+            [
+                new Line(sprintf(
+                    '%s * @coversNothing%s',
+                    $indent,
+                    $this->whitespacesConfig->getLineEnding()
+                )),
+            ]
+        );
+
+        $tokens[$docIndex] = new Token([T_DOC_COMMENT, implode('', $lines)]);
     }
 }


### PR DESCRIPTION
Refactor of the `PhpUnitTestClassRequiresCoversFixer` to reduce unneeded looping of token sets.