### PR TITLE
Add FinalClassFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -639,6 +639,12 @@ Choose from the list of available rules:
   Converts implicit variables into explicit ones in double-quoted strings
   or heredoc syntax.
 
+* **final_class**
+
+  All classes must be final, except abstract ones and Doctrine entities.
+
+  *Risky rule: risky when subclassing non-abstract classes.*
+
 * **final_internal_class** [@PhpCsFixer:risky]
 
   Internal classes should be ``final``.
@@ -649,10 +655,13 @@ Choose from the list of available rules:
 
   - ``annotation-black-list`` (``array``): class level annotations tags that must be
     omitted to fix the class, even if all of the white list ones are used
-    as well. (case insensitive); defaults to ``['@final', '@Entity', '@ORM']``
+    as well. (case insensitive); defaults to ``['@final', '@Entity',
+    '@ORM\\Entity']``
   - ``annotation-white-list`` (``array``): class level annotations tags that must be
     set in order to fix the class. (case insensitive); defaults to
     ``['@internal']``
+  - ``consider-absent-docblock-as-internal-class`` (``bool``): should classes
+    without any DocBlock be fixed to final?; defaults to ``false``
 
 * **fopen_flag_order** [@Symfony:risky, @PhpCsFixer:risky]
 

--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ClassNotation;
+
+use PhpCsFixer\AbstractProxyFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ */
+final class FinalClassFixer extends AbstractProxyFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'All classes must be final, except abstract ones and Doctrine entities.',
+            [
+                new CodeSample(
+                    '<?php
+class MyApp {}
+'
+                ),
+            ],
+            'No exception and no configuration are intentional. Beside Doctrine entities and of course abstract classes, there is no single reason not to declare all classes final. '
+            .'If you want to subclass a class, mark the parent class as abstract and create two child classes, one empty if necessary: you\'ll gain much more fine grained type-hinting. '
+            .'If you need to mock a standalone class, create an interface, or maybe it\'s a value-object that shouldn\'t be mocked at all. '
+            .'If you need to extend a standalone class, create an interface and use the Composite pattern. '
+            .'If you aren\'t ready yet for serious OOP, go with FinalInternalClassFixer, it\'s fine.',
+            'Risky when subclassing non-abstract classes.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createProxyFixers()
+    {
+        $fixer = new FinalInternalClassFixer();
+        $fixer->configure([
+            'annotation-white-list' => [],
+            'consider-absent-docblock-as-internal-class' => true,
+        ]);
+
+        return [$fixer];
+    }
+}

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -20,6 +20,7 @@ use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symfony\Component\OptionsResolver\Options;
@@ -73,7 +74,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT]);
+        return $tokens->isTokenKindFound(T_CLASS);
     }
 
     /**
@@ -143,8 +144,12 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
             (new FixerOptionBuilder('annotation-black-list', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues($annotationsAsserts)
-                ->setDefault(['@final', '@Entity', '@ORM'])
+                ->setDefault(['@final', '@Entity', '@ORM\Entity'])
                 ->setNormalizer($annotationsNormalizer)
+                ->getOption(),
+            (new FixerOptionBuilder('consider-absent-docblock-as-internal-class', 'Should classes without any DocBlock be fixed to final?'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
                 ->getOption(),
         ]);
     }
@@ -157,23 +162,26 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
      */
     private function isClassCandidate(Tokens $tokens, $index)
     {
-        if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([T_ABSTRACT, T_FINAL])) {
+        if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind([T_ABSTRACT, T_FINAL, T_NEW])) {
             return false; // ignore class; it is abstract or already final
         }
 
         $docToken = $tokens[$tokens->getPrevNonWhitespace($index)];
 
         if (!$docToken->isGivenKind(T_DOC_COMMENT)) {
-            return false; // ignore class; it has no class-level PHPDoc
+            return $this->configuration['consider-absent-docblock-as-internal-class'];
         }
 
         $doc = new DocBlock($docToken->getContent());
         $tags = [];
 
         foreach ($doc->getAnnotations() as $annotation) {
-            $tag = strtolower($annotation->getTag()->getName());
-            if (isset($this->configuration['annotation-black-list'][$tag])) {
-                return false; // ignore class: class-level PHPDoc contains tag that has been black listed through configuration
+            Preg::match('/@\S+(?=\s|$)/', $annotation->getContent(), $matches);
+            $tag = strtolower(substr(array_shift($matches), 1));
+            foreach ($this->configuration['annotation-black-list'] as $tagStart => $true) {
+                if (0 === strpos($tag, $tagStart)) {
+                    return false; // ignore class: class-level PHPDoc contains tag that has been black listed through configuration
+                }
             }
 
             $tags[$tag] = true;

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ClassNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Filippo Tessarotto <zoeslam@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ClassNotation\FinalClassFixer
+ */
+final class FinalClassFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            ['<?php /** @Entity */ class MyEntity {}'],
+            ['<?php use Doctrine\ORM\Mapping as ORM; /** @ORM\Entity */ class MyEntity {}'],
+            ['<?php /** @entity */ class MyEntity {}'],
+            ['<?php use Doctrine\ORM\Mapping as ORM; /** @orm\entity */ class MyEntity {}'],
+            ['<?php abstract class MyAbstract {}'],
+            ['<?php trait MyTrait {}'],
+            ['<?php interface MyInterface {}'],
+            ['<?php echo Exception::class;'],
+            [
+                '<?php final class MyClass {}',
+                '<?php class MyClass {}',
+            ],
+            [
+                '<?php final class MyClass extends MyAbstract {}',
+                '<?php class MyClass extends MyAbstract {}',
+            ],
+            [
+                '<?php final class MyClass implements MyInterface {}',
+                '<?php class MyClass implements MyInterface {}',
+            ],
+            [
+                '<?php /** @codeCoverageIgnore */ final class MyEntity {}',
+                '<?php /** @codeCoverageIgnore */ class MyEntity {}',
+            ],
+            [
+                '<?php final class A {} abstract class B {} final class C {}',
+                '<?php class A {} abstract class B {} class C {}',
+            ],
+            [
+                '<?php /** @internal Map my app to an @Entity */ final class MyMapper {}',
+                '<?php /** @internal Map my app to an @Entity */ class MyMapper {}',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected PHP source code
+     * @param null|string $input    PHP source code
+     *
+     * @dataProvider provideFix70Cases
+     * @requires PHP 7.0
+     */
+    public function testFix70($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix70Cases()
+    {
+        return [
+            ['<?php $anonymClass = new class {};'],
+        ];
+    }
+}


### PR DESCRIPTION
Closes #3923 #3902 

Two notes:

#### 1. No exception and no configuration are intentional

Beside [Doctrine entities](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/architecture.html#entities) (and there are rumors that Doctrine 3 will allow final entities), and of course abstract classes, there is no single reason not to declare all classes final.

If you want to subclass a class, mark the parent class as abstract and create two child classes, one empty if necessary: you'll gain much more fine grained type-hinting.

If you need to mock a standalone class, create an interface, or maybe it's a value-object that shouldn't be mocked at all.

If you need to extend a standalone class, create an interface and use the composite pattern.

If you aren't ready yet for serious OOP, go with [FinalInternalClassFixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3183), it's fine.

Further reading: [When to declare classes final](https://ocramius.github.io/blog/when-to-declare-classes-final/)

#### 2. Doctrine entities detection is brittle as of yet

- [x] Please point me out how to improve import and use detection for Doctrine Entities: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/basic-mapping.html
I don't have the full picture on how they can be marked as such, and how this projects handles import detections