### PR TITLE
StrictParamFixer - Don't detect functions in use statements

### DIFF
--- a/src/Fixer/Strict/StrictParamFixer.php
+++ b/src/Fixer/Strict/StrictParamFixer.php
@@ -75,8 +75,8 @@ final class StrictParamFixer extends AbstractFixer
         for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
             $token = $tokens[$index];
 
-            $previousIndex = $tokens->getPrevMeaningfulToken($index);
-            if (null !== $previousIndex && $tokens[$previousIndex]->isGivenKind(CT::T_FUNCTION_IMPORT)) {
+            $nextIndex = $tokens->getNextMeaningfulToken($index);
+            if (null !== $nextIndex && !$tokens[$nextIndex]->equals('(')) {
                 continue;
             }
 

--- a/tests/Fixer/Strict/StrictParamFixerTest.php
+++ b/tests/Fixer/Strict/StrictParamFixerTest.php
@@ -155,6 +155,16 @@ final class StrictParamFixerTest extends AbstractFixerTestCase
         array_keys($foo, $bar);
     }',
             ],
+            [
+                '<?php
+    use function \base64_decode;
+    foo($bar);',
+            ],
+            [
+                '<?php
+    use function Baz\base64_decode;
+    foo($bar);',
+            ],
         ];
     }
 


### PR DESCRIPTION
StrictParamFixer detects things like `use Safe\base64_decode;` and tries to fix the very next function, usually something like `__construct($foo)` by adding a `true` to it, making it something like `__construct($foo, true)`.

Failing test example:
```php
<?php
use function \base64_decode;
foo($bar);
```
(The leading backslash is the minimum requirement to trigger the bug, without it, the already existing tests will pass, because they check if the previous token is a `use function`.)

This change tries to make sure it's actually a function call that is detected.