### PR TITLE
Tokens - use parent::offset*() methods when moving items arround in insertAt()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1464,6 +1464,11 @@ Choose from the list of available rules:
 
   The correct case must be used for standard PHP types in PHPDoc.
 
+  Configuration options:
+
+  - ``groups`` (a subset of ``['simple', 'alias', 'meta']``): type groups to fix;
+    defaults to ``['simple', 'alias', 'meta']``
+
 * **phpdoc_types_order**
 
   Sorts PHPDoc types.

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -19,6 +19,7 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -262,27 +263,12 @@ $c = get_class($d);
      */
     private function fixFunctionCalls(Tokens $tokens, callable $functionFilter, $start, $end)
     {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
         $insertAtIndexes = [];
         for ($index = $start; $index < $end; ++$index) {
-            // test if we are at a function call
-            if (!$tokens[$index]->isGivenKind(T_STRING)) {
+            if (!$functionsAnalyzer->isGlobalFunctionCall($tokens, $index)) {
                 continue;
-            }
-
-            if (!$tokens[$tokens->getNextMeaningfulToken($index)]->equals('(')) {
-                continue;
-            }
-
-            $functionNamePrefix = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$functionNamePrefix]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_FUNCTION])) {
-                continue;
-            }
-
-            if (
-                $tokens[$functionNamePrefix]->isGivenKind(T_NS_SEPARATOR)
-                && $tokens[$tokens->getPrevMeaningfulToken($functionNamePrefix)]->isGivenKind([T_STRING, T_NEW])
-            ) {
-                continue; // skip if the call is to a constructor or to a function in a namespace other than the default
             }
 
             if (!$functionFilter($tokens[$index]->getContent())) {

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -75,11 +75,20 @@ function foo ($bar) {}
                     continue;
                 }
 
+                $lineAfterAnnotation = $doc->getLine($annotation->getEnd() + 1);
+                if (null !== $lineAfterAnnotation) {
+                    $lineAfterAnnotationTrimmed = ltrim($lineAfterAnnotation);
+                    if ('' === $lineAfterAnnotationTrimmed || '*' !== $lineAfterAnnotationTrimmed[0]) {
+                        // malformed PHPDoc, missing asterisk !
+                        continue;
+                    }
+                }
+
                 $content = $annotation->getContent();
 
                 if (
-                    1 !== Preg::match('/[.。]\h*(\R|$)/u', $content)
-                    || 0 !== Preg::match('/[.。](?!\h*(\R|$))/u', $content, $matches)
+                    1 !== Preg::match('/[.。]\h*$/u', $content)
+                    || 0 !== Preg::match('/[.。](?!\h*$)/u', $content, $matches)
                 ) {
                     continue;
                 }
@@ -92,9 +101,9 @@ function foo ($bar) {}
                     ? sprintf('(?:%s\s+(?:\$\w+\s+)?)?', preg_quote(implode('|', $annotation->getTypes()), '/'))
                     : '';
                 $content = Preg::replaceCallback(
-                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)(\R|$)/',
+                    '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     static function (array $matches) {
-                        return $matches[1].strtolower($matches[2]).$matches[3].$matches[4];
+                        return $matches[1].strtolower($matches[2]).$matches[3];
                     },
                     $startLine->getContent(),
                     1

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -92,6 +92,18 @@ function foo() {}
                 $this->fixAnnotation($doc, $annotation);
             }
 
+            $newContent = $doc->getContent();
+
+            if ($newContent === $token->getContent()) {
+                continue;
+            }
+
+            if ('' === $newContent) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+
+                continue;
+            }
+
             $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
         }
     }

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -13,45 +13,73 @@
 namespace PhpCsFixer\Fixer\Phpdoc;
 
 use PhpCsFixer\AbstractPhpdocTypesFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 
 /**
  * @author Graham Campbell <graham@alt-three.com>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer
+final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
-     * The types to process.
+     * Available types, grouped.
      *
-     * @var string[]
+     * @var array<string,string[]>
      */
-    private static $types = [
-        'array',
-        'bool',
-        'boolean',
-        'callable',
-        'callback',
-        'double',
-        'false',
-        'float',
-        'int',
-        'integer',
-        'iterable',
-        'mixed',
-        'null',
-        'object',
-        'parent',
-        'real',
-        'resource',
-        'scalar',
-        'self',
-        'static',
-        'string',
-        'true',
-        'void',
-        '$this',
+    private static $possibleTypes = [
+        'simple' => [
+            'array',
+            'bool',
+            'callable',
+            'float',
+            'int',
+            'iterable',
+            'null',
+            'object',
+            'string',
+        ],
+        'alias' => [
+            'boolean',
+            'callback',
+            'double',
+            'integer',
+            'real',
+        ],
+        'meta' => [
+            '$this',
+            'false',
+            'mixed',
+            'parent',
+            'resource',
+            'scalar',
+            'self',
+            'static',
+            'true',
+            'void',
+        ],
     ];
+
+    /**
+     * @var array string[]
+     */
+    private $typesToFix = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        parent::configure($configuration);
+
+        $this->typesToFix = array_merge(...array_map(function ($group) {
+            return self::$possibleTypes[$group];
+        }, $this->configuration['groups']));
+    }
 
     /**
      * {@inheritdoc}
@@ -94,10 +122,26 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer
     {
         $lower = strtolower($type);
 
-        if (\in_array($lower, self::$types, true)) {
+        if (\in_array($lower, $this->typesToFix, true)) {
             return $lower;
         }
 
         return $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        $possibleGroups = array_keys(self::$possibleTypes);
+
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('groups', 'Type groups to fix.'))
+                ->setAllowedTypes(['array'])
+                ->setAllowedValues([new AllowedValueSubset($possibleGroups)])
+                ->setDefault($possibleGroups)
+                ->getOption(),
+        ]);
     }
 }

--- a/src/Indicator/PhpUnitTestCaseIndicator.php
+++ b/src/Indicator/PhpUnitTestCaseIndicator.php
@@ -31,8 +31,7 @@ final class PhpUnitTestCaseIndicator
             return true;
         }
 
-        do {
-            $index = $tokens->getNextMeaningfulToken($index);
+        while (null !== $index = $tokens->getNextMeaningfulToken($index)) {
             if ($tokens[$index]->equals('{')) {
                 break; // end of class signature
             }
@@ -44,7 +43,7 @@ final class PhpUnitTestCaseIndicator
             if (0 !== Preg::match('/(?:Test|TestCase)(?:Interface)?$/', $tokens[$index]->getContent())) {
                 return true;
             }
-        } while (true); // safe `true` as we will always hit an `{` after a T_CLASS
+        }
 
         return false;
     }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -877,10 +877,14 @@ class Tokens extends \SplFixedArray
 
         $oldSize = \count($this);
         $this->changed = true;
+        $this->blockEndCache = [];
         $this->setSize($oldSize + $itemsCnt);
 
+        // since we only move already existing items around, we directly call into SplFixedArray::offset* methods.
+        // that way we get around additional overhead this class adds with overridden offset* methods.
         for ($i = $oldSize + $itemsCnt - 1; $i >= $index; --$i) {
-            $this[$i] = $this->offsetExists($i - $itemsCnt) ? $this[$i - $itemsCnt] : new Token('');
+            $oldItem = parent::offsetExists($i - $itemsCnt) ? parent::offsetGet($i - $itemsCnt) : new Token('');
+            parent::offsetSet($i, $oldItem);
         }
 
         for ($i = 0; $i < $itemsCnt; ++$i) {
@@ -888,7 +892,8 @@ class Tokens extends \SplFixedArray
                 throw new \InvalidArgumentException('Must not add empty token to collection.');
             }
 
-            $this[$i + $index] = $items[$i];
+            $this->registerFoundToken($items[$i]);
+            parent::offsetSet($i + $index, $items[$i]);
         }
     }
 

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -554,6 +554,13 @@ namespace {
                     'include' => ['@compiler_optimized'],
                 ],
             ],
+            [
+                '<?php class Foo {
+                        public function & strlen($name) {
+                        }
+                    }
+                ',
+            ],
         ];
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -56,6 +56,7 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @param string $ellipsis2  Ellipsis is this: 。。。
      * @param string $ellipsis3  Ellipsis is this: …
      * @param bool   $isStr      Is it a string?
+     * @param int    $int        Some single-line descrioption. With many dots.
      * @param int    $int        Some multiline
      *                           description. With many dots.
      *
@@ -81,6 +82,7 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      * @param string $ellipsis2  Ellipsis is this: 。。。
      * @param string $ellipsis3  Ellipsis is this: …
      * @param bool   $isStr      Is it a string?
+     * @param int    $int        Some single-line descrioption. With many dots.
      * @param int    $int        Some multiline
      *                           description. With many dots.
      *
@@ -162,32 +164,48 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
             [
                 '<?php
     /**
-     * This is a broken phpdoc
-     * @param string $str surprisingly, it is a string
-
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string    $eventName The name of the event to dispatch. The name of the event is
+     *                             the name of the method that is invoked on listeners.
+     * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
+     *                             If not supplied, the single empty EventArgs instance is used.
+     *
+     * @return bool
      */
-    function fixMe($str) {}',
-                '<?php
+    function dispatchEvent($eventName, EventArgs $eventArgs = null) {}
+
     /**
-     * This is a broken phpdoc
-     * @param string $str Surprisingly, it is a string.
-
+     * Extract the `object_to_populate` field from the context if it exists
+     * and is an instance of the provided $class.
+     *
+     * @param string $class   The class the object should be
+     * @param array  $context The denormalization context
+     * @param string $key     Key in which to look for the object to populate.
+     *                        Keeps backwards compatibility with `AbstractNormalizer`.
+     *
+     * @return null|object an object if things check out, null otherwise
      */
-    function fixMe($str) {}',
+    function extractObjectToPopulate($class, array $context, $key = null) {}
+                ',
             ],
             [
                 '<?php
     /**
-     * @return bool|null returns `true` if the class has a single-column ID
-                         Returns `false` otherwise.
+     * This is a broken phpdoc - missing asterisk
+     * @param string $str As it is broken, let us not apply the rule to description of parameter.
+
      */
-    function fixMe() {}',
+    function foo($str) {}',
+            ],
+            [
                 '<?php
     /**
      * @return bool|null Returns `true` if the class has a single-column ID.
                          Returns `false` otherwise.
+                         That was multilined comment. With plenty of sentenced.
      */
-    function fixMe() {}',
+    function nothingToDo() {}',
             ],
         ];
     }

--- a/tests/Fixer/Phpdoc/PhpdocNoEmptyReturnFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoEmptyReturnFixerTest.php
@@ -180,4 +180,23 @@ EOF;
 
         $this->doTest($expected);
     }
+
+    public function testHandleSingleLinePhpdoc()
+    {
+        $expected = <<<'EOF'
+<?php
+
+
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+
+/** @return null */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
 }

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -16,6 +16,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
  * @author Graham Campbell <graham@alt-three.com>
+ * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @internal
  *
@@ -197,5 +198,39 @@ EOF;
 EOF;
 
         $this->doTest($expected, $input);
+    }
+
+    public function testWithConfig()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param self|array|Foo $bar
+     *
+     * @return int|float|callback
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param SELF|Array|Foo $bar
+     *
+     * @return inT|Float|callback
+     */
+
+EOF;
+
+        $this->fixer->configure(['groups' => ['simple', 'meta']]);
+        $this->doTest($expected, $input);
+    }
+
+    public function testWrongConfig()
+    {
+        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessageRegExp('/^\[phpdoc_types\] Invalid configuration: The option "groups" .*\.$/');
+
+        $this->fixer->configure(['groups' => ['__TEST__']]);
     }
 }

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -188,6 +188,18 @@ class Foo implements TestInterface, SomethingElse
                     class Foo3 { public function A() { return function (){}; } }
                 ',
             ],
+            'class with anonymous class inside' => [
+                [],
+                '<?php
+                    class Foo
+                    {
+                        public function getClass()
+                        {
+                            return new class {};
+                        }
+                    }
+                ',
+            ],
         ];
     }
 }


### PR DESCRIPTION
since we only move already existing items arround, we directly call into SplFixedArray::offset* methods.

that way we get arround additional overhead Tokens class adds with overridden offset* methods.

blackfire shows a 35-40% runtime improvement in overall walltime.
in my testbenchmark this renders a ~20 second improvement.

https://blackfire.io/profiles/compare/4a0c1058-5910-446d-9641-8bcf2823cc63/graph

![image](https://user-images.githubusercontent.com/120441/47035734-06cbc400-d17b-11e8-8dd6-badf56512bd1.png)
