### PR TITLE
Travis: build against 7.4snapshot instead of nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: nightly
+            php: 7.4snapshot
             env: COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 SYMFONY_DEPRECATIONS_HELPER=weak
 
         -
@@ -151,5 +151,5 @@ jobs:
                 - ./dev-tools/trigger-website.sh ${TRAVIS_TOKEN} ${TRAVIS_TAG}
 
     allow_failures:
-        - php: nightly
+        - php: 7.4snapshot
         - env: COLLECT_COVERAGE=1


### PR DESCRIPTION
At the time of creating this PR, in Travis we have:

|TAG|PHP -v|
|-|-|
|`nightly`|8.0.0-dev|
|`7.4snapshot`|7.4.0-dev|

Ref: https://twitter.com/nikita_ppv/status/1094897743594770433

I think we can safely ignore PHP 8 for now, and instead check PHP 7.4 build results.

This PR base branch in `2.12` as this should also be merged in `2.14`, `3.0` and `master`.