### PR TITLE
Fix handling /** and */ on the same line as the first and/or last annotation

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -248,7 +248,23 @@ class Annotation
     public function remove()
     {
         foreach ($this->lines as $line) {
-            $line->remove();
+            if ($line->isTheStart() && $line->isTheEnd()) {
+                // Single line doc block, remove entirely
+                $line->remove();
+            } elseif ($line->isTheStart()) {
+                // Multi line doc block, but start is on the same line as the first annotation, keep only the start
+                $content = Preg::replace('#(\s*/\*\*).*#', '$1', $line->getContent());
+
+                $line->setContent($content);
+            } elseif ($line->isTheEnd()) {
+                // Multi line doc block, but end is on the same line as the last annotation, keep only the end
+                $content = Preg::replace('#(\s*)\S.*(\*/.*)#', '$1$2', $line->getContent());
+
+                $line->setContent($content);
+            } else {
+                // Multi line doc block, neither start nor end on this line, can be removed safely
+                $line->remove();
+            }
         }
 
         $this->clearCache();
@@ -286,7 +302,7 @@ class Annotation
             }
 
             $matchingResult = Preg::match(
-                '{^(?:\s*\*|/\*\*)\s*@'.$name.'\s+'.self::REGEX_TYPES.'(?:\h.*)?$}sx',
+                '{^(?:\s*\*|/\*\*)\s*@'.$name.'\s+'.self::REGEX_TYPES.'(?:[*\h].*)?$}sx',
                 $this->lines[0]->getContent(),
                 $matches
             );

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -214,6 +214,58 @@ final class AnnotationTest extends TestCase
     }
 
     /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideRemoveEdgeCasesCases
+     */
+    public function testRemoveEdgeCases($expected, $input)
+    {
+        $doc = new DocBlock($input);
+        $annotation = $doc->getAnnotation(0);
+
+        $annotation->remove();
+        static::assertSame($expected, $doc->getContent());
+    }
+
+    public function provideRemoveEdgeCasesCases()
+    {
+        return [
+            // Single line
+            ['', '/** @return null*/'],
+            ['', '/** @return null */'],
+            ['', '/** @return null  */'],
+
+            // Multi line, annotation on start line
+            [
+                '/**
+                 */',
+                '/** @return null
+                 */',
+            ],
+            [
+                '/**
+                 */',
+                '/** @return null '.'
+                 */',
+            ],
+            // Multi line, annotation on end line
+            [
+                '/**
+                 */',
+                '/**
+                 * @return null*/',
+            ],
+            [
+                '/**
+                 */',
+                '/**
+                 * @return null */',
+            ],
+        ];
+    }
+
+    /**
      * @param string   $input
      * @param string[] $expected
      *

--- a/tests/Fixer/Phpdoc/PhpdocNoEmptyReturnFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoEmptyReturnFixerTest.php
@@ -63,6 +63,44 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    public function testFixNullWithEndOnSameLine()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @return null */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixNullWithEndOnSameLineNoSpace()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @return null*/
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
     public function testFixVoidCaseInsensitive()
     {
         $expected = <<<'EOF'


### PR DESCRIPTION
In both `Annotation::remove()` and `PhpdocNoEmptyReturnFixer`

This PR is sort-of combined with #3891