### PR TITLE
NamespacesAnalyzer - Optimize performance

### DIFF
--- a/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+++ b/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
@@ -29,7 +29,9 @@ final class NamespacesAnalyzer
     {
         $namespaces = [];
 
-        foreach ($tokens as $index => $token) {
+        for ($index = 1, $count = \count($tokens); $index < $count; ++$index) {
+            $token = $tokens[$index];
+
             if (!$token->isGivenKind(T_NAMESPACE)) {
                 continue;
             }
@@ -57,6 +59,9 @@ final class NamespacesAnalyzer
                 $index,
                 $scopeEndIndex
             );
+
+            // Continue the analysis after the end of this namespace to find the next one
+            $index = $scopeEndIndex;
         }
 
         if (0 === count($namespaces)) {


### PR DESCRIPTION
Instead of looping on all tokens, even inside the namespace it identified, the analyzer now continues the analysis after the end of the identified namespace, thanks to the fact that namespaces cannot be nested.

When implementing #3876, I compared the NamespacesAnalyzer implementation with `\PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer::getUserDefinedNamespaces`. The NamespacesAnalyzer also identifies the namespace name instead of skipping over it (and returns the global namespace too). But I found out that NativeFunctionInvocationFixer was more optimized, as it was not re-analyzing all tokens inside a namespace. This makes NamespacesAnalyzer implement the same optimization.