### PR TITLE
PHP7.4 - Add support for magic methods (un)serialize.

### DIFF
--- a/src/Fixer/Casing/MagicMethodCasingFixer.php
+++ b/src/Fixer/Casing/MagicMethodCasingFixer.php
@@ -33,10 +33,12 @@ final class MagicMethodCasingFixer extends AbstractFixer
         '__get' => '__get',
         '__invoke' => '__invoke',
         '__isset' => '__isset',
+        '__serialize' => '__serialize',
         '__set' => '__set',
         '__set_state' => '__set_state',
         '__sleep' => '__sleep',
         '__tostring' => '__toString',
+        '__unserialize' => '__unserialize',
         '__unset' => '__unset',
         '__wakeup' => '__wakeup',
     ];

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -137,6 +137,35 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
             '<?php trait Foo {public function __toString(){}}',
             '<?php trait Foo {public function __tostring(){}}',
         ];
+
+        yield '(un)serialize' => [
+            '<?php
+
+class Foo extends Bar
+{
+    public function __serialize() {
+        $this->__serialize();
+    }
+
+    public function __unserialize($payload) {
+        $this->__unserialize($this_>$a);
+    }
+}
+',
+            '<?php
+
+class Foo extends Bar
+{
+    public function __SERIALIZE() {
+        $this->__SERIALIZE();
+    }
+
+    public function __unSERIALIZE($payload) {
+        $this->__unSERIALIZE($this_>$a);
+    }
+}
+',
+        ];
     }
 
     /**


### PR DESCRIPTION
@ see https://wiki.php.net/rfc/custom_object_serialization