### PR TITLE
DX: Fix collecting code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,4 +148,3 @@ jobs:
 
     allow_failures:
         - php: nightly
-        - env: COLLECT_COVERAGE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ jobs:
                 # Composer: boost installation
                 - composer global show hirak/prestissimo -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
             script:
-                - phpdbg -qrr vendor/bin/phpunit --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
+                - phpdbg -qrr vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
                 - php vendor/bin/php-coveralls -v
 
         -

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,13 @@
     verbose="true"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="all">
             <directory>./tests</directory>
+        </testsuite>
+        <testsuite name="coverage">
+            <directory>./tests</directory>
+            <exclude>./tests/AutoReview</exclude>
+            <exclude>./tests/Smoke</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -120,7 +120,7 @@ final class ProcessLinter implements LinterInterface
         }
 
         $process = $this->processBuilder->build($path);
-        $process->setTimeout(null);
+        $process->setTimeout(10);
         $process->start();
 
         return $process;

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -359,7 +359,7 @@ final class ProjectCodeTest extends TestCase
     public function provideDataProviderMethodNameCases()
     {
         if ((extension_loaded('xdebug') || 'phpdbg' === PHP_SAPI) && false === getenv('CI')) {
-            $this->markTestSkipped('Test too slow when Xdebug is loaded or running under phpdbg.');
+            $this->markTestSkipped('Data provider too slow when Xdebug is loaded or running under phpdbg.');
         }
 
         $data = [];
@@ -401,7 +401,7 @@ final class ProjectCodeTest extends TestCase
     public function provideClassesWherePregFunctionsAreForbiddenCases()
     {
         if ((extension_loaded('xdebug') || 'phpdbg' === PHP_SAPI) && false === getenv('CI')) {
-            $this->markTestSkipped('Test too slow when Xdebug is loaded or running under phpdbg.');
+            $this->markTestSkipped('Data provider too slow when Xdebug is loaded or running under phpdbg.');
         }
 
         return array_map(

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -358,8 +358,8 @@ final class ProjectCodeTest extends TestCase
 
     public function provideDataProviderMethodNameCases()
     {
-        if (extension_loaded('xdebug') && false === getenv('CI')) {
-            $this->markTestSkipped('Data provider too slow when Xdebug is loaded.');
+        if ((extension_loaded('xdebug') || 'phpdbg' === PHP_SAPI) && false === getenv('CI')) {
+            $this->markTestSkipped('Test too slow when Xdebug is loaded or running under phpdbg.');
         }
 
         $data = [];
@@ -400,8 +400,8 @@ final class ProjectCodeTest extends TestCase
 
     public function provideClassesWherePregFunctionsAreForbiddenCases()
     {
-        if (extension_loaded('xdebug') && false === getenv('CI')) {
-            $this->markTestSkipped('Test too slow when Xdebug is loaded.');
+        if ((extension_loaded('xdebug') || 'phpdbg' === PHP_SAPI) && false === getenv('CI')) {
+            $this->markTestSkipped('Test too slow when Xdebug is loaded or running under phpdbg.');
         }
 
         return array_map(


### PR DESCRIPTION
Extracted from: #3782

Issue: code coverage is not collected
------

Original issue - phpunit freezes during collecting code coverage:
https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/385970261#L778
> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.

it was caused because we run `process` without timeout, after setting timeout for a process, we no longer experience timeout, but tests are failing instead on reached timeout:
https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/386044680#L832
> Failed asserting that exception of type "Symfony\Component\Process\Exception\ProcessTimedOutException" matches expected exception "PhpCsFixer\Linter\LintingException". Message was: "The process ""/home/travis/.phpenv/versions/7.2.6/bin/php" -l "/home/travis/build/FriendsOfPHP/PHP-CS-Fixer/cs_fixer_tmp_IFFxt2"" exceeded the timeout of 10 seconds.


Reason and solution:
---------

1. In AutoReview/Smoke tests we were opening a lot of files, as even if those classes are under `covers-nothing` group that is not executed when we collect code coverage, PHPUnit still executes data providers (so one can `--filter` by them)
2. phpdbg was not releasing file handlers of opened files
3. With `ProcessLinter`, we were creating process without timeout, and on that phpunit hung out
4. The error we got under the hood was `proc_open(): unable to create pipe Too many open files`, meaning that we had too much opened file descriptors 
5. Don't load dataLoaders of tests we are not executing -> dedicated testsuite