### PR TITLE
Fix return void on "yield from" calls

### DIFF
--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -200,7 +200,7 @@ final class VoidReturnFixer extends AbstractFixer
                 continue;
             }
 
-            if ($tokens[$i]->isGivenKind(T_YIELD)) {
+            if ($tokens[$i]->isGivenKind(T_YIELD) || $tokens[$i]->isGivenKind(T_YIELD_FROM)) {
                 return false; // Generators cannot return void.
             }
 


### PR DESCRIPTION
the `yield from` token is not identical to `yield`

That PR fix does not change the signature of such method:
```
function foo() {
  yield from bar();
}
```

I don't figured out how to add a test that assert that the Fixer did not change the signature of the method...