### PR TITLE
Add AbstractConfigTestCase

### DIFF
--- a/src/Test/AbstractConfigTestCase.php
+++ b/src/Test/AbstractConfigTestCase.php
@@ -57,14 +57,14 @@ abstract class AbstractConfigTestCase extends TestCase
         $diff = array_diff($currentRules, $availableRules);
         static::assertEmpty($diff, sprintf("The following fixers are specified but non existing or deprecated:\n- %s", implode(\PHP_EOL.'- ', $diff)));
 
-        $currentSets = array_values(array_filter(array_keys($configRules), static function (string $fixerName): bool {
+        $currentSets = array_values(array_filter(array_keys($configRules), static function ($fixerName) {
             return isset($fixerName[0]) && '@' === $fixerName[0];
         }));
         $defaultSets = $ruleSet->getSetDefinitionNames();
         $intersectSets = array_values(array_intersect($defaultSets, $currentSets));
         static::assertSame($intersectSets, $currentSets, sprintf('Rule sets must be ordered as the appear in %s', RuleSet::class));
 
-        $currentRules = array_values(array_filter(array_keys($configRules), static function (string $fixerName): bool {
+        $currentRules = array_values(array_filter(array_keys($configRules), static function ($fixerName) {
             return isset($fixerName[0]) && '@' !== $fixerName[0];
         }));
         $orderedCurrentRules = $currentRules;

--- a/src/Test/AbstractConfigTestCase.php
+++ b/src/Test/AbstractConfigTestCase.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractConfigTestCase extends TestCase
 {
-    final protected function doTestAllDefaultRulesAreSpecified(ConfigInterface $config)
+    final protected function doTestAllBuiltInRulesAreConfigured(ConfigInterface $config)
     {
         $configuredRules = $config->getRules();
 

--- a/src/Test/AbstractConfigTestCase.php
+++ b/src/Test/AbstractConfigTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Test;
+
+use PhpCsFixer\ConfigInterface;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractConfigTestCase extends TestCase
+{
+    final protected function doTestAllDefaultRulesAreSpecified(ConfigInterface $config)
+    {
+        $configRules = $config->getRules();
+        $ruleSet = new RuleSet($configRules);
+        $rules = $ruleSet->getRules();
+
+        // RuleSet strips all disabled rules
+        foreach ($configRules as $name => $value) {
+            if ('@' === $name[0]) {
+                continue;
+            }
+            $rules[$name] = $value;
+        }
+
+        $currentRules = array_keys($rules);
+        sort($currentRules);
+
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+        $fixerFactory->registerCustomFixers($config->getCustomFixers());
+        $fixers = $fixerFactory->getFixers();
+
+        $availableRules = array_filter($fixers, function (FixerInterface $fixer) {
+            return !$fixer instanceof DeprecatedFixerInterface;
+        });
+        $availableRules = array_map(function (FixerInterface $fixer) {
+            return $fixer->getName();
+        }, $availableRules);
+        sort($availableRules);
+
+        $diff = array_diff($availableRules, $currentRules);
+        static::assertEmpty($diff, sprintf("The following fixers are missing:\n- %s", implode(\PHP_EOL.'- ', $diff)));
+
+        $diff = array_diff($currentRules, $availableRules);
+        static::assertEmpty($diff, sprintf("The following fixers are specified but non existing or deprecated:\n- %s", implode(\PHP_EOL.'- ', $diff)));
+
+        $currentRules = array_keys($configRules);
+        $orderedCurrentRules = $currentRules;
+        sort($orderedCurrentRules);
+        static::assertSame($orderedCurrentRules, $currentRules, 'Fixers must be alphabetically ordered');
+    }
+}

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -383,6 +383,7 @@ final class ProjectCodeTest extends TestCase
                     || 0 === \count($rc->getInterfaces())
                     || \in_array($className, [
                         \PhpCsFixer\Finder::class,
+                        \PhpCsFixer\Test\AbstractConfigTestCase::class,
                         \PhpCsFixer\Test\AbstractFixerTestCase::class,
                         \PhpCsFixer\Test\AbstractIntegrationTestCase::class,
                         \PhpCsFixer\Tests\Test\AbstractFixerTestCase::class,

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\ExpectationFailedException;
  */
 final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
 {
-    public function testAllFixersMustBeSpecified()
+    public function testAllFixersMustBeConfigured()
     {
         $config = new Config();
 
@@ -55,7 +55,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         }
     }
 
-    public function testRuleSetsAreHandled()
+    public function testSetDefinitionsAreHandled()
     {
         $config = new Config();
         $config->setRules([
@@ -109,7 +109,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         }
     }
 
-    public function testFixersMustBeOrdered()
+    public function testConfiguredRulesMustBeInAlphabeticalOrdered()
     {
         $config = $this->getFullConfig();
         $rules = $config->getRules();

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -38,6 +38,22 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         }
     }
 
+    public function testDisabledFixersAreOk()
+    {
+        $config = new Config();
+        $config->setRules([
+            'encoding' => false,
+        ]);
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('An empty config must raise an error reporting the missing fixers');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            static::assertNotContains('encoding', $expectationFailedException->getMessage());
+            static::assertContains('array_syntax', $expectationFailedException->getMessage());
+        }
+    }
+
     public function testRuleSetsAreHandled()
     {
         $config = new Config();

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -71,7 +71,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         }
     }
 
-    public function testRuleSetsMustBeOrderedAsTheyAppearInRuleSetClass()
+    public function testSetDefinitionsMustBeOrderedAsTheyAppearInRuleSetClass()
     {
         $config = $this->getFullConfig();
         $rules = $config->getRules();
@@ -123,7 +123,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             static::fail('Fixers randomly orderer must raise an error');
         } catch (ExpectationFailedException $expectationFailedException) {
             // Can't test $firstRule because the diff isn't in the Exception
-            static::assertContains('alphabetically', $expectationFailedException->getMessage());
+            static::assertContains('alphabetical order', $expectationFailedException->getMessage());
         }
     }
 

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -34,7 +34,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             $this->doTestAllDefaultRulesAreSpecified($config);
             static::fail('An empty config must raise an error reporting the missing fixers');
         } catch (ExpectationFailedException $expectationFailedException) {
-            static::assertStringContainsString('array_syntax', $expectationFailedException->getMessage());
+            static::assertContains('array_syntax', $expectationFailedException->getMessage());
         }
     }
 
@@ -49,8 +49,8 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             $this->doTestAllDefaultRulesAreSpecified($config);
             static::fail('A partial config must raise an error reporting the missing fixers');
         } catch (ExpectationFailedException $expectationFailedException) {
-            static::assertStringNotContainsString('encoding', $expectationFailedException->getMessage());
-            static::assertStringContainsString('array_syntax', $expectationFailedException->getMessage());
+            static::assertNotContains('encoding', $expectationFailedException->getMessage());
+            static::assertContains('array_syntax', $expectationFailedException->getMessage());
         }
     }
 
@@ -67,7 +67,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             $this->doTestAllDefaultRulesAreSpecified($config);
             static::fail('A non existing fixer must raise an error');
         } catch (ExpectationFailedException $expectationFailedException) {
-            static::assertStringContainsString($nonExistingRule, $expectationFailedException->getMessage());
+            static::assertContains($nonExistingRule, $expectationFailedException->getMessage());
         }
     }
 
@@ -85,7 +85,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             static::fail('Fixers randomly orderer must raise an error');
         } catch (ExpectationFailedException $expectationFailedException) {
             // Can't test $firstRule because the diff isn't in the Exception
-            static::assertStringContainsString('alphabetically', $expectationFailedException->getMessage());
+            static::assertContains('alphabetically', $expectationFailedException->getMessage());
         }
     }
 

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -16,6 +16,7 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
+use PhpCsFixer\RuleSet;
 use PhpCsFixer\Test\AbstractConfigTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
 
@@ -67,6 +68,27 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertNotContains('encoding', $expectationFailedException->getMessage());
             static::assertContains('array_syntax', $expectationFailedException->getMessage());
+        }
+    }
+
+    public function testRuleSetsMustBeOrderedAsTheyAppearInRuleSetClass()
+    {
+        $config = $this->getFullConfig();
+        $rules = $config->getRules();
+
+        unset($rules['@PHPUnit35Migration:risky'], $rules['@PHPUnit30Migration:risky']);
+
+        $rules['@PHPUnit35Migration:risky'] = true;
+        $rules['@PHPUnit30Migration:risky'] = true;
+
+        $config->setRules($rules);
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('Ruleset randomly ordered must raise an error reporting the expected order');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            static::assertNotContains('php_unit_dedicate_assert', $expectationFailedException->getMessage());
+            static::assertContains(RuleSet::class, $expectationFailedException->getMessage());
         }
     }
 

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -30,13 +30,13 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
     public function testAllFixersMustBeConfigured()
     {
         // Good run
-        $this->doTestAllDefaultRulesAreSpecified($this->getFullConfig());
+        $this->doTestAllBuiltInRulesAreConfigured($this->getFullConfig());
 
         // Bad run
         $config = new Config();
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($config);
+            $this->doTestAllBuiltInRulesAreConfigured($config);
             static::fail('An empty config must raise an error reporting the missing fixers');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertContains('array_syntax', $expectationFailedException->getMessage());
@@ -50,7 +50,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         $fullConfigRules = $fullConfig->getRules();
         $fullConfigRules['encoding'] = false;
         $fullConfig->setRules($fullConfigRules);
-        $this->doTestAllDefaultRulesAreSpecified($fullConfig);
+        $this->doTestAllBuiltInRulesAreConfigured($fullConfig);
 
         // Bad run
         $config = new Config();
@@ -59,7 +59,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         ]);
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($config);
+            $this->doTestAllBuiltInRulesAreConfigured($config);
             static::fail('An empty config must raise an error reporting the missing fixers');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertNotContains('encoding', $expectationFailedException->getMessage(), 'Disabled fixers should not appear in the error message');
@@ -75,7 +75,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         ]);
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($config);
+            $this->doTestAllBuiltInRulesAreConfigured($config);
             static::fail('A partial config must raise an error reporting the missing fixers');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertNotContains('encoding', $expectationFailedException->getMessage(), 'Fixers inside set definitions should not appear in the error message');
@@ -91,7 +91,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             '@PSR1' => true,
         ];
         $fullConfig->setRules(array_merge($rules, $fullConfig->getRules()));
-        $this->doTestAllDefaultRulesAreSpecified($fullConfig);
+        $this->doTestAllBuiltInRulesAreConfigured($fullConfig);
 
         // Bad run
         $fullConfig = $this->getFullConfig();
@@ -100,7 +100,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         $fullConfig->setRules($fullConfigRules);
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($fullConfig);
+            $this->doTestAllBuiltInRulesAreConfigured($fullConfig);
             static::fail('Set definitions not on the top of the rule list');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertContains('@PSR1', $expectationFailedException->getMessage());
@@ -117,7 +117,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
             '@PHPUnit35Migration:risky' => true,
         ];
         $fullConfig->setRules(array_merge($rules, $fullConfig->getRules()));
-        $this->doTestAllDefaultRulesAreSpecified($fullConfig);
+        $this->doTestAllBuiltInRulesAreConfigured($fullConfig);
 
         // Bad run
         $fullConfig = $this->getFullConfig();
@@ -128,7 +128,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         $fullConfig->setRules(array_merge($rules, $fullConfig->getRules()));
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($fullConfig);
+            $this->doTestAllBuiltInRulesAreConfigured($fullConfig);
             static::fail('Set definitions randomly ordered must raise an error reporting the expected order');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertNotContains('php_unit_dedicate_assert', $expectationFailedException->getMessage());
@@ -146,7 +146,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         $config->setRules($rules);
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($config);
+            $this->doTestAllBuiltInRulesAreConfigured($config);
             static::fail('A non existing fixer must raise an error');
         } catch (ExpectationFailedException $expectationFailedException) {
             static::assertContains($nonExistingRule, $expectationFailedException->getMessage());
@@ -163,7 +163,7 @@ final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
         $config->setRules($rules);
 
         try {
-            $this->doTestAllDefaultRulesAreSpecified($config);
+            $this->doTestAllBuiltInRulesAreConfigured($config);
             static::fail('Fixers randomly orderer must raise an error');
         } catch (ExpectationFailedException $expectationFailedException) {
             // Can't test $firstRule because the diff isn't in the Exception

--- a/tests/Test/AbstractConfigTestCaseTest.php
+++ b/tests/Test/AbstractConfigTestCaseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Test;
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Test\AbstractConfigTestCase;
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Test\AbstractConfigTestCase
+ */
+final class AbstractConfigTestCaseTest extends AbstractConfigTestCase
+{
+    public function testAllFixersMustBeSpecified()
+    {
+        $config = new Config();
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('An empty config must raise an error reporting the missing fixers');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            static::assertStringContainsString('array_syntax', $expectationFailedException->getMessage());
+        }
+    }
+
+    public function testRuleSetsAreHandled()
+    {
+        $config = new Config();
+        $config->setRules([
+            '@PSR1' => true,
+        ]);
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('A partial config must raise an error reporting the missing fixers');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            static::assertStringNotContainsString('encoding', $expectationFailedException->getMessage());
+            static::assertStringContainsString('array_syntax', $expectationFailedException->getMessage());
+        }
+    }
+
+    public function testNonExistingFixersRaiseError()
+    {
+        $nonExistingRule = uniqid('non_existing_rule_');
+
+        $config = $this->getFullConfig();
+        $rules = $config->getRules();
+        $rules[$nonExistingRule] = true;
+        $config->setRules($rules);
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('A non existing fixer must raise an error');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            static::assertStringContainsString($nonExistingRule, $expectationFailedException->getMessage());
+        }
+    }
+
+    public function testFixersMustBeOrdered()
+    {
+        $config = $this->getFullConfig();
+        $rules = $config->getRules();
+        $firstRule = key($rules);
+        unset($rules[$firstRule]);
+        $rules[$firstRule] = true;
+        $config->setRules($rules);
+
+        try {
+            $this->doTestAllDefaultRulesAreSpecified($config);
+            static::fail('Fixers randomly orderer must raise an error');
+        } catch (ExpectationFailedException $expectationFailedException) {
+            // Can't test $firstRule because the diff isn't in the Exception
+            static::assertStringContainsString('alphabetically', $expectationFailedException->getMessage());
+        }
+    }
+
+    /**
+     * @return Config
+     */
+    private function getFullConfig()
+    {
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+        $fixers = $fixerFactory->getFixers();
+
+        $availableRules = array_filter($fixers, function (FixerInterface $fixer) {
+            return !$fixer instanceof DeprecatedFixerInterface;
+        });
+        $availableRules = array_map(function (FixerInterface $fixer) {
+            return $fixer->getName();
+        }, $availableRules);
+        sort($availableRules);
+
+        $config = new Config();
+        $config->setRules(array_fill_keys($availableRules, true));
+
+        return $config;
+    }
+}


### PR DESCRIPTION
This test enforces a project to have all the fixers specified, either active or not, so it's always up to date. This can be viewed as a more aggressive form of https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3047.

Usage:
```php
final class ConfigTest extends \PhpCsFixer\Test\AbstractConfigTestCase
{
    public function testPhpCsFixerConfigIsUpToDate()
    {
        $this->doTestAllDefaultRulesAreSpecified(require dirname(__DIR__) . '/.php_cs');
    }
}
```

- [x] Check all rules are specified, either by name or RuleSet
- [x] Check all specified rules exist and are not deprecated
- [x] Check all rules are ordered alphabetically

It's 2 years I use this test in my project (for example in [Slamdunk/php-cs-fixer-extensions](https://github.com/Slamdunk/php-cs-fixer-extensions/blob/master/tests/ConfigTest.php)) and is sooo useful.

If you like it, I'll update the README too.