### PR TITLE
FunctionTypehintSpaceFixer - Ensure single space between type declaration and parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -679,7 +679,7 @@ Choose from the list of available rules:
 
 * **function_typehint_space** [@Symfony, @PhpCsFixer]
 
-  Add missing space between function's argument and its typehint.
+  Ensure single space between function's argument and its typehint.
 
 * **general_phpdoc_annotation_remove**
 

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -53,56 +53,122 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
                 '<?php function foo(/**int*/$param) {}',
             ],
             [
+                '<?php function foo(bool /**bla bla*/ $param) {}',
+            ],
+            [
+                '<?php function foo(bool /**bla bla*/$param) {}',
+                '<?php function foo(bool/**bla bla*/$param) {}',
+            ],
+            [
+                '<?php function foo(bool /**bla bla*/$param) {}',
+                '<?php function foo(bool  /**bla bla*/$param) {}',
+            ],
+            [
                 '<?php function foo(callable $param) {}',
                 '<?php function foo(callable$param) {}',
+            ],
+            [
+                '<?php function foo(callable $param) {}',
+                '<?php function foo(callable  $param) {}',
             ],
             [
                 '<?php function foo(array &$param) {}',
                 '<?php function foo(array&$param) {}',
             ],
             [
+                '<?php function foo(array &$param) {}',
+                '<?php function foo(array  &$param) {}',
+            ],
+            [
                 '<?php function foo(array & $param) {}',
                 '<?php function foo(array& $param) {}',
+            ],
+            [
+                '<?php function foo(array & $param) {}',
+                '<?php function foo(array  & $param) {}',
             ],
             [
                 '<?php function foo(Bar $param) {}',
                 '<?php function foo(Bar$param) {}',
             ],
             [
+                '<?php function foo(Bar $param) {}',
+                '<?php function foo(Bar  $param) {}',
+            ],
+            [
                 '<?php function foo(Bar\Baz $param) {}',
                 '<?php function foo(Bar\Baz$param) {}',
+            ],
+            [
+                '<?php function foo(Bar\Baz $param) {}',
+                '<?php function foo(Bar\Baz  $param) {}',
             ],
             [
                 '<?php function foo(Bar\Baz &$param) {}',
                 '<?php function foo(Bar\Baz&$param) {}',
             ],
             [
+                '<?php function foo(Bar\Baz &$param) {}',
+                '<?php function foo(Bar\Baz  &$param) {}',
+            ],
+            [
                 '<?php function foo(Bar\Baz & $param) {}',
                 '<?php function foo(Bar\Baz& $param) {}',
+            ],
+            [
+                '<?php function foo(Bar\Baz & $param) {}',
+                '<?php function foo(Bar\Baz  & $param) {}',
             ],
             [
                 '<?php $foo = function(Bar\Baz $param) {};',
                 '<?php $foo = function(Bar\Baz$param) {};',
             ],
             [
+                '<?php $foo = function(Bar\Baz $param) {};',
+                '<?php $foo = function(Bar\Baz  $param) {};',
+            ],
+            [
                 '<?php $foo = function(Bar\Baz &$param) {};',
                 '<?php $foo = function(Bar\Baz&$param) {};',
+            ],
+            [
+                '<?php $foo = function(Bar\Baz &$param) {};',
+                '<?php $foo = function(Bar\Baz  &$param) {};',
             ],
             [
                 '<?php $foo = function(Bar\Baz & $param) {};',
                 '<?php $foo = function(Bar\Baz& $param) {};',
             ],
             [
+                '<?php $foo = function(Bar\Baz & $param) {};',
+                '<?php $foo = function(Bar\Baz  & $param) {};',
+            ],
+            [
                 '<?php class Test { public function foo(Bar\Baz $param) {} }',
                 '<?php class Test { public function foo(Bar\Baz$param) {} }',
             ],
             [
+                '<?php class Test { public function foo(Bar\Baz $param) {} }',
+                '<?php class Test { public function foo(Bar\Baz  $param) {} }',
+            ],
+            [
                 '<?php $foo = function(array $a,
-                    array $b, array     $c, array
-                    $d) {};',
+                    array $b, array $c, array $d) {};',
                 '<?php $foo = function(array $a,
                     array$b, array     $c, array
                     $d) {};',
+            ],
+            [
+                '<?php $foo = function(
+                    array $a,
+                    $b
+                ) {};',
+            ],
+            [
+                '<?php $foo = function(
+                    $a,
+                    array $b
+                ) {};',
             ],
             [
                 '<?php function foo(...$param) {}',


### PR DESCRIPTION
This PR

* [x] adjusts the `FunctionTypehintSpaceFixer` to ensure a single (!) space between a type declaration and a parameter 

💁‍♂ Not sure, should this be a separate fixer, or can this go into this fixer? Is it a bug? Is it a feature?