### PR TITLE
MethodArgumentSpaceFixer - PHP7.3 trailing commas in function calls

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -350,7 +350,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
                 continue;
             }
 
-            if ($token->equals(',')) {
+            if ($token->equals(',') && !$tokens[$tokens->getNextMeaningfulToken($index)]->equals(')')) {
                 $this->fixNewline($tokens, $index, $indentation);
             }
         }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -192,11 +192,25 @@ $var2 = some_function(
                 ['keep_multiple_spaces_after_comma' => true],
             ],
             'skip array' => [
-                '<?php array(10 , 20 ,30);',
+                '<?php array(10 , 20 ,30); $foo = [ 10,50 , 60 ] ?>',
             ],
             'list call with trailing comma' => [
                 '<?php list($path, $mode, ) = foo();',
                 '<?php list($path, $mode,) = foo();',
+            ],
+            'list call with trailing comma multi line' => [
+                '<?php
+list(
+    $a,
+    $b,
+) = foo();
+',
+                '<?php
+list(
+    $a   ,
+    $b  ,
+) = foo();
+',
             ],
             'inline comments with spaces' => [
                 '<?php xyz($a=10, /*comment1*/ $b=2000, /*comment2*/ $c=30);',
@@ -925,5 +939,48 @@ functionCall(
 INPUT;
 
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     * @param null|array  $config
+     *
+     * @requires PHP 7.3
+     * @dataProvider provideFix73Cases
+     */
+    public function testFix73($expected, $input = null, array $config = null)
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix73Cases()
+    {
+        return [
+            [
+                '<?php
+functionCall(
+    1,
+    2,
+    3,
+);',
+                '<?php
+functionCall(
+    1, 2,
+    3,
+);',
+                [
+                    'on_multiline' => 'ensure_fully_multiline',
+                ],
+            ],
+            [
+                '<?php foo(1, 2, 3, );',
+                '<?php foo(1,2,3,);',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4414