### PR TITLE
[7.3] TrailingCommaInMultilineArrayFixer - fix comma after heredoc-end

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1780,6 +1780,11 @@ Choose from the list of available rules:
 
   PHP multi-line arrays should have a trailing comma.
 
+  Configuration options:
+
+  - ``after_heredoc`` (``bool``): whether a trailing comma should also be placed
+    after heredoc end; defaults to ``false``
+
 * **trim_array_spaces** [@Symfony, @PhpCsFixer]
 
   Arrays should be formatted like function/method arguments, without

--- a/src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+++ b/src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
@@ -13,18 +13,25 @@
 namespace PhpCsFixer\Fixer\ArrayNotation;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class TrailingCommaInMultilineArrayFixer extends AbstractFixer
+final class TrailingCommaInMultilineArrayFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
      * {@inheritdoc}
@@ -33,7 +40,24 @@ final class TrailingCommaInMultilineArrayFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'PHP multi-line arrays should have a trailing comma.',
-            [new CodeSample("<?php\narray(\n    1,\n    2\n);\n")]
+            [
+                new CodeSample("<?php\narray(\n    1,\n    2\n);\n"),
+                new VersionSpecificCodeSample(
+                    <<<'SAMPLE'
+<?php
+    $x = [
+        'foo',
+        <<<EOD
+            bar
+            EOD
+    ];
+
+SAMPLE
+                    ,
+                    new VersionSpecification(70300),
+                    ['after_heredoc' => true]
+                ),
+            ]
         );
     }
 
@@ -60,6 +84,26 @@ final class TrailingCommaInMultilineArrayFixer extends AbstractFixer
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('after_heredoc', 'Whether a trailing comma should also be placed after heredoc end.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->setNormalizer(static function (Options $options, $value) {
+                    if (\PHP_VERSION_ID < 70300 && $value) {
+                        throw new InvalidOptionsForEnvException('"after_heredoc" option can only be enabled with PHP 7.3+.');
+                    }
+
+                    return $value;
+                })
+                ->getOption(),
+        ]);
+    }
+
+    /**
      * @param Tokens $tokens
      * @param int    $index
      */
@@ -78,7 +122,10 @@ final class TrailingCommaInMultilineArrayFixer extends AbstractFixer
         $beforeEndToken = $tokens[$beforeEndIndex];
 
         // if there is some item between braces then add `,` after it
-        if ($startIndex !== $beforeEndIndex && !$beforeEndToken->equalsAny([',', [T_END_HEREDOC]])) {
+        if (
+            $startIndex !== $beforeEndIndex && !$beforeEndToken->equals(',') &&
+            ($this->configuration['after_heredoc'] || !$beforeEndToken->isGivenKind(T_END_HEREDOC))
+        ) {
             $tokens->insertAt($beforeEndIndex + 1, new Token(','));
 
             $endToken = $tokens[$endIndex];

--- a/tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
+++ b/tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
@@ -354,4 +354,44 @@ function a()
             ],
         ];
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFix73Cases
+     * @requires PHP 7.3
+     */
+    public function testFix73($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix73Cases()
+    {
+        return [
+            [
+                <<<'EXPECTED'
+<?php
+$a = [
+    <<<'EOD'
+        foo
+        EOD,
+];
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+$a = [
+    <<<'EOD'
+        foo
+        EOD
+];
+INPUT
+                ,
+                ['after_heredoc' => true],
+            ],
+        ];
+    }
 }

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -21,7 +21,8 @@ PHP 7.3 test.
     "php_unit_mock": true,
     "php_unit_strict": true,
     "php_unit_test_case_static_method_calls": {"call_type": "this"},
-    "strict_param": true
+    "strict_param": true,
+    "trailing_comma_in_multiline_array": {"after_heredoc": true}
 }
 --REQUIREMENTS--
 {"php": 70300}
@@ -102,6 +103,15 @@ $a = [<<<'EOD'
     EOD
 ];
 
+$a = [
+    <<<'EOD'
+        foo
+        EOD,
+    <<<'EOD'
+        bar
+        EOD,
+];
+
 foo(
     <<<'EOD'
         bar
@@ -180,6 +190,16 @@ $a = [<<<'EOD'
 foo
 EOD
     , <<<'EOD'
+bar
+EOD
+];
+
+$a = [
+    <<<'EOD'
+foo
+EOD
+    ,
+    <<<'EOD'
 bar
 EOD
 ];


### PR DESCRIPTION
Input:

```php
$a = [
    'foo', 
    <<<'EOD'
        bar
        EOD
];
```

With PHP 7.3 and new config option `after_heredoc` it is fixed to:

```php
$a = [
    'foo', 
    <<<'EOD'
        bar
        EOD,
];
```

(similar to #4191)