### PR TITLE
BinaryOperatorSpacesFixer - Add "no space" fix strategy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,7 +274,8 @@ Choose from the list of available rules:
     equals alignment; defaults to ``false``. DEPRECATED: use options
     ``operators`` and ``default`` instead
   - ``default`` (``'align'``, ``'align_single_space'``, ``'align_single_space_minimal'``,
-    ``'single_space'``, ``null``): default fix strategy; defaults to ``'single_space'``
+    ``'no_space'``, ``'single_space'``, ``null``): default fix strategy; defaults to
+    ``'single_space'``
   - ``operators`` (``array``): dictionary of ``binary operator`` => ``fix strategy``
     values that differ from the default strategy; defaults to ``[]``
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -401,6 +401,54 @@ $a//
                     );',
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE]],
             ],
+            [
+                '<?php
+                    $foo = 1+$bar;
+                ',
+                '<?php
+                    $foo  =  1 + $bar;
+                ',
+                [
+                    'default' => BinaryOperatorSpacesFixer::NO_SPACE,
+                    'operators' => ['=' => BinaryOperatorSpacesFixer::SINGLE_SPACE],
+                ],
+            ],
+            [
+                '<?php
+                    $foo = 1    +    $bar|$a;
+                ',
+                '<?php
+                    $foo  =  1    +    $bar | $a;
+                ',
+                [
+                    'default' => null,
+                    'operators' => [
+                        '=' => BinaryOperatorSpacesFixer::SINGLE_SPACE,
+                        '|' => BinaryOperatorSpacesFixer::NO_SPACE,
+                    ],
+                ],
+            ],
+            [
+                '<?php
+                    $foo = $d #
+  |
+ #
+$a|         // foo
+$b#
+   |$d;
+                ',
+                '<?php
+                    $foo           = $d #
+  |
+ #
+$a |         // foo
+$b#
+   | $d;
+                ',
+                [
+                    'operators' => ['|' => BinaryOperatorSpacesFixer::NO_SPACE],
+                ],
+            ],
         ];
     }
 
@@ -2072,9 +2120,14 @@ $a = $ae?? $b;
                 ',
                 ['operators' => ['=>' => BinaryOperatorSpacesFixer::ALIGN_SINGLE_SPACE_MINIMAL]],
             ],
-            'multiple exceptions catch' => [
+            'multiple exceptions catch, default config' => [
                 '<?php try {} catch (A | B $e) {}',
                 '<?php try {} catch (A   |     B $e) {}',
+            ],
+            'multiple exceptions catch, no space config' => [
+                '<?php try {} catch (A|B $e) {}',
+                '<?php try {} catch (A   |     B $e) {}',
+                ['operators' => ['|' => BinaryOperatorSpacesFixer::NO_SPACE]],
             ],
         ];
     }


### PR DESCRIPTION
closes #3827

also prepares for merging the `space around concat` fixers into the BinaryOperatorSpacesFixer