### PR TITLE
Fixing typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog for v2.13.1
 * minor #3980 Clarifies allow-risky usage (josephzidell)
 * minor #4016 Bump console component due to it's bug (keradus)
 * minor #4023 Enhancement: Update localheinz/composer-normalize (localheinz)
-* minor #4049 use parent::offset*() methods when moving items arround in insertAt() (staabm)
+* minor #4049 use parent::offset*() methods when moving items around in insertAt() (staabm)
 
 Changelog for v2.13.0
 ---------------------


### PR DESCRIPTION
It took me a while to understand - https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4175 fixed the typo on 2.12 branch and this one is for 2.13 branch.