### PR TITLE
NoSuperfluousPhpdocTagsFixer - Allow `mixed` in superfluous PHPDoc by configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1087,6 +1087,11 @@ Choose from the list of available rules:
   Removes ``@param`` and ``@return`` tags that don't provide any useful
   information.
 
+  Configuration options:
+
+  - ``allow_mixed`` (``bool``): whether type ``mixed`` without description is allowed
+    (``true``) or considered superfluous (``false``); defaults to ``false``
+
 * **no_trailing_comma_in_list_call** [@Symfony]
 
   Remove trailing commas in list function calls.

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -15,6 +15,9 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
@@ -25,7 +28,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-final class NoSuperfluousPhpdocTagsFixer extends AbstractFixer
+final class NoSuperfluousPhpdocTagsFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
      * {@inheritdoc}
@@ -132,6 +135,19 @@ class Foo {
 
             $tokens[$index] = new Token([T_DOC_COMMENT, $docBlock->getContent()]);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('allow_mixed', 'Whether type `mixed` without description is allowed (`true`) or considered superfluous (`false`)'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
+        ]);
     }
 
     private function findDocumentedFunction(Tokens $tokens, $index)
@@ -255,7 +271,7 @@ class Foo {
         $annotationTypes = $this->toComparableNames($annotation->getTypes(), $symbolShortNames);
 
         if (['mixed'] === $annotationTypes && null === $info['type']) {
-            return true;
+            return !$this->configuration['allow_mixed'];
         }
 
         $actualTypes = null === $info['type'] ? [] : [$info['type']];

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -602,4 +602,60 @@ class Foo {
             ],
         ];
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixWithAllowedMixedCases
+     */
+    public function testFixWithAllowedMixed($expected, $input = null)
+    {
+        $this->fixer->configure(['allow_mixed' => true]);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithAllowedMixedCases()
+    {
+        $cases = $this->provideFixCases();
+        $cases['no typehint mixed'] = [
+            '<?php
+class Foo {
+    /**
+     * @param mixed $bar
+     *
+     * @return mixed
+     */
+    public function doFoo($bar) {}
+}',
+        ];
+
+        return $cases;
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp70Cases
+     * @requires PHP 7.0
+     */
+    public function testFixPhp70WithAllowedMixed($expected, $input = null)
+    {
+        $this->fixer->configure(['allow_mixed' => true]);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp71Cases
+     * @requires PHP 7.1
+     */
+    public function testFixPhp71WithAllowedMixed($expected, $input = null)
+    {
+        $this->fixer->configure(['allow_mixed' => true]);
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Hello,

I'm facing a problem with `NoSuperfluousPhpdocTagsFixer`.

## Problem
When it is used with phpstan strict rules,  which needs an explicit annotation type even if it is mixed, I must choose either of them - or ignore the other.

## Solution
So I've decided to make a `NoSuperfluousPhpdocTagsFixer` configurable, to allow a `mixed` annotation for these cases.