### PR TITLE
remove complete line if becomes empty after removal

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,5 +48,8 @@ parameters:
         -
             message: '/^Parameter #1 \$finder of method PhpCsFixer\\Config::setFinder\(\) expects iterable<string>, int given\.$/'
             path: tests/ConfigTest.php
+        -
+            message: '/^Strict comparison using === between false and string will always evaluate to false\.$/'
+            path: src/Tokenizer/Manipulator/TokenRemover.php
         - '/has no return typehint specified\.$/'
     tipsOfTheDay: false

--- a/src/Tokenizer/Manipulator/TokenRemover.php
+++ b/src/Tokenizer/Manipulator/TokenRemover.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Manipulator;
+
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ */
+final class TokenRemover
+{
+    /**
+     * @var Tokens
+     */
+    private $tokens;
+
+    public function __construct(Tokens $tokens)
+    {
+        $this->tokens = $tokens;
+    }
+
+    public function clearToken($index)
+    {
+        $previous = $this->tokens->getNonEmptySibling($index, -1);
+        $next = $this->tokens->getNonEmptySibling($index, 1);
+
+        // --- if nothing before the token check space after it ----------
+
+        if (null === $previous) {
+            // remove trailing space if any
+            if (false === strpos($this->tokens[$index]->getContent(), "\n") && null !== $next && $this->tokens[$next]->isWhitespace()) {
+                $linebreakAfterTokenStrIndex = strpos($this->tokens[$next]->getContent(), "\n");
+
+                if (false === $linebreakAfterTokenStrIndex) {
+                    if (null === $this->tokens->getNonEmptySibling($next, 1)) {
+                        $this->tokens->clearTokenAndMergeSurroundingWhitespace($next);
+                    }
+                } else {
+                    $newContent = substr($this->tokens[$next]->getContent(), $linebreakAfterTokenStrIndex + 1);
+
+                    if ('' === $newContent || false === $newContent) { // false check for PHP5.6
+                        $this->tokens->clearTokenAndMergeSurroundingWhitespace($next);
+                    } else {
+                        $this->tokens[$next] = new Token([T_WHITESPACE, $newContent]);
+                    }
+                }
+            }
+
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+            return;
+        }
+
+        // --- check space before the token ------------------------------
+
+        if (!$this->tokens[$previous]->isWhitespace() && !$this->tokens[$previous]->isGivenKind(T_OPEN_TAG)) {
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+            return; // there is more content on the same line before the token
+        }
+
+        $prePrevious = null;
+        $linebreakBeforeTokenStrIndex = strrpos($this->tokens[$previous]->getContent(), "\n");
+
+        if (false === $linebreakBeforeTokenStrIndex && $this->tokens[$previous]->isWhitespace()) {
+            // test for open tag with line break followed by space without linebreak followed by token to remove
+            $prePrevious = $this->tokens->getNonEmptySibling($previous, -1);
+
+            if (null !== $prePrevious) {
+                $linebreakBeforeTokenStrIndex = strpos($this->tokens[$prePrevious]->getContent(), "\n");
+            }
+        }
+
+        if (false === $linebreakBeforeTokenStrIndex) {
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+            return; // there is more content on the same line before the token
+        }
+
+        // --- check space after the token -------------------------------
+
+        $linebreakAfterTokenStrIndex = false;
+
+        if (null !== $next) {
+            if (!$this->tokens[$next]->isWhitespace()) {
+                $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+                return; // more content on the same line after the token
+            }
+
+            $linebreakAfterTokenStrIndex = strpos($this->tokens[$next]->getContent(), "\n");
+
+            if (false === $linebreakAfterTokenStrIndex && null !== $this->tokens->getNonEmptySibling($next, 1)) {
+                $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+                return; // more content on the same line after the token (here trailing space that is not the last token)
+            }
+        }
+
+        // --- clear line break before the token -------------------------
+
+        if (null !== $prePrevious) {
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($previous);
+
+            // open tag -> space without line break -> token -> [nothing/trailing space with or without line break]
+            if (null === $next || false === $linebreakAfterTokenStrIndex) {
+                $this->tokens[$prePrevious] = new Token([T_OPEN_TAG, rtrim($this->tokens[$prePrevious]->getContent()).' ']);
+            } else {
+                // remove the line break from the next space token and not from the open tag
+                $newContent = substr($this->tokens[$next]->getContent(), $linebreakAfterTokenStrIndex + 1);
+                if ('' === $newContent || false === $newContent) { // false check for PHP5.6
+                    $this->tokens->clearTokenAndMergeSurroundingWhitespace($next);
+                } else {
+                    $this->tokens[$next] = new Token([T_WHITESPACE, $newContent]);
+                }
+
+                $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+                return; // return because both before and after the token has been dealt with
+            }
+        } elseif ($this->tokens[$previous]->isGivenKind(T_OPEN_TAG)) {
+            if (null === $next || false === $linebreakAfterTokenStrIndex) {
+                $this->tokens[$previous] = new Token([T_OPEN_TAG, rtrim($this->tokens[$previous]->getContent()).' ']);
+            } else {
+                // remove the line break from the next space token and not from the open tag
+                $newContent = substr($this->tokens[$next]->getContent(), $linebreakAfterTokenStrIndex + 1);
+
+                if ('' === $newContent || false === $newContent) { // false check for PHP5.6
+                    $this->tokens->clearTokenAndMergeSurroundingWhitespace($next);
+                } else {
+                    $this->tokens[$next] = new Token([T_WHITESPACE, $newContent]);
+                }
+
+                $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+                return; // return because both before and after the token has been dealt with
+            }
+        } else {
+            $newContent = substr($this->tokens[$previous]->getContent(), 0, $linebreakBeforeTokenStrIndex);
+
+            if ('' === $newContent) {
+                $this->tokens->clearTokenAndMergeSurroundingWhitespace($previous);
+            } else {
+                $this->tokens[$previous] = new Token([T_WHITESPACE, $newContent]);
+            }
+        }
+
+        // --- clear trailing space after token if any -------------------
+
+        if (null === $next) {
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+            return;
+        }
+
+        if (false === $linebreakAfterTokenStrIndex) {
+            $this->tokens->clearTokenAndMergeSurroundingWhitespace($next);
+        } else {
+            $this->tokens[$next] = new Token([T_WHITESPACE, substr($this->tokens[$next]->getContent(), $linebreakAfterTokenStrIndex)]);
+        }
+
+        $this->tokens->clearTokenAndMergeSurroundingWhitespace($index);
+    }
+}

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1228,13 +1228,21 @@ class Tokens extends \SplFixedArray
 
         $prevIndex = $this->getNonEmptySibling($index, -1);
 
-        if ($this[$prevIndex]->isWhitespace()) {
-            $this[$prevIndex] = new Token([T_WHITESPACE, $this[$prevIndex]->getContent().$this[$nextIndex]->getContent()]);
-        } elseif ($this->isEmptyAt($prevIndex + 1)) {
-            $this[$prevIndex + 1] = new Token([T_WHITESPACE, $this[$nextIndex]->getContent()]);
+        if (null === $prevIndex) {
+            return;
         }
 
-        $this->clearAt($nextIndex);
+        if ($this[$prevIndex]->isWhitespace()) { // merge space tokens
+            $this[$prevIndex] = new Token([T_WHITESPACE, $this[$prevIndex]->getContent().$this[$nextIndex]->getContent()]);
+            $this->clearAt($nextIndex);
+
+            return;
+        }
+
+        if ($this->isEmptyAt($prevIndex + 1)) { // move space token to before cleaned tokens
+            $this[$prevIndex + 1] = new Token([T_WHITESPACE, $this[$nextIndex]->getContent()]);
+            $this->clearAt($nextIndex);
+        }
     }
 
     private function removeWhitespaceSafely($index, $direction, $whitespaces = null)

--- a/tests/Tokenizer/Manipulator/TokenRemoverTest.php
+++ b/tests/Tokenizer/Manipulator/TokenRemoverTest.php
@@ -1,0 +1,647 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Manipulator;
+
+use PhpCsFixer\Tests\Test\Assert\AssertTokensTrait;
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Manipulator\TokenRemover;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\Manipulator\TokenRemover
+ */
+final class TokenRemoverTest extends TestCase
+{
+    use AssertTokensTrait;
+
+    /**
+     * @param int[]  $indexes  token index to clear
+     * @param string $expected PHP source expected after clearing
+     * @param string $input    PHP source input
+     *
+     * @dataProvider provideClearTokenCases
+     */
+    public function testClearToken(array $indexes, $expected, $input)
+    {
+        Tokens::clearCache();
+        $tokens = Tokens::fromCode($input);
+        $expectedTokens = Tokens::fromCode($expected);
+
+        $remover = new TokenRemover($tokens);
+
+        foreach ($indexes as $index) {
+            $remover->clearToken($index);
+        }
+
+        $tokens->clearEmptyTokens();
+        static::assertSame($expectedTokens->generateCode(), $tokens->generateCode());
+        static::assertTokens($expectedTokens, $tokens);
+    }
+
+    public function provideClearTokenCases()
+    {
+        $cases = [
+            [
+                [2],
+                '<?php
+/* other comment
+ */
+',
+                '<?php
+/* other comment
+ *//* to remove */
+',
+            ],
+            [
+                [1],
+                '<?php
+/* */',
+                '<?php
+/* remove */ '.'
+/* */',
+            ],
+            [
+                [6],
+                '<?php
+                    echo 12;
+                ',
+                '<?php
+                    echo 12;//
+                ',
+            ],
+            [
+                [2],
+                '<?php ',
+                '<?php
+   // 1100',
+            ],
+            '1011/' => [
+                [2],
+                '<?php ',
+                '<?php
+   /* 1011 */  ',
+            ],
+            '1010/' => [
+                [2],
+                '<?php
+',
+                '<?php
+   /* 1010 */
+',
+            ],
+            '1013/' => [
+                [2],
+                '<?php
+ echo 1;',
+                '<?php
+   /* 1013 */
+ echo 1;',
+            ],
+            [
+                [1],
+                '<?php
+ echo 100;
+',
+                '<?php
+/* */      '.'
+ echo 100;
+',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php
+/* */   ',
+            ],
+            [
+                [1],
+                '<?php
+',
+                '<?php
+/* */   '.'
+',
+            ],
+            [
+                [1],
+                '<?php   echo 1;',
+                '<?php /* */  echo 1;',
+            ],
+            [
+                [1],
+                '<?php
+ echo 1;',
+                '<?php
+/* */ echo 1;',
+            ],
+            [
+                [1],
+                '<?php
+echo 1;',
+                '<?php
+/* */echo 1;',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php
+/* */',
+            ],
+            [
+                [0],
+                '',
+                '<?php',
+            ],
+            [
+                [7],
+                '<?php
+                    echo 2;
+                      echo 122;
+                ',
+                '<?php
+                    echo 2;
+                    /* */  echo 122;
+                ',
+            ],
+            [
+                [7],
+                '<?php
+                    echo 27;
+                    echo 1;
+                ',
+                '<?php
+                    echo 27;
+                    /* */echo 1;
+                ',
+            ],
+            [
+                [5],
+                '<?php echo 18;
+echo 28;',
+                '<?php echo 18;/* */
+echo 28;',
+            ],
+            [
+                [6],
+                '<?php echo 19;    '.'
+echo 29;',
+                '<?php echo 19;  /* */  '.'
+echo 29;',
+            ],
+            [
+                [6],
+                '<?php
+echo 11;    '.'
+echo 21;
+                ',
+                '<?php
+echo 11;    '.'
+# 1
+echo 21;
+                ',
+            ],
+            [
+                [6],
+                '<?php
+echo 71;
+    '.'
+  ',
+                '<?php
+echo 71;
+        /* 1 */   '.'
+    '.'
+  ',
+            ],
+            [
+                [6],
+                '<?php
+echo 81;',
+                '<?php
+echo 81;
+        /* 1 */',
+            ],
+            [
+                [6],
+                '<?php
+echo 91;',
+                '<?php
+echo 91;
+        /* 1 */                              ',
+            ],
+            [
+                [6],
+                '<?php
+echo 61;
+echo 62;
+                ',
+                '<?php
+echo 61;
+        # 1
+echo 62;
+                ',
+            ],
+            [
+                [6],
+                '<?php
+echo 511;
+  echo 512;
+                ',
+                '<?php
+echo 511;
+# 1
+  echo 512;
+                ',
+            ],
+            [
+                [6],
+                '<?php
+echo 51;
+echo 52;
+                ',
+                '<?php
+echo 51;
+# 1
+echo 52;
+                ',
+            ],
+            [
+                [4],
+                '<?php
+
+ # A8
+ # B
+                ',
+                '<?php
+
+ # A8
+    ;    '.'
+ # B
+                ',
+            ],
+            [
+                [1],
+                '<?php
+',
+                '<?php
+;
+',
+            ],
+            [
+                [2],
+                '<?php ',
+                "<?php\n         ;",
+            ],
+            [
+                [1],
+                '<?php
+  '.'
+',
+                '<?php
+;
+  '.'
+',
+            ],
+            [
+                [3],
+                '<?php # 0',
+                '<?php # 0
+;',
+            ],
+            [
+                [3],
+                '<?php
+/* 1 */
+  ',
+                '<?php
+/* 1 */
+;
+  ',
+            ],
+            [
+                [3],
+                '<?php
+/* 1 */
+  # 1.2',
+                '<?php
+/* 1 */
+;
+  # 1.2',
+            ],
+            [
+                [4],
+                '<?php
+                /* 2 */  '.'
+                ',
+                '<?php
+                /* 2 */  ;
+                ',
+            ],
+            [
+                [3],
+                '<?php # 3
+    ',
+                '<?php # 3
+    '.'
+                ;',
+            ],
+            [
+                [2],
+                '<?php            ',
+                '<?php            ;',
+            ],
+            '5/' => [
+                [1],
+                '<?php ',
+                "<?php\n;",
+            ],
+            [
+                [3],
+                '<?php
+# A7
+# B7
+',
+                '<?php
+# A7
+;
+# B7
+',
+            ],
+            [
+                [4],
+                '<?php
+                # A9
+                # B
+                ',
+                '<?php
+                # A9
+                ;        '.'
+                # B
+                ',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php
+;     ',
+            ],
+            [
+                [2],
+                '<?php
+',
+                '<?php
+
+;     ',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php
+;',
+            ],
+            [
+                [3],
+                '<?php
+# a',
+                '<?php
+# a
+;     ',
+            ],
+            '16/' => [
+                [1],
+                '<?php
+ # 1
+',
+                '<?php
+; # 1
+',
+            ],
+            [
+                [3],
+                '<?php
+# 17a
+ # 18a
+',
+                '<?php
+# 17a
+; # 18a
+',
+            ],
+            [
+                [3],
+                '<?php
+# 17b
+  # 18b
+',
+                '<?php
+# 17b
+ ; # 18b
+',
+            ],
+            [
+                [3],
+                '<?php
+# 17c
+ # 18c
+',
+                '<?php
+# 17c
+ ;# 18c
+',
+            ],
+            [
+                [2],
+                '<?php
+/* 17d*/# 18d
+',
+                '<?php
+/* 17d*/;# 18d
+',
+            ],
+            [
+                [0],
+                '',
+                '<?php ',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php  ',
+            ],
+            [
+                [1],
+                '<?php ',
+                "<?php\n ",
+            ],
+            [
+                [2],
+                '<?php
+ '.'
+  '.'
+   '.'
+    '.'
+     '.'
+     '.'
+    '.'
+   '.'
+  '.'
+ ',
+                '<?php
+ '.'
+  '.'
+   '.'
+    '.'
+     '.'
+    # delete this line only 22
+     '.'
+    '.'
+   '.'
+  '.'
+ ',
+            ],
+            [
+                [1],
+                '<?php ',
+                '<?php
+;',
+            ],
+            [
+                [1],
+                '<?php
+# 1',
+                '<?php
+;# 1',
+            ],
+            [
+                [1],
+                '<?php
+ ;',
+                '<?php
+; ;',
+            ],
+            [
+                [1],
+                '<?php
+   #1',
+                '<?php
+;
+   #1',
+            ],
+            [
+                [1],
+                '<?php
+#2',
+                '<?php
+;
+#2',
+            ],
+            [
+                [1],
+                '<?php
+#3',
+                '<?php
+;#3',
+            ],
+            'A' => [
+                [2, 3, 4, 5],
+                '<?php
+                ',
+                '<?php
+                    /** A *//** B *//** C *//** D */
+                ',
+            ],
+            'B' => [
+                [3, 4, 5, 6, 7, 8, 10, 12, 14, 15, 16, 18, 20, 21, 22],
+                '<?php
+// 1
+// 2',
+                '<?php
+// 1
+/** A0 *//** B0 *//** C0 *//** D0 */
+                /** A1 */ /** B1 */ /** C1 */ /** D1 */
+            /** A2 */   /** B2 */     /** C2 */
+        /** D2 */
+// 2',
+            ],
+        ];
+
+        foreach ($cases  as $label => $test) {
+            yield $label => $test;
+
+            $test[0] = array_reverse($test[0]);
+
+            yield $label.' reversed' => $test;
+        }
+    }
+
+    /**
+     * @param int    $index    token index to clear
+     * @param string $expected PHP source expected after clearing
+     * @param string $input    PHP source input
+     *
+     * @dataProvider provideClearToken2Cases
+     */
+    public function testClearToken2($index, $expected, $input)
+    {
+        Tokens::clearCache();
+        $tokens = Tokens::fromCode($input);
+
+        $remover = new TokenRemover($tokens);
+        $remover->clearToken($index);
+
+        $tokens->clearEmptyTokens();
+
+        static::assertSame($expected, $tokens->generateCode());
+    }
+
+    public function provideClearToken2Cases()
+    {
+        return [
+            'A1' => [
+                0,
+                '',
+                '<?php ',
+            ],
+            'B1' => [
+                0,
+                '',
+                '<?php    ',
+            ],
+            'C1' => [
+                0,
+                '  ',
+                "<?php    \n  ",
+            ],
+            'C2' => [
+                0,
+                '',
+                "<?php    \n",
+            ],
+            'D1' => [
+                0,
+                'echo 1;',
+                "<?php\necho 1;",
+            ],
+            'D2' => [
+                0,
+                ' echo 12;',
+                "<?php\n echo 12;",
+            ],
+            'D3' => [
+                0,
+                " \necho 14;",
+                "<?php\n \necho 14;",
+            ],
+        ];
+    }
+}

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -349,6 +349,7 @@ PHP;
      */
     public function testMonolithicPhpDetection($source, $isMonolithic)
     {
+        Tokens::clearCache();
         $tokens = Tokens::fromCode($source);
         static::assertSame($isMonolithic, $tokens->isMonolithicPhp());
     }
@@ -611,6 +612,15 @@ PHP;
                 ],
             ],
         ];
+    }
+
+    public function testClearTokenAndMergeSurroundingWhitespaceEdgeCase()
+    {
+        Tokens::clearCache();
+        $tokens = Tokens::fromCode('<?php   ');
+        $tokens->clearTokenAndMergeSurroundingWhitespace(0);
+
+        static::assertSame('  ', $tokens->generateCode());
     }
 
     /**


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3604

This add a method ~~to the `Tokens` class~~ to remove a token and if that causes that the line on which the token was to become completely empty remove that line as well.
Adding this method is in the first commit, the naming is terrible IMHO but lets discuss if the naming is the issue or maybe we want some traits to bring this kind of functionality and not add it to the tokens class.

~~The other commits show some fixers that benefit from this new method.~~

~~There are a bunch of other candidate fixers that could use this new method (from the top of my head);~~
~~- useless elseif~~
~~- empty comment (blocked by transformer issue)~~
~~- header comment (when removing the header comment/PHPDoc)~~
~~- ReturnAssignmentFixer~~

~~I left those out because of other issues or just because I'm running out of time.~~