### PR TITLE
BracesFixer - add "allow_single_line_anonymous_class_with_empty_body" option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,6 +329,9 @@ Choose from the list of available rules:
 
   Configuration options:
 
+  - ``allow_single_line_anonymous_class_with_empty_body`` (``bool``): whether single
+    line anonymous class with empty body notation should be allowed;
+    defaults to ``false``
   - ``allow_single_line_closure`` (``bool``): whether single line lambda notation
     should be allowed; defaults to ``false``
   - ``position_after_anonymous_constructs`` (``'next'``, ``'same'``): whether the

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -159,6 +159,10 @@ class Foo
     protected function createConfigurationDefinition()
     {
         return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('allow_single_line_anonymous_class_with_empty_body', 'Whether single line anonymous class with empty body notation should be allowed.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
             (new FixerOptionBuilder('allow_single_line_closure', 'Whether single line lambda notation should be allowed.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
@@ -311,6 +315,23 @@ class Foo
                 && $tokensAnalyzer->isWhilePartOfDoWhile($index)
             ) {
                 continue;
+            }
+
+            if (
+                $this->configuration['allow_single_line_anonymous_class_with_empty_body']
+                && $token->isGivenKind(T_CLASS)
+            ) {
+                $prevIndex = $tokens->getPrevMeaningfulToken($index);
+                if ($tokens[$prevIndex]->isGivenKind(T_NEW)) {
+                    $braceStartIndex = $tokens->getNextTokenOfKind($index, ['{']);
+                    $braceEndIndex = $tokens->getNextMeaningfulToken($braceStartIndex);
+
+                    if ('}' === $tokens[$braceEndIndex]->getContent() && !$this->isMultilined($tokens, $index, $braceEndIndex)) {
+                        $index = $braceEndIndex;
+
+                        continue;
+                    }
+                }
             }
 
             if (

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -65,6 +65,7 @@ final class RuleSet implements RuleSetInterface
                 'statements' => ['return'],
             ],
             'braces' => [
+                'allow_single_line_anonymous_class_with_empty_body' => true,
                 'allow_single_line_closure' => true,
             ],
             'cast_spaces' => true,

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -4718,6 +4718,47 @@ use const some\a\{ConstA, ConstB, ConstC};
                 null,
                 self::$configurationOopPositionSameLine + self::$configurationAnonymousPositionNextLine,
             ],
+            [
+                '<?php
+$foo = new class () extends \Exception {
+};
+',
+                '<?php
+$foo = new class () extends \Exception {};
+',
+            ],
+            [
+                '<?php
+$foo = new class () extends \Exception {};
+',
+                null,
+                ['allow_single_line_anonymous_class_with_empty_body' => true],
+            ],
+            [
+                '<?php
+$foo = new class() {}; // comment
+',
+                null,
+                ['allow_single_line_anonymous_class_with_empty_body' => true],
+            ],
+            [
+                '<?php
+$foo = new class() { /* comment */ }; // another comment
+',
+                null,
+                ['allow_single_line_anonymous_class_with_empty_body' => true],
+            ],
+            [
+                '<?php
+$foo = new class () extends \Exception {
+    protected $message = "Surprise";
+};
+',
+                '<?php
+$foo = new class () extends \Exception { protected $message = "Surprise"; };
+',
+                ['allow_single_line_anonymous_class_with_empty_body' => true],
+            ],
         ];
     }
 

--- a/tests/Fixtures/Integration/misc/PHP7_0.test
+++ b/tests/Fixtures/Integration/misc/PHP7_0.test
@@ -110,10 +110,8 @@ class Foo implements FooInterface
 }
 
 // anonymous class
-$message = (new class() {
-});
-$message = (new class() implements FooInterface {
-});
+$message = (new class() {});
+$message = (new class() implements FooInterface {});
 if (1) {
     $message = (new class() extends Foo {
         public function bar()


### PR DESCRIPTION
Resolves https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3989.

Regarding https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2782 - I cannot see how `ClassDefinitionFixer` is affecting braces.