### PR TITLE
Priority conflict: NoUnneededControlParenthesesFixer & ReturnAssignmentFixer

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -192,6 +192,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['pow_to_exponentiation'], $fixers['no_spaces_inside_parenthesis']],
             [$fixers['protected_to_private'], $fixers['ordered_class_elements']],
             [$fixers['return_assignment'], $fixers['blank_line_before_statement']],
+            [$fixers['return_assignment'], $fixers['no_unneeded_control_parentheses']],
             [$fixers['simplified_null_return'], $fixers['no_useless_return']],
             [$fixers['single_import_per_statement'], $fixers['no_leading_import_slash']],
             [$fixers['single_import_per_statement'], $fixers['multiline_whitespace_before_semicolons']],

--- a/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,return_assignment.test
+++ b/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,return_assignment.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: no_unneeded_control_parentheses,return_assignment
+--RULESET--
+{"no_unneeded_control_parentheses": true, "return_assignment": true}
+--EXPECT--
+<?php
+
+$foo = function() {
+    return true
+        ? 1
+        : 2
+    ;
+};
+
+--INPUT--
+<?php
+
+$foo = function() {
+    $var = (true
+        ? 1
+        : 2
+    );
+
+    return $var;
+};


### PR DESCRIPTION
I don't know how to fixthis: priority numbers of the involved fixers are already stuck with other fixers.

Maybe we should can fix `NoUnneededControlParenthesesFixer` for the original variable assignment form, or maybe not, I don't know :disappointed: 