### PR TITLE
DX: add missing explicit return types

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -47,7 +47,7 @@ final class Cache implements CacheInterface
     public function get($file)
     {
         if (!$this->has($file)) {
-            return;
+            return null;
         }
 
         return $this->hashes[$file];

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -34,7 +34,7 @@ interface CacheInterface
     /**
      * @param string $file
      *
-     * @return int
+     * @return null|int
      */
     public function get($file);
 

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -42,7 +42,7 @@ final class FileHandler implements FileHandlerInterface
     public function read()
     {
         if (!file_exists($this->file)) {
-            return;
+            return null;
         }
 
         $content = file_get_contents($this->file);
@@ -50,7 +50,7 @@ final class FileHandler implements FileHandlerInterface
         try {
             $cache = Cache::fromJson($content);
         } catch (\InvalidArgumentException $exception) {
-            return;
+            return null;
         }
 
         return $cache;

--- a/src/Cache/FileHandlerInterface.php
+++ b/src/Cache/FileHandlerInterface.php
@@ -25,7 +25,7 @@ interface FileHandlerInterface
     public function getFile();
 
     /**
-     * @return CacheInterface
+     * @return null|CacheInterface
      */
     public function read();
 

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -107,7 +107,7 @@ final class DescribeCommand extends Command
             if ('@' === $name[0]) {
                 $this->describeSet($output, $name);
 
-                return;
+                return null;
             }
 
             $this->describeRule($output, $name);

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -36,7 +36,7 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
     private $candidatesMap;
 
     /**
-     * @var array<string, null|bool>
+     * @var array<int|string, null|bool>
      */
     private $candidateTypesConfiguration;
 

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -29,12 +29,12 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class FunctionToConstantFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
-     * @var string[]
+     * @var array<string, Token[]>
      */
     private static $availableFunctions;
 
     /**
-     * @var array<string, Token>
+     * @var array<string, Token[]>
      */
     private $functionsFixMap;
 

--- a/src/Linter/CachingLinter.php
+++ b/src/Linter/CachingLinter.php
@@ -25,7 +25,7 @@ final class CachingLinter implements LinterInterface
     private $sublinter;
 
     /**
-     * @var array<string, LintingResultInterface>
+     * @var array<int, LintingResultInterface>
      */
     private $cache = [];
 

--- a/src/Preg.php
+++ b/src/Preg.php
@@ -25,7 +25,7 @@ final class Preg
     /**
      * @param string        $pattern
      * @param string        $subject
-     * @param null|string[] &$matches
+     * @param null|string[] $matches
      * @param int           $flags
      * @param int           $offset
      *
@@ -51,7 +51,7 @@ final class Preg
     /**
      * @param string        $pattern
      * @param string        $subject
-     * @param null|string[] &$matches
+     * @param null|string[] $matches
      * @param int           $flags
      * @param int           $offset
      *
@@ -79,7 +79,7 @@ final class Preg
      * @param string|string[] $replacement
      * @param string|string[] $subject
      * @param int             $limit
-     * @param null|int        &$count
+     * @param null|int        $count
      *
      * @throws PregException
      *
@@ -105,7 +105,7 @@ final class Preg
      * @param callable        $callback
      * @param string|string[] $subject
      * @param int             $limit
-     * @param null|int        &$count
+     * @param null|int        $count
      *
      * @throws PregException
      *


### PR DESCRIPTION
Error was:
```
------ ----------------------------------------------------------------------------------------------------------------------- 
  Line   Console/Command/DescribeCommand.php                                                                                    
 ------ ----------------------------------------------------------------------------------------------------------------------- 
  110    Method PhpCsFixer\Console\Command\DescribeCommand::execute() should return int|null but empty return statement found.  
 ------ -----------------------------------------------------------------------------------------------------------------------
```