### PR TITLE
Allow multiple paths with rules

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -577,8 +577,8 @@ final class ConfigurationResolver
 
         if ($this->isStdIn() || 0 === \count($path)) {
             $configDir = $this->cwd;
-        } elseif (1 < \count($path)) {
-            throw new InvalidConfigurationException('For multiple paths config parameter is required.');
+        } elseif (1 < \count($path) && null === $this->options['rules']) {
+            throw new InvalidConfigurationException('For multiple paths the config or rules parameter is required.');
         } elseif (is_file($path[0]) && $dirName = pathinfo($path[0], PATHINFO_DIRNAME)) {
             $configDir = $dirName;
         } else {

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -296,16 +296,30 @@ final class ConfigurationResolverTest extends TestCase
         $resolver->getReporter();
     }
 
-    public function testResolveConfigFileChooseFileWithPathArrayWithoutConfig()
+    public function testResolveConfigFileChooseFileWithPathArrayWithoutConfigOrRules()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^For multiple paths config parameter is required\.$/');
+        $this->expectExceptionMessageRegExp('/^For multiple paths the config or rules parameter is required\.$/');
 
         $dirBase = $this->getFixtureDir();
 
         $resolver = $this->createConfigurationResolver(['path' => [$dirBase.'case_1/.php_cs.dist', $dirBase.'case_1/foo.php']]);
 
         $resolver->getConfig();
+    }
+
+    public function testResolveConfigFileChooseFileWithPathArrayAndRules()
+    {
+        $dirBase = $this->getFixtureDir();
+
+        $resolver = $this->createConfigurationResolver([
+            'rules' => '@PSR2',
+            'path' => [$dirBase.'case_1/.php_cs.dist', $dirBase.'case_1/foo.php']
+        ]);
+
+        $resolver->getConfig();
+
+        static::assertInstanceOf(\PhpCsFixer\Console\ConfigurationResolver::class, $resolver);
     }
 
     public function testResolveConfigFileChooseFileWithPathArrayAndConfig()

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -331,6 +331,8 @@ final class ConfigurationResolverTest extends TestCase
             'path' => [$dirBase.'case_1/.php_cs.dist', $dirBase.'case_1/foo.php'],
         ]);
 
+        $resolver->getConfig();
+
         static::assertInstanceOf(\PhpCsFixer\Console\ConfigurationResolver::class, $resolver);
     }
 


### PR DESCRIPTION
This will open the restriction when passing multiple paths from requiring the `config` parameter to allow the `rules` parameter to be passed instead.

This was opened based on multiple previous discussions, notable issue [#4279](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4279#issuecomment-490224873).