### PR TITLE
composer: allow PHP 7.3 to allow Travis testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || >=7.0 <7.3",
+        "php": "^5.6 || >=7.0 <7.4",
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer/semver": "^1.4",


### PR DESCRIPTION
At the moment this blocks testing any project/package that uses PHP CS Fixer.

https://travis-ci.org/TomasVotruba/tomasvotruba.cz/jobs/443022040

PHP 7.3 is availble: https://github.com/travis-ci/travis-ci/issues/9717#issuecomment-429564626 
and stable out in ~2 months. This would help to test code before