### PR TITLE
Preg::split - fix for non-UTF8 subject

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -36,12 +36,12 @@ final class Preg
     public static function match($pattern, $subject, &$matches = null, $flags = 0, $offset = 0)
     {
         $result = @preg_match(self::addUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
         $result = @preg_match(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
@@ -62,12 +62,12 @@ final class Preg
     public static function matchAll($pattern, $subject, &$matches = null, $flags = PREG_PATTERN_ORDER, $offset = 0)
     {
         $result = @preg_match_all(self::addUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
         $result = @preg_match_all(self::removeUtf8Modifier($pattern), $subject, $matches, $flags, $offset);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
@@ -88,12 +88,12 @@ final class Preg
     public static function replace($pattern, $replacement, $subject, $limit = -1, &$count = null)
     {
         $result = @preg_replace(self::addUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
-        if (null !== $result) {
+        if (null !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
         $result = @preg_replace(self::removeUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
-        if (null !== $result) {
+        if (null !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
@@ -114,12 +114,12 @@ final class Preg
     public static function replaceCallback($pattern, $callback, $subject, $limit = -1, &$count = null)
     {
         $result = @preg_replace_callback(self::addUtf8Modifier($pattern), $callback, $subject, $limit, $count);
-        if (null !== $result) {
+        if (null !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
         $result = @preg_replace_callback(self::removeUtf8Modifier($pattern), $callback, $subject, $limit, $count);
-        if (null !== $result) {
+        if (null !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
@@ -139,12 +139,12 @@ final class Preg
     public static function split($pattern, $subject, $limit = -1, $flags = 0)
     {
         $result = @preg_split(self::addUtf8Modifier($pattern), $subject, $limit, $flags);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 
         $result = @preg_split(self::removeUtf8Modifier($pattern), $subject, $limit, $flags);
-        if (false !== $result) {
+        if (false !== $result && PREG_NO_ERROR === preg_last_error()) {
             return $result;
         }
 

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -101,6 +101,13 @@ final class DiffConsoleFormatterTest extends TestCase
 ',
                 '| %s',
             ],
+            [
+                mb_convert_encoding("<fg=red>--- Original</fg=red>\n<fg=green>+ausgefüllt</fg=green>", 'ISO-8859-1'),
+                true,
+                '%s',
+                mb_convert_encoding("--- Original\n+ausgefüllt", 'ISO-8859-1'),
+                '%s',
+            ],
         ];
     }
 }

--- a/tests/Differ/DiffConsoleFormatterTest.php
+++ b/tests/Differ/DiffConsoleFormatterTest.php
@@ -108,6 +108,20 @@ final class DiffConsoleFormatterTest extends TestCase
                 mb_convert_encoding("--- Original\n+ausgefüllt", 'ISO-8859-1'),
                 '%s',
             ],
+            [
+                mb_convert_encoding("<fg=red>--- Original</fg=red>\n<fg=green>+++ New</fg=green>\n<fg=cyan>@@ @@</fg=cyan>\n<fg=red>-ausgefüllt</fg=red>", 'ISO-8859-1'),
+                true,
+                '%s',
+                mb_convert_encoding("--- Original\n+++ New\n@@ @@\n-ausgefüllt", 'ISO-8859-1'),
+                '%s',
+            ],
+            [
+                mb_convert_encoding("--- Original\n+++ New\n@@ @@\n-ausgefüllt", 'ISO-8859-1'),
+                false,
+                '%s',
+                mb_convert_encoding("--- Original\n+++ New\n@@ @@\n-ausgefüllt", 'ISO-8859-1'),
+                '%s',
+            ],
         ];
     }
 }

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -166,13 +166,14 @@ final class PregTest extends TestCase
 
     /**
      * @param string $pattern
+     * @param string $subject
      *
      * @dataProvider provideCommonCases
      */
-    public function testSplit($pattern)
+    public function testSplit($pattern, $subject)
     {
-        $expectedResult = preg_split($pattern, 'foo');
-        $actualResult = Preg::split($pattern, 'foo');
+        $expectedResult = preg_split($pattern, $subject);
+        $actualResult = Preg::split($pattern, $subject);
 
         $this->assertSame($expectedResult, $actualResult);
     }


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4093