### PR TITLE
Fixed TypeShortNameResolverTest::testResolver

### DIFF
--- a/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php
+++ b/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php
@@ -42,12 +42,12 @@ final class TypeShortNameResolverTest extends TestCase
     {
         return [
             [
-                '<?php',
+                '<?php ',
                 'SomeType',
                 'SomeType',
             ],
             [
-                '<?php',
+                '<?php ',
                 'string',
                 'string',
             ],


### PR DESCRIPTION
When `short_open_tag` is enabled, these tests would previously fail with:

```
1) PhpCsFixer\Tests\Tokenizer\Resolver\TypeShortNameResolverTest::testResolver with data set #0 ('<?php', 'SomeType', 'SomeType')
ParseError: syntax error, unexpected end of file

/builds/StyleCI/Fixing/PHP-CS-Fixer/src/Tokenizer/Tokens.php:1039
/builds/StyleCI/Fixing/PHP-CS-Fixer/src/Tokenizer/Tokens.php:222
/builds/StyleCI/Fixing/PHP-CS-Fixer/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php:36
/builds/StyleCI/Fixing/PHP-CS-Fixer/vendor/phpunitgoodpractices/traits/src/ExpectationViaCodeOverAnnotationTrait7.php:39

2) PhpCsFixer\Tests\Tokenizer\Resolver\TypeShortNameResolverTest::testResolver with data set #1 ('<?php', 'string', 'string')
ParseError: syntax error, unexpected end of file

/builds/StyleCI/Fixing/PHP-CS-Fixer/src/Tokenizer/Tokens.php:1039
/builds/StyleCI/Fixing/PHP-CS-Fixer/src/Tokenizer/Tokens.php:222
/builds/StyleCI/Fixing/PHP-CS-Fixer/tests/Tokenizer/Resolver/TypeShortNameResolverTest.php:36
/builds/StyleCI/Fixing/PHP-CS-Fixer/vendor/phpunitgoodpractices/traits/src/ExpectationViaCodeOverAnnotationTrait7.php:39
```

However, adding a space after the opening tag stops this happening.

---

I compare how `<?php` tokenizes with/without a trailing space:

1. No space, `short_open_tag` unset:

```
array(1) {
  [0] =>
  array(3) {
    [0] =>
    int(321)
    [1] =>
    string(5) "<?php"
    [2] =>
    int(1)
  }
}
```

2. No space, `short_open_tag` enabled:

```
array(2) {
  [0]=>
  array(3) {
    [0]=>
    int(379)
    [1]=>
    string(2) "<?"
    [2]=>
    int(1)
  }
  [1]=>
  array(3) {
    [0]=>
    int(319)
    [1]=>
    string(3) "php"
    [2]=>
    int(1)
  }
}
```


3. With a space, `short_open_tag` either unset or enabled:

```
array(1) {
  [0] =>
  array(3) {
    [0] =>
    int(379)
    [1] =>
    string(6) "<?php "
    [2] =>
    int(1)
  }
}
```
