### PR TITLE
NoExtraBlankLinesFixer - fix candidate detection

### DIFF
--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -362,7 +362,7 @@ switch($a) {
 
     private function removeBetweenUse($index)
     {
-        $next = $this->tokens->getNextTokenOfKind($index, [';', T_CLOSE_TAG]);
+        $next = $this->tokens->getNextTokenOfKind($index, [';', [T_CLOSE_TAG]]);
         if (null === $next || $this->tokens[$next]->isGivenKind(T_CLOSE_TAG)) {
             return;
         }

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -512,6 +512,8 @@ $b = 1;
             ['<?php use A\B;'],
             ['<?php use A\B?>'],
             ['<?php use A\B;use A\D; return 1;'],
+            ["<?php use A\\B?>\n\n<?php use D\\E\\F?>"],
+            ['<?php use Y\B;use A\D; return 1;'],
             [
                 '<?php
                     use A\B;


### PR DESCRIPTION
technically a bug, however the logic effected is for fast checking for candidate, so in the end the effect of the bug is "only" slower code