### PR TITLE
Run NoSuperfluousPhpdocTagsFixer before PhpdocAddMissingParamAnnotationFixer

### DIFF
--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -129,7 +129,7 @@ function my_foo()
     {
         // should be run after PhpdocScalarFixer.
         // should be run before ReturnTypeDeclarationFixer, FullyQualifiedStrictTypesFixer, NoSuperfluousPhpdocTagsFixer.
-        return 8;
+        return 12;
     }
 
     /**

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -62,8 +62,8 @@ class Foo {
      */
     public function getPriority()
     {
-        // should run before NoEmptyPhpdocFixer
-        return 6;
+        // should run before NoEmptyPhpdocFixer and PhpdocAddMissingParamAnnotationFixer
+        return 11;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -107,7 +107,7 @@ class Sample
     public function getPriority()
     {
         // must run before NoSuperfluousPhpdocTagsFixer
-        return 10;
+        return 12;
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -128,6 +128,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_spaces_after_function_name'], $fixers['function_to_constant']],
             [$fixers['no_spaces_inside_parenthesis'], $fixers['function_to_constant']],
             [$fixers['no_superfluous_phpdoc_tags'], $fixers['no_empty_phpdoc']],
+            [$fixers['no_superfluous_phpdoc_tags'], $fixers['phpdoc_add_missing_param_annotation']],
             [$fixers['no_unneeded_control_parentheses'], $fixers['no_trailing_whitespace']],
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_else']],
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_return']],

--- a/tests/Fixtures/Integration/priority/no_superfluous_phpdoc_tags,phpdoc_add_missing_param_annotation.test
+++ b/tests/Fixtures/Integration/priority/no_superfluous_phpdoc_tags,phpdoc_add_missing_param_annotation.test
@@ -1,0 +1,24 @@
+--TEST--
+Integration of fixers: no_superfluous_phpdoc_tags,phpdoc_add_missing_param_annotation.
+--RULESET--
+{"no_superfluous_phpdoc_tags": true, "phpdoc_add_missing_param_annotation": true}
+--EXPECT--
+<?php
+
+class Foo {
+    /**
+     * Foo method
+     * @param mixed $bar
+     */
+    public function doFoo($bar) {}
+}
+
+--INPUT--
+<?php
+
+class Foo {
+    /**
+     * Foo method
+     */
+    public function doFoo($bar) {}
+}


### PR DESCRIPTION
PhpdocAddMissingParamAnnotationFixer adds missing parameter with `mixed` type but NoSuperfluousPhpdocTagsFixer considers it is superfluous and remove it.