### PR TITLE
PhpUnitFqcnAnnotationFixer - handle only PhpUnit classes

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\PhpUnit;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -64,7 +65,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+        return $tokens->isAllTokenKindsFound([T_CLASS, T_DOC_COMMENT]);
     }
 
     /**
@@ -72,12 +73,30 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        foreach ($tokens as $index => $token) {
-            if ($token->isGivenKind(T_DOC_COMMENT)) {
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indexes) {
+            $startIndex = $indexes[0];
+            $prevDocCommentIndex = $tokens->getPrevTokenOfKind($startIndex, [[T_DOC_COMMENT]]);
+            if (null !== $prevDocCommentIndex) {
+                $startIndex = $prevDocCommentIndex;
+            }
+            $this->fixPhpUnitClass($tokens, $startIndex, $indexes[1]);
+        }
+    }
+
+    /**
+     * @param Tokens $tokens
+     * @param int    $startIndex
+     * @param int    $endIndex
+     */
+    private function fixPhpUnitClass(Tokens $tokens, $startIndex, $endIndex)
+    {
+        for ($index = $startIndex; $index < $endIndex; ++$index) {
+            if ($tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
                 $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace(
-                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(\w.*)$~m',
+                    '~^(\s*\*\s*@(?:expectedException|covers|coversDefaultClass|uses)\h+)(?!(?:self|static)::)(\w.*)$~m',
                     '$1\\\\$2',
-                    $token->getContent()
+                    $tokens[$index]->getContent()
                 )]);
             }
         }

--- a/tests/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixerTest.php
@@ -27,6 +27,12 @@ final class PhpUnitFqcnAnnotationFixerTest extends AbstractFixerTestCase
     {
         $expected = <<<'EOF'
 <?php
+/**
+ * @covers \Foo
+ * @covers ::fooMethod
+ * @coversDefaultClass \Bar
+ */
+class FooTest extends TestCase {
     /**
      * @ExpectedException Value
      * @expectedException \X
@@ -36,14 +42,21 @@ final class PhpUnitFqcnAnnotationFixerTest extends AbstractFixerTestCase
  * @expectedExceptionCode 123
      * @expectedExceptionMessage Foo bar
      *
-     * @covers \Foo
-     * @covers ::fooMethod
-     * @coversDefaultClass \Bar
      * @uses \Baz
+     * @uses \selfieGenerator
+     * @uses self::someFunction
+     * @uses static::someOtherFunction
      */
+}
 EOF;
         $input = <<<'EOF'
 <?php
+/**
+ * @covers Foo
+ * @covers ::fooMethod
+ * @coversDefaultClass Bar
+ */
+class FooTest extends TestCase {
     /**
      * @ExpectedException Value
      * @expectedException X
@@ -53,13 +66,29 @@ EOF;
  * @expectedExceptionCode 123
      * @expectedExceptionMessage Foo bar
      *
-     * @covers Foo
-     * @covers ::fooMethod
-     * @coversDefaultClass Bar
      * @uses Baz
+     * @uses selfieGenerator
+     * @uses self::someFunction
+     * @uses static::someOtherFunction
      */
+}
 EOF;
 
         $this->doTest($expected, $input);
+    }
+
+    public function testIgnoringNonPhpUnitClass()
+    {
+        $this->doTest('
+<?php
+class Foo {
+    /**
+     * @expectedException Some\Exception\ClassName
+     * @covers Foo
+     * @uses Baz
+     * @uses self::someFunction
+     */
+}
+');
     }
 }


### PR DESCRIPTION
 - handle only PhpUnit classes
 - do not add backslash to `self` and `static`