### PR TITLE
DX: do not insert Token when calling removeLeadingWhitespace/removeTrailingWhitespace from Tokens

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1254,9 +1254,10 @@ class Tokens extends \SplFixedArray
                 return;
             }
 
-            $this->clearAt($index - $offset);
-            if ('' !== $newContent) {
-                $this->insertAt($index - $offset, new Token([T_WHITESPACE, $newContent]));
+            if ('' === $newContent) {
+                $this->clearAt($index - $offset);
+            } else {
+                $this[$index - $offset] = new Token([T_WHITESPACE, $newContent]);
             }
         }
     }

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1175,6 +1175,48 @@ echo $a;',
     }
 
     /**
+     * Action that begins with the word "remove" should not change the size of collection.
+     */
+    public function testRemovingLeadingWhitespaceWillNotIncreaseTokensCount()
+    {
+        $tokens = Tokens::fromCode('<?php
+                                    // Foo
+                                    $bar;');
+        $originalCount = $tokens->count();
+
+        $tokens->removeLeadingWhitespace(4);
+
+        $this->assertSame($originalCount, $tokens->count());
+        $this->assertSame(
+            '<?php
+                                    // Foo
+$bar;',
+            $tokens->generateCode()
+        );
+    }
+
+    /**
+     * Action that begins with the word "remove" should not change the size of collection.
+     */
+    public function testRemovingTrailingWhitespaceWillNotIncreaseTokensCount()
+    {
+        $tokens = Tokens::fromCode('<?php
+                                    // Foo
+                                    $bar;');
+        $originalCount = $tokens->count();
+
+        $tokens->removeTrailingWhitespace(2);
+
+        $this->assertSame($originalCount, $tokens->count());
+        $this->assertSame(
+            '<?php
+                                    // Foo
+$bar;',
+            $tokens->generateCode()
+        );
+    }
+
+    /**
      * @param null|Token[] $expected
      * @param null|Token[] $input
      */


### PR DESCRIPTION
Previously when calling `Tokens::removeLeadingWhitespace`/`Tokens::removeTrailingWhitespace` it could happen that new `Token` was inserted to collection - which would result with changes of indices.