### PR TITLE
Run HeaderCommentFixer after NoBlankLinesAfterPhpdocFixer

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -112,6 +112,19 @@ echo 1;
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // should be run after the NoBlankLinesAfterPhpdocFixer.
+        //
+        // When this fixer is configured with ["separate" => "bottom", "commentType" => "PHPDoc"]
+        // and the target file has no namespace or declare() construct,
+        // the fixed header comment gets trimmed by NoBlankLinesAfterPhpdocFixer if we run before it.
+        return -30;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         // figure out where the comment should be placed

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -99,6 +99,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['method_separation'], $fixers['braces']],
             [$fixers['method_separation'], $fixers['indentation_type']],
             [$fixers['no_alias_functions'], $fixers['php_unit_dedicate_assert']],
+            [$fixers['no_blank_lines_after_phpdoc'], $fixers['header_comment']],
             [$fixers['no_blank_lines_after_phpdoc'], $fixers['single_blank_line_before_namespace']],
             [$fixers['no_empty_comment'], $fixers['no_extra_blank_lines']],
             [$fixers['no_empty_comment'], $fixers['no_trailing_whitespace']],

--- a/tests/Fixtures/Integration/priority/no_blank_lines_after_phpdoc,header_comment.test
+++ b/tests/Fixtures/Integration/priority/no_blank_lines_after_phpdoc,header_comment.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: no_blank_lines_after_phpdoc,header_comment.
+--RULESET--
+{"no_blank_lines_after_phpdoc": true, "header_comment": {"header": "Header", "commentType": "PHPDoc", "separate": "bottom"}}
+--EXPECT--
+<?php
+/**
+ * Header
+ */
+
+function F() {}
+
+--INPUT--
+<?php
+function F() {}


### PR DESCRIPTION
This ensures the output is stable when `HeaderCommentFixer` is configured with `["separate" => "bottom", "commentType" => "PHPDoc"]` and the target file has no `namespace` or `declare()` construct.

Test case added, test suite passes.