### PR TITLE
inline $other->getPrototype() to speedup equals()

### DIFF
--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -156,7 +156,19 @@ class Token
      */
     public function equals($other, $caseSensitive = true)
     {
-        $otherPrototype = $other instanceof self ? $other->getPrototype() : $other;
+        if ($other instanceof self) {
+            // inlined getPrototype() on this very hot path
+            if (!$other->isArray) {
+                $otherPrototype = $other->content;
+            } else {
+                $otherPrototype = [
+                    $other->id,
+                    $other->content,
+                ];
+            }
+        } else {
+            $otherPrototype = $other;
+        }
 
         if ($this->isArray !== \is_array($otherPrototype)) {
             return false;


### PR DESCRIPTION
as measured in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4026 we try to speedup equals() by inlinening the $this->getPrototype() call.

also we use FQCN for native functions, because equals() is called a lot.

this speedsup the process by 4-5%.

see https://blackfire.io/profiles/compare/f4eefae8-6d09-4ab4-a833-f828d74a7b52/graph
![image](https://user-images.githubusercontent.com/120441/46916011-d6d2c400-cfb4-11e8-89e1-ec64e77477f1.png)
