### PR TITLE
PhpdocVarWithoutNameFixer - fix for properties only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1632,7 +1632,8 @@ Choose from the list of available rules:
 
 * **phpdoc_var_without_name** [@Symfony, @PhpCsFixer]
 
-  ``@var`` and ``@type`` annotations should not contain the variable name.
+  ``@var`` and ``@type`` annotations of classy properties should not contain
+  the name.
 
 * **pow_to_exponentiation** [@PHP56Migration:risky, @PHP70Migration:risky, @PHP71Migration:risky]
 

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -56,114 +56,237 @@ final class PhpdocVarWithoutNameFixerTest extends AbstractFixerTestCase
             'testFixVar' => [
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var string Hello!
      */
-
+    public $foo;
+}
 EOF
                 ,
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var string $foo Hello!
      */
-
+    public $foo;
+}
 EOF
                 ,
             ],
             'testFixType' => [
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var int|null
      */
-
+    public $bar;
+}
 EOF
                 ,
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var int|null $bar
      */
-
+    public $bar;
+}
 EOF
                 ,
             ],
             'testDoNothing' => [
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var Foo\Bar This is a variable.
      */
-
+    public $bar;
+}
 EOF
-            ],
-            'testFixVarWithOtherAnnotation' => [
-                <<<'EOF'
-<?php
-    /**
-     * @var string Hello!
-     *
-     * @deprecated
-     */
-
-EOF
-                ,
-                <<<'EOF'
-<?php
-    /**
-     * @var string $foo Hello!
-     *
-     * @deprecated
-     */
-
-EOF
-                ,
             ],
             'testFixVarWithNestedKeys' => [
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var array {
      *     @var bool   $required Whether this element is required
      *     @var string $label    The display name for this element
      * }
      */
-
+     public $options;
+}
 EOF
                 ,
                 <<<'EOF'
 <?php
+
+class Foo
+{
     /**
      * @var array $options {
      *     @var bool   $required Whether this element is required
      *     @var string $label    The display name for this element
      * }
      */
-
+     public $options;
+}
 EOF
             ],
             'testSingleLine' => [
                 <<<'EOF'
-                <?php
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar */
+    public $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
     /** @var Foo\Bar $bar */
-    $bar;
+    public $bar;
+}
 EOF
                 ,
             ],
-            'testEmpty' => [
+            'testSingleLineProtected' => [
                 <<<'EOF'
-                <?php
-    /**
-     *
-     */
+<?php
 
+class Foo
+{
+    /** @var Foo\Bar */
+    protected $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar $bar */
+    protected $bar;
+}
+EOF
+                ,
+            ],
+            'testSingleLinePrivate' => [
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar */
+    private $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar $bar */
+    private $bar;
+}
+EOF
+                ,
+            ],
+            'testSingleLineVar' => [
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar */
+    var $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar $bar */
+    var $bar;
+}
+EOF
+                ,
+            ],
+            'testSingleLineStatic' => [
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar */
+    static public $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar $bar */
+    static public $bar;
+}
+EOF
+                ,
+            ],
+            'testSingleLineNoSpace' => [
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar*/
+    public $bar;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /** @var Foo\Bar $bar*/
+    public $bar;
+}
 EOF
                 ,
             ],
             'testInlineDoc' => [
                 <<<'EOF'
-                <?php
+<?php
+
+class Foo
+{
     /**
      * Initializes this class with the given options.
      *
@@ -172,21 +295,206 @@ EOF
      *     @var string $label    The display name for this element
      * }
      */
-
+    public function init($options)
+    {
+        // Do something
+    }
+}
 EOF
                 ,
             ],
-            'testInlineDocAgain' => [
+            'testSingleLineNoProperty' => [
                 <<<'EOF'
 <?php
-    /**
-     * @param int[] $stuff {
-     *     @var int $foo
-     * }
-     *
-     * @return void
-     */
 
+/** @var Foo\Bar $bar */
+$bar;
+EOF
+            ],
+            'testMultiLineNoProperty' => [
+                <<<'EOF'
+<?php
+
+/**
+ * @var Foo\Bar $bar
+ */
+$bar;
+EOF
+            ],
+            'testVeryNestedInlineDoc' => [
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /**
+     * @var array {
+     *     @var array $secondLevelOne   {
+     *         {@internal This should not break}
+     *         @var int $thirdLevel
+     *     }
+     *     @var array $secondLevelTwo   {
+     *         @var array $thirdLevel     {
+     *             @var string $fourthLevel
+     *         }
+     *         @var int   $moreThirdLevel
+     *     }
+     *     @var int   $secondLevelThree
+     * }
+     */
+    public $nestedFoo;
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Foo
+{
+    /**
+     * @var array $nestedFoo {
+     *     @var array $secondLevelOne   {
+     *         {@internal This should not break}
+     *         @var int $thirdLevel
+     *     }
+     *     @var array $secondLevelTwo   {
+     *         @var array $thirdLevel     {
+     *             @var string $fourthLevel
+     *         }
+     *         @var int   $moreThirdLevel
+     *     }
+     *     @var int   $secondLevelThree
+     * }
+     */
+    public $nestedFoo;
+}
+EOF
+            ],
+            [
+                '<?php
+/**
+ * Header
+ */
+
+class A {} // for the candidate check
+
+/**
+ * @var ClassLoader $loader
+ */
+$loader = require __DIR__.\'/../vendor/autoload.php\';
+
+/**
+ * @var \Foo\Bar $bar
+ */
+$bar->doSomething(1);
+
+/**
+ * @var $bar \Foo\Bar
+ */
+$bar->doSomething(2);
+
+/**
+ * @var User $bar
+ */
+($bar = tmp())->doSomething(3);
+
+/**
+ * @var User $bar
+ */
+list($bar) = a();
+                ',
+            ],
+            [
+                '<?php
+class Foo
+{
+    /**
+     * @no_candidate string Hello!
+     */
+    public $foo;
+}
+',
+            ],
+            [
+                '<?php
+class Foo{}
+/**  */',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     * @dataProvider provideFixVar70Cases
+     *
+     * @param string $expected
+     * @param string $input
+     */
+    public function testFixVar70($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixVar70Cases()
+    {
+        return [
+            'anonymousClass' => [
+                <<<'EOF'
+<?php
+
+class Anon
+{
+    public function getNewAnon()
+    {
+        return new class()
+        {
+            /**
+             * @var string
+             */
+            public $stringVar;
+
+            public function getNewAnon()
+            {
+                return new class()
+                {
+                    /**
+                     * @var string
+                     */
+                    public $stringVar;
+                };
+            }
+        };
+    }
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class Anon
+{
+    public function getNewAnon()
+    {
+        return new class()
+        {
+            /**
+             * @var $stringVar string
+             */
+            public $stringVar;
+
+            public function getNewAnon()
+            {
+                return new class()
+                {
+                    /**
+                     * @var $stringVar string
+                     */
+                    public $stringVar;
+                };
+            }
+        };
+    }
+}
 EOF
                 ,
             ],

--- a/tests/Fixtures/Integration/misc/phpdoc_to_comment,phpdoc_var_without_name.test
+++ b/tests/Fixtures/Integration/misc/phpdoc_to_comment,phpdoc_var_without_name.test
@@ -8,19 +8,35 @@ Integration of fixers: phpdoc_to_comment,phpdoc_var_without_name.
 --EXPECT--
 <?php
 
-$first = true;// needed because by default first docblock is never fixed.
+/**
+ * File docblock needed because by default first docblock is never fixed.
+ */
 
 /**
- * @var ClassLoader
+ * Class Foo holds only the autoloader
  */
-$loader = require_once __DIR__.'/../app/autoload.php';
+class Foo
+{
+    /**
+     * @var ClassLoader
+     */
+    public $loader;
+}
 
 --INPUT--
 <?php
 
-$first = true;// needed because by default first docblock is never fixed.
+/**
+ * File docblock needed because by default first docblock is never fixed.
+ */
 
 /**
- * @var ClassLoader $loader
+ * Class Foo holds only the autoloader
  */
-$loader = require_once __DIR__.'/../app/autoload.php';
+class Foo
+{
+    /**
+     * @var ClassLoader $loader
+     */
+    public $loader;
+}


### PR DESCRIPTION
This fixes #3112