### PR TITLE
Add --default-indentation option to use other style of indentation su…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,8 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 
     $ php php-cs-fixer.phar fix /path/to/project --rules='{"concat_space": {"spacing": "none"}}'
 
+The ``--default-indentation`` option (e.g. pass ``"  "`` or ``"\t"``) will use given indentation instead of 4 spaces as default.
+
 The ``--dry-run`` flag will run the fixer without making changes to your files.
 
 The ``--diff`` flag can be used to let the fixer output all the changes it makes.

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,12 +21,13 @@ use PhpCsFixer\Fixer\FixerInterface;
  */
 class Config implements ConfigInterface
 {
+    private static $defaultIndent = '    ';
     private $cacheFile = '.php_cs.cache';
     private $customFixers = [];
     private $finder;
     private $format = 'txt';
     private $hideProgress = false;
-    private $indent = '    ';
+    private $indent; // default to $defaultIndent
     private $isRiskyAllowed = false;
     private $lineEnding = "\n";
     private $name;
@@ -37,6 +38,14 @@ class Config implements ConfigInterface
     public function __construct($name = 'default')
     {
         $this->name = $name;
+        $this->indent = Config::$defaultIndent;
+    }
+
+    /**
+     * Used by --default-indentation option.  Not recommend to be used in .php_cs config file.
+     */
+    public static function setDefaultIndent($indent) {
+        Config::$defaultIndent = $indent;
     }
 
     /**

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -102,6 +102,7 @@ final class FixCommand extends Command
                     new InputOption('path-mode', '', InputOption::VALUE_REQUIRED, 'Specify path mode (can be override or intersection).', 'override'),
                     new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, 'Are risky fixers allowed (can be yes or no).'),
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php_cs file.'),
+                    new InputOption('default-indentation', '', InputOption::VALUE_REQUIRED, 'The default indentation to use instead of 4 spaces (you should not change it, if you follow strict PSR2 rule)'),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                     new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'The rules.'),
                     new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no).'),
@@ -126,6 +127,10 @@ final class FixCommand extends Command
 
         $passedConfig = $input->getOption('config');
         $passedRules = $input->getOption('rules');
+
+        $indent = $input->getOption('default-indentation');
+        Config::setDefaultIndent($indent);
+        $this->defaultConfig->setIndent($indent);
 
         $resolver = new ConfigurationResolver(
             $this->defaultConfig,

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -99,6 +99,8 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 
     <info>$ php %command.full_name% /path/to/project --rules='{"concat_space": {"spacing": "none"}}'</info>
 
+The <comment>--default-indentation</comment> option (e.g. pass ``"  "`` or ``"\t"``) will use given indentation instead of 4 spaces as default.
+
 The <comment>--dry-run</comment> flag will run the fixer without making changes to your files.
 
 The <comment>--diff</comment> flag can be used to let the fixer output all the changes it makes.


### PR DESCRIPTION
…ch as 2 spaces. Useful for editor plugin to make it follow indentation of current document.

My use case is that I want to preserve the indentation style of an opened file (which is mostly using tabs originally), during some auto format tidying, such as when typing '}' will auto format the block by default.  I'm using vscode-php-cs-fixer, and I preferred --default-indentation to be passed by that plugin and give the opened file's current indentation.

Creating .php_cs config file, which could force the indentation to a single style, will not work either. It is because some newer files are changed to use 4 spaces indentation.  Letting an older file partially indentation with spaces & some with tabs seems awful.  Follow current file's major indentation is preferred in this project.