### PR TITLE
NativeConstantInvocationFixer - better constant detection

### DIFF
--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -152,6 +152,13 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
             ['<?php class Foo { function bar() { $this->M_PI(self::M_PI); } }'],
             ['<?php namespace Foo; use M_PI;'],
             ['<?php namespace Foo; use Bar as M_PI;'],
+            ['<?php echo Foo\\M_PI\\Bar;'],
+            ['<?php M_PI::foo();'],
+            ['<?php function x(M_PI $foo, M_PI &$bar, M_PI ...$baz) {}'],
+            ['<?php $foo instanceof M_PI;'],
+            ['<?php class x implements FOO, M_PI, BAZ {}'],
+            ['<?php class Foo { use Bar, M_PI { Bar::baz insteadof M_PI; } }'],
+            ['<?php M_PI: goto M_PI;'],
             [
                 '<?php echo \\M_PI;',
                 '<?php echo M_PI;',
@@ -184,6 +191,29 @@ M_PI;
 echo M_PI;
 ',
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix70WithDefaultConfigurationCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     * @requires PHP 7.0
+     */
+    public function testFix70WithDefaultConfiguration($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFix70WithDefaultConfigurationCases()
+    {
+        return [
+            ['<?php function foo(): M_PI {}'],
+            ['<?php use X\Y\{FOO, BAR as BAR2, M_PI};'],
         ];
     }
 


### PR DESCRIPTION
Some previous failing test cases:

```php
M_PI::foo();

function foo(M_PI $a) {}

function foo(): M_PI {}

$foo instanceof M_PI;

class x implements FOO, BAR, BAZ {}

use X\Y\{FOO, BAR as BAR2, BAZ};

class Foo { use Bar, M_PI { Bar::baz insteadof M_PI; } }

M_PI: goto M_PI; // ;)
```