### PR TITLE
ExplicitStringVariableFixer - add failing test case with execution operators

### DIFF
--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -177,6 +177,9 @@ EOF;
                 '<?php $a = B"end {$a[1]}";',
                 '<?php $a = B"end $a[1]";',
             ],
+            [
+                '<?php $a = `echo $foo`;',
+            ],
         ];
     }
 


### PR DESCRIPTION
What should be the fix? Converting variable or leaving it untouched? Because definitely not `RuntimeException: Index invalid or out of range`.

Ping @Slamdunk 