### PR TITLE
[HeredocIndentationFixer] Should be run before NoTrailingWhitespaceFixer

### DIFF
--- a/src/Fixer/Whitespace/HeredocIndentationFixer.php
+++ b/src/Fixer/Whitespace/HeredocIndentationFixer.php
@@ -65,6 +65,15 @@ SAMPLE
     /**
      * {@inheritdoc}
      */
+    public function getPriority()
+    {
+        // should be run before NoTrailingWhitespaceFixer
+        return 5;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isCandidate(Tokens $tokens)
     {
         return \PHP_VERSION_ID >= 70300 && $tokens->isTokenKindFound(T_START_HEREDOC);

--- a/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
@@ -176,6 +176,26 @@ EOD;
 INPUT
                 ,
             ],
+            [
+                <<<'EXPECTED'
+<?php
+    $a = <<<'EOD'
+        first line
+        
+        ending line
+        EOD;
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+    $a = <<<'EOD'
+first line
+
+ending line
+EOD;
+INPUT
+                ,
+            ],
         ];
     }
 


### PR DESCRIPTION
With the proposed configuration, the expected result for this snippet
```php
<?php
····$a·=·<<<'EOD'
first line

ending line
EOD;
```
should be
```php
<?php
····$a·=·<<<'EOD'
········first line

········ending line
EOD;
```
instead of
```php
<?php
····$a·=·<<<'EOD'
········first line
········
········ending line
EOD;
```