### PR TITLE
Tokens - fix removal of leading/trailing whitespace with empty token in collection

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1006,7 +1006,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeLeadingWhitespace($index, $whitespaces = null)
     {
-        $this->removeWhitespaceSafely($index, 1, $whitespaces);
+        $this->removeWhitespaceSafely($index, -1, $whitespaces);
     }
 
     /**
@@ -1015,7 +1015,7 @@ class Tokens extends \SplFixedArray
      */
     public function removeTrailingWhitespace($index, $whitespaces = null)
     {
-        $this->removeWhitespaceSafely($index, -1, $whitespaces);
+        $this->removeWhitespaceSafely($index, 1, $whitespaces);
     }
 
     /**
@@ -1235,15 +1235,16 @@ class Tokens extends \SplFixedArray
         $this->clearAt($nextIndex);
     }
 
-    private function removeWhitespaceSafely($index, $offset, $whitespaces = null)
+    private function removeWhitespaceSafely($index, $direction, $whitespaces = null)
     {
-        if (isset($this[$index - $offset]) && $this[$index - $offset]->isWhitespace()) {
+        $whitespaceIndex = $this->getNonEmptySibling($index, $direction);
+        if (isset($this[$whitespaceIndex]) && $this[$whitespaceIndex]->isWhitespace()) {
             $newContent = '';
-            $tokenToCheck = $this[$index - $offset];
+            $tokenToCheck = $this[$whitespaceIndex];
 
             // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
-            if (isset($this[$index - $offset - 1]) && $this[$index - $offset - 1]->isComment() && '/*' !== substr($this[$index - $offset - 1]->getContent(), 0, 2)) {
-                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$index - $offset]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+            if (isset($this[$whitespaceIndex - 1]) && $this[$whitespaceIndex - 1]->isComment() && '/*' !== substr($this[$whitespaceIndex - 1]->getContent(), 0, 2)) {
+                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$whitespaceIndex]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
                 if ('' === $whitespacesToCheck) {
                     return;
                 }
@@ -1255,9 +1256,9 @@ class Tokens extends \SplFixedArray
             }
 
             if ('' === $newContent) {
-                $this->clearAt($index - $offset);
+                $this->clearAt($whitespaceIndex);
             } else {
-                $this[$index - $offset] = new Token([T_WHITESPACE, $newContent]);
+                $this[$whitespaceIndex] = new Token([T_WHITESPACE, $newContent]);
             }
         }
     }

--- a/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DirConstantFixerTest.php
@@ -150,6 +150,12 @@ __FILE__# D
                 $multiLinePatternFixed,
                 $multiLinePatternToFix,
             ],
+            [
+                '<?php $x = __DIR__;',
+                '<?php $x = \dirname(
+                    __FILE__                     '.'
+                );',
+            ],
         ];
     }
 
@@ -177,7 +183,7 @@ __FILE__# D
                 '<?php $x = \dirname(__FILE__/* a */,  /* b */)  .".dist";',
             ],
             [
-                '<?php $x = __DIR__   ;',
+                '<?php $x = __DIR__;',
                 '<?php $x = \dirname(
                     __FILE__   ,                     '.'
                 );',

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -1174,6 +1174,30 @@ echo $a;',
         return $cases;
     }
 
+    public function testRemovingLeadingWhitespaceWithEmptyTokenInCollection()
+    {
+        $code = "<?php\n    /* I will be removed */MY_INDEX_IS_THREE;foo();";
+        $tokens = Tokens::fromCode($code);
+        $tokens->clearAt(2);
+
+        $tokens->removeLeadingWhitespace(3);
+
+        $tokens->clearEmptyTokens();
+        $this->assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_THREE;foo();"), $tokens);
+    }
+
+    public function testRemovingTrailingWhitespaceWithEmptyTokenInCollection()
+    {
+        $code = "<?php\nMY_INDEX_IS_ONE/* I will be removed */    ;foo();";
+        $tokens = Tokens::fromCode($code);
+        $tokens->clearAt(2);
+
+        $tokens->removeTrailingWhitespace(1);
+
+        $tokens->clearEmptyTokens();
+        $this->assertTokens(Tokens::fromCode("<?php\nMY_INDEX_IS_ONE;foo();"), $tokens);
+    }
+
     /**
      * Action that begins with the word "remove" should not change the size of collection.
      */


### PR DESCRIPTION
It might happen that `Tokens` collection contain a sequence:
 - `T_WHITESPACE`
 - `new Token('')` (from `Tokens::clearAt(N - 1)`)
 - a token at index `N`

When we call `Tokens::removeLeadingWhitespace(N)` currently `Tokens` will try with offset `-1`, checks that it is not whitespace and does nothing.

(Of course similar situation applies to `Tokens::removeTrailingWhitespace`)