### PR TITLE
Psr0Fixer and Psr4Fixer  - fix for multiple classes in file with anonymous class

### DIFF
--- a/src/Fixer/Basic/Psr0Fixer.php
+++ b/src/Fixer/Basic/Psr0Fixer.php
@@ -83,7 +83,7 @@ class InvalidName {}
             } elseif ($token->isClassy()) {
                 $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
                 if ($prevToken->isGivenKind(T_NEW)) {
-                    break;
+                    continue;
                 }
 
                 if (null !== $classyName) {

--- a/src/Fixer/Basic/Psr4Fixer.php
+++ b/src/Fixer/Basic/Psr4Fixer.php
@@ -66,7 +66,7 @@ class InvalidName {}
             } elseif ($token->isClassy()) {
                 $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
                 if ($prevToken->isGivenKind(T_NEW)) {
-                    break;
+                    continue;
                 }
 
                 if (null !== $classyName) {

--- a/tests/Fixer/Basic/Psr0FixerTest.php
+++ b/tests/Fixer/Basic/Psr0FixerTest.php
@@ -245,6 +245,24 @@ EOF;
     }
 
     /**
+     * @requires PHP 7.0
+     */
+    public function testIgnoreMultipleClassWithAnonymousClass()
+    {
+        $file = $this->getTestFile(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+class ClassOne {};
+new class extends stdClass {};
+class ClassTwo {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+    }
+
+    /**
      * @param string $filename
      *
      * @dataProvider provideIgnoredCases

--- a/tests/Fixer/Basic/Psr4FixerTest.php
+++ b/tests/Fixer/Basic/Psr4FixerTest.php
@@ -232,6 +232,24 @@ EOF;
     }
 
     /**
+     * @requires PHP 7.0
+     */
+    public function testIgnoreMultipleClassWithAnonymousClass()
+    {
+        $file = $this->getTestFile(__FILE__);
+
+        $expected = <<<'EOF'
+<?php
+namespace PhpCsFixer\Tests\Fixer\Basic;
+class ClassOne {};
+new class extends stdClass {};
+class ClassTwo {};
+EOF;
+
+        $this->doTest($expected, null, $file);
+    }
+
+    /**
      * @param string $filename
      *
      * @dataProvider provideIgnoredCases


### PR DESCRIPTION
Found when working on https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4259