### PR TITLE
Suppress warnings emitted by token_get_all

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1030,8 +1030,8 @@ class Tokens extends \SplFixedArray
         $this->setSize(0);
 
         $tokens = \defined('TOKEN_PARSE')
-            ? token_get_all($code, TOKEN_PARSE)
-            : token_get_all($code);
+            ? @token_get_all($code, TOKEN_PARSE)
+            : @token_get_all($code);
 
         $this->setSize(\count($tokens));
 


### PR DESCRIPTION
Hello, when `token_get_all()` encounters the octal sequence greater than `\377` it emits a warning.

See: https://wiki.php.net/rfc/octal.overload-checking

For example:

```php
<?php

var_dump("\542");
```
Emits this warning when running php-cs-fixer on such file:
```
Warning: Octal escape sequence overflow \542 is greater than \377
```

Thanks...