### PR TITLE
[7.3] IsNullFixer - failing tests: trailing comma

### DIFF
--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -297,6 +297,20 @@ FIXED;
                 '<?php if ((null === $u or $v) and ($w || null === $x) xor (null !== $y and $z)) echo "foo"; ?>',
                 '<?php if ((is_null($u, ) or $v) and ($w || is_null($x, )) xor (!is_null($y, ) and $z)) echo "foo"; ?>',
             ],
+
+            // edge cases: $isContainingDangerousConstructs, $wrapIntoParentheses
+            [
+                '<?php null === ($a ? $x : $y);',
+                '<?php is_null($a ? $x : $y, );',
+            ],
+            [
+                '<?php $a === (null === $x);',
+                '<?php $a === is_null($x, );',
+            ],
+            [
+                '<?php $a === (null === ($a ? $x : $y));',
+                '<?php $a === is_null($a ? $x : $y, );',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Refs #4187, #4184

The last failure also implies #4225 (missing second closing parenthese)