### PR TITLE
WIP use parent::offset*() methods when moving items arround in insertAt()

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -883,9 +883,8 @@ class Tokens extends \SplFixedArray
         // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
             if ($this->offsetExists($i - $itemsCnt)) {
-                $oldItem = parent::offsetGet($i - $itemsCnt);
-                $this->blockEndCache = [];
-                parent::offsetSet($i, $oldItem);
+                $oldItem = $this[$i - $itemsCnt];
+                $this->offsetSet($i, $oldItem);
             } else {
                 $this->offsetSet($i, new Token(''));
             }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -879,8 +879,17 @@ class Tokens extends \SplFixedArray
         $this->changed = true;
         $this->setSize($oldSize + $itemsCnt);
 
+        // since we only move already existing items arround, we directly call into SplFixedArray::offset* methods.
+        // that way we get arround additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            $this[$i] = $this->offsetExists($i - $itemsCnt) ? $this[$i - $itemsCnt] : new Token('');
+            $oldItem = parent::offsetGet($i - $itemsCnt);
+            // NULL might indicate a explicitly set NULl value, or a not existing index
+            if ($oldItem === null) {
+                if (!parent::offsetExists($i - $itemsCnt)) {
+                    $oldItem = new Token('');
+                }
+            }
+            parent::offsetSet($i, $oldItem);
         }
 
         for ($i = 0; $i < $itemsCnt; ++$i) {

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -882,12 +882,10 @@ class Tokens extends \SplFixedArray
         // since we only move already existing items arround, we directly call into SplFixedArray::offset* methods.
         // that way we get arround additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            $oldItem = parent::offsetGet($i - $itemsCnt);
-            // NULL might indicate a explicitly set NULl value, or a not existing index
-            if ($oldItem === null) {
-                if (!parent::offsetExists($i - $itemsCnt)) {
-                    $oldItem = new Token('');
-                }
+            if (parent::offsetExists($i - $itemsCnt)) {
+                $oldItem = parent::offsetGet($i - $itemsCnt);
+            } else {
+                $oldItem = new Token('');
             }
             parent::offsetSet($i, $oldItem);
         }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -882,7 +882,7 @@ class Tokens extends \SplFixedArray
         // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
         // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            if (parent::offsetExists($i - $itemsCnt)) {
+            if ($this->offsetExists($i - $itemsCnt)) {
                 $oldItem = parent::offsetGet($i - $itemsCnt);
                 $this->blockEndCache = [];
                 parent::offsetSet($i, $oldItem);

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -879,11 +879,12 @@ class Tokens extends \SplFixedArray
         $this->changed = true;
         $this->setSize($oldSize + $itemsCnt);
 
-        // since we only move already existing items arround, we directly call into SplFixedArray::offset* methods.
-        // that way we get arround additional overhead this class adds with overridden offset* methods.
+        // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
+        // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
             if (parent::offsetExists($i - $itemsCnt)) {
                 $oldItem = parent::offsetGet($i - $itemsCnt);
+                $this->blockEndCache = [];
                 parent::offsetSet($i, $oldItem);
             } else {
                 $this->offsetSet($i, new Token(''));

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -884,10 +884,10 @@ class Tokens extends \SplFixedArray
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
             if (parent::offsetExists($i - $itemsCnt)) {
                 $oldItem = parent::offsetGet($i - $itemsCnt);
+                parent::offsetSet($i, $oldItem);
             } else {
-                $oldItem = new Token('');
+                $this->offsetSet($i, new Token(''));
             }
-            parent::offsetSet($i, $oldItem);
         }
 
         for ($i = 0; $i < $itemsCnt; ++$i) {

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -883,7 +883,12 @@ class Tokens extends \SplFixedArray
         // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
         // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            $oldItem = $this->offsetExists($i - $itemsCnt) ? parent::offsetGet($i - $itemsCnt) : new Token('');
+            $oldItem = parent::offsetGet($i - $itemsCnt);
+            if ($oldItem === null) {
+                if (!$this->offsetExists($i - $itemsCnt)) {
+                    $oldItem = new Token('');
+                }
+            }
             parent::offsetSet($i, $oldItem);
         }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -883,12 +883,7 @@ class Tokens extends \SplFixedArray
         // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
         // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            $oldItem = parent::offsetGet($i - $itemsCnt);
-            if ($oldItem === null) {
-                if (!$this->offsetExists($i - $itemsCnt)) {
-                    $oldItem = new Token('');
-                }
-            }
+            $oldItem = $this->offsetExists($i - $itemsCnt) ? parent::offsetGet($i - $itemsCnt) : new Token('');
             parent::offsetSet($i, $oldItem);
         }
 

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -877,6 +877,7 @@ class Tokens extends \SplFixedArray
 
         $oldSize = \count($this);
         $this->changed = true;
+        $this->blockEndCache = [];
         $this->setSize($oldSize + $itemsCnt);
 
         // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -882,12 +882,8 @@ class Tokens extends \SplFixedArray
         // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
         // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            if ($this->offsetExists($i - $itemsCnt)) {
-                $oldItem = $this[$i - $itemsCnt];
-                $this->offsetSet($i, $oldItem);
-            } else {
-                $this->offsetSet($i, new Token(''));
-            }
+            $oldItem = $this->offsetExists($i - $itemsCnt) ? parent::offsetGet($i - $itemsCnt) : new Token('');
+            parent::offsetSet($i, $oldItem);
         }
 
         for ($i = 0; $i < $itemsCnt; ++$i) {
@@ -895,7 +891,8 @@ class Tokens extends \SplFixedArray
                 throw new \InvalidArgumentException('Must not add empty token to collection.');
             }
 
-            $this[$i + $index] = $items[$i];
+            $this->registerFoundToken($items[$i]);
+            parent::offsetSet($i + $index, $items[$i]);
         }
     }
 


### PR DESCRIPTION
*Work in Progress... do no merge!*

since we only move already existing items arround, we directly call into SplFixedArray::offset* methods.
that way we get arround additional overhead this class adds with overridden offset* methods.
