### PR TITLE
[7.3] ErrorSuppressionFixer - support PHP 7.3

### DIFF
--- a/src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+++ b/src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
@@ -164,8 +164,13 @@ final class ErrorSuppressionFixer extends AbstractFixer implements Configuration
             return false;
         }
 
-        $end = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextTokenOfKind($index, [T_STRING, '(']));
+        $endBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $tokens->getNextTokenOfKind($index, [T_STRING, '(']));
 
-        return $tokens[$tokens->getPrevMeaningfulToken($end)]->equals([T_STRING, 'E_USER_DEPRECATED']);
+        $prevIndex = $tokens->getPrevMeaningfulToken($endBraceIndex);
+        if ($tokens[$prevIndex]->equals(',')) {
+            $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
+        }
+
+        return $tokens[$prevIndex]->equals([T_STRING, 'E_USER_DEPRECATED']);
     }
 }

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -122,4 +122,15 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
             ],
         ];
     }
+
+    /**
+     * @requires PHP 7.3
+     */
+    public function testFix73()
+    {
+        $this->doTest(
+            '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED, );',
+            '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED, );'
+        );
+    }
 }

--- a/tests/Fixer/LanguageConstruct/SilencedDeprecationErrorFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SilencedDeprecationErrorFixerTest.php
@@ -81,4 +81,15 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
             ],
         ];
     }
+
+    /**
+     * @requires PHP 7.3
+     */
+    public function testFix73()
+    {
+        $this->doTest(
+            '<?php @trigger_error("This is a deprecation warning.", E_USER_DEPRECATED, );',
+            '<?php trigger_error("This is a deprecation warning.", E_USER_DEPRECATED, );'
+        );
+    }
 }

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -11,7 +11,6 @@ PHP 7.3 test.
     "multiline_whitespace_before_semicolons": true,
     "native_function_invocation": {"include": ["get_class"]},
     "php_unit_test_case_static_method_calls": {"call_type": "this"},
-    "silenced_deprecation_error": true,
     "strict_param": true
 }
 --REQUIREMENTS--
@@ -56,6 +55,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 random_int($a, $b, ); // `random_api_migration` rule
 $foo = (int) $foo; // `set_type_to_cast` rule
 in_array($b, $c, true, ); // `strict_param` rule
+@trigger_error('Warning.', E_USER_DEPRECATED, ); // `error_suppression` rule
 foo(null === $a, ); // `yoda_style` rule
 
 --INPUT--
@@ -96,4 +96,5 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 rand($a, $b, ); // `random_api_migration` rule
 settype($foo, "integer", ); // `set_type_to_cast` rule
 in_array($b, $c, ); // `strict_param` rule
+trigger_error('Warning.', E_USER_DEPRECATED, ); // `error_suppression` rule
 foo($a === null, ); // `yoda_style` rule


### PR DESCRIPTION
Handles also `SilencedDeprecationErrorFixer` and it's proxy to `ErrorSuppressionFixer`.