### PR TITLE
Travis: PHP 7.4 isn't allowed to fail anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,6 +165,3 @@ jobs:
                     tags: true
             after_deploy:
                 - ./dev-tools/trigger-website.sh ${TRAVIS_TOKEN} ${TRAVIS_TAG}
-
-    allow_failures:
-        - php: 7.4snapshot


### PR DESCRIPTION
Following https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4340, stated that currently `7.4snapshot` isn't failing and that the community seems to already trust the state of art of the PHP 7.4 branch (see e.g. [Ocramius/ProxyManager](https://github.com/Ocramius/ProxyManager/blob/2.3.1/composer.json#L22)), I suggest to start right now to require PHP 7.4 green builds