### PR TITLE
PhpUnitNamespacedFixer - properly translate classes which do not follow translation pattern

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
@@ -33,6 +33,18 @@ final class PhpUnitNamespacedFixer extends AbstractFixer implements Configuratio
     private $originalClassRegEx;
 
     /**
+     * Class Mappings.
+     *
+     *  * [original classname => new classname] Some classes which match the
+     *    original class regular expression do not have a same-compound name-
+     *    space class and need a dedicated translation table. This trans-
+     *    lation table is defined in @see configure.
+     *
+     * @var array|string[] Class Mappings
+     */
+    private $classMap;
+
+    /**
      * {@inheritdoc}
      */
     public function getDefinition()
@@ -81,10 +93,42 @@ final class MyTest extends \PHPUnit_Framework_TestCase
 
         if (PhpUnitTargetVersion::fulfills($this->configuration['target'], PhpUnitTargetVersion::VERSION_6_0)) {
             $this->originalClassRegEx = '/^PHPUnit_\w+$/i';
+            // @noinspection ClassConstantCanBeUsedInspection
+            $this->classMap = [
+                'PHPUnit_Extensions_PhptTestCase' => 'PHPUnit\Runner\PhptTestCase',
+                'PHPUnit_Framework_Constraint' => 'PHPUnit\Framework\Constraint\Constraint',
+                'PHPUnit_Framework_Constraint_StringMatches' => 'PHPUnit\Framework\Constraint\StringMatchesFormatDescription',
+                'PHPUnit_Framework_Constraint_JsonMatches_ErrorMessageProvider' => 'PHPUnit\Framework\Constraint\JsonMatchesErrorMessageProvider',
+                'PHPUnit_Framework_Constraint_PCREMatch' => 'PHPUnit\Framework\Constraint\RegularExpression',
+                'PHPUnit_Framework_Constraint_ExceptionMessageRegExp' => 'PHPUnit\Framework\Constraint\ExceptionMessageRegularExpression',
+                'PHPUnit_Framework_Constraint_And' => 'PHPUnit\Framework\Constraint\LogicalAnd',
+                'PHPUnit_Framework_Constraint_Or' => 'PHPUnit\Framework\Constraint\LogicalOr',
+                'PHPUnit_Framework_Constraint_Not' => 'PHPUnit\Framework\Constraint\LogicalNot',
+                'PHPUnit_Framework_Constraint_Xor' => 'PHPUnit\Framework\Constraint\LogicalXor',
+                'PHPUnit_Framework_Error' => 'PHPUnit\Framework\Error\Error',
+                'PHPUnit_Framework_TestSuite_DataProvider' => 'PHPUnit\Framework\DataProviderTestSuite',
+                'PHPUnit_Framework_MockObject_Invocation_Static' => 'PHPUnit\Framework\MockObject\Invocation\StaticInvocation',
+                'PHPUnit_Framework_MockObject_Invocation_Object' => 'PHPUnit\Framework\MockObject\Invocation\ObjectInvocation',
+                'PHPUnit_Framework_MockObject_Stub_Return' => 'PHPUnit\Framework\MockObject\Stub\ReturnStub',
+                'PHPUnit_Runner_Filter_Group_Exclude' => 'PHPUnit\Runner\Filter\ExcludeGroupFilterIterator',
+                'PHPUnit_Runner_Filter_Group_Include' => 'PHPUnit\Runner\Filter\IncludeGroupFilterIterator',
+                'PHPUnit_Runner_Filter_Test' => 'PHPUnit\Runner\Filter\NameFilterIterator',
+                'PHPUnit_Util_PHP' => 'PHPUnit\Util\PHP\AbstractPhpProcess',
+                'PHPUnit_Util_PHP_Default' => 'PHPUnit\Util\PHP\DefaultPhpProcess',
+                'PHPUnit_Util_PHP_Windows' => 'PHPUnit\Util\PHP\WindowsPhpProcess',
+                'PHPUnit_Util_Regex' => 'PHPUnit\Util\RegularExpression',
+                'PHPUnit_Util_TestDox_ResultPrinter_XML' => 'PHPUnit\Util\TestDox\XmlResultPrinter',
+                'PHPUnit_Util_TestDox_ResultPrinter_HTML' => 'PHPUnit\Util\TestDox\HtmlResultPrinter',
+                'PHPUnit_Util_TestDox_ResultPrinter_Text' => 'PHPUnit\Util\TestDox\TextResultPrinter',
+                'PHPUnit_Util_TestSuiteIterator' => 'PHPUnit\Framework\TestSuiteIterator',
+                'PHPUnit_Util_XML' => 'PHPUnit\Util\Xml',
+            ];
         } elseif (PhpUnitTargetVersion::fulfills($this->configuration['target'], PhpUnitTargetVersion::VERSION_5_7)) {
             $this->originalClassRegEx = '/^PHPUnit_Framework_TestCase|PHPUnit_Framework_Assert|PHPUnit_Framework_BaseTestListener|PHPUnit_Framework_TestListener$/i';
+            $this->classMap = [];
         } else {
             $this->originalClassRegEx = '/^PHPUnit_Framework_TestCase$/i';
+            $this->classMap = [];
         }
     }
 
@@ -153,7 +197,15 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     private function generateReplacement($originalClassName)
     {
-        $parts = explode('_', $originalClassName);
+        $delimiter = '_';
+        $string = $originalClassName;
+
+        if (isset($this->classMap[$originalClassName])) {
+            $delimiter = '\\';
+            $string = $this->classMap[$originalClassName];
+        }
+
+        $parts = explode($delimiter, $string);
 
         $tokensArray = [];
         while (!empty($parts)) {

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -40,6 +40,14 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
     public function provideTestFixCases()
     {
         return [
+            'class_mapping' => [
+                '<?php new PHPUnit\Framework\Error\Error();',
+                '<?php new PHPUnit_Framework_Error();',
+            ],
+            'class_mapping_bogus_fqcn' => [
+                '<?php new \PHPUnit\Framework\MockObject\Stub\ReturnStub();',
+                '<?php new \PHPUnit_Framework_MockObject_Stub_Return();',
+            ],
             [
                 '<?php
     final class MyTest extends \PHPUnit\Framework\TestCase


### PR DESCRIPTION
Fixes #4417

When cs-fix the name-space of the class

    PHPUnit_Framework_MockObject_Stub_Return

it results in a new class name which causes a PHP parse error b/c of the
reserved word "return" as the new class-name.

Phpunit has renamed that class to ...\ReturnStub (5 -> 6).

Fix is to translate it to the "new" name so that it transposes correctly.

Fixer: PhpUnitNamespacedFixer