### PR TITLE
NativeFunctionInvocationFixer - add option to remove redundant backslashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
             stage: Test
             php: 7.2
             before_script:
-                - php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,blank_line_after_opening_tag,native_function_invocation -q || travis_terminate 1
+                - php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q || travis_terminate 1
 
         -
             <<: *STANDARD_TEST_JOB

--- a/README.rst
+++ b/README.rst
@@ -926,6 +926,8 @@ Choose from the list of available rules:
     defaults to ``['@internal']``
   - ``scope`` (``'all'``, ``'namespaced'``): only fix function calls that are made
     within a namespace or fix all; defaults to ``'all'``
+  - ``strict`` (``bool``): whether leading ``\`` of function call not meant to have it
+    should be removed; defaults to ``false``
 
 * **new_with_braces** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+++ b/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
@@ -115,19 +115,19 @@ namespace {
     {
         parent::configure($configuration);
 
-        $uniqueConfiguredExclude = \array_unique($this->configuration['exclude']);
+        $uniqueConfiguredExclude = array_unique($this->configuration['exclude']);
 
         // Case sensitive constants handling
-        $constantsToEscape = \array_values($this->configuration['include']);
+        $constantsToEscape = array_values($this->configuration['include']);
         if (true === $this->configuration['fix_built_in']) {
-            $getDefinedConstants = \get_defined_constants(true);
+            $getDefinedConstants = get_defined_constants(true);
             unset($getDefinedConstants['user']);
             foreach ($getDefinedConstants as $constants) {
-                $constantsToEscape = \array_merge($constantsToEscape, \array_keys($constants));
+                $constantsToEscape = array_merge($constantsToEscape, array_keys($constants));
             }
         }
-        $constantsToEscape = \array_diff(
-            \array_unique($constantsToEscape),
+        $constantsToEscape = array_diff(
+            array_unique($constantsToEscape),
             $uniqueConfiguredExclude
         );
 
@@ -135,24 +135,24 @@ namespace {
         static $caseInsensitiveConstants = ['null', 'false', 'true'];
         $caseInsensitiveConstantsToEscape = [];
         foreach ($constantsToEscape as $constantIndex => $constant) {
-            $loweredConstant = \strtolower($constant);
+            $loweredConstant = strtolower($constant);
             if (\in_array($loweredConstant, $caseInsensitiveConstants, true)) {
                 $caseInsensitiveConstantsToEscape[] = $loweredConstant;
                 unset($constantsToEscape[$constantIndex]);
             }
         }
 
-        $caseInsensitiveConstantsToEscape = \array_diff(
-            \array_unique($caseInsensitiveConstantsToEscape),
-            \array_map('strtolower', $uniqueConfiguredExclude)
+        $caseInsensitiveConstantsToEscape = array_diff(
+            array_unique($caseInsensitiveConstantsToEscape),
+            array_map(function ($function) { return strtolower($function); }, $uniqueConfiguredExclude)
         );
 
         // Store the cache
-        $this->constantsToEscape = \array_fill_keys($constantsToEscape, true);
-        \ksort($this->constantsToEscape);
+        $this->constantsToEscape = array_fill_keys($constantsToEscape, true);
+        ksort($this->constantsToEscape);
 
-        $this->caseInsensitiveConstantsToEscape = \array_fill_keys($caseInsensitiveConstantsToEscape, true);
-        \ksort($this->caseInsensitiveConstantsToEscape);
+        $this->caseInsensitiveConstantsToEscape = array_fill_keys($caseInsensitiveConstantsToEscape, true);
+        ksort($this->caseInsensitiveConstantsToEscape);
     }
 
     /**
@@ -170,7 +170,7 @@ namespace {
 
         // 'scope' is 'namespaced' here
         /** @var NamespaceAnalysis $namespace */
-        foreach (\array_reverse($namespaces) as $namespace) {
+        foreach (array_reverse($namespaces) as $namespace) {
             if ('' === $namespace->getFullName()) {
                 continue;
             }
@@ -186,8 +186,8 @@ namespace {
     {
         $constantChecker = static function ($value) {
             foreach ($value as $constantName) {
-                if (!\is_string($constantName) || '' === \trim($constantName) || \trim($constantName) !== $constantName) {
-                    throw new InvalidOptionsException(\sprintf(
+                if (!\is_string($constantName) || '' === trim($constantName) || trim($constantName) !== $constantName) {
+                    throw new InvalidOptionsException(sprintf(
                         'Each element must be a non-empty, trimmed string, got "%s" instead.',
                         \is_object($constantName) ? \get_class($constantName) : \gettype($constantName)
                     ));
@@ -267,7 +267,7 @@ namespace {
             $indexes[] = $index;
         }
 
-        $indexes = \array_reverse($indexes);
+        $indexes = array_reverse($indexes);
         foreach ($indexes as $index) {
             $tokens->insertAt($index, new Token([T_NS_SEPARATOR, '\\']));
         }

--- a/src/Fixer/FunctionNotation/ImplodeCallFixer.php
+++ b/src/Fixer/FunctionNotation/ImplodeCallFixer.php
@@ -86,7 +86,7 @@ final class ImplodeCallFixer extends AbstractFixer
             $argumentsIndices = $this->getArgumentIndices($tokens, $index);
 
             if (1 === \count($argumentsIndices)) {
-                $firstArgumentIndex = \key($argumentsIndices);
+                $firstArgumentIndex = key($argumentsIndices);
                 $tokens->insertAt($firstArgumentIndex, [
                     new Token([T_CONSTANT_ENCAPSED_STRING, "''"]),
                     new Token(','),
@@ -97,7 +97,7 @@ final class ImplodeCallFixer extends AbstractFixer
             }
 
             if (2 === \count($argumentsIndices)) {
-                list($firstArgumentIndex, $secondArgumentIndex) = \array_keys($argumentsIndices);
+                list($firstArgumentIndex, $secondArgumentIndex) = array_keys($argumentsIndices);
 
                 // If the first argument is string we have nothing to do
                 if ($tokens[$firstArgumentIndex]->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
@@ -109,9 +109,9 @@ final class ImplodeCallFixer extends AbstractFixer
                 }
 
                 // collect tokens from first argument
-                $firstArgumentEndIndex = $argumentsIndices[\key($argumentsIndices)];
+                $firstArgumentEndIndex = $argumentsIndices[key($argumentsIndices)];
                 $newSecondArgumentTokens = [];
-                for ($i = \key($argumentsIndices); $i <= $firstArgumentEndIndex; ++$i) {
+                for ($i = key($argumentsIndices); $i <= $firstArgumentEndIndex; ++$i) {
                     $newSecondArgumentTokens[] = clone $tokens[$i];
                     $tokens->clearAt($i);
                 }

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -191,7 +191,7 @@ $c = get_class($d);
 
         // 'scope' is 'namespaced' here
         /** @var NamespaceAnalysis $namespace */
-        foreach (\array_reverse($namespaces) as $namespace) {
+        foreach (array_reverse($namespaces) as $namespace) {
             if ('' === $namespace->getFullName()) {
                 continue;
             }
@@ -210,8 +210,8 @@ $c = get_class($d);
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $value) {
                     foreach ($value as $functionName) {
-                        if (!\is_string($functionName) || '' === \trim($functionName) || \trim($functionName) !== $functionName) {
-                            throw new InvalidOptionsException(\sprintf(
+                        if (!\is_string($functionName) || '' === trim($functionName) || trim($functionName) !== $functionName) {
+                            throw new InvalidOptionsException(sprintf(
                                 'Each element must be a non-empty, trimmed string, got "%s" instead.',
                                 \is_object($functionName) ? \get_class($functionName) : \gettype($functionName)
                             ));
@@ -226,8 +226,8 @@ $c = get_class($d);
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $value) {
                     foreach ($value as $functionName) {
-                        if (!\is_string($functionName) || '' === \trim($functionName) || \trim($functionName) !== $functionName) {
-                            throw new InvalidOptionsException(\sprintf(
+                        if (!\is_string($functionName) || '' === trim($functionName) || trim($functionName) !== $functionName) {
+                            throw new InvalidOptionsException(sprintf(
                                 'Each element must be a non-empty, trimmed string, got "%s" instead.',
                                 \is_object($functionName) ? \get_class($functionName) : \gettype($functionName)
                             ));
@@ -240,7 +240,7 @@ $c = get_class($d);
                         ];
 
                         if ('@' === $functionName[0] && !\in_array($functionName, $sets, true)) {
-                            throw new InvalidOptionsException(\sprintf('Unknown set "%s", known sets are "%s".', $functionName, \implode('", "', $sets)));
+                            throw new InvalidOptionsException(sprintf('Unknown set "%s", known sets are "%s".', $functionName, implode('", "', $sets)));
                         }
                     }
 
@@ -251,6 +251,10 @@ $c = get_class($d);
             (new FixerOptionBuilder('scope', 'Only fix function calls that are made within a namespace or fix all.'))
                 ->setAllowedValues(['all', 'namespaced'])
                 ->setDefault('all')
+                ->getOption(),
+            (new FixerOptionBuilder('strict', 'Whether leading `\` of function call not meant to have it should be removed.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false) // @TODO: 3.0 change to true as default
                 ->getOption(),
         ]);
     }
@@ -271,18 +275,24 @@ $c = get_class($d);
                 continue;
             }
 
+            $prevIndex = $tokens->getPrevMeaningfulToken($index);
+
             if (!$functionFilter($tokens[$index]->getContent())) {
+                if ($this->configuration['strict'] && $tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {
+                    $tokens->clearTokenAndMergeSurroundingWhitespace($prevIndex);
+                }
+
                 continue;
             }
 
-            if ($tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind(T_NS_SEPARATOR)) {
+            if ($tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {
                 continue; // do not bother if previous token is already namespace separator
             }
 
             $insertAtIndexes[] = $index;
         }
 
-        foreach (\array_reverse($insertAtIndexes) as $index) {
+        foreach (array_reverse($insertAtIndexes) as $index) {
             $tokens->insertAt($index, new Token([T_NS_SEPARATOR, '\\']));
         }
     }
@@ -297,7 +307,7 @@ $c = get_class($d);
         if (\in_array(self::SET_ALL, $this->configuration['include'], true)) {
             if (\count($exclude) > 0) {
                 return static function ($functionName) use ($exclude) {
-                    return !isset($exclude[\strtolower($functionName)]);
+                    return !isset($exclude[strtolower($functionName)]);
                 };
             }
 
@@ -315,18 +325,18 @@ $c = get_class($d);
 
         foreach ($this->configuration['include'] as $additional) {
             if ('@' !== $additional[0]) {
-                $include[\strtolower($additional)] = true;
+                $include[strtolower($additional)] = true;
             }
         }
 
         if (\count($exclude) > 0) {
             return static function ($functionName) use ($include, $exclude) {
-                return isset($include[\strtolower($functionName)]) && !isset($exclude[\strtolower($functionName)]);
+                return isset($include[strtolower($functionName)]) && !isset($exclude[strtolower($functionName)]);
             };
         }
 
         return static function ($functionName) use ($include) {
-            return isset($include[\strtolower($functionName)]);
+            return isset($include[strtolower($functionName)]);
         };
     }
 
@@ -384,7 +394,7 @@ $c = get_class($d);
      */
     private function getAllInternalFunctionsNormalized()
     {
-        return $this->normalizeFunctionNames(\get_defined_functions()['internal']);
+        return $this->normalizeFunctionNames(get_defined_functions()['internal']);
     }
 
     /**
@@ -395,7 +405,7 @@ $c = get_class($d);
     private function normalizeFunctionNames(array $functionNames)
     {
         foreach ($functionNames as $index => $functionName) {
-            $functionNames[\strtolower($functionName)] = true;
+            $functionNames[strtolower($functionName)] = true;
             unset($functionNames[$index]);
         }
 

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -263,9 +263,9 @@ final class PhpUnitInternalClassFixer extends AbstractFixer implements Whitespac
     private function getSingleLineDocBlockEntry($line)
     {
         $line = $line[0];
-        $line = \str_replace('*/', '', $line);
+        $line = str_replace('*/', '', $line);
         $line = trim($line);
-        $line = \str_split($line);
+        $line = str_split($line);
         $i = \count($line);
         do {
             --$i;

--- a/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
@@ -135,7 +135,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         }
 
         $functionNameIndex = $tokens->getNextMeaningfulToken($index);
-        $functionName = \strtolower($tokens[$functionNameIndex]->getContent());
+        $functionName = strtolower($tokens[$functionNameIndex]->getContent());
 
         return 'setup' === $functionName || 'teardown' === $functionName;
     }

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -391,9 +391,9 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             }
 
             if (!$needsAnnotation &&
-                false !== \strpos($lines[$i]->getContent(), ' @test') &&
-                false === \strpos($lines[$i]->getContent(), '@testWith') &&
-                false === \strpos($lines[$i]->getContent(), '@testdox')
+                false !== strpos($lines[$i]->getContent(), ' @test') &&
+                false === strpos($lines[$i]->getContent(), '@testWith') &&
+                false === strpos($lines[$i]->getContent(), '@testdox')
             ) {
                 // We remove @test from the doc block
                 $lines[$i] = new Line(str_replace(' @test', '', $lines[$i]->getContent()));
@@ -439,9 +439,9 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
     private function getSingleLineDocBlockEntry($line)
     {
         $line = $line[0];
-        $line = \str_replace('*/', '', $line);
+        $line = str_replace('*/', '', $line);
         $line = trim($line);
-        $line = \str_split($line);
+        $line = str_split($line);
         $i = \count($line);
         do {
             --$i;
@@ -477,7 +477,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     private function removeTestPrefixFromDependsAnnotation(Line $line)
     {
-        $line = \str_split($line->getContent());
+        $line = str_split($line->getContent());
 
         $dependsIndex = $this->findWhereDependsFunctionNameStarts($line);
         $dependsFunctionName = implode('', \array_slice($line, $dependsIndex));
@@ -497,7 +497,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     private function addTestPrefixToDependsAnnotation(Line $line)
     {
-        $line = \str_split($line->getContent());
+        $line = str_split($line->getContent());
         $dependsIndex = $this->findWhereDependsFunctionNameStarts($line);
         $dependsFunctionName = implode('', \array_slice($line, $dependsIndex));
 

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -378,7 +378,7 @@ EOF;
     {
         $indent = self::ALIGN_VERTICAL === $this->align ? $verticalAlignIndent : $leftAlignIndent;
 
-        return \str_repeat(' ', $indent);
+        return str_repeat(' ', $indent);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -189,6 +189,7 @@ final class RuleSet implements RuleSetInterface
             'native_function_invocation' => [
                 'include' => [NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED],
                 'scope' => 'namespaced',
+                'strict' => true,
             ],
             'no_alias_functions' => true,
             'no_homoglyph_names' => true,

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -538,6 +538,7 @@ namespace {
                     // do not fix
                     $a = strrev($a);
                     $a .= str_repeat($a, 4);
+                    $b = \already_prefixed_function();
                     // fix
                     $c = \get_class($d);
                     $e = \intval($f);
@@ -546,6 +547,7 @@ namespace {
                     // do not fix
                     $a = strrev($a);
                     $a .= str_repeat($a, 4);
+                    $b = \already_prefixed_function();
                     // fix
                     $c = get_class($d);
                     $e = intval($f);
@@ -560,6 +562,22 @@ namespace {
                         }
                     }
                 ',
+            ],
+            'include @compiler_optimized with strict enabled' => [
+                '<?php
+                    $a = not_compiler_optimized_function();
+                    $b =  not_compiler_optimized_function();
+                    $c = \intval($d);
+                ',
+                '<?php
+                    $a = \not_compiler_optimized_function();
+                    $b = \ not_compiler_optimized_function();
+                    $c = intval($d);
+                ',
+                [
+                    'include' => ['@compiler_optimized'],
+                    'strict' => true,
+                ],
             ],
         ];
     }


### PR DESCRIPTION
If we add it to `@Symfony` rule set with `true` then in Symfony v4.1.6 26 files would be affected, and here - at master - 6 files.