### PR TITLE
Fixed brew install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ You can update ``php-cs-fixer`` through this command:
 
 .. code-block:: bash
 
-    $ brew upgrade php-cs-fixer
+    $ brew install php-cs-fixer
 
 Locally (PHIVE)
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`brew upgrade php-cs-fixer` won't work on fresh install, it will yield: `Error: php-cs-fixer not installed`
Fixed to be `brew install php-cs-fixer`