### PR TITLE
DX - AutoReview - options sanity

### DIFF
--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -15,6 +15,8 @@ namespace PhpCsFixer\Tests\AutoReview;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
+use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\FixerDefinition\FileSpecificCodeSampleInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
 use PhpCsFixer\FixerFactory;
@@ -128,8 +130,25 @@ final class FixerTest extends TestCase
 
             $options = $fixer->getConfigurationDefinition()->getOptions();
 
+            /** @var FixerOptionInterface $option */
             foreach ($options as $option) {
                 $this->assertRegExp('/^[a-z_]*$/', $option->getName(), sprintf('[%s] Option %s is not snake_case.', $fixerName, $option->getName()));
+
+                $types = $option->getAllowedTypes();
+                $values = $option->getAllowedValues();
+
+                $this->assertFalse(
+                    (null === $types || 0 === count($types)) && (null === $values || 0 === count($values)),
+                    sprintf('[%s] Option %s has no allowed types and values set.', $fixerName, $option->getName())
+                );
+
+                if ($values !== null) {
+                    foreach ($values as $value) {
+                        if ($value instanceof AllowedValueSubset) {
+                            $this->assertContains('array', $types, sprintf('[%s] Option %s has allowed value of type "AllowedValueSubset" but not allowed type "array".', $fixerName, $option->getName()));
+                        }
+                    }
+                }
             }
         }
 

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -142,7 +142,7 @@ final class FixerTest extends TestCase
                     sprintf('[%s] Option %s has no allowed types and values set.', $fixerName, $option->getName())
                 );
 
-                if ($values !== null) {
+                if (null !== $values) {
                     foreach ($values as $value) {
                         if ($value instanceof AllowedValueSubset) {
                             $this->assertContains('array', $types, sprintf('[%s] Option %s has allowed value of type "AllowedValueSubset" but not allowed type "array".', $fixerName, $option->getName()));


### PR DESCRIPTION
While we allow `null`/`empty` values in the API we shouldn't use that combination ourselves because:
- more info is better ;)
- when leaving out the HelpCommand/Readme will fail to be generated
