### PR TITLE
DX: enable multiline_whitespace_before_semicolons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -836,7 +836,7 @@ Choose from the list of available rules:
   with a single asterisk, after the opening slash. Both must end with a
   single asterisk before the closing slash.
 
-* **multiline_whitespace_before_semicolons**
+* **multiline_whitespace_before_semicolons** [@PhpCsFixer]
 
   Forbid multi-line whitespace before the closing semicolon or move the
   semicolon to the new line for chained calls.

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -324,7 +324,8 @@ final class ConfigurationResolver
             $this->fixers = $this->createFixerFactory()
                 ->useRuleSet($this->getRuleSet())
                 ->setWhitespacesConfig(new WhitespacesFixerConfig($this->config->getIndent(), $this->config->getLineEnding()))
-                ->getFixers();
+                ->getFixers()
+            ;
 
             if (false === $this->getRiskyAllowed()) {
                 $riskyFixers = array_map(

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -203,6 +203,7 @@ final class RuleSet implements RuleSetInterface
             'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
             'method_chaining_indentation' => true,
             'multiline_comment_opening_closing' => true,
+            'multiline_whitespace_before_semicolons' => ['strategy' => 'new_line_for_chained_calls'],
             'no_alternative_syntax' => true,
             'no_binary_string' => true,
             'no_extra_blank_lines' => ['tokens' => [

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -347,7 +347,8 @@ final class ConfigurationResolverTest extends TestCase
         $config = new Config();
         $config->getFinder()
             ->in(__DIR__)
-            ->notPath(basename(__FILE__));
+            ->notPath(basename(__FILE__))
+        ;
 
         $resolver = $this->createConfigurationResolver(
             ['path' => [__FILE__]],
@@ -362,7 +363,8 @@ final class ConfigurationResolverTest extends TestCase
         $config = new Config();
         $config->getFinder()
             ->in(__DIR__)
-            ->notPath(basename(__FILE__));
+            ->notPath(basename(__FILE__))
+        ;
 
         $resolver = $this->createConfigurationResolver([
             'path' => [__FILE__],
@@ -378,7 +380,8 @@ final class ConfigurationResolverTest extends TestCase
         $config = new Config();
         $config->getFinder()
             ->in($dir)
-            ->exclude(basename(__DIR__));
+            ->exclude(basename(__DIR__))
+        ;
 
         $resolver = $this->createConfigurationResolver(
             ['path' => [__FILE__]],
@@ -394,7 +397,8 @@ final class ConfigurationResolverTest extends TestCase
         $config = new Config();
         $config->getFinder()
             ->in($dir)
-            ->exclude(basename(__DIR__));
+            ->exclude(basename(__DIR__))
+        ;
 
         $resolver = $this->createConfigurationResolver([
             'path-mode' => 'intersection',
@@ -410,7 +414,8 @@ final class ConfigurationResolverTest extends TestCase
         $config = new Config();
         $config->getFinder()
             ->in($dir)
-            ->notPath('foo-'.basename(__FILE__));
+            ->notPath('foo-'.basename(__FILE__))
+        ;
 
         $resolver = $this->createConfigurationResolver(
             ['path' => [__FILE__]],

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -65,7 +65,8 @@ final class VersionSpecificCodeSampleTest extends TestCase
 
         $versionSpecification
             ->isSatisfiedBy($version)
-            ->willReturn($isSatisfied);
+            ->willReturn($isSatisfied)
+        ;
 
         $codeSample = new VersionSpecificCodeSample(
             '<php echo $foo;',

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -40,13 +40,16 @@ final class RunnerTest extends TestCase
         $linterProphecy = $this->prophesize(\PhpCsFixer\Linter\LinterInterface::class);
         $linterProphecy
             ->isAsync()
-            ->willReturn(false);
+            ->willReturn(false)
+        ;
         $linterProphecy
             ->lintFile(Argument::type('string'))
-            ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal());
+            ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal())
+        ;
         $linterProphecy
             ->lintSource(Argument::type('string'))
-            ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal());
+            ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal())
+        ;
 
         $fixers = [
             new Fixer\ClassNotation\VisibilityRequiredFixer(),

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -194,7 +194,8 @@ abstract class AbstractFixerTestCase extends TestCase
                 $linterProphecy = $this->prophesize(\PhpCsFixer\Linter\LinterInterface::class);
                 $linterProphecy
                     ->lintSource(Argument::type('string'))
-                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal());
+                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal())
+                ;
 
                 $linter = $linterProphecy->reveal();
             } else {

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -353,7 +353,8 @@ abstract class AbstractIntegrationTestCase extends TestCase
             ->setWhitespacesConfig(
                 new WhitespacesFixerConfig($config['indent'], $config['lineEnding'])
             )
-            ->getFixers();
+            ->getFixers()
+        ;
     }
 
     /**
@@ -384,13 +385,16 @@ abstract class AbstractIntegrationTestCase extends TestCase
                 $linterProphecy = $this->prophesize(\PhpCsFixer\Linter\LinterInterface::class);
                 $linterProphecy
                     ->lintSource(Argument::type('string'))
-                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal());
+                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal())
+                ;
                 $linterProphecy
                     ->lintFile(Argument::type('string'))
-                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal());
+                    ->willReturn($this->prophesize(\PhpCsFixer\Linter\LintingResultInterface::class)->reveal())
+                ;
                 $linterProphecy
                     ->isAsync()
-                    ->willReturn(false);
+                    ->willReturn(false)
+                ;
 
                 $linter = $linterProphecy->reveal();
             } else {


### PR DESCRIPTION
existing violations with current config: 6
existing violation with reverse config: 37

we were following the rule already, as it minimizes diff size