### PR TITLE
Ignore invalid mode strings, add option to remove the "b" flag.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -662,9 +662,15 @@ Choose from the list of available rules:
 
 * **fopen_flags** [@Symfony:risky]
 
-  The flags in ``fopen`` calls must contain ``b`` and must omit ``t``.
+  The flags in ``fopen`` calls must omit ``t``, and ``b`` must be omitted or
+  included consistently.
 
   *Risky rule: risky when the function ``fopen`` is overridden.*
+
+  Configuration options:
+
+  - ``b_mode`` (``bool``): the ``b`` flag must be used (``true``) or omitted (``false``);
+    defaults to ``true``
 
 * **full_opening_tag** [@PSR1, @PSR2, @Symfony]
 

--- a/src/AbstractFopenFlagFixer.php
+++ b/src/AbstractFopenFlagFixer.php
@@ -72,4 +72,56 @@ abstract class AbstractFopenFlagFixer extends AbstractFunctionReferenceFixer
     }
 
     abstract protected function fixFopenFlagToken(Tokens $tokens, $argumentStartIndex, $argumentEndIndex);
+
+    /**
+     * @param string $mode
+     *
+     * @return bool
+     */
+    protected function isValidModeString($mode)
+    {
+        $modeLength = \strlen($mode);
+        if ($modeLength < 1 || $modeLength > 13) { // 13 === length 'r+w+a+x+c+etb'
+            return false;
+        }
+
+        $validFlags = [
+            'a' => true,
+            'b' => true,
+            'c' => true,
+            'e' => true,
+            'r' => true,
+            't' => true,
+            'w' => true,
+            'x' => true,
+        ];
+
+        if (!isset($validFlags[$mode[0]])) {
+            return false;
+        }
+
+        unset($validFlags[$mode[0]]);
+
+        for ($i = 1; $i < $modeLength; ++$i) {
+            if (isset($validFlags[$mode[$i]])) {
+                unset($validFlags[$mode[$i]]);
+
+                continue;
+            }
+
+            if ('+' !== $mode[$i]
+                || (
+                    'a' !== $mode[$i - 1] // 'a+','c+','r+','w+','x+'
+                    && 'c' !== $mode[$i - 1]
+                    && 'r' !== $mode[$i - 1]
+                    && 'w' !== $mode[$i - 1]
+                    && 'x' !== $mode[$i - 1]
+                )
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
+++ b/src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
@@ -76,8 +76,12 @@ final class FopenFlagOrderFixer extends AbstractFopenFlagFixer
         }
 
         $modeLength = \strlen($mode);
-        if ($modeLength < 2 || $modeLength > 13) { // 13 === length 'r+w+a+x+c+etb'
-            return; // sanity check to be less risky
+        if ($modeLength < 2) {
+            return; // nothing to sort
+        }
+
+        if (false === $this->isValidModeString($mode)) {
+            return;
         }
 
         $split = $this->sortFlags(Preg::split('#([^\+]\+?)#', $mode, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE));

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -168,7 +168,7 @@ final class RuleSet implements RuleSetInterface
             'ereg_to_preg' => true,
             'error_suppression' => true,
             'fopen_flag_order' => true,
-            'fopen_flags' => true,
+            'fopen_flags' => ['b_mode' => false],
             'function_to_constant' => true,
             'implode_call' => true,
             'is_null' => true,

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -151,7 +151,7 @@ EOT;
      */
     private function createStreamOutput($verbosityLevel)
     {
-        $output = new StreamOutput(fopen('php://memory', 'wb', false));
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
         $output->setDecorated(false);
         $output->setVerbosity($verbosityLevel);
 

--- a/tests/Fixer/FunctionNotation/FopenFlagOrderFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FopenFlagOrderFixerTest.php
@@ -37,7 +37,7 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
     public function provideFixCases()
     {
         return [
-            [
+            'most simple fix case' => [
                 '<?php
                     $a = fopen($foo, \'rw+b\');
                 ',
@@ -45,17 +45,17 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
                     $a = fopen($foo, \'brw+\');
                 ',
             ],
-            [
+            '"fopen" casing insensitive' => [
                 '<?php
-                    $a = \FOPEN($foo, "cr+w+b");
+                    $a = \FOPen($foo, "cr+w+b");
                     $a = \FOPEN($foo, "crw+b");
                 ',
                 '<?php
-                    $a = \FOPEN($foo, "bw+r+c");
+                    $a = \FOPen($foo, "bw+r+c");
                     $a = \FOPEN($foo, "bw+rc");
                 ',
             ],
-            [
+            'comments around flags' => [
                 '<?php
                     $a = fopen($foo,/*0*/\'rb\'/*1*/);
                 ',
@@ -80,7 +80,7 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
             'common typos' => [
                 '<?php
                      $a = fopen($a, "b+r");
-                     $b = fopen($b, "b+w");
+                     $b = fopen($b, \'b+w\');
                 ',
             ],
             // `t` cases
@@ -94,10 +94,10 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php
-                    $a = fopen($foo, \'rw+tb\');
+                    $a = \fopen($foo, \'rw+tb\');
                 ',
                 '<?php
-                    $a = fopen($foo, \'btrw+\');
+                    $a = \fopen($foo, \'btrw+\');
                 ',
             ],
             // don't fix cases
@@ -114,7 +114,7 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
             ],
             'wrong # of arguments' => [
                 '<?php
-                    $b = fopen("br+");
+                    $b = \fopen("br+");
                     $c = fopen($foo, "bw+", 1, 2 , 3);
                 ',
             ],
@@ -138,6 +138,29 @@ final class FopenFlagOrderFixerTest extends AbstractFixerTestCase
                     // fopen($foo, "brw");
                     /* fopen($foo, "brw"); */
                     echo("fopen($foo, \"brw\")");
+                ',
+            ],
+            'invalid flag values' => [
+                '<?php
+                    $a = fopen($foo, \'\');
+                    $a = fopen($foo, \'x\'); // ok but should not mark collection as changed
+                    $a = fopen($foo, \'k\');
+                    $a = fopen($foo, \'kz\');
+                    $a = fopen($foo, \'k+\');
+                    $a = fopen($foo, \'+k\');
+                    $a = fopen($foo, \'xc++\');
+                    $a = fopen($foo, \'w+r+r+\');
+                    $a = fopen($foo, \'+brw+\');
+                    $a = fopen($foo, \'b+rw\');
+                    $a = fopen($foo, \'bbrw+\');
+                    $a = fopen($foo, \'brw++\');
+                    $a = fopen($foo, \'++brw\');
+                    $a = fopen($foo, \'ybrw+\');
+                    $a = fopen($foo, \'rr\');
+                    $a = fopen($foo, \'ロ\');
+                    $a = fopen($foo, \'ロ+\');
+                    $a = \fopen($foo, \'rロ\');
+                    $a = \fopen($foo, \'w+ロ\');
                 ',
             ],
         ];

--- a/tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
@@ -24,13 +24,15 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class FopenFlagsFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @param string      $expected
-     * @param null|string $input
+     * @param string $expected
+     * @param string $input
+     * @param array  $config
      *
      * @dataProvider provideFixCases
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -47,10 +49,10 @@ final class FopenFlagsFixerTest extends AbstractFixerTestCase
             ],
             'has "t" and "b"' => [
                 '<?php
-                    $a = fopen($foo, "rw+b");
+                    $a = \fopen($foo, "rw+b");
                 ',
                 '<?php
-                    $a = fopen($foo, "rw+bt");
+                    $a = \fopen($foo, "rw+bt");
                 ',
             ],
             'has "t" and no "b" and binary string mod' => [
@@ -61,11 +63,62 @@ final class FopenFlagsFixerTest extends AbstractFixerTestCase
                     $a = fopen($foo, b\'trw+\');
                 ',
             ],
-            // don't fix cases
-            'not simple flags' => [
+            // configure remove b
+            'missing "b" but not configured' => [
                 '<?php
-                    $a = fopen($foo, "t".$a);
+                    $a = fopen($foo, \'rw+\');
                 ',
+                '<?php
+                    $a = fopen($foo, \'rw+t\');
+                ',
+                ['b_mode' => false],
+            ],
+            '"t" and superfluous "b"' => [
+                '<?php
+                    $a = fopen($foo, \'r+\');
+                    $a = fopen($foo, \'w+r\');
+                    $a = fopen($foo, \'r+\');
+                    $a = fopen($foo, \'w+r\');
+                ',
+                '<?php
+                    $a = fopen($foo, \'r+bt\');
+                    $a = fopen($foo, \'btw+r\');
+                    $a = fopen($foo, \'r+tb\');
+                    $a = fopen($foo, \'tbw+r\');
+                ',
+                ['b_mode' => false],
+            ],
+            'superfluous "b"' => [
+                '<?php
+                    $a = fopen($foo, \'r+\');
+                    $a = fopen($foo, \'w+r\');
+                ',
+                '<?php
+                    $a = fopen($foo, \'r+b\');
+                    $a = fopen($foo, \'bw+r\');
+                ',
+                ['b_mode' => false],
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideDoNotFixCases
+     */
+    public function testDoNotFix($expected)
+    {
+        $this->doTest($expected);
+        $this->fixer->configure(['b_mode' => false]);
+        $this->doTest($expected);
+    }
+
+    public function provideDoNotFixCases()
+    {
+        return [
+            'not simple flags' => [
+                '<?php $a = fopen($foo, "t".$a);',
             ],
             'wrong # of arguments' => [
                 '<?php
@@ -74,30 +127,44 @@ final class FopenFlagsFixerTest extends AbstractFixerTestCase
                 ',
             ],
             '"flags" is too long (must be overridden)' => [
-                '<?php
-                    $d = fopen($foo, "r+w+a+x+c+etXY");
-                ',
+                '<?php $d = fopen($foo, "r+w+a+x+c+etXY");',
             ],
             '"flags" is too short (must be overridden)' => [
-                '<?php
-                    $d = fopen($foo, "");
-                ',
+                '<?php $d = fopen($foo, "");',
             ],
             'static method call' => [
-                '<?php
-                    $e = A::fopen($foo, "w+");
-                ',
+                '<?php $e = A::fopen($foo, "w+");',
             ],
             'method call' => [
-                '<?php
-                    $f = $b->fopen($foo, "r+");
-                ',
+                '<?php $f = $b->fopen($foo, "r+");',
             ],
             'comments, PHPDoc and literal' => [
                 '<?php
                     // fopen($foo, "rw");
                     /* fopen($foo, "rw"); */
                     echo("fopen($foo, \"rw\")");
+                ',
+            ],
+            'invalid flag values' => [
+                '<?php
+                $a = fopen($foo, \'\');
+                $a = fopen($foo, \'k\');
+                $a = fopen($foo, \'kz\');
+                $a = fopen($foo, \'k+\');
+                $a = fopen($foo, \'+k\');
+                $a = fopen($foo, \'xct++\');
+                $a = fopen($foo, \'w+r+r+\');
+                $a = fopen($foo, \'+btrw+\');
+                $a = fopen($foo, \'b+rw\');
+                $a = fopen($foo, \'bbrw+\');
+                $a = fopen($foo, \'brw++\');
+                $a = fopen($foo, \'++brw\');
+                $a = fopen($foo, \'ybrw+\');
+                $a = fopen($foo, \'rr\');
+                $a = fopen($foo, \'ロ\');
+                $a = fopen($foo, \'ロ+\');
+                $a = fopen($foo, \'rロ\');
+                $a = \fopen($foo, \'w+ロ\');
                 ',
             ],
         ];


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3983
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4011

- ignore invalid mode-strings
- add config option to add or remove the `b` flag