### PR TITLE
NoSuperfluousPhpdocTagsFixer - Make null only type not considered superfluous

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -254,6 +254,10 @@ class Foo {
 
         $annotationTypes = $this->toComparableNames($annotation->getTypes(), $symbolShortNames);
 
+        if (['null'] === $annotationTypes) {
+            return false;
+        }
+
         if (['mixed'] === $annotationTypes && null === $info['type']) {
             return true;
         }

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -279,6 +279,16 @@ class Foo {
     public function doFoo($foo) {}
 }',
             ],
+            'with_null' => [
+                '<?php
+class Foo {
+    /**
+     * @param null $foo
+     * @return null
+     */
+    public function doFoo($foo) {}
+}',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #4269.