### PR TITLE
DX: ProjectCodeTest - shall not depends on xdebug/phpdbg anymore

### DIFF
--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -365,10 +365,6 @@ final class ProjectCodeTest extends TestCase
 
     public function provideClassesWherePregFunctionsAreForbiddenCases()
     {
-        if ((extension_loaded('xdebug') || 'phpdbg' === PHP_SAPI) && false === getenv('CI')) {
-            $this->markTestSkipped('Data provider too slow when Xdebug is loaded or running under phpdbg.');
-        }
-
         return array_map(
             function ($item) {
                 return [$item];


### PR DESCRIPTION
shall not be needed anymore after #3789 and #3791