### PR TITLE
NoSuperfluousPhpdocTagsFixer - handle null in every position

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -255,8 +255,8 @@ class Foo {
     /**
      * Normalizes types to make them comparable.
      *
-     * Converts given types to lowercase and replaces imports aliases with
-     * their matching FQCN.
+     * Converts given types to lowercase, replaces imports aliases with
+     * their matching FQCN, and finally sorts the result.
      *
      * @param array $types            The types to normalize
      * @param array $symbolShortNames The imports aliases
@@ -265,7 +265,7 @@ class Foo {
      */
     private function toComparableNames(array $types, array $symbolShortNames)
     {
-        return array_map(
+        $normalized = array_map(
             function ($type) use ($symbolShortNames) {
                 $type = strtolower($type);
 
@@ -277,5 +277,9 @@ class Foo {
             },
             $types
         );
+
+        sort($normalized);
+
+        return $normalized;
     }
 }

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -444,6 +444,24 @@ class Foo {
     public function doFoo(?Bar $bar): ?Baz {}
 }',
             ],
+            'same_nullable_typehint_reversed' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    public function doFoo(?Bar $bar): ?Baz {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @param null|Bar $bar
+     *
+     * @return null|Baz
+     */
+    public function doFoo(?Bar $bar): ?Baz {}
+}',
+            ],
             'same_nullable_typehint_with_description' => [
                 '<?php
 class Foo {


### PR DESCRIPTION
… instead of last only.

This fixes #3849