### PR TITLE
Raise deprecation warnings on usage of deprecated aliases

### DIFF
--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -63,10 +63,11 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
                 $alias = $option->getAlias();
 
                 if (\array_key_exists($alias, $options)) {
-                    // @TODO 2.12 Trigger a deprecation notice and add a test for it
                     if (\array_key_exists($name, $options)) {
                         throw new InvalidOptionsException(sprintf('Aliased option %s/%s is passed multiple times.', $name, $alias));
                     }
+
+                    @trigger_error(sprintf('Option "%s" is deprecated, use "%s" instead.', $alias, $name), E_USER_DEPRECATED);
 
                     $options[$name] = $options[$alias];
                     unset($options[$alias]);

--- a/tests/FixerConfiguration/FixerConfigurationResolverTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverTest.php
@@ -200,4 +200,18 @@ final class FixerConfigurationResolverTest extends TestCase
             'baz' => '2',
         ]);
     }
+
+    /**
+     * @expectedDeprecation Option "baz" is deprecated, use "bar" instead.
+     */
+    public function testResolveWithDeprecatedAlias()
+    {
+        $configuration = new FixerConfigurationResolver([
+            new AliasedFixerOption(new FixerOption('bar', 'Bar.'), 'baz'),
+        ]);
+
+        $configuration->resolve([
+            'baz' => '1',
+        ]);
+    }
 }


### PR DESCRIPTION
Forgot to do this one (sorry 😬), reference: #3568

However, I need a way to still have the aliases tested. I could add a `@expectedDeprecation` for every test that uses a deprecated alias, but I was wondering if there was an easier way of doing this, maybe in the `AbstractFixerWithAliasedOptionsTestCase::doTest`.