### PR TITLE
PhpUnitTestCaseStaticMethodCallsFixer - fix for having property with name as method to update

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -380,6 +380,11 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 continue;
             }
 
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            if (!$tokens[$nextIndex]->equals('(')) {
+                continue;
+            }
+
             $methodName = $tokens[$index]->getContent();
             $callType = $this->configuration['call_type'];
             if (isset($this->configuration['methods'][$methodName])) {

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -433,6 +433,19 @@ EOF
                     'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
                 ],
             ],
+            [
+                <<<'EOF'
+<?php
+class HavingPropertyWithNameAsMethodToUpdateTest extends PHPUnit
+{
+    public function foo()
+    {
+        $this->assertSame = 42;
+    }
+}
+EOF
+                ,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4312

Pinging @Slamdunk (as original author) and @ro0NL (as reporter) for review.