### PR TITLE
Add phpdoc_types_order rule to Symfony's ruleset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1520,7 +1520,7 @@ Choose from the list of available rules:
   - ``groups`` (a subset of ``['simple', 'alias', 'meta']``): type groups to fix;
     defaults to ``['simple', 'alias', 'meta']``
 
-* **phpdoc_types_order**
+* **phpdoc_types_order** [@Symfony]
 
   Sorts PHPDoc types.
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -140,6 +140,10 @@ final class RuleSet implements RuleSetInterface
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_types' => true,
+            'phpdoc_types_order' => [
+                'null_adjustment' => 'always_last',
+                'sort_algorithm' => 'none',
+            ],
             'phpdoc_var_without_name' => true,
             'protected_to_private' => true,
             'return_type_declaration' => true,


### PR DESCRIPTION
As suggested by @julienfalque in https://github.com/symfony/symfony/pull/28780, besides add this new rule due to https://github.com/symfony/symfony/pull/28675, we should also enforces it in Symfony's ruleset here too :blush: 