### PR TITLE
Tokens - inlined extractTokenKind() call on the hot path

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1401,7 +1401,11 @@ class Tokens extends \SplFixedArray
      */
     private function registerFoundToken($token)
     {
-        $tokenKind = $this->extractTokenKind($token);
+        // inlined extractTokenKind() call on the hot path
+        $tokenKind = $token instanceof Token
+            ? ($token->isArray() ? $token->getId() : $token->getContent())
+            : (\is_array($token) ? $token[0] : $token)
+        ;
 
         if (!isset($this->foundTokenKinds[$tokenKind])) {
             $this->foundTokenKinds[$tokenKind] = 0;
@@ -1417,7 +1421,11 @@ class Tokens extends \SplFixedArray
      */
     private function unregisterFoundToken($token)
     {
-        $tokenKind = $this->extractTokenKind($token);
+        // inlined extractTokenKind() call on the hot path
+        $tokenKind = $token instanceof Token
+            ? ($token->isArray() ? $token->getId() : $token->getContent())
+            : (\is_array($token) ? $token[0] : $token)
+        ;
 
         if (!isset($this->foundTokenKinds[$tokenKind])) {
             return;


### PR DESCRIPTION
as identified in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4026 we inline calls to `extractTokenKind()` which leads to a 5-7% speed increase.

most calls of this method happen thru the changed code as can be seen in the blackfire profile

![image](https://user-images.githubusercontent.com/120441/46915856-1a77fe80-cfb2-11e8-9e0c-531b88059ad4.png)
