### PR TITLE
StrictParamFixer - fix edge case

### DIFF
--- a/src/Fixer/Strict/StrictParamFixer.php
+++ b/src/Fixer/Strict/StrictParamFixer.php
@@ -77,7 +77,7 @@ final class StrictParamFixer extends AbstractFixer
 
             $previousIndex = $tokens->getPrevMeaningfulToken($index);
             if (null !== $previousIndex && $tokens[$previousIndex]->isGivenKind(CT::T_FUNCTION_IMPORT)) {
-                return;
+                continue;
             }
 
             $lowercaseContent = strtolower($token->getContent());

--- a/tests/Fixer/Strict/StrictParamFixerTest.php
+++ b/tests/Fixer/Strict/StrictParamFixerTest.php
@@ -137,6 +137,24 @@ final class StrictParamFixerTest extends AbstractFixerTestCase
         public function __construct($foo, $bar) {}
     }',
             ],
+            [
+                '<?php
+    namespace Foo {
+        array_keys($foo, $bar, true);
+    }
+    namespace Bar {
+        use function Foo\LoremIpsum;
+        array_keys($foo, $bar, true);
+    }',
+                '<?php
+    namespace Foo {
+        array_keys($foo, $bar);
+    }
+    namespace Bar {
+        use function Foo\LoremIpsum;
+        array_keys($foo, $bar);
+    }',
+            ],
         ];
     }
 }


### PR DESCRIPTION
No matter how stupid, this is valid PHP syntax, so should be fixed, right?