### PR TITLE
PhpdocTypesFixer > Remove spaces around pipes

### DIFF
--- a/src/AbstractPhpdocTypesFixer.php
+++ b/src/AbstractPhpdocTypesFixer.php
@@ -128,6 +128,9 @@ abstract class AbstractPhpdocTypesFixer extends AbstractFixer
      */
     private function normalizeType($type)
     {
+        // Remove spaces around pipes
+        $type = Preg::replace('/[[:blank:]]*\|[[:blank:]]*/', '|', trim($type));
+
         if ('[]' === substr($type, -2)) {
             return $this->normalize(substr($type, 0, -2)).'[]';
         }

--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -51,7 +51,15 @@ class Annotation
             )
         )
         (?:
+            (?<whitespaceBeforePipe>[[:blank:]]*)
             \|
+            (?<whitespaceAfterPipe>[[:blank:]]*)
+            (?:(?&simple)|(?&array)|(?&generic))
+        )?
+        (?:
+            (?:[[:blank:]]*)
+            \|
+            (?:[[:blank:]]*)
             (?:(?&simple)|(?&array)|(?&generic))
         )*
     )
@@ -197,6 +205,7 @@ class Annotation
 
             $content = $this->getTypesContent();
 
+            $previousWhitespace = '';
             while ('' !== $content && false !== $content) {
                 Preg::match(
                     '{^'.self::REGEX_TYPES.'$}x',
@@ -204,8 +213,21 @@ class Annotation
                     $matches
                 );
 
-                $this->types[] = $matches['type'];
-                $content = substr($content, \strlen($matches['type']) + 1);
+                $whitespaceBeforePipe = '';
+                if (isset($matches['whitespaceBeforePipe'])) {
+                    $whitespaceBeforePipe = $matches['whitespaceBeforePipe'];
+                }
+
+                $this->types[] = $previousWhitespace.$matches['type'].$whitespaceBeforePipe;
+
+                $whitespaceAfterPipe = '';
+                if (isset($matches['whitespaceAfterPipe'])) {
+                    $whitespaceAfterPipe = $matches['whitespaceAfterPipe'];
+                }
+
+                $previousWhitespace = $whitespaceAfterPipe;
+
+                $content = substr($content, \strlen($matches['type']) + \strlen($whitespaceBeforePipe) + 1 + \strlen($whitespaceAfterPipe));
             }
         }
 

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -242,6 +242,22 @@ final class AnnotationTest extends TestCase
                 ['int[]', 'null'],
             ],
             [
+                ' * @method int[] | null method()',
+                ['int[] ', ' null'],
+            ],
+            [
+                ' * @method int | null| array method()',
+                ['int ', ' null', ' array'],
+            ],
+            [
+                ' * @method int[] | null| array| ?string method()',
+                ['int[] ', ' null', ' array', ' ?string'],
+            ],
+            [
+                ' * @method int[] | array<int | string> |null method()',
+                ['int[] ', ' array<int | string> ', 'null'],
+            ],
+            [
                 ' * @method int[]|null|?int|array method()',
                 ['int[]', 'null', '?int', 'array'],
             ],

--- a/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
@@ -233,4 +233,54 @@ EOF;
 
         $this->fixer->configure(['groups' => ['__TEST__']]);
     }
+
+    public function testRemoveSpacesBeforeAndAfterPipe()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param self|array|Foo $bar
+     *
+     * @return int|float|callback
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param self | array | Foo $bar
+     *
+     * @return int | float | callback
+     */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testRemoveSpacesBeforeAndAfterPipe2()
+    {
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param self|array<int|string>|Foo $bar
+     *
+     * @return int|float|callback
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @param self | array<int | string> | Foo $bar
+     *
+     * @return int | float | callback
+     */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Sometimes, when adding multiple types in `@param` or `@return`, people add spaces before or after the pipe. That should be cleaned up as it's not standard.