### PR TITLE
LowercaseStaticReferenceFixer - Fix invalid PHP version in example

### DIFF
--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -62,7 +62,7 @@ class Foo extends Bar
     }
 }
 ',
-                    new VersionSpecification(71000)
+                    new VersionSpecification(70100)
                 ),
             ]
         );


### PR DESCRIPTION
The PHP version in `LowercaseStaticReferenceFixer` is invalid, probably should be `70100`.