### PR TITLE
Issue 4283 allow phpdoc summary to end with colon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1504,8 +1504,8 @@ Choose from the list of available rules:
 
 * **phpdoc_summary** [@Symfony, @PhpCsFixer]
 
-  PHPDoc summary should end in either a full stop, exclamation mark, or
-  question mark.
+  PHPDoc summary should end in either a full stop, colon, exclamation
+  mark, or question mark.
 
 * **phpdoc_to_comment** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -33,7 +33,7 @@ final class PhpdocSummaryFixer extends AbstractFixer implements WhitespacesAware
     public function getDefinition()
     {
         return new FixerDefinition(
-            'PHPDoc summary should end in either a full stop, exclamation mark, or question mark.',
+            'PHPDoc summary should end in either a full stop, colon, exclamation mark, or question mark.',
             [new CodeSample('<?php
 /**
  * Foo function is great
@@ -89,6 +89,6 @@ function foo () {}
             return true;
         }
 
-        return $content !== rtrim($content, '.。!?¡¿！？');
+        return $content !== rtrim($content, '.。:：!?¡¿！？');
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
@@ -57,6 +57,42 @@ EOF;
         $this->doTest($expected);
     }
 
+    public function testWithColon()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * The description has a list with items and line ends with colon:
+     *
+     *      - First item in a list
+     *      - Last item in a list
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->doTest($expected);
+    }
+
+    public function testWithFullwidthColon()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * The description has a list with items and line ends with colon：
+     *
+     *      - First item in a list
+     *      - Last item in a list
+     *
+     * @return bool
+     */
+
+EOF;
+
+        $this->doTest($expected);
+    }
+
     public function testWithQuestionMark()
     {
         $expected = <<<'EOF'


### PR DESCRIPTION
The changes here address #4283.