### PR TITLE
FullyQualifiedStrictTypesFixer - Fix the short type detection when a question mark (nullable) is prefixing it.

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -21,8 +21,10 @@ use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Generator\NamespacedStringTokenGenerator;
 use PhpCsFixer\Tokenizer\Resolver\TypeShortNameResolver;
+use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -156,15 +158,21 @@ class SomeClass
         }
 
         $typeName = $type->getName();
-        $shortType = (new TypeShortNameResolver())->resolve($tokens, $type->getName());
+        $shortType = (new TypeShortNameResolver())->resolve($tokens, $typeName);
         if ($shortType === $typeName) {
             return;
+        }
+
+        $shortType = (new NamespacedStringTokenGenerator())->generate($shortType);
+
+        if (true === $type->isNullable()) {
+            array_unshift($shortType, new Token([CT::T_NULLABLE_TYPE, '?']));
         }
 
         $tokens->overrideRange(
             $type->getStartIndex(),
             $type->getEndIndex(),
-            (new NamespacedStringTokenGenerator())->generate($shortType)
+            $shortType
         );
     }
 }

--- a/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
@@ -60,6 +60,11 @@ final class TypeAnalysis implements StartEndTokenAwareAnalysis
     private $endIndex;
 
     /**
+     * @var bool
+     */
+    private $nullable;
+
+    /**
      * @param string $name
      * @param int    $startIndex
      * @param int    $endIndex
@@ -67,6 +72,13 @@ final class TypeAnalysis implements StartEndTokenAwareAnalysis
     public function __construct($name, $startIndex, $endIndex)
     {
         $this->name = $name;
+        $this->nullable = false;
+
+        if (0 === strpos($name, '?')) {
+            $this->name = substr($name, 1);
+            $this->nullable = true;
+        }
+
         $this->startIndex = $startIndex;
         $this->endIndex = $endIndex;
     }
@@ -101,5 +113,13 @@ final class TypeAnalysis implements StartEndTokenAwareAnalysis
     public function isReservedType()
     {
         return \in_array($this->name, self::$reservedTypes, true);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNullable()
+    {
+        return $this->nullable;
     }
 }

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -28,8 +28,8 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideCodeWithReturnTypesCases
      *
-     * @param mixed      $expected
-     * @param null|mixed $input
+     * @param string      $expected
+     * @param null|string $input
      */
     public function testCodeWithReturnTypes($expected, $input = null)
     {
@@ -37,10 +37,23 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
     }
 
     /**
+     * @requires PHP 7.1
+     *
+     * @dataProvider provideCodeWithReturnTypesCasesWithNullableCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testCodeWithReturnTypesWithNullable($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
      * @dataProvider provideCodeWithoutReturnTypesCases
      *
-     * @param mixed      $expected
-     * @param null|mixed $input
+     * @param string      $expected
+     * @param null|string $input
      */
     public function testCodeWithoutReturnTypes($expected, $input = null)
     {
@@ -50,8 +63,7 @@ final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
     public function provideCodeWithReturnTypesCases()
     {
         return [
-            // Import common strict types:
-            [
+            'Import common strict types' => [
                 '<?php
 
 use Foo\Bar;
@@ -75,8 +87,7 @@ class SomeClass
     }
 }',
             ],
-            // Test namespace fixes:
-            [
+            'Test namespace fixes' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -102,8 +113,7 @@ class SomeClass
     }
 }',
             ],
-            // Test multi namespace fixes
-            [
+            'Test multi namespace fixes' => [
                 '<?php
 namespace Foo\Other {
 }
@@ -119,8 +129,7 @@ namespace Foo\Bar {
     }
 }',
             ],
-            // Test fixes in interface
-            [
+            'Test fixes in interface' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -142,8 +151,7 @@ interface SomeClass
     public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz): \Foo\Bar\Baz;
 }',
             ],
-            // Test fixes in trait
-            [
+            'Test fixes in trait' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -169,8 +177,7 @@ trait SomeClass
     }
 }',
             ],
-            // Test fixes in regular functions
-            [
+            'Test fixes in regular functions' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -196,8 +203,7 @@ function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\B
     public function provideCodeWithoutReturnTypesCases()
     {
         return [
-            // Import common strict types:
-            [
+            'Import common strict types' => [
                 '<?php
 
 use Foo\Bar;
@@ -219,8 +225,7 @@ class SomeClass
     }
 }',
             ],
-            // Test namespace fixes:
-            [
+            'Test namespace fixes' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -242,8 +247,7 @@ class SomeClass
     }
 }',
             ],
-            // Test multi namespace fixes
-            [
+            'Test multi namespace fixes' => [
                 '<?php
 namespace Foo\Other {
 }
@@ -257,8 +261,7 @@ namespace Foo\Bar {
     }
 }',
             ],
-            // Test fixes in interface
-            [
+            'Test fixes in interface' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -280,8 +283,7 @@ interface SomeClass
     public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\Buz $barbuz);
 }',
             ],
-            // Test fixes in trait
-            [
+            'Test fixes in trait' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -307,8 +309,7 @@ trait SomeClass
     }
 }',
             ],
-            // Test fixes in regular functions
-            [
+            'Test fixes in regular functions' => [
                 '<?php
 
 namespace Foo\Bar;
@@ -328,8 +329,7 @@ function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, \Foo\Bar\Zoof\B
 {
 }',
             ],
-            // Test partial namespace and use imports
-            [
+            'Test partial namespace and use imports' => [
                 '<?php
 
 namespace Ping\Pong;
@@ -371,12 +371,43 @@ class SomeClass
     ){}
 }',
             ],
-            // Test reference
-            [
+            'Test reference' => [
                 '<?php
 function withReference(Exception &$e) {}',
                 '<?php
 function withReference(\Exception &$e) {}',
+            ],
+        ];
+    }
+
+    public function provideCodeWithReturnTypesCasesWithNullableCases()
+    {
+        return [
+            'Test namespace fixes with nullable types' => [
+                '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Baz;
+
+class SomeClass
+{
+    public function doSomething(SomeClass $foo, Buz $buz, ?Zoof\Buz $barbuz): ?Baz
+    {
+    }
+}',
+                '<?php
+
+namespace Foo\Bar;
+
+use Foo\Bar\Baz;
+
+class SomeClass
+{
+    public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, ?\Foo\Bar\Zoof\Buz $barbuz): ?\Foo\Bar\Baz
+    {
+    }
+}',
             ],
         ];
     }

--- a/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
@@ -35,6 +35,11 @@ final class TypeAnalysisTest extends TestCase
     {
         $analysis = new TypeAnalysis('string', 1, 2);
         $this->assertSame('string', $analysis->getName());
+        $this->assertFalse($analysis->isNullable());
+
+        $analysis = new TypeAnalysis('?\foo\bar', 1, 2);
+        $this->assertSame('\foo\bar', $analysis->getName());
+        $this->assertTrue($analysis->isNullable());
     }
 
     public function testStartIndex()


### PR DESCRIPTION
Fix #4302 