### PR TITLE
PhpdocAnnotationWithoutDotFixer - Handle empty line in comment

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -78,8 +78,8 @@ function foo ($bar) {}
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== Preg::match('/[.。]\h*$/u', $content)
-                    || 0 !== Preg::match('/[.。](?!\h*$)/u', $content, $matches)
+                    1 !== Preg::match('/[.。]\h*(\R|$)/u', $content)
+                    || 0 !== Preg::match('/[.。](?!\h*(\R|$))/u', $content, $matches)
                 ) {
                     continue;
                 }
@@ -92,9 +92,9 @@ function foo ($bar) {}
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes()), '/'))
                     : '';
                 $content = Preg::replaceCallback(
-                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)(\R|$)/',
                     static function (array $matches) {
-                        return $matches[1].strtolower($matches[2]).$matches[3];
+                        return $matches[1].strtolower($matches[2]).$matches[3].$matches[4];
                     },
                     $startLine->getContent(),
                     1

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -159,6 +159,36 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @throws \Exception having tabs after dot, yet I am fixed.		'.'
      */',
             ],
+            [
+                '<?php
+    /**
+     * This is a broken phpdoc
+     * @param string $str surprisingly, it is a string
+
+     */
+    function fixMe($str) {}',
+                '<?php
+    /**
+     * This is a broken phpdoc
+     * @param string $str Surprisingly, it is a string.
+
+     */
+    function fixMe($str) {}',
+            ],
+            [
+                '<?php
+    /**
+     * @return bool|null returns `true` if the class has a single-column ID
+                         Returns `false` otherwise.
+     */
+    function fixMe() {}',
+                '<?php
+    /**
+     * @return bool|null Returns `true` if the class has a single-column ID.
+                         Returns `false` otherwise.
+     */
+    function fixMe() {}',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Solves https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3857#issuecomment-402697765 - yet, feels too easy - I'm pessimistic about this one - can we easily trick it? @SpacePossum @dmvdbrugge what do you think?