### PR TITLE
DX: cleanup - fixing PHPDoc types in ConfigInterface

### DIFF
--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -37,7 +37,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable|\Traversable
+     * @return iterable|\SplFileInfo[]|\Traversable
      */
     public function getFinder();
 
@@ -121,7 +121,7 @@ interface ConfigInterface
     public function setCacheFile($cacheFile);
 
     /**
-     * @param iterable|string[]|\Traversable $finder
+     * @param iterable|\SplFileInfo[]|\Traversable $finder
      *
      * @return self
      */


### PR DESCRIPTION
Solves https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3917

Simply following the https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3917#issuecomment-408616281