### PR TITLE
Failing test case for non-utf8 diff

### DIFF
--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -101,6 +101,13 @@ final class DiffConsoleFormatterTest extends TestCase
 ',
                 '| %s',
             ],
+            [
+                mb_convert_encoding("<fg=red>--- Original</fg=red>\n<fg=green>+ausgefüllt</fg=green>", 'ISO-8859-1'),
+                true,
+                '%s',
+                mb_convert_encoding("--- Original\n+ausgefüllt", 'ISO-8859-1'),
+                '%s',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Hello, I work on some legacy projects and PHP-CS-Fixer differ does not work properly there, because it has some issues with non utf8 files