### PR TITLE
Fixed composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
         "justinrainbow/json-schema": "^5.0",
         "keradus/cli-executor": "^1.2",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "php-coveralls/php-coveralls": "^2.1",
         "php-cs-fixer/accessible-object": "^1.0",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",


### PR DESCRIPTION
> Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.