### PR TITLE
Travis CI - fix config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,4 +153,4 @@ jobs:
 
     allow_failures:
         - php: nightly
-        - env: COLLECT_COVERAGE=1
+        - env: COLLECT_COVERAGE=1 COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 SYMFONY_DEPRECATIONS_HELPER=weak


### PR DESCRIPTION
We allow build job with collecting coverage to fail, but since it was changed to use PHP 7.3 it has more flags and make builds [failing](https://travis-ci.org/FriendsOfPHP/PHP-CS-Fixer/builds/474074754) thus we need to update the config.