### PR TITLE
Change default config of native_function_invocation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -889,7 +889,7 @@ Choose from the list of available rules:
   - ``include`` (``array``): list of function names or sets to fix. Defined sets are
     ``@internal`` (all native functions), ``@all`` (all global functions) and
     ``@compiler_optimized`` (functions that are specially optimized by Zend);
-    defaults to ``['@internal']``
+    defaults to ``['@compiler_optimized']``
   - ``scope`` (``'all'``, ``'namespaced'``): only fix function calls that are made
     within a namespace or fix all; defaults to ``'all'``
   - ``strict`` (``bool``): whether leading ``\`` of function call not meant to have it

--- a/UPGRADE-v3.md
+++ b/UPGRADE-v3.md
@@ -63,5 +63,6 @@ Rule | Option | Old value | New value
 ---- | ---- | ---- | ----
 `function_to_constant` | `functions` | `['get_class', 'php_sapi_name', 'phpversion', 'pi']` | `['get_called_class', 'get_class', 'php_sapi_name', 'phpversion', 'pi']`
 `method_argument_space` | `on_multiline` | `'ignore'` | `'ensure_fully_multiline'`
+`native_function_invocation` | `include` | `@internal` | `@compiler_optimized`
 `php_unit_dedicate_assert` | `target` | `5.0` | `newest`
 `phpdoc_align` | `tags` | `['param', 'return', 'throws', 'type', 'var']` | `['method', 'param', 'property', 'return', 'throws', 'type', 'var']`

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -242,7 +242,7 @@ $c = get_class($d);
 
                     return true;
                 }])
-                ->setDefault([self::SET_INTERNAL])
+                ->setDefault([self::SET_COMPILER_OPTIMIZED])
                 ->getOption(),
             (new FixerOptionBuilder('scope', 'Only fix function calls that are made within a namespace or fix all.'))
                 ->setAllowedValues(['all', 'namespaced'])

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -73,7 +73,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
             'array' => [[]],
             'float' => [0.1],
             'object' => [new \stdClass()],
-            'not-trimmed' => ['  json_encode  '],
+            'not-trimmed' => ['  is_string  '],
         ];
     }
 
@@ -124,7 +124,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure([
             'exclude' => [
-                'json_encode',
+                'is_string',
             ],
         ]);
 
@@ -138,7 +138,7 @@ class Bar
     public function baz($foo)
     {
         if (isset($foo)) {
-            json_encode($foo);
+            is_string($foo);
         }
     }
 }
@@ -154,7 +154,7 @@ class Bar
     public function baz($foo)
     {
         if (isset($foo)) {
-            \json_encode($foo);
+            \is_string($foo);
         }
     }
 }
@@ -194,17 +194,17 @@ PHP;
             [
                 '<?php
 
-\json_encode($foo);
+\is_string($foo);
 ',
             ],
             [
                 '<?php
 
-\json_encode($foo);
+\is_string($foo);
 ',
                 '<?php
 
-json_encode($foo);
+is_string($foo);
 ',
             ],
             [
@@ -214,7 +214,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return \json_encode($foo);
+        return \is_string($foo);
     }
 }
 ',
@@ -226,7 +226,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return \JSON_ENCODE($foo);
+        return \IS_STRING($foo);
     }
 }
 ',
@@ -236,7 +236,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return JSON_ENCODE($foo);
+        return IS_STRING($foo);
     }
 }
 ',
@@ -272,7 +272,7 @@ echo strlen($a);
     {
         $this->fixer->configure([
             'exclude' => [
-                'json_encode',
+                'is_string',
             ],
         ]);
 
@@ -288,7 +288,7 @@ echo strlen($a);
             [
                 '<?php
 
-json_encode($foo);
+is_string($foo);
 ',
             ],
             [
@@ -298,7 +298,7 @@ class Foo
 {
     public function bar($foo)
     {
-        return json_encode($foo);
+        return is_string($foo);
     }
 }
 ',
@@ -340,44 +340,44 @@ namespace space1 { ?>
             [
                 '<?php
 namespace Bar {
-    echo \strtoLOWER("in 1");
+    echo \strLEN("in 1");
 }
 
 namespace {
-    echo strtolower("out 1");
+    echo strlen("out 1");
 }
 
 namespace {
-    echo strtolower("out 2");
+    echo strlen("out 2");
 }
 
 namespace Bar{
-    echo \strtolower("in 2");
+    echo \strlen("in 2");
 }
 
 namespace {
-    echo strtolower("out 3");
+    echo strlen("out 3");
 }
 ',
                 '<?php
 namespace Bar {
-    echo strtoLOWER("in 1");
+    echo strLEN("in 1");
 }
 
 namespace {
-    echo strtolower("out 1");
+    echo strlen("out 1");
 }
 
 namespace {
-    echo strtolower("out 2");
+    echo strlen("out 2");
 }
 
 namespace Bar{
-    echo strtolower("in 2");
+    echo strlen("in 2");
 }
 
 namespace {
-    echo strtolower("out 3");
+    echo strlen("out 3");
 }
 ',
             ],
@@ -386,17 +386,17 @@ namespace {
 namespace space11 ?>
 
     <?php
-echo \strtolower(__NAMESPACE__);
+echo \strlen(__NAMESPACE__);
 namespace space2;
-echo \strtolower(__NAMESPACE__);
+echo \strlen(__NAMESPACE__);
 ',
                 '<?php
 namespace space11 ?>
 
     <?php
-echo strtolower(__NAMESPACE__);
+echo strlen(__NAMESPACE__);
 namespace space2;
-echo strtolower(__NAMESPACE__);
+echo strlen(__NAMESPACE__);
 ',
             ],
             [
@@ -426,33 +426,33 @@ echo count([1]);
 ',
             ],
             [
-                '<?php namespace {echo strtolower("out 2");}',
+                '<?php namespace {echo strlen("out 2");}',
             ],
             [
                 '<?php
 namespace space13 {
-    echo \strtolower("in 1");
+    echo \strlen("in 1");
 }
 
 namespace space2 {
-    echo \strtolower("in 2");
+    echo \strlen("in 2");
 }
 
 namespace { // global
-    echo strtolower("global 1");
+    echo strlen("global 1");
 }
 ',
                 '<?php
 namespace space13 {
-    echo strtolower("in 1");
+    echo strlen("in 1");
 }
 
 namespace space2 {
-    echo strtolower("in 2");
+    echo strlen("in 2");
 }
 
 namespace { // global
-    echo strtolower("global 1");
+    echo strlen("global 1");
 }
 ',
             ],


### PR DESCRIPTION
According to the following comment of @nicolas-grekas, the default configuration of `native_function_invocation` should be changed to prepend a backslash only to functions that can be optimized by the PHP engine:

> Adding more functions as opcodes would make the engine slower, because routing more opcodes requires more CPU. So this will not happen :)
> The policy is to never add \, except when it provides a significant advantage, i.e. for those special functions that php-cs-fixer/fabbot handle.

https://github.com/symfony/panther/pull/61#discussion_r212794498

This PR changes the default config accordingly.

