### PR TITLE
[7.3] NoAliasFunctionsFixer - mbregex_encoding' => 'mb_regex_encoding

### DIFF
--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -79,6 +79,7 @@ final class NoAliasFunctionsFixer extends AbstractFixer implements Configuration
         'mbereg_search_setpos' => 'mb_ereg_search_setpos',
         'mberegi' => 'mb_eregi',
         'mberegi_replace' => 'mb_eregi_replace',
+        'mbregex_encoding' => 'mb_regex_encoding',
         'mbsplit' => 'mb_split',
     ];
 


### PR DESCRIPTION
@ see https://wiki.php.net/rfc/deprecations_php_7_3