### PR TITLE
MethodChainingIndentationFixer - ArrayIndentationFixer - Priority

### DIFF
--- a/src/Fixer/Whitespace/ArrayIndentationFixer.php
+++ b/src/Fixer/Whitespace/ArrayIndentationFixer.php
@@ -49,7 +49,7 @@ final class ArrayIndentationFixer extends AbstractFixer implements WhitespacesAw
      */
     public function getPriority()
     {
-        // should run after BracesFixer
+        // should run after BracesFixer, MethodChainingIndentationFixer
         return -30;
     }
 

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -43,7 +43,8 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
     public function getPriority()
     {
         // Should run after BracesFixer
-        return -30;
+        // Should run before ArrayIndentationFixer
+        return -29;
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -98,6 +98,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['is_null'], $fixers['yoda_style']],
             [$fixers['list_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']],
+            [$fixers['method_chaining_indentation'], $fixers['array_indentation']],
             [$fixers['method_separation'], $fixers['braces']],
             [$fixers['method_separation'], $fixers['indentation_type']],
             [$fixers['no_alias_functions'], $fixers['php_unit_dedicate_assert']],

--- a/tests/Fixtures/Integration/priority/method_chaining_indentation,array_indentation.test
+++ b/tests/Fixtures/Integration/priority/method_chaining_indentation,array_indentation.test
@@ -1,0 +1,27 @@
+--TEST--
+Integration of fixers: method_chaining_indentation,array_indentation.
+--RULESET--
+{"array_indentation": true, "method_chaining_indentation": true}
+--EXPECT--
+<?php
+function foo($foo)
+{
+    $foo
+        ->bar()
+        ->baz([
+            'foo' => 'bar',
+        ])
+    ;
+}
+
+--INPUT--
+<?php
+function foo($foo)
+{
+    $foo
+        ->bar()
+           ->baz([
+                'foo' => 'bar',
+            ])
+    ;
+}


### PR DESCRIPTION
Fixes #4271.

Pre-2.12.5 `MethodChainingIndentationFixer` had no priority, I introduced it in #4084. It now needs to be upped because it needs to keep running before `ArrayIndentationFixer`.

Lowering `ArrayIndentationFixer` was not an option as it already has multiple fixers running after it (which are in the `FixerFactoryTest`, but not in its comments, however the comments are already being fixed in #4245).