### PR TITLE
NoEmptyPhpdocFixer/PhpdocAddMissingParamAnnotationFixer - missing priority test

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -77,8 +77,9 @@ function f9(string $foo, $bar, $baz) {}',
      */
     public function getPriority()
     {
-        // must be run after PhpdocNoAliasTagFixer and before PhpdocAlignFixer
-        return -1;
+        // must be run after PhpdocNoAliasTagFixer
+        // must be run before PhpdocAlignFixer and PhpdocNoEmptyReturnFixer
+        return 10;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -84,6 +84,15 @@ final class Example
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // must be run before PhpdocAddMissingParamAnnotationFixer
+        return 11;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $searchFor = array_keys($this->configuration['replacements']);

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -67,7 +67,8 @@ function foo() {}
      */
     public function getPriority()
     {
-        // must be run before the PhpdocSeparationFixer and PhpdocOrderFixer
+        // must be run before the PhpdocSeparationFixer, PhpdocOrderFixer
+        // must be run after the PhpdocAddMissingParamAnnotationFixer
         return 10;
     }
 

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -128,6 +128,7 @@ final class FixerFactoryTest extends TestCase
             array($fixers['ordered_class_elements'], $fixers['space_after_semicolon']),
             array($fixers['php_unit_construct'], $fixers['php_unit_dedicate_assert']),
             array($fixers['php_unit_fqcn_annotation'], $fixers['no_unused_imports']),
+            array($fixers['phpdoc_add_missing_param_annotation'], $fixers['no_empty_phpdoc']),
             array($fixers['phpdoc_add_missing_param_annotation'], $fixers['phpdoc_align']),
             array($fixers['phpdoc_add_missing_param_annotation'], $fixers['phpdoc_order']),
             array($fixers['phpdoc_no_access'], $fixers['no_empty_phpdoc']),

--- a/tests/Fixtures/Integration/priority/no_empty_phpdoc,phpdoc_add_missing_param_annotation.test
+++ b/tests/Fixtures/Integration/priority/no_empty_phpdoc,phpdoc_add_missing_param_annotation.test
@@ -1,0 +1,22 @@
+--TEST--
+Integration of fixers: no_empty_phpdoc, phpdoc_add_missing_param_annotation
+--RULESET--
+{"no_empty_phpdoc": true, "phpdoc_add_missing_param_annotation": true}
+--EXPECT--
+<?php
+/**
+ *
+ * @param mixed $a
+ */
+function f9($a = 1)
+{
+}
+
+--INPUT--
+<?php
+/**
+ *
+ */
+function f9($a = 1)
+{
+}


### PR DESCRIPTION
Add missing priority test "no_empty_phpdoc,phpdoc_add_missing_param_annotation.test".