### PR TITLE
Add .gitignore and .gitattributes support to the config by the Finder

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -31,6 +31,7 @@ class Finder extends BaseFinder
             ->ignoreDotFiles(true)
             ->ignoreVCS(true)
             ->exclude('vendor')
+            ->exclude('node_modules')
         ;
     }
 }


### PR DESCRIPTION
Many PHP projects use NPM to build frontend assets. NPM installs third party packages to the `node_modules` directory. These packages sometimes contain PHP files, for example jquery-ui examples. Avoid running php-cs-fixer on these files in the default configuration.