### PR TITLE
[7.3] MethodArgumentSpaceFixer - fix comma after heredoc-end

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -845,6 +845,8 @@ Choose from the list of available rules:
 
   Configuration options:
 
+  - ``after_heredoc`` (``bool``): whether the whitespace between heredoc end and
+    comma should be removed; defaults to ``false``
   - ``ensure_fully_multiline`` (``bool``): ensure every argument of a multiline
     argument list is on its own line; defaults to ``false``. DEPRECATED: use
     option ``on_multiline`` instead

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -889,6 +889,49 @@ INPUT
     }
 
     /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFix73Cases
+     * @requires PHP 7.3
+     */
+    public function testFix73($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix73Cases()
+    {
+        return [
+            [
+                <<<'EXPECTED'
+<?php
+foo(
+    <<<'EOD'
+        bar
+        EOD,
+    'baz'
+);
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+foo(
+    <<<'EOD'
+        bar
+        EOD
+    ,
+    'baz'
+);
+INPUT
+                ,
+                ['after_heredoc' => true],
+            ],
+        ];
+    }
+
+    /**
      * @group legacy
      * @expectedDeprecation PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer::fixSpace is deprecated and will be removed in 3.0.
      */

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -9,6 +9,7 @@ PHP 7.3 test.
     "heredoc_indentation": true,
     "list_syntax": {"syntax": "short"},
     "mb_str_functions": true,
+    "method_argument_space": {"after_heredoc": true},
     "method_chaining_indentation": true,
     "multiline_whitespace_before_semicolons": true,
     "native_function_invocation": {"include": ["get_class"]},
@@ -101,6 +102,13 @@ $a = [<<<'EOD'
     EOD
 ];
 
+foo(
+    <<<'EOD'
+        bar
+        EOD,
+    'baz'
+);
+
 --INPUT--
 <?php
 
@@ -175,3 +183,11 @@ EOD
 bar
 EOD
 ];
+
+foo(
+    <<<'EOD'
+bar
+EOD
+    ,
+    'baz'
+);


### PR DESCRIPTION
Input:

```php
foo(
    <<<'EOD'
        bar
        EOD
    ,
    'baz'
);
```

With PHP 7.3 and new config option `after_heredoc` it is fixed to:

```php
foo(
    <<<'EOD'
        bar
        EOD,
    'baz'
);
```

(similar to #4191)