### PR TITLE
NoUnreachableDefaultArgumentValueFixer - remove `null` for nullable typehints

### DIFF
--- a/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+++ b/src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
@@ -99,7 +99,7 @@ function example($foo = "two words", $bar) {}
                 continue;
             }
 
-            if (!$token->equals('=') || $this->isTypehintedNullableVariable($tokens, $i)) {
+            if (!$token->equals('=') || $this->isNonNullableTypehintedNullableVariable($tokens, $i)) {
                 continue;
             }
 
@@ -164,7 +164,7 @@ function example($foo = "two words", $bar) {}
      *
      * @return bool
      */
-    private function isTypehintedNullableVariable(Tokens $tokens, $index)
+    private function isNonNullableTypehintedNullableVariable(Tokens $tokens, $index)
     {
         $nextToken = $tokens[$tokens->getNextMeaningfulToken($index)];
 
@@ -179,7 +179,11 @@ function example($foo = "two words", $bar) {}
 
         $prevIndex = $tokens->getPrevTokenOfKind($variableIndex, $searchTokens);
 
-        return $tokens[$prevIndex]->isGivenKind($typehintKinds);
+        if (!$tokens[$prevIndex]->isGivenKind($typehintKinds)) {
+            return false;
+        }
+
+        return !$tokens[$tokens->getPrevMeaningfulToken($prevIndex)]->isGivenKind(CT::T_NULLABLE_TYPE);
     }
 
     /**

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -192,4 +192,33 @@ $bar) {}',
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix71Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.1
+     */
+    public function testFix71($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideFix71cases()
+    {
+        return [
+            [
+                '<?php function foo (?Foo $bar, $baz) {}',
+                '<?php function foo (?Foo $bar = null, $baz) {}',
+            ],
+            [
+                '<?php function foo (?Foo $bar = null, ?Baz $baz = null) {}',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3883#issuecomment-402994377