### PR TITLE
CI: Check that tag is matching version of PHP CS Fixer during deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,10 @@ jobs:
             install: ./dev-tools/build.sh
             script:
                 - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_PHAR_TESTS=0 vendor/bin/phpunit tests/Smoke/
+
+            before_deploy:
+                # ensure that deployment is happening only if tag matches version of PHP CS Fixer
+                - test $(php dev-tools/info-extractor.php | jq .version.number) == echo "\"$TRAVIS_TAG\""
             deploy:
                 provider: releases
                 api_key:

--- a/dev-tools/info-extractor.php
+++ b/dev-tools/info-extractor.php
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+$version = [
+    'number' => PhpCsFixer\Console\Application::VERSION,
+    'codename' => PhpCsFixer\Console\Application::VERSION_CODENAME,
+];
+
+echo json_encode([
+    'version' => $version,
+], JSON_PRETTY_PRINT);


### PR DESCRIPTION
So, if I would made a typo in tag name, it would not deploy.

https://travis-ci.org/keradus/PHP-CS-Fixer/jobs/473606514#L708
vs
https://travis-ci.org/keradus/PHP-CS-Fixer/builds/473607313#L707