### PR TITLE
NativeFunctionTypeDeclarationCasingFixer - Introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -929,6 +929,10 @@ Choose from the list of available rules:
   - ``strict`` (``bool``): whether leading ``\`` of function call not meant to have it
     should be removed; defaults to ``false``
 
+* **native_function_type_declaration_casing** [@Symfony, @PhpCsFixer]
+
+  Native type hints for functions should use the correct case.
+
 * **new_with_braces** [@Symfony, @PhpCsFixer]
 
   All instances created with new keyword must be followed by braces.

--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Casing;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
+{
+    /**
+     * https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.
+     *
+     * self     PHP 5.0.0
+     * array    PHP 5.1.0
+     * callable PHP 5.4.0
+     * bool     PHP 7.0.0
+     * float    PHP 7.0.0
+     * int      PHP 7.0.0
+     * string   PHP 7.0.0
+     * iterable PHP 7.1.0
+     * void     PHP 7.1.0
+     * object   PHP 7.2.0
+     *
+     * @var array<string, true>
+     */
+    private $hints;
+
+    /**
+     * @var FunctionsAnalyzer
+     */
+    private $functionsAnalyzer;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->hints = [
+            'array' => true,
+            'callable' => true,
+            'self' => true,
+        ];
+
+        if (\PHP_VERSION_ID >= 70000) {
+            $this->hints = array_merge(
+                $this->hints,
+                [
+                    'bool' => true,
+                    'float' => true,
+                    'int' => true,
+                    'string' => true,
+                ]
+            );
+        }
+
+        if (\PHP_VERSION_ID >= 70100) {
+            $this->hints = array_merge(
+                $this->hints,
+                [
+                    'iterable' => true,
+                    'void' => true,
+                ]
+            );
+        }
+
+        if (\PHP_VERSION_ID >= 70200) {
+            $this->hints = array_merge($this->hints, ['object' => true]);
+        }
+
+        $this->functionsAnalyzer = new FunctionsAnalyzer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Native type hints for functions should use the correct case.',
+            [
+                new CodeSample("<?php\nclass Bar {\n    public function Foo(CALLABLE \$bar)\n    {\n        return 1;\n    }\n}\n"),
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction Foo(INT \$a): Bool\n{\n    return true;\n}\n",
+                    new VersionSpecification(70000)
+                ),
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction Foo(Iterable \$a): VOID\n{\n    echo 'Hello world';\n}\n",
+                    new VersionSpecification(70100)
+                ),
+                new VersionSpecificCodeSample(
+                    "<?php\nfunction Foo(Object \$a)\n{\n    return 'hi!';\n}\n",
+                    new VersionSpecification(70200)
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_FUNCTION, T_STRING]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            if ($tokens[$index]->isGivenKind(T_FUNCTION)) {
+                if (\PHP_VERSION_ID >= 70000) {
+                    $this->fixFunctionReturnType($tokens, $index);
+                }
+
+                $this->fixFunctionArgumentTypes($tokens, $index);
+            }
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     */
+    private function fixFunctionArgumentTypes(Tokens $tokens, $index)
+    {
+        foreach ($this->functionsAnalyzer->getFunctionArguments($tokens, $index) as $argument) {
+            $this->fixArgumentType($tokens, $argument->getTypeAnalysis());
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $index
+     */
+    private function fixFunctionReturnType(Tokens $tokens, $index)
+    {
+        $this->fixArgumentType($tokens, $this->functionsAnalyzer->getFunctionReturnType($tokens, $index));
+    }
+
+    private function fixArgumentType(Tokens $tokens, TypeAnalysis $type = null)
+    {
+        if (null === $type) {
+            return;
+        }
+
+        $argumentIndex = $type->getStartIndex();
+        if ($argumentIndex !== $type->getEndIndex()) {
+            return; // the type to fix are always unqualified and so are always composed as one token
+        }
+
+        $lowerCasedName = strtolower($type->getName());
+        if (!isset($this->hints[$lowerCasedName])) {
+            return; // check of type is of interest based on name (slower check than previous index based)
+        }
+
+        $tokens[$argumentIndex] = new Token([$tokens[$argumentIndex]->getId(), $lowerCasedName]);
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -80,6 +80,7 @@ final class RuleSet implements RuleSetInterface
             'magic_method_casing' => true,
             'method_argument_space' => true,
             'native_function_casing' => true,
+            'native_function_type_declaration_casing' => true,
             'new_with_braces' => true,
             'no_blank_lines_after_class_opening' => true,
             'no_blank_lines_after_phpdoc' => true,

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Casing;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Casing\NativeFunctionTypeDeclarationCasingFixer
+ */
+final class NativeFunctionTypeDeclarationCasingFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+class Foo
+{
+    private function Bar(array $bar) {
+        return false;
+    }
+}
+',
+                '<?php
+class Foo
+{
+    private function Bar(ARRAY $bar) {
+        return false;
+    }
+}
+',
+            ],
+            [
+                '<?php
+interface Foo
+{
+    public function Bar(array $bar);
+}
+',
+                '<?php
+interface Foo
+{
+    public function Bar(ArrAY $bar);
+}
+',
+            ],
+            [
+                '<?php
+function Foo(/**/array/**/$bar) {
+    return false;
+}
+',
+                '<?php
+function Foo(/**/ARRAY/**/$bar) {
+    return false;
+}
+',
+            ],
+            [
+                '<?php
+function Foo(array $a, callable $b, self $c) {}
+                ',
+                '<?php
+function Foo(ARRAY $a, CALLABLE $b, Self $c) {}
+                ',
+            ],
+            [
+                '<?php
+function Foo(INTEGER $a) {}
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP <7.0
+     *
+     * @param string $expected
+     *
+     * @dataProvider provideFixPre70Cases
+     */
+    public function testFixPre70($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideFixPre70Cases()
+    {
+        return [
+            ['<?php function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D, ITERABLE $E, VOID $F, OBJECT $o) {}'],
+            ['<?php class Foo { public function Foo(\INT $a) {}}'],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix70Cases
+     * @requires PHP 7.0
+     */
+    public function testFix70($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix70Cases()
+    {
+        return [
+            [
+                '<?php final class Foo1 { final public function Foo(bool $A, float $B, int $C, string $D): int {} }',
+                '<?php final class Foo1 { final public function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D): INT {} }',
+            ],
+            [
+                '<?php function Foo(bool $A, float $B, int $C, string $D): int {}',
+                '<?php function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D): INT {}',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix70Cases
+     * @requires PHP 7.1
+     */
+    public function testFix71($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix71Cases()
+    {
+        return [
+            [
+                '<?php trait XYZ { function Foo(iterable $A): void {} }',
+                '<?php trait XYZ { function Foo(ITERABLE $A): VOID {} }',
+            ],
+            [
+                '<?php function Foo(iterable $A): void {}',
+                '<?php function Foo(ITERABLE $A): VOID {}',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix70Cases
+     * @requires PHP 7.2
+     */
+    public function testFix72($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix72Cases()
+    {
+        return [
+            [
+                '<?php function Foo(object $A): void {}',
+                '<?php function Foo(OBJECT $A): VOID {}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3553

```
$ php php-cs-fixer describe native_function_type_declaration_casing
Description of native_function_type_hint_casing rule.
Type hints (of functions) defined by PHP should be called using the correct casing.

Fixing examples:
 * Example #1.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,4 +1,4 @@
    <?php
   -function Foo(CALLABLE $bar) {
   +function Foo(callable $bar) {
        return 1;
    }
   
   ----------- end diff -----------

 * Example #2.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,5 @@
    <?php
   -function Foo(INT $a): Bool
   +function Foo(int $a): bool
    {
        return true;
    }
   
   ----------- end diff -----------

 * Example #3.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,5 @@
    <?php
   -function Foo(Iterable $a): VOID
   +function Foo(iterable $a): void
    {
        echo 'Hello world';
    }
   
   ----------- end diff -----------

 * Example #4.
   ---------- begin diff ----------
   --- Original
   +++ New
   @@ -1,5 +1,5 @@
    <?php
   -function Foo(Object $a)
   +function Foo(object $a)
    {
        return 'hi!';
    }
   
   ----------- end diff -----------

```