### PR TITLE
Add --default-indentation option to use other style of indentation su…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,8 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 
     $ php php-cs-fixer.phar fix /path/to/project --rules='{"concat_space": {"spacing": "none"}}'
 
+The ``--default-indentation`` option (e.g. pass ``"  "`` or ``"\t"``) will use given indentation instead of 4 spaces as default.
+
 The ``--dry-run`` flag will run the fixer without making changes to your files.
 
 The ``--diff`` flag can be used to let the fixer output all the changes it makes.

--- a/src/Config.php
+++ b/src/Config.php
@@ -26,7 +26,7 @@ class Config implements ConfigInterface
     private $finder;
     private $format = 'txt';
     private $hideProgress = false;
-    private $indent = '    ';
+    private $indent; // initializes to null for a state meaning not explicitly set -> getIndent() will return default '    '.  @see isIndentSet()
     private $isRiskyAllowed = false;
     private $lineEnding = "\n";
     private $name;
@@ -93,10 +93,22 @@ class Config implements ConfigInterface
 
     /**
      * {@inheritdoc}
+     *
+     * If setIndent() is not called with non-null indent, the indent given in
+     * fix command's --default-indentation option is used (for this class only).
+     * Otherwise, it use '    '.
      */
     public function getIndent()
     {
-        return $this->indent;
+        return null !== $this->indent ? $this->indent : '    ';
+    }
+
+    /**
+     * Check whether a (non-null) indent is set via setIndent().
+     */
+    public function isIndentSet()
+    {
+        return null !== $this->indent;
     }
 
     /**

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -102,6 +102,7 @@ final class FixCommand extends Command
                     new InputOption('path-mode', '', InputOption::VALUE_REQUIRED, 'Specify path mode (can be override or intersection).', 'override'),
                     new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, 'Are risky fixers allowed (can be yes or no).'),
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php_cs file.'),
+                    new InputOption('default-indentation', '', InputOption::VALUE_REQUIRED, 'The default indentation to use instead of 4 spaces (you should not change it, if you follow strict PSR2 rule)'),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
                     new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'The rules.'),
                     new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no).'),
@@ -132,6 +133,7 @@ final class FixCommand extends Command
             [
                 'allow-risky' => $input->getOption('allow-risky'),
                 'config' => $passedConfig,
+                'default-indentation' => $input->getOption('default-indentation'),
                 'dry-run' => $input->getOption('dry-run'),
                 'rules' => $passedRules,
                 'path' => $input->getArgument('path'),

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -99,6 +99,8 @@ Complete configuration for rules can be supplied using a ``json`` formatted stri
 
     <info>$ php %command.full_name% /path/to/project --rules='{"concat_space": {"spacing": "none"}}'</info>
 
+The <comment>--default-indentation</comment> option (e.g. pass ``"  "`` or ``"\t"``) will use given indentation instead of 4 spaces as default.
+
 The <comment>--dry-run</comment> flag will run the fixer without making changes to your files.
 
 The <comment>--diff</comment> flag can be used to let the fixer output all the changes it makes.

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -119,6 +119,7 @@ final class ConfigurationResolver
         'allow-risky' => null,
         'cache-file' => null,
         'config' => null,
+        'default-indentation' => null,
         'diff' => null,
         'diff-format' => null,
         'dry-run' => null,
@@ -167,6 +168,9 @@ final class ConfigurationResolver
 
         foreach ($options as $name => $value) {
             $this->setOption($name, $value);
+        }
+        if (null !== $this->options['default-indentation']) {
+            $this->defaultConfig->setIndent($this->options['default-indentation']);
         }
     }
 
@@ -241,6 +245,12 @@ final class ConfigurationResolver
 
             if (null === $this->config) {
                 $this->config = $this->defaultConfig;
+            } elseif (null !== $this->options['default-indentation']) {
+                if ($this->config instanceof \PhpCsFixer\Config) { // only support \PhpCsFixer\Config for --default-indentation option
+                    if (!$this->config->isIndentSet()) {
+                        $this->config->setIndent($this->options['default-indentation']);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
…ch as 2 spaces. Useful for editor plugin to make it follow indentation of current document.  (.php_cs config file's setIndent() still higher precedence)


Pull request update from this: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3834

BTW:  it allow editor plugin to config custom indent char (2 spaces or tab) without overhead of .php_cs