### PR TITLE
DX: more specific @param types

### DIFF
--- a/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+++ b/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
@@ -89,7 +89,7 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
      * @param Tokens $tokens
      * @param int    $index
      *
-     * @return string[]
+     * @return array<array<string, bool|int>>
      */
     private function getUnsetsInfo(Tokens $tokens, $index)
     {
@@ -152,7 +152,7 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
     }
 
     /**
-     * @param string[] $unsetsInfo
+     * @param array<array<string, bool|int>> $unsetsInfo
      *
      * @return bool
      */
@@ -168,9 +168,9 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
     }
 
     /**
-     * @param Tokens   $tokens
-     * @param string[] $unsetInfo
-     * @param bool     $isLastUnset
+     * @param Tokens                  $tokens
+     * @param array<string, bool|int> $unsetInfo
+     * @param bool                    $isLastUnset
      */
     private function updateTokens(Tokens $tokens, array $unsetInfo, $isLastUnset)
     {

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -64,7 +64,7 @@ final class TokensAnalyzer
      *
      * @param bool $perNamespace Return namespace uses per namespace
      *
-     * @return array|array[]
+     * @return int[]|int[][]
      */
     public function getImportUseIndexes($perNamespace = false)
     {


### PR DESCRIPTION
A source was this part of the PHPStan report:
```
 ------ ------------------------------------------------------------------ 
  Line   Fixer/Import/SingleLineAfterImportsFixer.php                      
 ------ ------------------------------------------------------------------ 
  86     Binary operation "+=" between array and int results in an error.  
 ------ ------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------- 
  Line   Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php              
 ------ ---------------------------------------------------------------- 
  204    Binary operation "+" between string and 1 results in an error.  
  222    Binary operation "+" between string and 1 results in an error.  
 ------ ---------------------------------------------------------------- 
```

