### PR TITLE
Add the native_function_invocation fixer in the Symfony:risky ruleset

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -43,6 +43,7 @@ $config = PhpCsFixer\Config::create()
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'method_chaining_indentation' => true,
         'multiline_comment_opening_closing' => true,
+        'native_function_invocation' => false,
         'no_alternative_syntax' => true,
         'no_binary_string' => true,
         'no_extra_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],

--- a/README.rst
+++ b/README.rst
@@ -869,7 +869,7 @@ Choose from the list of available rules:
 
   Function defined by PHP should be called using the correct casing.
 
-* **native_function_invocation**
+* **native_function_invocation** [@Symfony:risky]
 
   Add leading ``\`` before function invocation to speed up resolving.
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
 
 /**
@@ -175,6 +176,10 @@ final class RuleSet implements RuleSetInterface
                     'PHP_SAPI',
                     'PHP_VERSION_ID',
                 ],
+            ],
+            'native_function_invocation' => [
+                'include' => [NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED],
+                'scope' => 'namespaced',
             ],
             'no_alias_functions' => true,
             'no_homoglyph_names' => true,


### PR DESCRIPTION
Symfony wants this fixer applied for compiler-optimized functions (we were the ones requesting the feature).