### PR TITLE
Fix: Symfony 4.2 deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
         "justinrainbow/json-schema": "^5.0",
-        "keradus/cli-executor": "^1.1",
+        "keradus/cli-executor": "^1.2",
         "mikey179/vfsStream": "^1.6",
         "php-coveralls/php-coveralls": "^2.1",
         "php-cs-fixer/accessible-object": "^1.0",

--- a/src/Linter/ProcessLinterProcessBuilder.php
+++ b/src/Linter/ProcessLinterProcessBuilder.php
@@ -41,10 +41,10 @@ final class ProcessLinterProcessBuilder
      */
     public function build($path)
     {
-        return new Process(sprintf(
-            '"%s" -l "%s"',
+        return new Process([
             $this->executable,
-            $path
-        ));
+            '-l',
+            $path,
+        ]);
     }
 }

--- a/tests/Linter/ProcessLinterProcessBuilderTest.php
+++ b/tests/Linter/ProcessLinterProcessBuilderTest.php
@@ -29,8 +29,8 @@ final class ProcessLinterProcessBuilderTest extends TestCase
      * @param string $file
      * @param string $expected
      *
-     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
-     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     * @testWith ["php", "foo.php", "'php' '-l' 'foo.php'"]
+     *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"]
      * @requires OS Linux|Darwin
      */
     public function testPrepareCommandOnPhpOnLinuxOrMac($executable, $file, $expected)
@@ -48,7 +48,7 @@ final class ProcessLinterProcessBuilderTest extends TestCase
      * @param string $file
      * @param string $expected
      *
-     * @testWith ["php", "foo.php", "\"php\" -l \"foo.php\""]
+     * @testWith ["php", "foo.php", "php -l foo.php"]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
      * @requires OS ^Win
      */


### PR DESCRIPTION
- [x] [Fix Travis CI](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4138)
- [x] [Fix CircleCI](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4139)
- [x] Manage deprecations in [`keradus/cli-executor`](https://github.com/keradus/cli-executor/pull/2)
- [x] Update `composer.json` with new `keradus/cli-executor` version