### PR TITLE
Unset the auxillary variable $a

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -60,6 +60,8 @@ if ($require) {
     } else {
         require_once __DIR__.'/vendor/autoload.php';
     }
+
+    unset($a);
 }
 unset($require);
 


### PR DESCRIPTION
Otherwise it remains in scope, even if falsy: https://3v4l.org/RRGda.