### PR TITLE
Add allow_untyped option to NoSuperfluousPhpdocTagsFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1047,6 +1047,11 @@ Choose from the list of available rules:
   Removes ``@param`` and ``@return`` tags that don't provide any useful
   information.
 
+  Configuration options:
+
+  - ``allow_untyped`` (``bool``): whether to remove superfluous ``@param`` annotations
+    for parameters with specified type only; defaults to ``false``
+
 * **no_trailing_comma_in_list_call** [@Symfony]
 
   Remove trailing commas in list function calls.

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -24,11 +24,14 @@ final class NoSuperfluousPhpdocTagsFixerTest extends AbstractFixerTestCase
     /**
      * @param string      $expected
      * @param null|string $input
+     * @param null|array  $config
      *
      * @dataProvider provideFixCases
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $config = null)
     {
+        $this->fixer->configure($config ?: ['allow_untyped' => false]);
+
         $this->doTest($expected, $input);
     }
 
@@ -102,6 +105,19 @@ class Foo {
      */
     public function doFoo($bar) {}
 }',
+            ],
+            'no typehint mixed allow untyped' => [
+                '<?php
+class Foo {
+    /**
+     * @param mixed $bar
+     *
+     * @return mixed
+     */
+    public function doFoo($bar) {}
+}',
+                null,
+                ['allow_untyped' => true],
             ],
             'multiple different types' => [
                 '<?php


### PR DESCRIPTION
This PR continues #3930.
I described my point of view in that PR conversation.