### PR TITLE
CommentToPhpdocFixer - allow to ignore tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -404,6 +404,10 @@ Choose from the list of available rules:
 
   *Risky rule: risky as new docblocks might mean more, e.g. a Doctrine entity might have a new column in database.*
 
+  Configuration options:
+
+  - ``ignored_tags`` (``array``): list of ignored tags; defaults to ``[]``
+
 * **compact_nullable_typehint** [@PhpCsFixer]
 
   Remove extra spaces in a nullable typehint.

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -26,11 +26,13 @@ final class CommentToPhpdocFixerTest extends AbstractFixerTestCase
     /**
      * @param string      $expected
      * @param null|string $input
+     * @param array       $config
      *
      * @dataProvider provideTestCases
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -245,6 +247,70 @@ EOT
 $foo = 1;
 EOT
                 ,
+            ],
+            [
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+// @todo do something later
+$foo = 1;
+EOT
+                ,
+                null,
+                ['ignored_tags' => ['todo']],
+            ],
+            [
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+// @TODO do something later
+$foo = 1;
+EOT
+                ,
+                null,
+                ['ignored_tags' => ['todo']],
+            ],
+            [
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+/**
+ * @todo do something later
+ * @var int $foo
+ */
+$foo = 1;
+EOT
+                ,
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+// @todo do something later
+// @var int $foo
+$foo = 1;
+EOT
+                ,
+                ['ignored_tags' => ['todo']],
+            ],
+            [
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+/**
+ * @var int $foo
+ * @todo do something later
+ */
+$foo = 1;
+EOT
+                ,
+                <<<'EOT'
+<?php /* header comment */ $foo = true;
+
+// @var int $foo
+// @todo do something later
+$foo = 1;
+EOT
+                ,
+                ['ignored_tags' => ['todo']],
             ],
         ];
     }


### PR DESCRIPTION
Resolves https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3628

Ping @julienfalque for review, I've made the list case insensitive - I figured it's more natural, would you agree?