### PR TITLE
DX: namespace casing

### DIFF
--- a/tests/AutoReview/ComposerTest.php
+++ b/tests/AutoReview/ComposerTest.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\tests\AutoReview;
+namespace PhpCsFixer\Tests\AutoReview;
 
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Tests\TestCase;

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\tests\AutoReview;
+namespace PhpCsFixer\Tests\AutoReview;
 
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\TransformerInterface;

--- a/tests/Tokenizer/Generator/NamespacedStringTokenGeneratorTest.php
+++ b/tests/Tokenizer/Generator/NamespacedStringTokenGeneratorTest.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\tests\Tokenizer\Generator;
+namespace PhpCsFixer\Tests\Tokenizer\Generator;
 
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Generator\NamespacedStringTokenGenerator;

--- a/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php
+++ b/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php
@@ -10,7 +10,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace PhpCsFixer\tests\Tokenizer\Resolver;
+namespace PhpCsFixer\Tests\Tokenizer\Resolver;
 
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Resolver\TypeShortNameResolver;


### PR DESCRIPTION
Just spotted this - not sure if it's worth to write an AutoReview test to prevent it in future.