### PR TITLE
ReturnAssignmentFixer with PHPDoc @var for the variable

### DIFF
--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -407,6 +407,22 @@ var names are case insensitive */ }
 var names are case insensitive */ return $a   ;}
                 ',
             ],
+            [
+                '<?php
+                function foo()
+                {
+                    return SomeService::getSomeValue();
+                }
+                ',
+                '<?php
+                function foo()
+                {
+                    /** @var ValueFromSomeService $bar */
+                    $bar = SomeService::getSomeValue();
+                    return $bar;
+                }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
We have to do something with such annotation as `phpdoc_to_comment` would want to change it if it wasn't run before - which means of course that in practice it will happen after flushing cache.