### PR TITLE
Show not so usefull verbose output only with -v

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -173,7 +173,7 @@ final class FixCommand extends Command
                 sprintf(
                     'Loaded config <comment>%s</comment>%s.',
                     $resolver->getConfig()->getName(),
-                    null === $configFile ? '' : ' from "' . $configFile . '"'
+                    null === $configFile ? '' : ' from "'.$configFile.'"'
                 ),
                 OutputInterface::VERBOSITY_VERBOSE
             );

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -183,7 +183,7 @@ final class FixCommand extends Command
                 if (is_file($cacheFile)) {
                     $stdErr->writeln(
                         sprintf('Using cache file "%s".', $cacheFile),
-                        OutputInterface::VERBOSITY_VERY_VERBOSE
+                        OutputInterface::VERBOSITY_VERBOSE
                     );
                 }
             }

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -169,12 +169,22 @@ final class FixCommand extends Command
             }
 
             $configFile = $resolver->getConfigFile();
-            $stdErr->writeln(sprintf('Loaded config <comment>%s</comment>%s.', $resolver->getConfig()->getName(), null === $configFile ? '' : ' from "'.$configFile.'"'));
+            $stdErr->writeln(
+                sprintf(
+                    'Loaded config <comment>%s</comment>%s.',
+                    $resolver->getConfig()->getName(),
+                    null === $configFile ? '' : ' from "' . $configFile . '"'
+                ),
+                OutputInterface::VERBOSITY_VERBOSE
+            );
 
             if ($resolver->getUsingCache()) {
                 $cacheFile = $resolver->getCacheFile();
                 if (is_file($cacheFile)) {
-                    $stdErr->writeln(sprintf('Using cache file "%s".', $cacheFile));
+                    $stdErr->writeln(
+                        sprintf('Using cache file "%s".', $cacheFile),
+                        OutputInterface::VERBOSITY_VERY_VERBOSE
+                    );
                 }
             }
         }
@@ -184,7 +194,11 @@ final class FixCommand extends Command
 
         if (null !== $stdErr && $resolver->configFinderIsOverridden()) {
             $stdErr->writeln(
-                sprintf($stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s', 'Paths from configuration file have been overridden by paths provided as command arguments.')
+                sprintf(
+                    $stdErr->isDecorated() ? '<bg=yellow;fg=black;>%s</>' : '%s',
+                    'Paths from configuration file have been overridden by paths provided as command arguments.'
+                ),
+                OutputInterface::VERBOSITY_VERBOSE
             );
         }
 


### PR DESCRIPTION
Currently these 3 lines are outputed for every single file php-cs-fixer scans
```
Loaded config default from ".../.php_cs.dist".
Using cache file ".php_cs.cache".
Paths from configuration file have been overridden by paths provided as command arguments.
```

which adds a lot of noise on pre-commit hooks and there is no way to turn it off