### PR TITLE
NativeConstantInvocationFixer - add the scope option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -864,6 +864,8 @@ Choose from the list of available rules:
     ``get_defined_constants``. User constants are not accounted in this list
     and must be specified in the include one; defaults to ``true``
   - ``include`` (``array``): list of additional constants to fix; defaults to ``[]``
+  - ``scope`` (``'all'``, ``'namespaced'``): only fix constant invocations that are made
+    within a namespace or fix all; defaults to ``'all'``
 
 * **native_function_casing** [@Symfony]
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -176,6 +176,7 @@ final class RuleSet implements RuleSetInterface
                     'PHP_SAPI',
                     'PHP_VERSION_ID',
                 ],
+                'scope' => 'namespaced',
             ],
             'native_function_invocation' => [
                 'include' => [NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED],

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -454,4 +454,46 @@ EOT;
 
         $this->doTest($expected, $input);
     }
+
+    public function testFixScopedOnly()
+    {
+        $this->fixer->configure(['scope' => 'namespaced']);
+
+        $expected = <<<'EOT'
+<?php
+
+namespace space1 {
+    echo \PHP_VERSION;
+}
+namespace {
+    echo PHP_VERSION;
+}
+EOT;
+
+        $input = <<<'EOT'
+<?php
+
+namespace space1 {
+    echo PHP_VERSION;
+}
+namespace {
+    echo PHP_VERSION;
+}
+EOT;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixScopedOnlyNoNamespace()
+    {
+        $this->fixer->configure(['scope' => 'namespaced']);
+
+        $expected = <<<'EOT'
+<?php
+
+echo PHP_VERSION . PHP_EOL;
+EOT;
+
+        $this->doTest($expected);
+    }
 }


### PR DESCRIPTION
Closes #3872 

The way to implement the option is heavily inspired by the existing feature in NativeFunctionInvocationFixer, except that I reused the NamespacesAnalyzer implementation instead of copy-pasting `\PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer::getUserDefinedNamespaces`

I also updated the Symfony ruleset to restrict the fixer to the namespaced scope as adding the `\` when the code is already in the global scope has no benefit for performance (as both cases are fully qualified) while increasing visual burden (which was the reason to limit it to only a few constants in the Symfony ruleset).