### PR TITLE
Token - Added fast isset() path to token->equals()

### DIFF
--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -166,11 +166,11 @@ class Token
             return $this->content === $otherPrototype;
         }
 
-        if (array_key_exists(0, $otherPrototype) && $this->id !== $otherPrototype[0]) {
+        if ($this->id !== $otherPrototype[0]) {
             return false;
         }
 
-        if (array_key_exists(1, $otherPrototype)) {
+        if (isset($otherPrototype[1])) {
             if ($caseSensitive) {
                 if ($this->content !== $otherPrototype[1]) {
                     return false;


### PR DESCRIPTION
looking up the existance of a property via isset() is waaaaay faster then array_key_exists().
we still need array_key_exists() as a fallback, when properties exist with a null-value to work properly. this case is very rare, therefore this can be considered a speedup.

this change speeds up php-cs-fixer by 5.6%.

![image](https://user-images.githubusercontent.com/120441/46920181-bd4c6f00-cfea-11e8-8145-069ff58f63c4.png)
