### PR TITLE
[7.3] NoWhitespaceBeforeCommaInArrayFixer - fix comma after heredoc-end

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1173,6 +1173,11 @@ Choose from the list of available rules:
 
   In array declaration, there MUST NOT be a whitespace before each comma.
 
+  Configuration options:
+
+  - ``after_heredoc`` (``bool``): whether the whitespace between heredoc end and
+    comma should be removed; defaults to ``false``
+
 * **no_whitespace_in_blank_line** [@Symfony, @PhpCsFixer]
 
   Remove trailing whitespace at the end of blank lines.

--- a/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
@@ -140,4 +140,39 @@ EOF
             ],
         ];
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFix73Cases
+     * @requires PHP 7.3
+     */
+    public function testFix73($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix73Cases()
+    {
+        return [
+            [
+                "<?php \$x = array(<<<'EOF'
+<?php \$a = '\\foo\\bar\\\\';
+EOF, <<<'EOF'
+<?php \$a = \"\\foo\\bar\\\\\";
+EOF
+                    );",
+                "<?php \$x = array(<<<'EOF'
+<?php \$a = '\\foo\\bar\\\\';
+EOF
+                , <<<'EOF'
+<?php \$a = \"\\foo\\bar\\\\\";
+EOF
+                    );",
+                ['after_heredoc' => true],
+            ],
+        ];
+    }
 }

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -14,6 +14,7 @@ PHP 7.3 test.
     "native_function_invocation": {"include": ["get_class"]},
     "no_unset_cast": true,
     "no_unset_on_property": true,
+    "no_whitespace_before_comma_in_array": {"after_heredoc": true},
     "php_unit_dedicate_assert": true,
     "php_unit_expectation": true,
     "php_unit_mock": true,
@@ -86,12 +87,19 @@ in_array($b, $c, true, ); // `strict_param` rule
 foo(null === $a, ); // `yoda_style` rule
 $a = null; // `no_unset_cast` rule
 $foo->bar = null; // `no_unset_on_property` rule
-// `heredoc_indentation` rule
+
+// https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
     $a = <<<'EOD'
         abc
             def
             ghi
         EOD;
+$a = [<<<'EOD'
+    foo
+    EOD, <<<'EOD'
+    bar
+    EOD
+];
 
 --INPUT--
 <?php
@@ -153,9 +161,17 @@ trigger_error('Warning.', E_USER_DEPRECATED, ); // `error_suppression` rule
 foo($a === null, ); // `yoda_style` rule
 $a =(unset)$z; // `no_unset_cast` rule
 unset($foo->bar,); // `no_unset_on_property` rule
-// `heredoc_indentation` rule
+
+// https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes
     $a = <<<'EOD'
 abc
     def
     ghi
 EOD;
+$a = [<<<'EOD'
+foo
+EOD
+    , <<<'EOD'
+bar
+EOD
+];


### PR DESCRIPTION
Input:

```php
$a = [<<<'EOD'
foo
EOD
    , <<<'EOD'
bar
EOD
];
```

With PHP < 7.3 this is not changed (like before). With PHP >= 7.3 it would be changed now to:

```php
$a = [<<<'EOD'
foo
EOD, <<<'EOD'
bar
EOD
];
```