### PR TITLE
NoTrailingWhitespaceInCommentFixer - fix for non-Unix line separators

### DIFF
--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -53,14 +53,14 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_DOC_COMMENT)) {
-                $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace('/[ \t]+$/m', '', $token->getContent())]);
+                $tokens[$index] = new Token([T_DOC_COMMENT, Preg::replace('/(*ANY)[ \t]+$/m', '', $token->getContent())]);
 
                 continue;
             }
 
             if ($token->isGivenKind(T_COMMENT)) {
                 if ('/*' === substr($token->getContent(), 0, 2)) {
-                    $tokens[$index] = new Token([T_COMMENT, Preg::replace('/[ \t]+$/m', '', $token->getContent())]);
+                    $tokens[$index] = new Token([T_COMMENT, Preg::replace('/(*ANY)[ \t]+$/m', '', $token->getContent())]);
                 } elseif (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
                     $trimmedContent = ltrim($tokens[$index + 1]->getContent(), " \t");
                     if ('' !== $trimmedContent) {

--- a/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoTrailingWhitespaceInCommentFixerTest.php
@@ -89,6 +89,50 @@ final class NoTrailingWhitespaceInCommentFixerTest extends AbstractFixerTestCase
      *  Foo '.'
      */',
             ],
+            [
+                str_replace(
+                    "\n",
+                    "\r\n",
+                    '<?php
+    /**
+     * Summary
+     *'.'
+     * Description
+    */'
+                ),
+                str_replace(
+                    "\n",
+                    "\r\n",
+                    '<?php
+    /**
+     * Summary
+     * '.'
+     * Description
+    */'
+                ),
+            ],
+            [
+                str_replace(
+                    "\n",
+                    "\r",
+                    '<?php
+    /**
+     * Summary
+     *'.'
+     * Description
+    */'
+                ),
+                str_replace(
+                    "\n",
+                    "\r",
+                    '<?php
+    /**
+     * Summary
+     * '.'
+     * Description
+    */'
+                ),
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4294

I've started with RegEx `/\h+(\R)/`, but this looks cool.