### PR TITLE
Add Gitlab Reporter

### DIFF
--- a/src/Report/GitlabReporter.php
+++ b/src/Report/GitlabReporter.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Report;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
+/**
+ * Generates a report according to gitlabs subset of codeclimate json files.
+ *
+ * @author Hans-Christian Otto <c.otto@suora.com>
+ *
+ * @internal
+ */
+final class GitlabReporter implements ReporterInterface
+{
+    public function getFormat()
+    {
+        return 'gitlab';
+    }
+
+    /**
+     * Process changed files array. Returns generated report.
+     *
+     * @param ReportSummary $reportSummary
+     *
+     * @return string
+     */
+    public function generate(ReportSummary $reportSummary)
+    {
+        $report = [];
+        foreach ($reportSummary->getChanged() as $fileName => $change) {
+            foreach ($change['appliedFixers'] as $fixerName) {
+                $report[] = [
+                    'description' => $fixerName,
+                    'location.path' => $fileName,
+                    'fingerprint' => md5($fileName.$fixerName),
+                    'location.lines.begin' => 0, // line numbers are required in the format, but not available to reports
+                ];
+            }
+        }
+
+        $jsonString = json_encode($report);
+
+        return $reportSummary->isDecoratedOutput() ? OutputFormatter::escape($jsonString) : $jsonString;
+    }
+}

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -287,7 +287,7 @@ final class ConfigurationResolverTest extends TestCase
     public function testResolveConfigFileChooseFileWithInvalidFormat()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are "checkstyle", "json", "junit", "txt", "xml"\.$/');
+        $this->expectExceptionMessageRegExp('/^The format "xls" is not defined, supported are "checkstyle", "gitlab", "json", "junit", "txt", "xml"\.$/');
 
         $dirBase = $this->getFixtureDir();
 

--- a/tests/Report/GitlabReporterTest.php
+++ b/tests/Report/GitlabReporterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Report;
+
+use PhpCsFixer\Report\GitlabReporter;
+
+/**
+ * @author Hans-Christian Otto <c.otto@suora.com>
+ *
+ * @internal
+ * @covers \PhpCsFixer\Report\GitlabReporter
+ */
+final class GitlabReporterTest extends AbstractReporterTestCase
+{
+    protected function createReporter()
+    {
+        return new GitlabReporter();
+    }
+
+    protected function getFormat()
+    {
+        return 'gitlab';
+    }
+
+    /**
+     * @return string
+     */
+    protected function createNoErrorReport()
+    {
+        return '[]';
+    }
+
+    /**
+     * @return string
+     */
+    protected function createSimpleReport()
+    {
+        return <<<'JSON'
+            [{
+                "description": "some_fixer_name_here",
+                "location.path": "someFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "ad098ea6ea7a28dd85dfcdfc9e2bded0"
+            }]
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    protected function createWithDiffReport()
+    {
+        return $this->createSimpleReport();
+    }
+
+    /**
+     * @return string
+     */
+    protected function createWithAppliedFixersReport()
+    {
+        return <<<'JSON'
+            [{
+                "description": "some_fixer_name_here_1",
+                "location.path": "someFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "b74e9385c8ae5b1f575c9c8226c7deff"
+            },{
+                "description": "some_fixer_name_here_2",
+                "location.path": "someFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "acad4672140c737a83c18d1474d84074"
+            }]
+JSON;
+    }
+
+    /**
+     * @return string
+     */
+    protected function createWithTimeAndMemoryReport()
+    {
+        return $this->createSimpleReport();
+    }
+
+    /**
+     * @return string
+     */
+    protected function createComplexReport()
+    {
+        return <<<'JSON'
+            [{
+                "description": "some_fixer_name_here_1",
+                "location.path": "someFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "b74e9385c8ae5b1f575c9c8226c7deff"
+            },{
+                "description": "some_fixer_name_here_2",
+                "location.path": "someFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "acad4672140c737a83c18d1474d84074"
+            },{
+                "description": "another_fixer_name_here",
+                "location.path": "anotherFile.php",
+                "location.lines.begin": 0,
+                "fingerprint": "30e86e533dac0f1b93bbc3a55c6908f8"
+            }]
+JSON;
+    }
+
+    protected function assertFormat($expected, $input)
+    {
+        $this->assertJsonStringEqualsJsonString($expected, $input);
+    }
+}

--- a/tests/Report/ReporterFactoryTest.php
+++ b/tests/Report/ReporterFactoryTest.php
@@ -51,7 +51,7 @@ final class ReporterFactoryTest extends TestCase
 
         $builder->registerBuiltInReporters();
         $this->assertSame(
-            ['checkstyle', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $builder->getFormats()
         );
     }

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -94,7 +94,7 @@ TEST;
         sort($formats);
 
         $this->assertSame(
-            ['checkstyle', 'json', 'junit', 'txt', 'xml'],
+            ['checkstyle', 'gitlab', 'json', 'junit', 'txt', 'xml'],
             $formats
         );
     }


### PR DESCRIPTION
Gitlab does support a subset of the CodeClimate JSON Format.
I initially called the Reporter "CodeClimate", but that would "require" more fields that we currently cannot fill appropriately from a report generator, I think.
So I decided to rename it to "Gitlab Reporter".

It will result in a pull request annotation like this:
![image](https://user-images.githubusercontent.com/156839/52041883-f8dc5c00-253b-11e9-9f04-07faa7eaa351.png)

I will be happy to maintain this reporter, if problems arise.

In a next step I would be happy to add meaningful line numbers, if someone can assist me on that, but after reading https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3601 it does not seem to be so easy, and I think the current state is enough for an "MVP" ;-)
