### PR TITLE
DX: remove Utils::splitLines

### DIFF
--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\DocBlock;
 
-use PhpCsFixer\Utils;
+use PhpCsFixer\Preg;
 
 /**
  * This class represents a docblock.
@@ -44,7 +44,7 @@ class DocBlock
      */
     public function __construct($content)
     {
-        foreach (Utils::splitLines($content) as $line) {
+        foreach (Preg::split('/([^\n\r]+\R*)/', $content, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $line) {
             $this->lines[] = new Line($line);
         }
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -83,25 +83,6 @@ final class Utils
     }
 
     /**
-     * Split a multi-line string up into an array of strings.
-     *
-     * We're retaining a newline character at the end of non-blank lines, and
-     * discarding other lines, so this function is unsuitable for anyone for
-     * wishing to retain the exact number of line endings. If a single-line
-     * string is passed, we'll just return an array with a element.
-     *
-     * @param string $content
-     *
-     * @return string[]
-     */
-    public static function splitLines($content)
-    {
-        Preg::matchAll("/[^\n\r]+[\r\n]*/", $content, $matches);
-
-        return $matches[0];
-    }
-
-    /**
      * Calculate the trailing whitespace.
      *
      * What we're doing here is grabbing everything after the final newline.

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -91,39 +91,6 @@ final class UtilsTest extends TestCase
     }
 
     /**
-     * @param array  $expected
-     * @param string $input
-     *
-     * @dataProvider provideSplitLinesCases
-     */
-    public function testSplitLines(array $expected, $input)
-    {
-        $this->assertSame($expected, Utils::splitLines($input));
-    }
-
-    public function provideSplitLinesCases()
-    {
-        return [
-            [
-                ["\t aaa\n", " bbb\n", "\t"],
-                "\t aaa\n bbb\n\t",
-            ],
-            [
-                ["aaa\r\n", " bbb\r\n"],
-                "aaa\r\n bbb\r\n",
-            ],
-            [
-                ["aaa\r\n", " bbb\n"],
-                "aaa\r\n bbb\n",
-            ],
-            [
-                ["aaa\r\n\n\n\r\n", " bbb\n"],
-                "aaa\r\n\n\n\r\n bbb\n",
-            ],
-        ];
-    }
-
-    /**
      * @param string       $spaces
      * @param array|string $input  token prototype
      *


### PR DESCRIPTION
This is the surprise mentioned [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4205#issue-241654313).

Class `Utils` is internal so no [backward compatibility](https://symfony.com/doc/current/contributing/code/bc.html) break.