### PR TITLE
PhpdocSeparationFixer - add more tests, drop priority

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -183,7 +183,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['phpdoc_order'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_return_self_reference'], $fixers['no_superfluous_phpdoc_tags']],
             [$fixers['phpdoc_scalar'], $fixers['phpdoc_to_return_type']],
-            [$fixers['phpdoc_separation'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_summary'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_to_comment'], $fixers['no_empty_comment']],
             [$fixers['phpdoc_to_comment'], $fixers['phpdoc_no_useless_inheritdoc']],
@@ -284,7 +283,6 @@ final class FixerFactoryTest extends TestCase
             'phpdoc_no_package,phpdoc_order.test',
             'phpdoc_order,phpdoc_separation.test',
             'phpdoc_order,phpdoc_trim.test',
-            'phpdoc_separation,phpdoc_trim.test',
             'phpdoc_summary,phpdoc_trim.test',
         ];
 

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -585,4 +585,31 @@ EOF;
 
         $this->doTest($expected, $input);
     }
+
+    public function testWithSpacing()
+    {
+        $expected = '<?php
+    /**
+     * Foo
+     *
+     * @bar 123
+     *
+     * {@inheritdoc}       '.'
+     *
+     *   @param string $expected
+     * @param string $input
+     */';
+
+        $input = '<?php
+    /**
+     * Foo
+     * @bar 123
+     *
+     * {@inheritdoc}       '.'
+     *   @param string $expected
+     * @param string $input
+     */';
+
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1760

1760 can be closed as the requested rule has been made by the author a while back ;)
I also dropped the priority from the tests, as no priority issue seems to exists.