### PR TITLE
Cleanup: remove useless constructor comment

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -146,8 +146,6 @@ final class ConfigurationResolver
     private $fixerFactory;
 
     /**
-     * ConfigurationResolver constructor.
-     *
      * @param ConfigInterface   $config
      * @param array             $options
      * @param string            $cwd


### PR DESCRIPTION
It's the only one such comment in the repo.