### PR TITLE
Change BracesFixer to avoid indenting PHP inline braces

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -342,6 +342,11 @@ class Foo
                 continue;
             }
 
+            /* if CLOSE_TAG is after { on the same line, do not indent. e.g. <?php if ($condition) { ?> */
+            if ($tokens[$tokens->getNextNonWhitespace($startBraceIndex, " \t")]->isGivenKind(T_CLOSE_TAG)) {
+                continue;
+            }
+
             $endBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $startBraceIndex);
 
             $indent = $this->detectIndent($tokens, $index);

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -806,6 +806,14 @@ class Foo {
     }
 }',
             ],
+            [
+                '<?php if ($condition) { ?>
+echo 1;
+<?php } else { ?>
+echo 2;
+<?php } ?>
+',
+            ],
         ];
     }
 


### PR DESCRIPTION
See @junstyle's original PR here: #3781.

This is a small change that allows for inline `<?php` tags without forcing indentation for opening braces. This is especially useful when mixing HTML with PHP. Here's an example of inline PHP that can cause issues:

```php
<div class="column recent-posts">
    <?php foreach ($posts as $post) { ?>
    <div class="post">
        <div class="post-title"><?php echo esc_html($post->post_title); ?></div>

        <?php if ($post->post_status === 'active') { ?>
        <strong><?php esc_html_e('Live'); ?></strong>
        <?php } ?>
    </div>
    <?php } ?>
</div>
```

After running `php-cs-fixer`:

```php
<div class="column recent-posts">
    <?php foreach ($posts as $post) {
    ?>
    <div class="post">
        <div class="post-title"><?php echo esc_html($post->post_title); ?></div>

        <?php if ('active' === $post->post_status) {
        ?>
        <strong><?php esc_html_e('Live'); ?></strong>
        <?php
    } ?>
    </div>
    <?php
} ?>
</div>
```

The current behavior, which forces braces onto the next line, adds a lot of whitespace and can reduce readability. This is especially evident in larger documents with deeply nested PHP as demonstrated in the [linked PR from @junstyle](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3781). The fix in my PR is based on @junstyle's original changes, with the addition of test fixes and a new test for the behavior.

This is my first time contributing to this project, so please let me know if I'm missing anything. Thank you!