### PR TITLE
FileLintingIterator - fix current value on end/invalid

### DIFF
--- a/src/Runner/FileLintingIterator.php
+++ b/src/Runner/FileLintingIterator.php
@@ -28,7 +28,7 @@ final class FileLintingIterator extends \IteratorIterator
     private $currentResult;
 
     /**
-     * @var LinterInterface
+     * @var null|LinterInterface
      */
     private $linter;
 
@@ -39,6 +39,9 @@ final class FileLintingIterator extends \IteratorIterator
         $this->linter = $linter;
     }
 
+    /**
+     * @return null|LinterInterface
+     */
     public function currentLintingResult()
     {
         return $this->currentResult;
@@ -48,18 +51,14 @@ final class FileLintingIterator extends \IteratorIterator
     {
         parent::next();
 
-        if ($this->valid()) {
-            $this->currentResult = $this->handleItem($this->current());
-        }
+        $this->currentResult = $this->valid() ? $this->handleItem($this->current()) : null;
     }
 
     public function rewind()
     {
         parent::rewind();
 
-        if ($this->valid()) {
-            $this->currentResult = $this->handleItem($this->current());
-        }
+        $this->currentResult = $this->valid() ? $this->handleItem($this->current()) : null;
     }
 
     private function handleItem(\SplFileInfo $file)

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -48,7 +48,6 @@ final class ProjectCodeTest extends TestCase
         \PhpCsFixer\Fixer\Operator\AlignEqualsFixerHelper::class,
         \PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer::class,
         \PhpCsFixer\Runner\FileCachingLintingIterator::class,
-        \PhpCsFixer\Runner\FileLintingIterator::class,
         \PhpCsFixer\Test\AccessibleObject::class,
     ];
 

--- a/tests/Runner/FileLintingIteratorTest.php
+++ b/tests/Runner/FileLintingIteratorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Runner;
+
+use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\Linter\LintingResultInterface;
+use PhpCsFixer\Runner\FileLintingIterator;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Runner\FileLintingIterator
+ */
+final class FileLintingIteratorTest extends TestCase
+{
+    public function testFileLintingIteratorEmpty()
+    {
+        $fileLintingIteratorProphecy = $this->prophesize(LinterInterface::class);
+
+        $iterator = new \ArrayIterator([]);
+
+        $fileLintingIterator = new FileLintingIterator(
+            $iterator,
+            $fileLintingIteratorProphecy->reveal()
+        );
+
+        static::assertNull($fileLintingIterator->current());
+        static::assertNull($fileLintingIterator->currentLintingResult());
+        static::assertSame($iterator, $fileLintingIterator->getInnerIterator());
+        static::assertFalse($fileLintingIterator->valid());
+    }
+
+    public function testFileLintingIterator()
+    {
+        $file = new \SplFileInfo(__FILE__);
+        $fileLintingIteratorProphecy = $this->prophesize(LinterInterface::class);
+
+        $lintingResultInterfaceProphecy = $this->prophesize(LintingResultInterface::class)->reveal();
+        $fileLintingIteratorProphecy->lintFile($file)->willReturn($lintingResultInterfaceProphecy);
+
+        $iterator = new \ArrayIterator([$file]);
+
+        $fileLintingIterator = new FileLintingIterator(
+            $iterator,
+            $fileLintingIteratorProphecy->reveal()
+        );
+
+        // test when not touched current is null
+
+        static::assertNull($fileLintingIterator->currentLintingResult());
+
+        // test iterating
+
+        $this->fileLintingIteratorIterationTest($fileLintingIterator, $file, $lintingResultInterfaceProphecy);
+
+        // rewind and test again
+
+        $fileLintingIterator->rewind();
+
+        $this->fileLintingIteratorIterationTest($fileLintingIterator, $file, $lintingResultInterfaceProphecy);
+    }
+
+    private function fileLintingIteratorIterationTest(
+        FileLintingIterator $fileLintingIterator,
+        \SplFileInfo $file,
+        LintingResultInterface $lintingResultInterface
+    ) {
+        $iterations = 0;
+
+        foreach ($fileLintingIterator as $lintedFile) {
+            static::assertSame($file, $lintedFile);
+            static::assertSame($lintingResultInterface, $fileLintingIterator->currentLintingResult());
+            ++$iterations;
+        }
+
+        static::assertSame(1, $iterations);
+
+        $fileLintingIterator->next();
+
+        static::assertNull($fileLintingIterator->currentLintingResult());
+    }
+}


### PR DESCRIPTION
Current implementation keeps the last value and does not reset the value to `null` at the end of an iteration or when an invalid value has been encountered.