### PR TITLE
PhpdocAnnotationWithoutDotFixer - Handle trailing whitespaces

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -78,14 +78,14 @@ function foo ($bar) {}
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== Preg::match('/[.。]$/u', $content)
-                    || 0 !== Preg::match('/[.。](?!$)/u', $content, $matches)
+                    1 !== Preg::match('/[.。]\h*$/u', $content)
+                    || 0 !== Preg::match('/[.。](?!\h*$)/u', $content, $matches)
                 ) {
                     continue;
                 }
 
                 $endLine = $doc->getLine($annotation->getEnd());
-                $endLine->setContent(Preg::replace('/(?<![.。])[.。](\s+)$/u', '\1', $endLine->getContent()));
+                $endLine->setContent(Preg::replace('/(?<![.。])[.。]\h*(\H+)$/u', '\1', $endLine->getContent()));
 
                 $startLine = $doc->getLine($annotation->getStart());
                 $optionalTypeRegEx = $annotation->supportTypes()

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -139,6 +139,26 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      *                   and Returns `false` otherwise.
      */',
             ],
+            [
+                '<?php
+    /**
+     * @throws \Exception having whitespaces after dot, yet I am fixed
+     */',
+                '<?php
+    /**
+     * @throws \Exception having whitespaces after dot, yet I am fixed.   '.'
+     */',
+            ],
+            [
+                '<?php
+    /**
+     * @throws \Exception having tabs after dot, yet I am fixed
+     */',
+                '<?php
+    /**
+     * @throws \Exception having tabs after dot, yet I am fixed.		'.'
+     */',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Solves #3857 - I guess @SpacePossum will have some more fancy test cases.