### PR TITLE
DX: fixing typo

### DIFF
--- a/src/Fixer/FunctionNotation/ImplodeCallFixer.php
+++ b/src/Fixer/FunctionNotation/ImplodeCallFixer.php
@@ -109,9 +109,9 @@ final class ImplodeCallFixer extends AbstractFixer
                 }
 
                 // collect tokens from first argument
-                $firstArgumenteEndIndex = $argumentsIndices[\key($argumentsIndices)];
+                $firstArgumentEndIndex = $argumentsIndices[\key($argumentsIndices)];
                 $newSecondArgumentTokens = [];
-                for ($i = \key($argumentsIndices); $i <= $firstArgumenteEndIndex; ++$i) {
+                for ($i = \key($argumentsIndices); $i <= $firstArgumentEndIndex; ++$i) {
                     $newSecondArgumentTokens[] = clone $tokens[$i];
                     $tokens->clearAt($i);
                 }


### PR DESCRIPTION
Some noob could not correctly write word "argument" :)

After discovering this I'd created [this](https://gist.github.com/kubawerlos/d187e42d209d00dda2cea6284e42a220) test - do you think it would be useful? To unify "indexes" vs "indixes", "regex" vs "regexp" and more, in future.