### PR TITLE
PhpUnitTestCaseStaticMethodCallsFixer - skip anonymous classes and lambda

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
@@ -317,7 +317,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
-        foreach (array_reverse(iterator_to_array($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens))) as $indexes) {
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indexes) {
             $this->fixPhpUnitClass($tokens, $indexes[0], $indexes[1]);
         }
     }
@@ -377,18 +377,48 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         $analyzer = new TokensAnalyzer($tokens);
 
-        for ($index = $endIndex - 1; $index > $startIndex; --$index) {
+        for ($index = $startIndex; $index < $endIndex; ++$index) {
+            // skip anonymous classes
+            if ($tokens[$index]->isGivenKind(T_CLASS)) {
+                $index = $this->findEndOfNextBlock($tokens, $index);
+
+                continue;
+            }
+
+            $callType = $this->configuration['call_type'];
+
+            if ($tokens[$index]->isGivenKind(T_FUNCTION)) {
+                // skip lambda
+                if ($analyzer->isLambda($index)) {
+                    $index = $this->findEndOfNextBlock($tokens, $index);
+
+                    continue;
+                }
+
+                // do not change `self` to `this` in static methods
+                if ('this' === $callType) {
+                    $attributes = $analyzer->getMethodAttributes($index);
+                    if (false !== $attributes['static']) {
+                        $index = $this->findEndOfNextBlock($tokens, $index);
+
+                        continue;
+                    }
+                }
+            }
+
             if (!$tokens[$index]->isGivenKind(T_STRING) || !isset($this->staticMethods[$tokens[$index]->getContent()])) {
                 continue;
             }
 
             $nextIndex = $tokens->getNextMeaningfulToken($index);
             if (!$tokens[$nextIndex]->equals('(')) {
+                $index = $nextIndex;
+
                 continue;
             }
 
             $methodName = $tokens[$index]->getContent();
-            $callType = $this->configuration['call_type'];
+
             if (isset($this->configuration['methods'][$methodName])) {
                 $callType = $this->configuration['methods'][$methodName];
             }
@@ -396,10 +426,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $operatorIndex = $tokens->getPrevMeaningfulToken($index);
             $referenceIndex = $tokens->getPrevMeaningfulToken($operatorIndex);
             if (!$this->needsConversion($tokens, $operatorIndex, $referenceIndex, $callType)) {
-                continue;
-            }
-
-            if (self::CALL_TYPE_THIS === $callType && $this->isInsideStaticFunction($tokens, $analyzer, $index)) {
                 continue;
             }
 
@@ -434,34 +460,15 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param Tokens         $tokens
-     * @param TokensAnalyzer $analyzer
-     * @param int            $index
+     * @param Tokens $tokens
+     * @param int    $index
      *
-     * @return bool
+     * @return int
      */
-    private function isInsideStaticFunction(Tokens $tokens, TokensAnalyzer $analyzer, $index)
+    private function findEndOfNextBlock(Tokens $tokens, $index)
     {
-        $functionIndex = $tokens->getPrevTokenOfKind($index, [[T_FUNCTION]]);
-        while ($analyzer->isLambda($functionIndex)) {
-            $openingCurlyBraceIndex = $tokens->getNextTokenOfKind($functionIndex, ['{']);
-            $closingCurlyBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openingCurlyBraceIndex);
+        $index = $tokens->getNextTokenOfKind($index, ['{']);
 
-            if ($closingCurlyBraceIndex > $index) {
-                $prev = $tokens->getPrevMeaningfulToken($functionIndex);
-                if ($tokens[$prev]->isGivenKind(T_STATIC)) {
-                    return true;
-                }
-            }
-
-            $functionIndex = $tokens->getPrevTokenOfKind($functionIndex, [[T_FUNCTION]]);
-        }
-
-        $prev = $functionIndex;
-        do {
-            $prev = $tokens->getPrevMeaningfulToken($prev);
-        } while ($tokens[$prev]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL]));
-
-        return $tokens[$prev]->isGivenKind(T_STATIC);
+        return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -204,9 +204,9 @@ class MyTest extends \PHPUnit_Framework_TestCase
         $this->fail('foo');
 
         $lambda = function () {
-            $this->assertSame(1, 2);
-            $this->assertSame(1, 2);
-            $this->assertSame(1, 2);
+            $this->assertSame(1, 23);
+            self::assertSame(1, 23);
+            static::assertSame(1, 23);
         };
     }
 }
@@ -223,9 +223,9 @@ class MyTest extends \PHPUnit_Framework_TestCase
         static::fail('foo');
 
         $lambda = function () {
-            $this->assertSame(1, 2);
-            self::assertSame(1, 2);
-            static::assertSame(1, 2);
+            $this->assertSame(1, 23);
+            self::assertSame(1, 23);
+            static::assertSame(1, 23);
         };
     }
 }
@@ -329,6 +329,10 @@ class MyTest extends \PHPUnit_Framework_TestCase
             self::assertSame(1, 2);
             static::assertSame(1, 2);
         };
+
+        $myProphecy->setCount(0)->will(function () {
+            $this->getCount()->willReturn(0);
+        });
     }
 
     static public function baz()
@@ -371,23 +375,23 @@ class MyTest extends \PHPUnit_Framework_TestCase
     public function bar()
     {
         $lambdaOne = static function () {
-            $this->assertSame(1, 2);
-            self::assertSame(1, 2);
-            static::assertSame(1, 2);
+            $this->assertSame(1, 21);
+            self::assertSame(1, 21);
+            static::assertSame(1, 21);
         };
 
         $lambdaTwo = function () {
-            $this->assertSame(1, 2);
-            $this->assertSame(1, 2);
-            $this->assertSame(1, 2);
+            $this->assertSame(1, 21);
+            self::assertSame(1, 21);
+            static::assertSame(1, 21);
         };
     }
 
-    public function baz()
+    public function baz2()
     {
-        $this->assertSame(1, 2);
-        $this->assertSame(1, 2);
-        $this->assertSame(1, 2);
+        $this->assertSame(1, 22);
+        $this->assertSame(1, 22);
+        $this->assertSame(1, 22);
     }
 
 }
@@ -407,23 +411,23 @@ class MyTest extends \PHPUnit_Framework_TestCase
     public function bar()
     {
         $lambdaOne = static function () {
-            $this->assertSame(1, 2);
-            self::assertSame(1, 2);
-            static::assertSame(1, 2);
+            $this->assertSame(1, 21);
+            self::assertSame(1, 21);
+            static::assertSame(1, 21);
         };
 
         $lambdaTwo = function () {
-            $this->assertSame(1, 2);
-            self::assertSame(1, 2);
-            static::assertSame(1, 2);
+            $this->assertSame(1, 21);
+            self::assertSame(1, 21);
+            static::assertSame(1, 21);
         };
     }
 
-    public function baz()
+    public function baz2()
     {
-        $this->assertSame(1, 2);
-        self::assertSame(1, 2);
-        static::assertSame(1, 2);
+        $this->assertSame(1, 22);
+        self::assertSame(1, 22);
+        static::assertSame(1, 22);
     }
 
 }
@@ -433,7 +437,7 @@ EOF
                     'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
                 ],
             ],
-            [
+            'do not change class property and method signature' => [
                 <<<'EOF'
 <?php
 class HavingPropertyWithNameAsMethodToUpdateTest extends PHPUnit
@@ -442,10 +446,51 @@ class HavingPropertyWithNameAsMethodToUpdateTest extends PHPUnit
     {
         $this->assertSame = 42;
     }
+
+    public function assertSame($foo, $bar){}
 }
 EOF
                 ,
             ],
         ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testAnonymousClassFixing()
+    {
+        $this->doTest(
+            '<?php
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBaseCase()
+    {
+        static::assertSame(1, 2);
+
+        $foo = new class() {
+            public function assertSame($a, $b)
+            {
+                $this->assertSame(1, 2);
+            }
+        };
+    }
+}',
+            '<?php
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBaseCase()
+    {
+        $this->assertSame(1, 2);
+
+        $foo = new class() {
+            public function assertSame($a, $b)
+            {
+                $this->assertSame(1, 2);
+            }
+        };
+    }
+}'
+        );
     }
 }


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4415