### PR TITLE
Collect coverage with PCOV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,8 +118,24 @@ jobs:
 
                 # Composer: boost installation
                 - composer global show hirak/prestissimo -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
+
+                # Require PHPUnit 8
+                - composer require --dev --no-update phpunit/phpunit:^8
+
+                # Install PCOV
+                - |
+                    git clone --single-branch --branch=v1.0.2 --depth=1 https://github.com/krakjoe/pcov
+                    cd pcov
+                    phpize
+                    ./configure
+                    make clean install
+                    echo "extension=pcov.so" > $HOME/.phpenv/versions/$TRAVIS_PHP_VERSION/etc/conf.d/pcov.ini
+                    cd $TRAVIS_BUILD_DIR
+            before_script:
+                # Make code compatible with PHPUnit 8
+                - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer fix --rules=void_return -q tests || return 0
             script:
-                - phpdbg -qrr vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
+                - vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
                 - php vendor/bin/php-coveralls -v
 
         -
@@ -152,4 +168,3 @@ jobs:
 
     allow_failures:
         - php: 7.4snapshot
-        - env: COLLECT_COVERAGE=1

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,10 @@
         "mikey179/vfsstream": "^1.6",
         "php-coveralls/php-coveralls": "^2.1",
         "php-cs-fixer/accessible-object": "^1.0",
-        "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
-        "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
+        "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+        "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
         "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-        "phpunitgoodpractices/traits": "^1.5.1",
+        "phpunitgoodpractices/traits": "^1.8",
         "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {


### PR DESCRIPTION
TODO:
- [x] merge and release https://github.com/PHP-CS-Fixer/phpunit-constraint-isidenticalstring/pull/3
- [x] merge and release https://github.com/PHP-CS-Fixer/phpunit-constraint-xmlmatchesxsd/pull/5
- [x] [prepare](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4337) `PhpUnitTestCaseStaticMethodCallsFixerTest` for PHPUnit 8

Optional:
- cache cloning `krakjoe/pcov` (will be faster that PHP 5.6 without it, that's why optional)
- [allow PHPUnit 8](https://github.com/PHPUnitGoodPractices/Traits/pull/41) for `phpunitgoodpractices/traits`