### PR TITLE
PhpUnitDedicateAssertFixer - fix to assertCount too

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -177,28 +177,24 @@ $this->assertTrue(is_readable($a));
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
-            $methodIndex = $tokens->getNextTokenOfKind($index, [[T_STRING]]);
-            if (null === $methodIndex) {
-                break;
+        foreach ($this->getPreviousAssertCall($tokens) as $assertCall) {
+            // test and fix for assertTrue/False to dedicated asserts
+            if ('asserttrue' === $assertCall['loweredName'] || 'assertfalse' === $assertCall['loweredName']) {
+                $this->fixAssertTrueFalse($tokens, $assertCall);
+
+                continue;
             }
 
-            $operatorIndex = $tokens->getPrevMeaningfulToken($methodIndex);
-            $referenceIndex = $tokens->getPrevMeaningfulToken($operatorIndex);
             if (
-                !($tokens[$operatorIndex]->equals([T_OBJECT_OPERATOR, '->']) && $tokens[$referenceIndex]->equals([T_VARIABLE, '$this']))
-                && !($tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STRING, 'self']))
-                && !($tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STATIC, 'static']))
+                'assertsame' === $assertCall['loweredName']
+                || 'assertnotsame' === $assertCall['loweredName']
+                || 'assertequals' === $assertCall['loweredName']
+                || 'assertnotequals' === $assertCall['loweredName']
             ) {
+                $this->fixAssertSameEquals($tokens, $assertCall);
+
                 continue;
             }
-
-            $index = $this->getAssertCandidate($tokens, $methodIndex);
-            if (!is_array($index)) {
-                continue;
-            }
-
-            $index = $this->fixAssert($tokens, $index);
         }
     }
 
@@ -258,33 +254,16 @@ $this->assertTrue(is_readable($a));
 
     /**
      * @param Tokens $tokens
-     * @param int    $assertCallIndex Token index of assert method call
-     *
-     * @return int|int[] indexes of assert call, test call and positive flag, or last index checked
+     * @param array  $assertCall
      */
-    private function getAssertCandidate(Tokens $tokens, $assertCallIndex)
+    private function fixAssertTrueFalse(Tokens $tokens, array $assertCall)
     {
-        $content = strtolower($tokens[$assertCallIndex]->getContent());
-        if ('asserttrue' === $content) {
-            $isPositive = 1;
-        } elseif ('assertfalse' === $content) {
-            $isPositive = 0;
-        } else {
-            return $assertCallIndex;
-        }
-
-        // test candidate for simple calls like: ([\]+'some fixable call'(...))
-        $assertCallOpenIndex = $tokens->getNextMeaningfulToken($assertCallIndex);
-        if (!$tokens[$assertCallOpenIndex]->equals('(')) {
-            return $assertCallIndex;
-        }
-
         $testDefaultNamespaceTokenIndex = false;
-        $testIndex = $tokens->getNextMeaningfulToken($assertCallOpenIndex);
+        $testIndex = $tokens->getNextMeaningfulToken($assertCall['openBraceIndex']);
 
         if (!$tokens[$testIndex]->isGivenKind([T_EMPTY, T_STRING])) {
             if (!$tokens[$testIndex]->isGivenKind(T_NS_SEPARATOR)) {
-                return $testIndex;
+                return;
             }
 
             $testDefaultNamespaceTokenIndex = $testIndex;
@@ -293,64 +272,35 @@ $this->assertTrue(is_readable($a));
 
         $testOpenIndex = $tokens->getNextMeaningfulToken($testIndex);
         if (!$tokens[$testOpenIndex]->equals('(')) {
-            return $testOpenIndex;
+            return;
         }
 
         $testCloseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $testOpenIndex);
 
         $assertCallCloseIndex = $tokens->getNextMeaningfulToken($testCloseIndex);
         if (!$tokens[$assertCallCloseIndex]->equalsAny([')', ','])) {
-            return $assertCallCloseIndex;
+            return;
         }
 
-        return [
-            $isPositive,
-            $assertCallIndex,
-            $assertCallOpenIndex,
-            $testDefaultNamespaceTokenIndex,
-            $testIndex,
-            $testOpenIndex,
-            $testCloseIndex,
-            $assertCallCloseIndex,
-        ];
-    }
-
-    /**
-     * @param Tokens $tokens
-     * @param array  $assertIndexes
-     *
-     * @return int index up till processed, number of tokens added
-     */
-    private function fixAssert(Tokens $tokens, array $assertIndexes)
-    {
-        list(
-            $isPositive,
-            $assertCallIndex,
-            ,
-            $testDefaultNamespaceTokenIndex,
-            $testIndex,
-            $testOpenIndex,
-            $testCloseIndex,
-            $assertCallCloseIndex
-        ) = $assertIndexes;
+        $isPositive = 'asserttrue' === $assertCall['loweredName'];
 
         $content = strtolower($tokens[$testIndex]->getContent());
         if (!in_array($content, $this->functions, true)) {
-            return $assertCallCloseIndex;
+            return;
         }
 
         if (is_array(self::$fixMap[$content])) {
             if (false !== self::$fixMap[$content][$isPositive]) {
-                $tokens[$assertCallIndex] = new Token([T_STRING, self::$fixMap[$content][$isPositive]]);
+                $tokens[$assertCall['index']] = new Token([T_STRING, self::$fixMap[$content][$isPositive]]);
                 $this->removeFunctionCall($tokens, $testDefaultNamespaceTokenIndex, $testIndex, $testOpenIndex, $testCloseIndex);
             }
 
-            return $assertCallCloseIndex;
+            return;
         }
 
         $type = substr($content, 3);
 
-        $tokens[$assertCallIndex] = new Token([T_STRING, $isPositive ? 'assertInternalType' : 'assertNotInternalType']);
+        $tokens[$assertCall['index']] = new Token([T_STRING, $isPositive ? 'assertInternalType' : 'assertNotInternalType']);
         $tokens[$testIndex] = new Token([T_CONSTANT_ENCAPSED_STRING, "'".$type."'"]);
         $tokens[$testOpenIndex] = new Token(',');
 
@@ -363,8 +313,102 @@ $this->assertTrue(is_readable($a));
         if (false !== $testDefaultNamespaceTokenIndex) {
             $tokens->clearTokenAndMergeSurroundingWhitespace($testDefaultNamespaceTokenIndex);
         }
+    }
 
-        return $assertCallCloseIndex;
+    /**
+     * @param Tokens $tokens
+     * @param array  $assertCall
+     */
+    private function fixAssertSameEquals(Tokens $tokens, array $assertCall)
+    {
+        // @ $this->/self::assertEquals/Same([$nextIndex])
+        $expectedIndex = $tokens->getNextMeaningfulToken($assertCall['openBraceIndex']);
+
+        // do not fix
+        // let $a = [1,2]; $b = "2";
+        // "$this->assertEquals("2", count($a)); $this->assertEquals($b, count($a)); $this->assertEquals(2.1, count($a));"
+
+        if (!$tokens[$expectedIndex]->isGivenKind(T_LNUMBER)) {
+            return;
+        }
+
+        // @ $this->/self::assertEquals/Same([$nextIndex,$commaIndex])
+        $commaIndex = $tokens->getNextMeaningfulToken($expectedIndex);
+        if (!$tokens[$commaIndex]->equals(',')) {
+            return;
+        }
+
+        // @ $this->/self::assertEquals/Same([$nextIndex,$commaIndex,$countCallIndex])
+        $countCallIndex = $tokens->getNextMeaningfulToken($commaIndex);
+        if ($tokens[$countCallIndex]->isGivenKind(T_NS_SEPARATOR)) {
+            $defaultNamespaceTokenIndex = $countCallIndex;
+            $countCallIndex = $tokens->getNextMeaningfulToken($countCallIndex);
+        } else {
+            $defaultNamespaceTokenIndex = false;
+        }
+
+        if (!$tokens[$countCallIndex]->isGivenKind(T_STRING) || 'count' !== strtolower($tokens[$countCallIndex]->getContent())) {
+            return; // not a call to "count"
+        }
+
+        // @ $this->/self::assertEquals/Same([$nextIndex,$commaIndex,[$defaultNamespaceTokenIndex,]$countCallIndex,$countCallOpenBraceIndex])
+        $countCallOpenBraceIndex = $tokens->getNextMeaningfulToken($countCallIndex);
+        if (!$tokens[$countCallOpenBraceIndex]->equals('(')) {
+            return;
+        }
+
+        $this->removeFunctionCall(
+            $tokens,
+            $defaultNamespaceTokenIndex,
+            $countCallIndex,
+            $countCallOpenBraceIndex,
+            $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $countCallOpenBraceIndex)
+        );
+
+        $tokens[$assertCall['index']] = new Token([
+            T_STRING,
+            false === strpos($assertCall['loweredName'], 'not', 6) ? 'assertCount' : 'assertNotCount',
+        ]);
+    }
+
+    private function getPreviousAssertCall(Tokens $tokens)
+    {
+        for ($index = $tokens->count(); $index > 0; --$index) {
+            $index = $tokens->getPrevTokenOfKind($index, [[T_STRING]]);
+            if (null === $index) {
+                return;
+            }
+
+            // test if "assert" something call
+            $loweredContent = strtolower($tokens[$index]->getContent());
+            if ('assert' !== substr($loweredContent, 0, 6)) {
+                continue;
+            }
+
+            // test candidate for simple calls like: ([\]+'some fixable call'(...))
+            $openBraceIndex = $tokens->getNextMeaningfulToken($index);
+            if (!$tokens[$openBraceIndex]->equals('(')) {
+                continue;
+            }
+
+            $operatorIndex = $tokens->getPrevMeaningfulToken($index);
+            $referenceIndex = $tokens->getPrevMeaningfulToken($operatorIndex);
+
+            if (
+                !($tokens[$operatorIndex]->equals([T_OBJECT_OPERATOR, '->']) && $tokens[$referenceIndex]->equals([T_VARIABLE, '$this']))
+                && !($tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STRING, 'self']))
+                && !($tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STATIC, 'static']))
+            ) {
+                continue;
+            }
+
+            yield [
+                'index' => $index,
+                'loweredName' => $loweredContent,
+                'openBraceIndex' => $openBraceIndex,
+                'closeBraceIndex' => $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openBraceIndex),
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -344,4 +344,136 @@ $a#
 
         $this->fixer->configure(['target' => '_unknown_']);
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestAssertCountCases
+     */
+    public function testAssertCount($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestAssertCountCases()
+    {
+        return [
+            // positive fixing
+            'assert same' => [
+                '<?php $this->assertCount(1, $a);',
+                '<?php $this->assertSame(1, count($a));',
+            ],
+            'assert equals' => [
+                '<?php $this->assertCount(2, $b);',
+                '<?php $this->assertEquals(2, count($b));',
+            ],
+            // negative fixing
+            'assert not same' => [
+                '<?php $this->assertNotCount(11, $c);',
+                '<?php $this->assertNotSame(11, count($c));',
+            ],
+            'assert not equals' => [
+                '<?php $this->assertNotCount(122, $d);',
+                '<?php $this->assertNotEquals(122, count($d));',
+            ],
+            // other cases
+            'assert same with namespace' => [
+                '<?php $this->assertCount(1, $a);',
+                '<?php $this->assertSame(1, \COUnt($a));',
+            ],
+            'no spacing' => [
+                '<?php $this->assertCount(1,$a);',
+                '<?php $this->assertSame(1,count($a));',
+            ],
+            'lot of spacing' => [
+                '<?php $this->assertCount(
+                1
+                ,
+                '.'
+                '.'
+                $a
+                '.'
+                )
+                ;',
+                '<?php $this->assertSame(
+                1
+                ,
+                count
+                (
+                $a
+                )
+                )
+                ;',
+            ],
+            'lot of fix cases' => [
+                '<?php
+                    $this->assertCount(1, $a);
+                    $this->assertCount(2, $a);
+                    $this->assertCount(3, $a);
+                    $this->assertNotCount(4, $a);
+                    $this->assertCount(5, $a, "abc");
+                    $this->assertCount(6, $a, "def");
+                ',
+                '<?php
+                    $this->assertSame(1, count($a));
+                    $this->assertSame(2, count($a));
+                    $this->assertEquals(3, count($a));
+                    $this->assertNotSame(4, count($a));
+                    $this->assertEquals(5, count($a), "abc");
+                    $this->assertSame(6, \count($a), "def");
+                ',
+            ],
+            'comment handling' => [
+                '<?php $this->assertCount(# 0
+1# 1
+,# 2
+# 3
+# 4
+$a# 5
+# 6
+)# 7
+;# 8',
+                '<?php $this->assertSame(# 0
+1# 1
+,# 2
+count# 3
+(# 4
+$a# 5
+)# 6
+)# 7
+;# 8',
+            ],
+            'do not fix 1' => [
+                '<?php
+                    $this->assertSame($b, count($a));
+                ',
+            ],
+            'do not fix 2' => [
+                '<?php
+                    $this->assertSame(b(), count($a));
+                ',
+            ],
+            'do not fix 3' => [
+                '<?php
+                    $this->assertSame(1.0, count($a));
+                ',
+            ],
+            'do not fix 4' => [
+                '<?php
+                    $this->assertSame(1); // overridden
+                ',
+            ],
+            'do not fix 5' => [
+                '<?php
+                    $this->assertSame(1, "count");
+                ',
+            ],
+            'do not fix 6' => [
+                '<?php
+                    $this->test(); // $this->assertSame($b, count($a));
+                ',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
closes #3750

```
            'assert same' => [
                '<?php $this->assertCount(1, $a);',
                '<?php $this->assertSame(1, count($a));',
            ],
```

for more example please see the tests