### PR TITLE
Add NoUnsetCastFixer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1146,6 +1146,10 @@ Choose from the list of available rules:
 
   *Risky rule: modifies the signature of functions; therefore risky when using systems (such as some Symfony components) that rely on those (for example through reflection).*
 
+* **no_unset_cast** [@PhpCsFixer]
+
+  Variables must be set ``null`` instead of using ``(unset)`` casting.
+
 * **no_unset_on_property** [@PhpCsFixer:risky]
 
   Properties should be set to ``null`` instead of using ``unset``.

--- a/src/Fixer/CastNotation/NoUnsetCastFixer.php
+++ b/src/Fixer/CastNotation/NoUnsetCastFixer.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\CastNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class NoUnsetCastFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Variables must be set `null` instead of using `(unset)` casting.',
+            [new CodeSample("<?php\n\$a = (unset) \$b;\n")]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_UNSET_CAST);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        for ($index = \count($tokens) - 1; $index > 0; --$index) {
+            if ($tokens[$index]->isGivenKind(T_UNSET_CAST)) {
+                $this->fixUnsetCast($tokens, $index);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     */
+    private function fixUnsetCast(Tokens $tokens, $index)
+    {
+        $assignmentIndex = $tokens->getPrevMeaningfulToken($index);
+        if (null === $assignmentIndex || !$tokens[$assignmentIndex]->equals('=')) {
+            return;
+        }
+
+        $varIndex = $tokens->getNextMeaningfulToken($index);
+        if (null === $varIndex || !$tokens[$varIndex]->isGivenKind(T_VARIABLE)) {
+            return;
+        }
+
+        $nextIsWhiteSpace = $tokens[$assignmentIndex + 1]->isWhitespace();
+
+        $tokens->clearTokenAndMergeSurroundingWhitespace($index);
+        $tokens->clearTokenAndMergeSurroundingWhitespace($varIndex);
+
+        ++$assignmentIndex;
+        if (!$nextIsWhiteSpace) {
+            $tokens->insertAt($assignmentIndex, new Token([T_WHITESPACE, ' ']));
+        }
+
+        ++$assignmentIndex;
+        $tokens->insertAt($assignmentIndex, new Token([T_STRING, 'null']));
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -236,6 +236,7 @@ final class RuleSet implements RuleSetInterface
             'no_superfluous_elseif' => true,
             'no_unneeded_curly_braces' => true,
             'no_unneeded_final_method' => true,
+            'no_unset_cast' => true,
             'no_useless_else' => true,
             'no_useless_return' => true,
             'ordered_class_elements' => true,

--- a/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\CastNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\CastNotation\NoUnsetCastFixer
+ */
+final class NoUnsetCastFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'simple form I' => [
+                "<?php\n\$a = null;",
+                "<?php\n\$a =(unset)\$z;",
+            ],
+            'simple form II' => [
+                "<?php\n\$a = null;",
+                "<?php\n\$a = (unset)\$z;",
+            ],
+            'lot of spaces' => [
+                "<?php\n\$a = \t \t \t null;",
+                "<?php\n\$a = \t (unset)\$z\t \t ;",
+            ],
+            'comments' => [
+                '<?php
+#0
+$a#1
+#2
+= null#3
+#4
+#5
+#6
+#7
+#8
+;
+',
+                '<?php
+#0
+$a#1
+#2
+=#3
+#4
+(unset)#5
+#6
+$b#7
+#8
+;
+',
+            ],
+            [
+                "<?php\n(unset) \$b;",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3767

```
$ php php-cs-fixer describe no_unset_cast
Description of no_unset_cast rule.
Using `$foo = (unset) $bar` must not be used, but `$foo = null;`.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,2 +1,2 @@
    <?php
   -$a = (unset) $b;
   +$a =  null;
   
   ----------- end diff -----------
```
