### PR TITLE
NoSuperfluousPhpdocTagsFixer - Fix handling of description with variable

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -108,7 +108,7 @@ class Foo {
             );
 
             foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
-                if (0 === Preg::match('/@param\s+(?:\S|\s(?!\$))+\s(\$\S+)/', $annotation->getContent(), $matches)) {
+                if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
                     continue;
                 }
 

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -270,6 +270,15 @@ class Foo {
  * Foo
  */',
             ],
+            'with_variable_in_description' => [
+                '<?php
+class Foo {
+    /**
+     * @param $foo Some description that includes a $variable
+     */
+    public function doFoo($foo) {}
+}',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #3976.