### PR TITLE
Changes for upcoming Travis' infra migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 git:
     depth: 1
 


### PR DESCRIPTION
Travis is deprecating the `sudo` keyword and moves everything to the same infrastructure (sudo really selects between two infrastructures).

See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration