### PR TITLE
PhpdocAnnotationWithoutDotFixer - add failing cases

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -78,8 +78,8 @@ function foo ($bar) {}
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== Preg::match('/[.。]\h*(\R|$)/u', $content)
-                    || 0 !== Preg::match('/[.。](?!\h*(\R|$))/u', $content, $matches)
+                    1 !== Preg::match('/[.。]\h*$/u', $content)
+                    || 0 !== Preg::match('/[.。](?!\h*$)/u', $content, $matches)
                 ) {
                     continue;
                 }
@@ -92,9 +92,9 @@ function foo ($bar) {}
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes()), '/'))
                     : '';
                 $content = Preg::replaceCallback(
-                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)(\R|$)/',
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     static function (array $matches) {
-                        return $matches[1].strtolower($matches[2]).$matches[3].$matches[4];
+                        return $matches[1].strtolower($matches[2]).$matches[3];
                     },
                     $startLine->getContent(),
                     1

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -75,6 +75,15 @@ function foo ($bar) {}
                     continue;
                 }
 
+                $lineAfterAnnotation = $doc->getLine($annotation->getEnd() + 1);
+                if (null !== $lineAfterAnnotation) {
+                    $lineAfterAnnotationTrimmed = ltrim($lineAfterAnnotation);
+                    if ('' === $lineAfterAnnotationTrimmed || '*' !== $lineAfterAnnotationTrimmed[0]) {
+                        // malformed PHPDoc, missing asterisk !
+                        continue;
+                    }
+                }
+
                 $content = $annotation->getContent();
 
                 if (

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -56,6 +56,7 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @param string $ellipsis2  Ellipsis is this: 。。。
      * @param string $ellipsis3  Ellipsis is this: …
      * @param bool   $isStr      Is it a string?
+     * @param int    $int        Some single-line descrioption. With many dots.
      * @param int    $int        Some multiline
      *                           description. With many dots.
      *
@@ -81,6 +82,7 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @param string $ellipsis2  Ellipsis is this: 。。。
      * @param string $ellipsis3  Ellipsis is this: …
      * @param bool   $isStr      Is it a string?
+     * @param int    $int        Some single-line descrioption. With many dots.
      * @param int    $int        Some multiline
      *                           description. With many dots.
      *
@@ -178,16 +180,39 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
             [
                 '<?php
     /**
-     * @return bool|null returns `true` if the class has a single-column ID
-                         Returns `false` otherwise.
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string    $eventName The name of the event to dispatch. The name of the event is
+     *                             the name of the method that is invoked on listeners.
+     * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
+     *                             If not supplied, the single empty EventArgs instance is used.
+     *
+     * @return bool
      */
-    function fixMe() {}',
+    function dispatchEvent($eventName, EventArgs $eventArgs = null) {}
+
+    /**
+     * Extract the `object_to_populate` field from the context if it exists
+     * and is an instance of the provided $class.
+     *
+     * @param string $class   The class the object should be
+     * @param array  $context The denormalization context
+     * @param string $key     Key in which to look for the object to populate.
+     *                        Keeps backwards compatibility with `AbstractNormalizer`.
+     *
+     * @return null|object an object if things check out, null otherwise
+     */
+    function extractObjectToPopulate($class, array $context, $key = null) {}
+                ',
+            ],
+            [
                 '<?php
     /**
      * @return bool|null Returns `true` if the class has a single-column ID.
                          Returns `false` otherwise.
+                         That was multilined comment. With plenty of sentenced.
      */
-    function fixMe() {}',
+    function nothingToDo() {}',
             ],
         ];
     }

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -164,22 +164,6 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
             [
                 '<?php
     /**
-     * This is a broken phpdoc
-     * @param string $str surprisingly, it is a string
-
-     */
-    function fixMe($str) {}',
-                '<?php
-    /**
-     * This is a broken phpdoc
-     * @param string $str Surprisingly, it is a string.
-
-     */
-    function fixMe($str) {}',
-            ],
-            [
-                '<?php
-    /**
      * Dispatches an event to all registered listeners.
      *
      * @param string    $eventName The name of the event to dispatch. The name of the event is
@@ -204,6 +188,15 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      */
     function extractObjectToPopulate($class, array $context, $key = null) {}
                 ',
+            ],
+            [
+                '<?php
+    /**
+     * This is a broken phpdoc - missing asterisk
+     * @param string $str As it is broken, let us not apply the rule to description of parameter.
+
+     */
+    function foo($str) {}',
             ],
             [
                 '<?php


### PR DESCRIPTION
introduced in #3882

ref https://github.com/symfony/symfony/pull/28814
ref https://github.com/symfony/symfony/pull/28817