### PR TITLE
MethodArgumentSpaceFixer - Fix method argument alignment

### DIFF
--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -271,7 +271,7 @@ EOF;
         //      `description <http://...>`_
 
         $help = Preg::replaceCallback(
-           '#`(.+)`\s?\(<url>(.+)<\/url>\)#',
+            '#`(.+)`\s?\(<url>(.+)<\/url>\)#',
             static function (array $matches) {
                 return sprintf('`%s <%s>`_', str_replace('\\', '\\\\', $matches[1]), $matches[2]);
             },

--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -41,7 +41,7 @@ final class BacktickToShellExecFixer extends AbstractFixer
             'Converts backtick operators to `shell_exec` calls.',
             [
                 new CodeSample(
-<<<'EOT'
+                    <<<'EOT'
 <?php
 $plain = `ls -lah`;
 $withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;

--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -51,7 +51,7 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
             'Replace non multibyte-safe functions with corresponding mb function.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 $a = strlen($a);
 $a = strpos($a, $b);
 $a = strrpos($a, $b);

--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -63,7 +63,7 @@ final class NoAliasFunctionsFixer extends AbstractFixer
             'Master functions shall be used instead of aliases.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 $a = chop($b);
 close($b);
 $a = doubleval($b);

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -51,7 +51,7 @@ final class BracesFixer extends AbstractFixer implements ConfigurationDefinition
             'The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo {
     public function bar($baz) {
@@ -79,7 +79,7 @@ class Foo {
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 $positive = function ($item) { return $item >= 0; };
 $negative = function ($item) {
                 return $item < 0; };
@@ -87,7 +87,7 @@ $negative = function ($item) {
                     ['allow_single_line_closure' => true]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo
 {

--- a/src/Fixer/Basic/EncodingFixer.php
+++ b/src/Fixer/Basic/EncodingFixer.php
@@ -43,7 +43,7 @@ final class EncodingFixer extends AbstractFixer
             'PHP code MUST use only UTF-8 without BOM (remove BOM).',
             [
                 new CodeSample(
-$this->BOM.'<?php
+                    $this->BOM.'<?php
 
 echo "Hello!";
 '

--- a/src/Fixer/Casing/LowercaseKeywordsFixer.php
+++ b/src/Fixer/Casing/LowercaseKeywordsFixer.php
@@ -36,7 +36,7 @@ final class LowercaseKeywordsFixer extends AbstractFixer
             'PHP keywords MUST be in lower case.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
     FOREACH($a AS $B) {
         TRY {
             NEW $C($a, ISSET($B));

--- a/src/Fixer/CastNotation/LowercaseCastFixer.php
+++ b/src/Fixer/CastNotation/LowercaseCastFixer.php
@@ -32,7 +32,7 @@ final class LowercaseCastFixer extends AbstractFixer
             'Cast should be written in lower case.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
     $a = (BOOLEAN) $b;
     $a = (BOOL) $b;
     $a = (INTEGER) $b;

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -42,7 +42,7 @@ final class ClassDefinitionFixer extends AbstractFixer implements ConfigurationD
             'Whitespace around the keywords of a class, trait or interfaces definition should be one space.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 class  Foo  extends  Bar  implements  Baz,  BarBaz
 {
@@ -58,14 +58,14 @@ trait  Foo
 '
                 ),
                 new VersionSpecificCodeSample(
-'<?php
+                    '<?php
 
 $foo = new  class  extends  Bar  implements  Baz,  BarBaz {};
 ',
                     new VersionSpecification(70100)
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo
 extends Bar
@@ -75,7 +75,7 @@ implements Baz, BarBaz
                     ['single_line' => true]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo
 extends Bar
@@ -85,7 +85,7 @@ implements Baz
                     ['single_item_single_line' => true]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 interface Bar extends
     Bar, BarBaz, FooBarBaz

--- a/src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+++ b/src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
@@ -31,7 +31,7 @@ final class NoNullPropertyInitializationFixer extends AbstractFixer
             'Properties MUST not be explicitly initialized with `null`.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 class Foo {
     public $foo = null;
 }

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -31,7 +31,7 @@ final class NoUnneededFinalMethodFixer extends AbstractFixer
             'A final class must not have final methods.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 final class Foo {
     final public function foo() {}
     final protected function bar() {}
@@ -40,7 +40,7 @@ final class Foo {
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 class Foo {
     final private function bar() {}
 }

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -34,7 +34,7 @@ final class ProtectedToPrivateFixer extends AbstractFixer
             'Converts `protected` variables and methods to `private` where possible.',
             [
                 new CodeSample(
-                '<?php
+                    '<?php
 final class Sample
 {
     protected $a;

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -44,7 +44,7 @@ final class VisibilityRequiredFixer extends AbstractFixer implements Configurati
             'Visibility MUST be declared on all properties and methods; `abstract` and `final` MUST be declared before the visibility; `static` MUST be declared after the visibility.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 class Sample
 {
     var $a;
@@ -57,7 +57,7 @@ class Sample
 '
                 ),
                 new VersionSpecificCodeSample(
-'<?php
+                    '<?php
 class Sample
 {
     const SAMPLE = 1;

--- a/src/Fixer/Comment/MultilineCommentOpeningClosingFixer.php
+++ b/src/Fixer/Comment/MultilineCommentOpeningClosingFixer.php
@@ -33,7 +33,7 @@ final class MultilineCommentOpeningClosingFixer extends AbstractFixer
             'DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash.',
             [
                 new CodeSample(
-<<<'EOT'
+                    <<<'EOT'
 <?php
 
 /******

--- a/src/Fixer/ControlStructure/IncludeFixer.php
+++ b/src/Fixer/ControlStructure/IncludeFixer.php
@@ -33,7 +33,7 @@ final class IncludeFixer extends AbstractFixer
             'Include/Require and file path should be divided with a single space. File path should not be placed under brackets.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 require ("sample1.php");
 require_once  "sample2.php";
 include       "sample3.php";

--- a/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
@@ -34,7 +34,7 @@ final class SwitchCaseSemicolonToColonFixer extends AbstractFixer
             'A case should be followed by a colon and not a semicolon.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
     switch ($a) {
         case 1;
             break;

--- a/src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
@@ -33,7 +33,7 @@ final class SwitchCaseSpaceFixer extends AbstractFixer
             'Removes extra spaces between colon and case value.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
     switch($a) {
         case 1   :
             break;

--- a/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
@@ -60,7 +60,7 @@ final class FunctionDeclarationFixer extends AbstractFixer implements Configurat
             'Spaces should be properly placed in a function declaration.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo
 {
@@ -77,7 +77,7 @@ function  foo  ($bar, $baz)
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 $f = function () {};
 ',
                     ['closure_function_spacing' => self::SPACING_NONE]

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -368,7 +368,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
      */
     private function fixNewline(Tokens $tokens, $index, $indentation, $override = true)
     {
-        if ($this->isNewline($tokens[$index + 1]) || $tokens[$index + 1]->isComment()) {
+        if ($tokens[$index + 1]->isComment()) {
             return;
         }
 

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -74,7 +74,7 @@ final class NativeFunctionInvocationFixer extends AbstractFixer implements Confi
             'Add leading `\` before function invocation to speed up resolving.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 function baz($options)
 {
@@ -87,7 +87,7 @@ function baz($options)
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 function baz($options)
 {

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -74,7 +74,7 @@ final class OrderedImportsFixer extends AbstractFixer implements ConfigurationDe
             [
                 new CodeSample("<?php\nuse Z; use A;\n"),
                 new CodeSample(
-'<?php
+                    '<?php
 use Acme\Bar;
 use Bar1;
 use Acme;
@@ -87,7 +87,7 @@ use Bar;
                     new VersionSpecification(70000)
                 ),
                 new VersionSpecificCodeSample(
-'<?php
+                    '<?php
 use const AAAA;
 use const BBB;
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -39,7 +39,7 @@ final class ClassKeywordRemoveFixer extends AbstractFixer
             'Converts `::class` keywords to FQCN strings.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 use Foo\Bar\Baz;
 

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -34,7 +34,7 @@ final class ExplicitIndirectVariableFixer extends AbstractFixer
             'Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.',
             [
                 new VersionSpecificCodeSample(
-<<<'EOT'
+                    <<<'EOT'
 <?php
 echo $$foo;
 echo $$foo['bar'];

--- a/src/Fixer/Operator/LogicalOperatorsFixer.php
+++ b/src/Fixer/Operator/LogicalOperatorsFixer.php
@@ -32,7 +32,7 @@ final class LogicalOperatorsFixer extends AbstractFixer
             'Use `&&` and `||` logical operators instead of `and` and `or`.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 if ($a == "foo" and ($b == "bar" or $c == "baz")) {
 }

--- a/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
@@ -31,7 +31,7 @@ final class NotOperatorWithSpaceFixer extends AbstractFixer
         return new FixerDefinition(
             'Logical NOT operators (`!`) should have leading and trailing whitespaces.',
             [new CodeSample(
-'<?php
+                '<?php
 
 if (!$bar) {
     echo "Help!";

--- a/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
@@ -31,7 +31,7 @@ final class NotOperatorWithSuccessorSpaceFixer extends AbstractFixer
         return new FixerDefinition(
             'Logical NOT operators (`!`) should have one trailing whitespace.',
             [new CodeSample(
-'<?php
+                '<?php
 
 if (!$bar) {
     echo "Help!";

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -35,7 +35,7 @@ final class FullOpeningTagFixer extends AbstractFixer
             'PHP code must use the long `<?php` tags or short-echo `<?=` tags and not other tag variations.',
             [
                 new CodeSample(
-'<?
+                    '<?
 
 echo "Hello!";
 '

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -33,7 +33,7 @@ final class PhpUnitFqcnAnnotationFixer extends AbstractFixer
         return new FixerDefinition(
             'PHPUnit annotations should be a FQCNs including a root namespace.',
             [new CodeSample(
-'<?php
+                '<?php
 final class MyTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
@@ -41,7 +41,7 @@ final class PhpUnitNamespacedFixer extends AbstractFixer implements Configuratio
             'PHPUnit classes MUST be used in namespaced version, eg `\PHPUnit\Framework\TestCase` instead of `\PHPUnit_Framework_TestCase`.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 final class MyTest extends \PHPUnit_Framework_TestCase
 {
 }

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -34,7 +34,7 @@ final class PhpUnitOrderedCoversFixer extends AbstractFixer
             'Order `@covers` annotation of PHPUnit tests.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 /**
  * @covers Foo
  * @covers Bar

--- a/src/Fixer/PhpUnit/PhpUnitStrictFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitStrictFixer.php
@@ -44,7 +44,7 @@ final class PhpUnitStrictFixer extends AbstractFixer implements ConfigurationDef
             'PHPUnit methods like `assertSame` should be used instead of `assertEquals`.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 final class MyTest extends \PHPUnit_Framework_TestCase
 {
     public function testSomeTest()

--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -37,7 +37,7 @@ final class PhpUnitTestClassRequiresCoversFixer extends AbstractFixer implements
             'Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 final class MyTest extends \PHPUnit_Framework_TestCase
 {
     public function testSomeTest()

--- a/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+++ b/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
@@ -53,7 +53,7 @@ final class AlignMultilineCommentFixer extends AbstractFixer implements Configur
             'Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
     /**
             * This is a DOC Comment
 with a line not prefixed with asterisk
@@ -62,7 +62,7 @@ with a line not prefixed with asterisk
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
     /*
             * This is a doc-like multiline comment
 */
@@ -70,7 +70,7 @@ with a line not prefixed with asterisk
                     ['comment_type' => 'phpdocs_like']
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
     /*
             * This is a doc-like multiline comment
 with a line not prefixed with asterisk

--- a/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
@@ -32,7 +32,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
         return new FixerDefinition(
             'Fix PHPDoc inline tags, make `@inheritdoc` always inline.',
             [new CodeSample(
-'<?php
+                '<?php
 /**
  * @{TUTORIAL}
  * {{ @link }}

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -35,7 +35,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             [
                 new CodeSample("<?php return null;\n"),
                 new VersionSpecificCodeSample(
-<<<'EOT'
+                    <<<'EOT'
 <?php
 function foo() { return null; }
 function bar(): int { return null; }

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -83,8 +83,8 @@ function foo () {
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder(
-                    'strategy',
-                    'Forbid multi-line whitespace or move the semicolon to the new line for chained calls.'
+                'strategy',
+                'Forbid multi-line whitespace or move the semicolon to the new line for chained calls.'
             ))
                 ->setAllowedValues([self::STRATEGY_NO_MULTI_LINE, self::STRATEGY_NEW_LINE_FOR_CHAINED_CALLS])
                 ->setDefault(self::STRATEGY_NO_MULTI_LINE)

--- a/src/Fixer/StringNotation/HeredocToNowdocFixer.php
+++ b/src/Fixer/StringNotation/HeredocToNowdocFixer.php
@@ -33,7 +33,7 @@ final class HeredocToNowdocFixer extends AbstractFixer
             'Convert `heredoc` to `nowdoc` where possible.',
             [
                 new CodeSample(
-<<<'EOF'
+                    <<<'EOF'
 <?php $a = <<<"TEST"
 Foo
 TEST;

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -209,7 +209,7 @@ switch ($a) {
                     ]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 if (null === $a) {
     $foo->bar();
     throw new \UnexpectedValueException("A cannot be null");
@@ -220,7 +220,7 @@ if (null === $a) {
                     ]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 $a = 9000;
 try {
     $foo->bar();

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -131,7 +131,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configuratio
             'Removes extra blank lines and/or blank lines following configuration.',
             [
                 new CodeSample(
-'<?php
+                    '<?php
 
 $foo = array("foo");
 
@@ -140,7 +140,7 @@ $bar = "bar";
 '
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 switch ($foo) {
     case 41:
@@ -154,7 +154,7 @@ switch ($foo) {
                     ['tokens' => ['break']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 for ($i = 0; $i < 9000; ++$i) {
     if (true) {
@@ -166,7 +166,7 @@ for ($i = 0; $i < 9000; ++$i) {
                     ['tokens' => ['continue']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 for ($i = 0; $i < 9000; ++$i) {
 
@@ -177,7 +177,7 @@ for ($i = 0; $i < 9000; ++$i) {
                     ['tokens' => ['curly_brace_block']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 $foo = array("foo");
 
@@ -187,7 +187,7 @@ $bar = "bar";
                     ['tokens' => ['extra']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 $foo = array(
 
@@ -198,7 +198,7 @@ $foo = array(
                     ['tokens' => ['parenthesis_brace_block']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 function foo($bar)
 {
@@ -209,7 +209,7 @@ function foo($bar)
                     ['tokens' => ['return']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 $foo = [
 
@@ -220,7 +220,7 @@ $foo = [
                     ['tokens' => ['square_brace_block']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 function foo($bar)
 {
@@ -231,7 +231,7 @@ function foo($bar)
                     ['tokens' => ['throw']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 namespace Foo;
 
@@ -246,7 +246,7 @@ class Bar
                     ['tokens' => ['use']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 
 class Foo
 {
@@ -258,7 +258,7 @@ class Foo
                     ['tokens' => ['use_trait']]
                 ),
                 new CodeSample(
-'<?php
+                    '<?php
 switch($a) {
 
     case 1:

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -359,7 +359,7 @@ INPUT
 f(
     1,
     2,
-3
+    3
 );',
                 '<?php
 f(1,2,
@@ -396,7 +396,6 @@ INPUT
 functionCall(
     'a',
     'b',
-
     'c'
 );
 EXPECTED
@@ -718,7 +717,7 @@ call_user_func(
     function ($arguments) {
     echo 'a', 'b';
 },
-$argv
+    $argv
 );
 EXPECTED
                 ,

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -570,8 +570,8 @@ namespace {
     public function testFix73()
     {
         $this->doTest(
-             '<?php $name = \get_class($foo, );',
-             '<?php $name = get_class($foo, );'
+            '<?php $name = \get_class($foo, );',
+            '<?php $name = get_class($foo, );'
          );
     }
 }

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -32,7 +32,7 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure(null);
         $this->doTest(
-             '<?php declare(ticks=1);',
+            '<?php declare(ticks=1);',
             '<?php declare(ticks= 1);'
         );
     }

--- a/tests/Fixer/Strict/StrictParamFixerTest.php
+++ b/tests/Fixer/Strict/StrictParamFixerTest.php
@@ -164,8 +164,8 @@ final class StrictParamFixerTest extends AbstractFixerTestCase
     public function testFix73()
     {
         $this->doTest(
-             '<?php in_array($b, $c, true, );',
-             '<?php in_array($b, $c, );'
+            '<?php in_array($b, $c, true, );',
+            '<?php in_array($b, $c, );'
          );
     }
 }


### PR DESCRIPTION
Fixes #3712 
Original PR #4277 

New PR is made in order to target long term support version (2.12),
**For more discussion please see #4277** 

Below is a duplicated description of #4277 for ease of reading:

As mentioned in the above issue, the code will not be aligned properly when forced into multiline (https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3712#issue-316138499)
```php
<?php
function a($a, $b,
           $c, $d) {
}
```
would be fixed to
```diff
--- Original
+++ New
@@ @@
 <?php

-function a($a, $b,
-           $c, $d) {
+function a(
+    $a,
+    $b,
+           $c,
+    $d
+) {
 }
```
However, the expected result is 
```diff
--- Original
+++ New
@@ @@
 <?php

-function a($a, $b,
-           $c, $d) {
+function a(
+    $a,
+    $b,
+    $c,
+    $d
+) {
 }
```
This is caused by function `MethodArgumentSpaceFixer::fixNewline`, where it simply returns without applying any fix when the token after `,` is newline.

This is not ideal, from the above code snippet, we can see the token after `$b,` is `newline + many spaces`. Instead, what we expect should be `newline + indentation`.

Therefore, by simply removing `$this->isNewline($token[$index + 1])` from early return check, it fixes this indentation issue.

Any related unit tests has also been modified to allow proper alignment.

However, I'm not sure whether this will have any other side effect, if so, please point it out. Thanks!