### PR TITLE
NoTrailingWhitespaceFixer - trim space after opening tag

### DIFF
--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -62,17 +62,37 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
+        for ($index = count($tokens) - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+            if (
+                $token->isGivenKind(T_OPEN_TAG)
+                && $tokens->offsetExists($index + 1)
+                && $tokens[$index + 1]->isWhitespace()
+                && 1 === Preg::match('/(.*)\h$/', $token->getContent(), $openTagMatches)
+                && 1 === Preg::match('/^(\R)(.*)$/s', $tokens[$index + 1]->getContent(), $whitespaceMatches)
+            ) {
+                $tokens[$index] = new Token([T_OPEN_TAG, $openTagMatches[1].$whitespaceMatches[1]]);
+                if ('' === $whitespaceMatches[2]) {
+                    $tokens->clearAt($index + 1);
+                } else {
+                    $tokens[$index + 1] = new Token([T_WHITESPACE, $whitespaceMatches[2]]);
+                }
+
+                continue;
+            }
+
             if (!$token->isWhitespace()) {
                 continue;
             }
 
-            $lines = Preg::split("/([\r\n]+)/", $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+            $lines = Preg::split('/(\\R+)/', $token->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
             $linesSize = count($lines);
 
             // fix only multiline whitespaces or singleline whitespaces at the end of file
             if ($linesSize > 1 || !isset($tokens[$index + 1])) {
-                $lines[0] = rtrim($lines[0], " \t");
+                if (!$tokens[$index - 1]->isGivenKind(T_OPEN_TAG) || 1 !== Preg::match('/(.*)\R$/', $tokens[$index - 1]->getContent())) {
+                    $lines[0] = rtrim($lines[0], " \t");
+                }
 
                 for ($i = 1; $i < $linesSize; ++$i) {
                     $trimmedLine = rtrim($lines[$i], " \t");

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -96,6 +96,44 @@ EOT;
             [
                 "<?php\necho <<<'EOT'\nInline Il y eut un   \r\nrire éclatant    \n     \n   \r\nEOT;\n\n",
             ],
+            [
+                "<?php\necho 'Hello World';",
+                "<?php \necho 'Hello World';",
+            ],
+            [
+                "<?php\n\necho 'Hello World';",
+                "<?php \n\necho 'Hello World';",
+            ],
+            [
+                "<?php\r\necho 'Hello World';",
+                "<?php \r\necho 'Hello World';",
+            ],
+            [
+                "<?php\necho 'Hello World';",
+                "<?php  \necho 'Hello World';",
+            ],
+            [
+                "<?php\necho 'Hello World';",
+                "<?php	\necho 'Hello World';",
+            ],
+            [
+                '<?php ',
+                '<?php  ',
+            ],
+            [
+                "<?php\t",
+                "<?php\t\t",
+            ],
+            [
+                '<?php ', // do not trim this as "<?php" is not valid PHP
+            ],
+            [
+                "<?php\n      \n   \n    ",
+            ],
+            [
+                "<?php\n   \n    ",
+                "<?php      \n   \n    ",
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3956

That's what I call edge case :)

The iteration over `$tokens` has to be reversed, so the whitespace after the `T_OPEN_TAG` is already trimmed (otherwise we could replace space with another space) when handing the open tag.