### PR TITLE
[7.3] CombineNestedDirnameFixer - support PHP 7.3

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -81,8 +81,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['combine_consecutive_unsets'], $fixers['space_after_semicolon']],
             [$fixers['combine_nested_dirname'], $fixers['method_argument_space']],
             [$fixers['combine_nested_dirname'], $fixers['no_spaces_inside_parenthesis']],
-            [$fixers['combine_nested_dirname'], $fixers['no_trailing_whitespace']],
-            [$fixers['combine_nested_dirname'], $fixers['no_whitespace_in_blank_line']],
             [$fixers['declare_strict_types'], $fixers['blank_line_after_opening_tag']],
             [$fixers['declare_strict_types'], $fixers['declare_equal_normalize']],
             [$fixers['dir_constant'], $fixers['combine_nested_dirname']],

--- a/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
@@ -52,7 +52,7 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
                 '<?php dirname(dirname($path));',
             ],
             [
-                '<?php dirname /* a */ ( /* b */  /* c */ $path /* d */,2);',
+                '<?php dirname /* a */ ( /* b */ /* c */ $path /* d */,2);',
                 '<?php dirname /* a */ ( /* b */ dirname( /* c */ $path) /* d */);',
             ],
             [
@@ -60,7 +60,7 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
                 '<?php dirname(\dirname(dirname($path)));',
             ],
             [
-                '<?php dirname($path ,4);',
+                '<?php dirname($path,4);',
                 '<?php dirname(dirname($path, 3));',
             ],
             [
@@ -68,11 +68,11 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
                 '<?php dirname(dirname($path), 3);',
             ],
             [
-                '<?php dirname($path , 5);',
+                '<?php dirname($path, 5);',
                 '<?php dirname(dirname($path, 2), 3);',
             ],
             [
-                '<?php dirname($path ,5);',
+                '<?php dirname($path,5);',
                 '<?php dirname(dirname(dirname($path), 3));',
             ],
             [
@@ -104,5 +104,31 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
     public function testDoNotFix()
     {
         $this->doTest('<?php dirname(dirname($path));');
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @requires PHP 7.3
+     * @dataProvider provideFix73Cases
+     */
+    public function testFix73($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix73Cases()
+    {
+        return [
+            [
+                '<?php dirname($path,3);',
+                '<?php dirname(dirname(dirname($path, ), ));',
+            ],
+            [
+                '<?php dirname($path, 3);',
+                '<?php dirname(dirname(dirname($path, ), ), );',
+            ],
+        ];
     }
 }

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -37,6 +37,7 @@ foo(
     $arg2,
 );
 __DIR__; // `dir_constant` rule
+dirname($path, 3); // `combine_nested_dirname` rule
 $foo->__invoke(1, ); // `magic_method_casing` rule
 implode('', $pieces, ); // `implode_call` rule
 implode('', $pieces, ); // `implode_call` rule
@@ -85,6 +86,7 @@ foo(
     $arg2,
 );
 dirname(__FILE__, ); // `dir_constant` rule
+dirname(dirname(dirname($path, ), ), ); // `combine_nested_dirname` rule
 $foo->__INVOKE(1, ); // `magic_method_casing` rule
 implode($pieces, '', ); // `implode_call` rule
 implode($pieces, ); // `implode_call` rule

--- a/tests/Fixtures/Integration/misc/combine_nested_dirname,no_trailing_whitespace.test
+++ b/tests/Fixtures/Integration/misc/combine_nested_dirname,no_trailing_whitespace.test
@@ -6,8 +6,7 @@ Integration of fixers: combine_nested_dirname,no_trailing_whitespace.
 {"php": 70000}
 --EXPECT--
 <?php
-dirname(
-    $path
+dirname($path
 ,3);
 
 --INPUT--

--- a/tests/Fixtures/Integration/misc/combine_nested_dirname,no_whitespace_in_blank_line.test
+++ b/tests/Fixtures/Integration/misc/combine_nested_dirname,no_whitespace_in_blank_line.test
@@ -7,9 +7,7 @@ Integration of fixers: combine_nested_dirname,no_whitespace_in_blank_line.
 --EXPECT--
 <?php
 dirname(
-
         $path
-
 ,2);
 
 --INPUT--

--- a/tests/Fixtures/Integration/priority/combine_nested_dirname,method_argument_space.test
+++ b/tests/Fixtures/Integration/priority/combine_nested_dirname,method_argument_space.test
@@ -6,7 +6,7 @@ Integration of fixers: combine_nested_dirname,method_argument_space.
 {"php": 70000}
 --EXPECT--
 <?php
-dirname(  $path, 2);
+dirname( $path, 2);
 
 --INPUT--
 <?php


### PR DESCRIPTION
To `2.13` branch as the fixer was added in `2.13`.

Ping @gharlan (as original author) for review.