### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,10 +63,6 @@ jobs:
             stage: Fast Test
             php: 7.0
             install:
-                # Composer: enforce given Symfony components version
-                - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/force-lowest:$SYMFONY_VERSION; fi
-                - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/lts:$(echo $SYMFONY_VERSION | grep -o 'v[0-9]\+') || true; fi
-
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
             script:
@@ -83,7 +79,7 @@ jobs:
             <<: *STANDARD_TEST_JOB
             stage: Test
             php: 7.1
-            env: SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="v4.0"
+            env: SYMFONY_DEPRECATIONS_HELPER=weak PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
         -
             <<: *STANDARD_TEST_JOB

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -56,5 +56,6 @@
         <env name="SKIP_LINT_TEST_CASES" value="0"/>
         <env name="PHP_CS_FIXER_TEST_ALLOW_SKIPPING_PHAR_TESTS" value="1"/>
         <env name="PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER" value="0"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     </php>
 </phpunit>


### PR DESCRIPTION
[This](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3639) is PR that introduced `symfony/lts` usage - when you go to Travis log you can [see](https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/jobs/359259428) (click on the line with "symfony/lts" to expand logs) that it was failing from the begging. It started to break builds after Composer 1.8.0 was released. Run this series of commands to see:
```bash
mkdir test173 test180
composer self-update 1.7.3
composer require --no-update symfony/lts:v4.0 --working-dir=test173
composer self-update 1.8.0
composer require --no-update symfony/lts:v4.0 --working-dir=test180
cat test173/composer.json
cat test180/composer.json

```

P.S. I have disabled deprecations related to Symfony 4.2 to verify all CI builds - I'd like to enable it in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4129.