### PR TITLE
NativeFunctionInvocationFixer - namespaced strict to remove backslash

### DIFF
--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -579,6 +579,20 @@ namespace {
                     'strict' => true,
                 ],
             ],
+            'scope namespaced and strict enabled' => [
+                '<?php
+                    $a = not_compiler_optimized_function();
+                    $b = intval($c);
+                ',
+                '<?php
+                    $a = \not_compiler_optimized_function();
+                    $b = \intval($c);
+                ',
+                [
+                    'scope' => 'namespaced',
+                    'strict' => true,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
When we want only namespaced calls to have `\` in strict mode we should remove `\` for global namespace call.