### PR TITLE
DX: Tokens - do not unregister/register found tokens when collection is not changing

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -313,13 +313,14 @@ class Tokens extends \SplFixedArray
 
         if (!$this[$index] || !$this[$index]->equals($newval)) {
             $this->changed = true;
+
+            if (isset($this[$index])) {
+                $this->unregisterFoundToken($this[$index]);
+            }
+
+            $this->registerFoundToken($newval);
         }
 
-        if (isset($this[$index])) {
-            $this->unregisterFoundToken($this[$index]);
-        }
-
-        $this->registerFoundToken($newval);
         parent::offsetSet($index, $newval);
     }
 


### PR DESCRIPTION
This makes sence, right?

Only run `unregisterFoundToken`/`registerFoundToken` when changing collection.