### PR TITLE
SingleSpaceAfterConstructFixer - Introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2053,6 +2053,31 @@ Choose from the list of available rules:
   - ``strings_containing_single_quote_chars`` (``bool``): whether to fix
     double-quoted strings that contains single-quotes; defaults to ``false``
 
+* **single_space_after_construct** [@PhpCsFixer]
+
+  Ensures a single space after language constructs.
+
+  Configuration options:
+
+  - ``constructs`` (a subset of ``['abstract', 'as', 'break', 'case', 'catch',
+    'class', 'clone', 'const', 'const_import', 'continue', 'do', 'echo',
+    'else', 'elseif', 'extends', 'final', 'finally', 'for', 'foreach',
+    'function', 'function_import', 'global', 'goto', 'if', 'implements',
+    'include', 'include_once', 'instanceof', 'insteadof', 'interface',
+    'new', 'open_tag_with_echo', 'php_open', 'print', 'private',
+    'protected', 'public', 'require', 'require_once', 'return', 'static',
+    'throw', 'trait', 'try', 'use', 'use_lambda', 'use_trait', 'var',
+    'while', 'yield', 'yield_from']``): list of constructs which must be
+    followed by a single space; defaults to ``['abstract', 'as', 'break',
+    'case', 'catch', 'class', 'clone', 'const', 'const_import', 'continue',
+    'do', 'echo', 'else', 'elseif', 'extends', 'final', 'finally', 'for',
+    'foreach', 'function', 'function_import', 'global', 'goto', 'if',
+    'implements', 'include', 'include_once', 'instanceof', 'insteadof',
+    'interface', 'new', 'open_tag_with_echo', 'php_open', 'print',
+    'private', 'protected', 'public', 'require', 'require_once', 'return',
+    'static', 'throw', 'trait', 'try', 'use', 'use_lambda', 'use_trait',
+    'var', 'while', 'yield', 'yield_from']``
+
 * **single_trait_insert_per_statement** [@Symfony, @PhpCsFixer]
 
   Each trait ``use`` must be done as single statement.

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -1,0 +1,272 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\LanguageConstruct;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ */
+final class SingleSpaceAfterConstructFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    /**
+     * @var array<string, null|int>
+     */
+    private static $tokenMap = [
+        'abstract' => T_ABSTRACT,
+        'as' => T_AS,
+        'break' => T_BREAK,
+        'case' => T_CASE,
+        'catch' => T_CATCH,
+        'class' => T_CLASS,
+        'clone' => T_CLONE,
+        'const' => T_CONST,
+        'const_import' => CT::T_CONST_IMPORT,
+        'continue' => T_CONTINUE,
+        'do' => T_DO,
+        'echo' => T_ECHO,
+        'else' => T_ELSE,
+        'elseif' => T_ELSEIF,
+        'extends' => T_EXTENDS,
+        'final' => T_FINAL,
+        'finally' => T_FINALLY,
+        'for' => T_FOR,
+        'foreach' => T_FOREACH,
+        'function' => T_FUNCTION,
+        'function_import' => CT::T_FUNCTION_IMPORT,
+        'global' => T_GLOBAL,
+        'goto' => T_GOTO,
+        'if' => T_IF,
+        'implements' => T_IMPLEMENTS,
+        'include' => T_INCLUDE,
+        'include_once' => T_INCLUDE_ONCE,
+        'instanceof' => T_INSTANCEOF,
+        'insteadof' => T_INSTEADOF,
+        'interface' => T_INTERFACE,
+        'new' => T_NEW,
+        'open_tag_with_echo' => T_OPEN_TAG_WITH_ECHO,
+        'php_open' => T_OPEN_TAG,
+        'print' => T_PRINT,
+        'private' => T_PRIVATE,
+        'protected' => T_PROTECTED,
+        'public' => T_PUBLIC,
+        'require' => T_REQUIRE,
+        'require_once' => T_REQUIRE_ONCE,
+        'return' => T_RETURN,
+        'static' => T_STATIC,
+        'throw' => T_THROW,
+        'trait' => T_TRAIT,
+        'try' => T_TRY,
+        'use' => T_USE,
+        'use_lambda' => CT::T_USE_LAMBDA,
+        'use_trait' => CT::T_USE_TRAIT,
+        'var' => T_VAR,
+        'while' => T_WHILE,
+        'yield' => T_YIELD,
+        'yield_from' => null,
+    ];
+
+    /**
+     * @var array<string, int>
+     */
+    private $fixTokenMap = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        parent::configure($configuration);
+
+        if (70000 <= \PHP_VERSION_ID) {
+            self::$tokenMap['yield_from'] = T_YIELD_FROM;
+        }
+
+        $this->fixTokenMap = [];
+
+        foreach ($this->configuration['constructs'] as $key) {
+            $this->fixTokenMap[$key] = self::$tokenMap[$key];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Ensures a single space after language constructs.',
+            [
+                new CodeSample(
+                    '<?php
+
+throw  new  \Exception();
+'
+                ),
+                new CodeSample(
+                    '<?php
+
+echo  "Hello!";
+',
+                    [
+                        'constructs' => [
+                            'echo',
+                        ],
+                    ]
+                ),
+                new VersionSpecificCodeSample(
+                    '<?php
+
+yield  from  baz();
+',
+                    new VersionSpecification(70000),
+                    [
+                        'constructs' => [
+                            'yield_from',
+                        ],
+                    ]
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAnyTokenKindsFound(array_values($this->fixTokenMap)) && !$tokens->hasAlternativeSyntax();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $tokenKinds = array_values($this->fixTokenMap);
+
+        for ($index = $tokens->count() - 2; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if (!$token->isGivenKind($tokenKinds)) {
+                continue;
+            }
+
+            $whitespaceTokenIndex = $index + 1;
+
+            if (';' === $tokens[$whitespaceTokenIndex]->getContent()) {
+                continue;
+            }
+
+            if (
+                $token->isGivenKind(T_STATIC)
+                && !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind([T_FUNCTION, T_VARIABLE])
+            ) {
+                continue;
+            }
+
+            if ($token->isGivenKind(T_OPEN_TAG)) {
+                if ($tokens[$whitespaceTokenIndex]->equals([T_WHITESPACE]) && false === strpos($token->getContent(), "\n")) {
+                    $tokens->clearAt($whitespaceTokenIndex);
+                }
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_CLASS) && $tokens[$tokens->getNextMeaningfulToken($index)]->equals('(')) {
+                continue;
+            }
+
+            if ($token->isGivenKind(T_RETURN) && $this->isMultiLineReturn($tokens, $index)) {
+                continue;
+            }
+
+            if (!$tokens[$whitespaceTokenIndex]->equals([T_WHITESPACE])) {
+                $tokens->insertAt($whitespaceTokenIndex, new Token([T_WHITESPACE, ' ']));
+            } elseif (' ' !== $tokens[$whitespaceTokenIndex]->getContent()) {
+                $tokens[$whitespaceTokenIndex] = new Token([T_WHITESPACE, ' ']);
+            }
+
+            if (
+                70000 <= \PHP_VERSION_ID
+                && $token->isGivenKind(T_YIELD_FROM)
+                && 'yield from' !== strtolower($token->getContent())
+            ) {
+                $tokens[$index] = new Token([T_YIELD_FROM, Preg::replace(
+                    '/\s+/',
+                    ' ',
+                    $token->getContent()
+                )]);
+            }
+        }
+    }
+
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('constructs', 'List of constructs which must be followed by a single space.'))
+                ->setAllowedTypes(['array'])
+                ->setAllowedValues([new AllowedValueSubset(array_keys(self::$tokenMap))])
+                ->setDefault(array_keys(self::$tokenMap))
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return bool
+     */
+    private function isMultiLineReturn(Tokens $tokens, $index)
+    {
+        ++$index;
+        $tokenFollowingReturn = $tokens[$index];
+
+        if (
+            !$tokenFollowingReturn->isGivenKind(T_WHITESPACE)
+            || false === strpos($tokenFollowingReturn->getContent(), "\n")
+        ) {
+            return false;
+        }
+
+        $nestedCount = 0;
+
+        for ($indexEnd = \count($tokens) - 1, ++$index; $index < $indexEnd; ++$index) {
+            if (false !== strpos($tokens[$index]->getContent(), "\n")) {
+                return true;
+            }
+
+            if ($tokens[$index]->equals('{')) {
+                ++$nestedCount;
+            } elseif ($tokens[$index]->equals('}')) {
+                --$nestedCount;
+            } elseif (0 === $nestedCount && $tokens[$index]->equalsAny([';', [T_CLOSE_TAG]])) {
+                break;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -305,7 +305,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
             return 'test_'.$functionName;
         }
 
-        return'test'.ucfirst($functionName);
+        return 'test'.ucfirst($functionName);
     }
 
     /**

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -333,6 +333,7 @@ final class RuleSet implements RuleSetInterface
             'simple_to_complex_string_variable' => true,
             'single_line_comment_style' => true,
             'single_line_throw' => false,
+            'single_space_after_construct' => true,
         ],
         '@PhpCsFixer:risky' => [
             '@Symfony:risky' => true,

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -1,0 +1,3086 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\LanguageConstruct;
+
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Andreas Möller <am@localheinz.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\LanguageConstruct\SingleSpaceAfterConstructFixer
+ */
+final class SingleSpaceAfterConstructFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideInvalidConstructCases
+     *
+     * @param mixed $construct
+     */
+    public function testConfigureRejectsInvalidControlStatement($construct)
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+
+        $this->fixer->configure([
+            'constructs' => [
+                $construct,
+            ],
+        ]);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideInvalidConstructCases()
+    {
+        return [
+            'null' => [null],
+            'false' => [false],
+            'true' => [true],
+            'int' => [0],
+            'float' => [3.14],
+            'array' => [[]],
+            'object' => [new \stdClass()],
+            'unknown' => ['foo'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithAbstractCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithAbstract($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'abstract',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithAbstractCases()
+    {
+        return [
+            [
+                '<?php abstract class Foo {};',
+                '<?php abstract  class Foo {};',
+            ],
+            [
+                '<?php abstract class Foo {};',
+                '<?php abstract
+
+class Foo {};',
+            ],
+            [
+                '<?php abstract /* foo */class Foo {};',
+                '<?php abstract/* foo */class Foo {};',
+            ],
+            [
+                '<?php abstract /* foo */class Foo {};',
+                '<?php abstract  /* foo */class Foo {};',
+            ],
+            [
+                '<?php
+
+abstract class Foo
+{
+    abstract function bar();
+}',
+                '<?php
+
+abstract class Foo
+{
+    abstract  function bar();
+}',
+            ],
+            [
+                '<?php
+
+abstract class Foo
+{
+    abstract function bar();
+}',
+                '<?php
+
+abstract class Foo
+{
+    abstract
+
+function bar();
+}',
+            ],
+            [
+                '<?php
+
+abstract class Foo
+{
+    abstract /* foo */function bar();
+}',
+                '<?php
+
+abstract class Foo
+{
+    abstract  /* foo */function bar();
+}',
+            ],
+            [
+                '<?php
+
+abstract class Foo
+{
+    abstract /* foo */function bar();
+}',
+                '<?php
+
+abstract class Foo
+{
+    abstract/* foo */function bar();
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithBreakCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithBreak($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'break',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithBreakCases()
+    {
+        return [
+            [
+                '<?php while (true) { break; }',
+            ],
+            [
+                '<?php while (true) { break /* foo */; }',
+                '<?php while (true) { break/* foo */; }',
+            ],
+            [
+                '<?php while (true) { break /* foo */; }',
+                '<?php while (true) { break  /* foo */; }',
+            ],
+            [
+                '<?php while (true) { break 1; }',
+                '<?php while (true) { break  1; }',
+            ],
+            [
+                '<?php while (true) { break 1; }',
+                '<?php while (true) { break
+
+1; }',
+            ],
+            [
+                '<?php while (true) { break /* foo */1; }',
+                '<?php while (true) { break/* foo */1; }',
+            ],
+            [
+                '<?php while (true) { break /* foo */1; }',
+                '<?php while (true) { break  /* foo */1; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithAsCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithAs($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'as',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithAsCases()
+    {
+        return [
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach ($foo as$bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach ($foo as  $bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach ($foo as
+
+$bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as /* foo */$bar) {}',
+                '<?php foreach ($foo as/* foo */$bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as /* foo */$bar) {}',
+                '<?php foreach ($foo as  /* foo */$bar) {}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as bar;
+    }
+}',
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as  bar;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as bar;
+    }
+}',
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as
+
+bar;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as /* foo */bar;
+    }
+}',
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as/* foo */bar;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as /* foo */bar;
+    }
+}',
+                '<?php
+
+class Foo
+{
+    use Bar {
+        Bar::baz as  /* foo */bar;
+    }
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithCaseCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithCase($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'case',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithCaseCases()
+    {
+        return [
+            [
+                '<?php
+switch ($i) {
+    case $j:
+        break;
+}',
+                '<?php
+switch ($i) {
+    case$j:
+        break;
+}',
+            ],
+            [
+                '<?php
+switch ($i) {
+    case 0:
+        break;
+}',
+                '<?php
+switch ($i) {
+    case  0:
+        break;
+}',
+            ],
+            [
+                '<?php
+switch ($i) {
+    case 0:
+        break;
+}',
+                '<?php
+switch ($i) {
+    case
+
+0:
+        break;
+}',
+            ],
+            [
+                '<?php
+switch ($i) {
+    case /* foo */0:
+        break;
+}',
+                '<?php
+switch ($i) {
+    case/* foo */0:
+        break;
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithCatchCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithCatch($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'catch',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithCatchCases()
+    {
+        return [
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try {} catch(\Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try {} catch  (\Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try {} catch
+
+(\Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch /* foo */(Exception $exception) {}',
+                '<?php try {} catch/* foo */(Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch /* foo */(Exception $exception) {}',
+                '<?php try {} catch  /* foo */(Exception $exception) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithClassCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithClass($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'class',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithClassCases()
+    {
+        return [
+            [
+                '<?php class Foo {}',
+                '<?php class  Foo {}',
+            ],
+            [
+                '<?php class Foo {}',
+                '<?php class
+
+Foo {}',
+            ],
+            [
+                '<?php class /* foo */Foo {}',
+                '<?php class  /* foo */Foo {}',
+            ],
+            [
+                '<?php class /* foo */Foo {}',
+                '<?php class/* foo */Foo {}',
+            ],
+            [
+                '<?php $foo = stdClass::class;',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     *
+     * @dataProvider provideFixWithClassPhp70Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithClassPhp70($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithClassPhp70Cases()
+    {
+        return [
+            [
+                '<?php $foo = new class {};',
+                '<?php $foo = new class  {};',
+                ['constructs' => ['class']],
+            ],
+            [
+                '<?php $foo = new class {};',
+                '<?php $foo = new class{};',
+                ['constructs' => ['class']],
+            ],
+            [
+                '<?php $foo = new class /* foo */{};',
+                '<?php $foo = new class/* foo */{};',
+                ['constructs' => ['class']],
+            ],
+            [
+                '<?php $foo = new class /* foo */{};',
+                '<?php $foo = new class  /* foo */{};',
+                ['constructs' => ['class']],
+            ],
+            [
+                '<?php $foo = new class(){};',
+                null,
+                ['constructs' => ['class']],
+            ],
+            [
+                '<?php return
+                    $a ? new class(){ public function foo() { echo 1; }}
+                    : 1
+                ;',
+                null,
+                ['constructs' => ['return']],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithContinueCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithContinue($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'continue',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithContinueCases()
+    {
+        return [
+            [
+                '<?php while (true) { continue; }',
+            ],
+            [
+                '<?php while (true) { continue /* foo */; }',
+                '<?php while (true) { continue/* foo */; }',
+            ],
+            [
+                '<?php while (true) { continue /* foo */; }',
+                '<?php while (true) { continue  /* foo */; }',
+            ],
+            [
+                '<?php while (true) { continue 1; }',
+                '<?php while (true) { continue  1; }',
+            ],
+            [
+                '<?php while (true) { continue 1; }',
+                '<?php while (true) { continue
+
+1; }',
+            ],
+            [
+                '<?php while (true) { continue /* foo*/ 1; }',
+                '<?php while (true) { continue  /* foo*/ 1; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithConstCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithConst($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'const',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithConstCases()
+    {
+        return [
+            [
+                '<?php class Foo { const FOO = 9000; }',
+                '<?php class Foo { const  FOO = 9000; }',
+            ],
+            [
+                '<?php class Foo { const FOO = 9000; }',
+                '<?php class Foo { const
+
+FOO = 9000; }',
+            ],
+            [
+                '<?php class Foo { const /* foo */FOO = 9000; }',
+                '<?php class Foo { const/* foo */FOO = 9000; }',
+            ],
+            [
+                '<?php class Foo { const /* foo */FOO = 9000; }',
+                '<?php class Foo { const  /* foo */FOO = 9000; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithConstImportCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithConstImport($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'const_import',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithConstImportCases()
+    {
+        return [
+            [
+                '<?php use const FOO\BAR;',
+                '<?php use const  FOO\BAR;',
+            ],
+            [
+                '<?php use const FOO\BAR;',
+                '<?php use const
+
+FOO\BAR;',
+            ],
+            [
+                '<?php use const /* foo */FOO\BAR;',
+                '<?php use const/* foo */FOO\BAR;',
+            ],
+            [
+                '<?php use const /* foo */FOO\BAR;',
+                '<?php use const  /* foo */FOO\BAR;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithCloneCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithClone($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'clone',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithCloneCases()
+    {
+        return [
+            [
+                '<?php clone $foo;',
+                '<?php clone$foo;',
+            ],
+            [
+                '<?php clone $foo;',
+                '<?php clone  $foo;',
+            ],
+            [
+                '<?php clone $foo;',
+                '<?php clone
+
+$foo;',
+            ],
+            [
+                '<?php clone /* foo */$foo;',
+                '<?php clone/* foo */$foo;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithDoCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithDo($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'do',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithDoCases()
+    {
+        return [
+            [
+                '<?php do {} while (true);',
+                '<?php do{} while (true);',
+            ],
+            [
+                '<?php do {} while (true);',
+                '<?php do  {} while (true);',
+            ],
+            [
+                '<?php do {} while (true);',
+                '<?php do
+
+{} while (true);',
+            ],
+            [
+                '<?php do /* foo*/{} while (true);',
+                '<?php do/* foo*/{} while (true);',
+            ],
+            [
+                '<?php do /* foo*/{} while (true);',
+                '<?php do  /* foo*/{} while (true);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithEchoCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithEcho($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'echo',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithEchoCases()
+    {
+        return [
+            [
+                '<?php echo $foo;',
+                '<?php echo$foo;',
+            ],
+            [
+                '<?php echo 9000;',
+                '<?php echo  9000;',
+            ],
+            [
+                '<?php echo 9000;',
+                '<?php echo
+
+9000;',
+            ],
+            [
+                '<?php echo /* foo */9000;',
+                '<?php echo/* foo */9000;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithElseCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithElse($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'else',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithElseCases()
+    {
+        return [
+            [
+                '<?php if (true) {} else {}',
+                '<?php if (true) {} else{}',
+            ],
+            [
+                '<?php if (true) {} else {}',
+                '<?php if (true) {} else  {}',
+            ],
+            [
+                '<?php if (true) {} else {}',
+                '<?php if (true) {} else
+
+{}',
+            ],
+            [
+                '<?php if (true) {} else /* foo */{}',
+                '<?php if (true) {} else/* foo */{}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithElseIfCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithElseIf($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'elseif',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithElseIfCases()
+    {
+        return [
+            [
+                '<?php if (true) {} elseif (false) {}',
+                '<?php if (true) {} elseif(false) {}',
+            ],
+            [
+                '<?php if (true) {} elseif (false) {}',
+                '<?php if (true) {} elseif  (false) {}',
+            ],
+            [
+                '<?php if (true) {} elseif (false) {}',
+                '<?php if (true) {} elseif
+
+(false) {}',
+            ],
+            [
+                '<?php if (true) {} elseif /* foo */(false) {}',
+                '<?php if (true) {} elseif/* foo */(false) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithExtendsCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithExtends($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'extends',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithExtendsCases()
+    {
+        return [
+            [
+                '<?php class Foo extends \InvalidArgumentException {}',
+                '<?php class Foo extends  \InvalidArgumentException {}',
+            ],
+            [
+                '<?php class Foo extends \InvalidArgumentException {}',
+                '<?php class Foo extends
+
+\InvalidArgumentException {}',
+            ],
+            [
+                '<?php class Foo extends /* foo */\InvalidArgumentException {}',
+                '<?php class Foo extends/* foo */\InvalidArgumentException {}',
+            ],
+            [
+                '<?php class Foo extends /* foo */\InvalidArgumentException {}',
+                '<?php class Foo extends  /* foo */\InvalidArgumentException {}',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     *
+     * @dataProvider provideFixWithExtendsPhp70Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithExtendsPhp70($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'extends',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithExtendsPhp70Cases()
+    {
+        return [
+            [
+                '<?php $foo = new class extends \InvalidArgumentException {};',
+                '<?php $foo = new class extends  \InvalidArgumentException {};',
+            ],
+            [
+                '<?php $foo = new class extends \InvalidArgumentException {};',
+                '<?php $foo = new class extends
+
+\InvalidArgumentException {};',
+            ],
+            [
+                '<?php $foo = new class extends /* foo */\InvalidArgumentException {};',
+                '<?php $foo = new class extends/* foo */\InvalidArgumentException {};',
+            ],
+            [
+                '<?php $foo = new class extends /* foo */\InvalidArgumentException {};',
+                '<?php $foo = new class extends  /* foo */\InvalidArgumentException {};',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithFinalCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithFinal($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'final',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithFinalCases()
+    {
+        return [
+            [
+                '<?php final class Foo {}',
+                '<?php final  class Foo {}',
+            ],
+            [
+                '<?php final class Foo {}',
+                '<?php final
+
+class Foo {}',
+            ],
+            [
+                '<?php final /* foo */class Foo {}',
+                '<?php final/* foo */class Foo {}',
+            ],
+            [
+                '<?php final /* foo */class Foo {}',
+                '<?php final  /* foo */class Foo {}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    final function bar() {}
+}',
+                '<?php
+
+class Foo
+{
+    final  function bar() {}
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    final function bar() {}
+}',
+                '<?php
+
+class Foo
+{
+    final
+
+function bar() {}
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    final /* foo */function bar() {}
+}',
+                '<?php
+
+class Foo
+{
+    final/* foo */function bar() {}
+}',
+            ],
+            [
+                '<?php
+
+class Foo
+{
+    final /* foo */function bar() {}
+}',
+                '<?php
+
+class Foo
+{
+    final  /* foo */function bar() {}
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithFinallyCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithFinally($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'finally',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithFinallyCases()
+    {
+        return [
+            [
+                '<?php try {} finally {}',
+                '<?php try {} finally{}',
+            ],
+            [
+                '<?php try {} finally {}',
+                '<?php try {} finally  {}',
+            ],
+            [
+                '<?php try {} finally {}',
+                '<?php try {} finally
+
+{}',
+            ],
+            [
+                '<?php try {} finally /* foo */{}',
+                '<?php try {} finally/* foo */{}',
+            ],
+            [
+                '<?php try {} finally /* foo */{}',
+                '<?php try {} finally  /* foo */{}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithForCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithFor($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'for',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithForCases()
+    {
+        return [
+            [
+                '<?php for ($i = 0; $i < 3; ++$i) {}',
+                '<?php for($i = 0; $i < 3; ++$i) {}',
+            ],
+            [
+                '<?php for ($i = 0; $i < 3; ++$i) {}',
+                '<?php for  ($i = 0; $i < 3; ++$i) {}',
+            ],
+            [
+                '<?php for ($i = 0; $i < 3; ++$i) {}',
+                '<?php for
+
+($i = 0; $i < 3; ++$i) {}',
+            ],
+            [
+                '<?php for /* foo */($i = 0; $i < 3; ++$i) {}',
+                '<?php for/* foo */($i = 0; $i < 3; ++$i) {}',
+            ],
+            [
+                '<?php for /* foo */($i = 0; $i < 3; ++$i) {}',
+                '<?php for  /* foo */($i = 0; $i < 3; ++$i) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithForeachCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithForeach($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'foreach',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithForeachCases()
+    {
+        return [
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach($foo as $bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach  ($foo as $bar) {}',
+            ],
+            [
+                '<?php foreach ($foo as $bar) {}',
+                '<?php foreach
+
+($foo as $bar) {}',
+            ],
+            [
+                '<?php foreach /* foo */($foo as $bar) {}',
+                '<?php foreach/* foo */($foo as $bar) {}',
+            ],
+            [
+                '<?php foreach /* foo */($foo as $bar) {}',
+                '<?php foreach  /* foo */($foo as $bar) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithFunctionCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithFunction($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'function',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithFunctionCases()
+    {
+        return [
+            [
+                '<?php function foo() {}',
+                '<?php function  foo() {}',
+            ],
+            [
+                '<?php function foo() {}',
+                '<?php function
+
+foo() {}',
+            ],
+            [
+                '<?php function /* foo */foo() {}',
+                '<?php function/* foo */foo() {}',
+            ],
+            [
+                '<?php function /* foo */foo() {}',
+                '<?php function  /* foo */foo() {}',
+            ],
+            [
+                '<?php
+class Foo
+{
+    function bar() {}
+}
+',
+                '<?php
+class Foo
+{
+    function  bar() {}
+}
+',
+            ],
+            [
+                '<?php
+class Foo
+{
+    function bar() {}
+}
+',
+                '<?php
+class Foo
+{
+    function
+
+bar() {}
+}
+',
+            ],
+            [
+                '<?php
+class Foo
+{
+    function /* foo */bar() {}
+}
+',
+                '<?php
+class Foo
+{
+    function/* foo */bar() {}
+}
+',
+            ],
+            [
+                '<?php
+class Foo
+{
+    function /* foo */bar() {}
+}
+',
+                '<?php
+class Foo
+{
+    function  /* foo */bar() {}
+}
+',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithFunctionImportCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithFunctionImport($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'function_import',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithFunctionImportCases()
+    {
+        return [
+            [
+                '<?php use function Foo\bar;',
+                '<?php use function  Foo\bar;',
+            ],
+            [
+                '<?php use function Foo\bar;',
+                '<?php use function
+
+Foo\bar;',
+            ],
+            [
+                '<?php use function /* foo */Foo\bar;',
+                '<?php use function/* foo */Foo\bar;',
+            ],
+            [
+                '<?php use function /* foo */Foo\bar;',
+                '<?php use function  /* foo */Foo\bar;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithGlobalCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithGlobal($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'global',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithGlobalCases()
+    {
+        return [
+            [
+                '<?php function foo() { global $bar; }',
+                '<?php function foo() { global$bar; }',
+            ],
+            [
+                '<?php function foo() { global $bar; }',
+                '<?php function foo() { global  $bar; }',
+            ],
+            [
+                '<?php function foo() { global $bar; }',
+                '<?php function foo() { global
+
+$bar; }',
+            ],
+            [
+                '<?php function foo() { global /* foo */$bar; }',
+                '<?php function foo() { global/* foo */$bar; }',
+            ],
+            [
+                '<?php function foo() { global /* foo */$bar; }',
+                '<?php function foo() { global  /* foo */$bar; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithGotoCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithGoto($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'goto',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithGotoCases()
+    {
+        return [
+            [
+                '<?php goto foo; foo: echo "Bar";',
+                '<?php goto  foo; foo: echo "Bar";',
+            ],
+            [
+                '<?php goto foo; foo: echo "Bar";',
+                '<?php goto
+
+foo; foo: echo "Bar";',
+            ],
+            [
+                '<?php goto /* foo */foo; foo: echo "Bar";',
+                '<?php goto/* foo */foo; foo: echo "Bar";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithIfCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithIf($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'if',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithIfCases()
+    {
+        return [
+            [
+                '<?php if ($foo === $bar) {}',
+                '<?php if($foo === $bar) {}',
+            ],
+            [
+                '<?php if ($foo === $bar) {}',
+                '<?php if  ($foo === $bar) {}',
+            ],
+            [
+                '<?php if ($foo === $bar) {}',
+                '<?php if
+
+($foo === $bar) {}',
+            ],
+            [
+                '<?php if /* foo */($foo === $bar) {}',
+                '<?php if/* foo */($foo === $bar) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithImplementsCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithImplements($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'implements',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithImplementsCases()
+    {
+        return [
+            [
+                '<?php class Foo implements \Countable {}',
+                '<?php class Foo implements  \Countable {}',
+            ],
+            [
+                '<?php class Foo implements \Countable {}',
+                '<?php class Foo implements
+
+\Countable {}',
+            ],
+            [
+                '<?php class Foo implements /* foo */\Countable {}',
+                '<?php class Foo implements/* foo */\Countable {}',
+            ],
+            [
+                '<?php class Foo implements /* foo */\Countable {}',
+                '<?php class Foo implements  /* foo */\Countable {}',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     *
+     * @dataProvider provideFixWithImplementsPhp70Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithImplementsPhp70($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'implements',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithImplementsPhp70Cases()
+    {
+        return [
+            [
+                '<?php $foo = new class implements \Countable {};',
+                '<?php $foo = new class implements  \Countable {};',
+            ],
+            [
+                '<?php $foo = new class implements \Countable {};',
+                '<?php $foo = new class implements
+
+\Countable {};',
+            ],
+            [
+                '<?php $foo = new class implements /* foo */\Countable {};',
+                '<?php $foo = new class implements/* foo */\Countable {};',
+            ],
+            [
+                '<?php $foo = new class implements /* foo */\Countable {};',
+                '<?php $foo = new class implements  /* foo */\Countable {};',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithIncludeCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithInclude($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'include',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithIncludeCases()
+    {
+        return [
+            [
+                '<?php include "vendor/autoload.php";',
+                '<?php include"vendor/autoload.php";',
+            ],
+            [
+                '<?php include "vendor/autoload.php";',
+                '<?php include  "vendor/autoload.php";',
+            ],
+            [
+                '<?php include "vendor/autoload.php";',
+                '<?php include
+
+"vendor/autoload.php";',
+            ],
+            [
+                '<?php include /* foo */"vendor/autoload.php";',
+                '<?php include/* foo */"vendor/autoload.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithIncludeOnceCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithIncludeOnce($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'include_once',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithIncludeOnceCases()
+    {
+        return [
+            [
+                '<?php include_once "vendor/autoload.php";',
+                '<?php include_once"vendor/autoload.php";',
+            ],
+            [
+                '<?php include_once "vendor/autoload.php";',
+                '<?php include_once  "vendor/autoload.php";',
+            ],
+            [
+                '<?php include_once "vendor/autoload.php";',
+                '<?php include_once
+
+"vendor/autoload.php";',
+            ],
+            [
+                '<?php include_once /* foo */"vendor/autoload.php";',
+                '<?php include_once/* foo */"vendor/autoload.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithInstanceofCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithInstanceof($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'instanceof',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithInstanceofCases()
+    {
+        return [
+            [
+                '<?php $foo instanceof \stdClass;',
+                '<?php $foo instanceof  \stdClass;',
+            ],
+            [
+                '<?php $foo instanceof \stdClass;',
+                '<?php $foo instanceof
+
+\stdClass;',
+            ],
+            [
+                '<?php $foo instanceof /* foo */\stdClass;',
+                '<?php $foo instanceof/* foo */\stdClass;',
+            ],
+            [
+                '<?php $foo instanceof /* foo */\stdClass;',
+                '<?php $foo instanceof  /* foo */\stdClass;',
+            ],
+            [
+                '<?php $foo instanceof $bar;',
+                '<?php $foo instanceof$bar;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithInsteadofCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithInsteadof($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'insteadof',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithInsteadofCases()
+    {
+        return [
+            [
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+    }
+}',
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof  A;
+        A::bigTalk insteadof B;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+    }
+}',
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof
+
+A;
+        A::bigTalk insteadof B;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof /* foo */A;
+        A::bigTalk insteadof B;
+    }
+}',
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof/* foo */A;
+        A::bigTalk insteadof B;
+    }
+}',
+            ],
+            [
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof /* foo */A;
+        A::bigTalk insteadof B;
+    }
+}',
+                '<?php
+
+class Talker {
+    use A, B {
+        B::smallTalk insteadof  /* foo */A;
+        A::bigTalk insteadof B;
+    }
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithInterfaceCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithInterface($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'interface',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithInterfaceCases()
+    {
+        return [
+            [
+                '<?php interface Foo {}',
+                '<?php interface  Foo {}',
+            ],
+            [
+                '<?php interface Foo {}',
+                '<?php interface
+
+Foo {}',
+            ],
+            [
+                '<?php interface /* foo */Foo {}',
+                '<?php interface  /* foo */Foo {}',
+            ],
+            [
+                '<?php interface /* foo */Foo {}',
+                '<?php interface/* foo */Foo {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithNewCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithNew($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'new',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithNewCases()
+    {
+        return [
+            [
+                '<?php new $foo();',
+                '<?php new$foo();',
+            ],
+            [
+                '<?php new Bar();',
+                '<?php new  Bar();',
+            ],
+            [
+                '<?php new Bar();',
+                '<?php new
+
+Bar();',
+            ],
+            [
+                '<?php new /* foo */Bar();',
+                '<?php new/* foo */Bar();',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithOpenTagWithEchoCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithOpenTagWithEcho($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'open_tag_with_echo',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithOpenTagWithEchoCases()
+    {
+        return [
+            [
+                '<?= $foo ?>',
+                '<?=$foo ?>',
+            ],
+            [
+                '<?= $foo ?>',
+                '<?=  $foo ?>',
+            ],
+            [
+                '<?= $foo ?>',
+                '<?=
+
+$foo ?>',
+            ],
+            [
+                '<?= /* foo */$foo ?>',
+                '<?=/* foo */$foo ?>',
+            ],
+            [
+                '<?= /* foo */$foo ?>',
+                '<?=  /* foo */$foo ?>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithPrintCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPrint($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'print',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPrintCases()
+    {
+        return [
+            [
+                '<?php print $foo;',
+                '<?php print$foo;',
+            ],
+            [
+                '<?php print 9000;',
+                '<?php print  9000;',
+            ],
+            [
+                '<?php print 9000;',
+                '<?php print
+
+9000;',
+            ],
+            [
+                '<?php print /* foo */9000;',
+                '<?php print/* foo */9000;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithPrivateCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPrivate($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'private',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPrivateCases()
+    {
+        return [
+            [
+                '<?php class Foo { private $bar; }',
+                '<?php class Foo { private$bar; }',
+            ],
+            [
+                '<?php class Foo { private $bar; }',
+                '<?php class Foo { private  $bar; }',
+            ],
+            [
+                '<?php class Foo { private $bar; }',
+                '<?php class Foo { private
+
+$bar; }',
+            ],
+            [
+                '<?php class Foo { private /* foo */$bar; }',
+                '<?php class Foo { private/* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { private /* foo */$bar; }',
+                '<?php class Foo { private  /* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { private function bar() {} }',
+                '<?php class Foo { private  function bar() {} }',
+            ],
+            [
+                '<?php class Foo { private function bar() {} }',
+                '<?php class Foo { private
+
+function bar() {} }',
+            ],
+            [
+                '<?php class Foo { private /* foo */function bar() {} }',
+                '<?php class Foo { private/* foo */function bar() {} }',
+            ],
+            [
+                '<?php class Foo { private /* foo */function bar() {} }',
+                '<?php class Foo { private  /* foo */function bar() {} }',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.1
+     *
+     * @dataProvider provideFixWithPrivatePhp71Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPrivatePhp71($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'private',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPrivatePhp71Cases()
+    {
+        return [
+            [
+                '<?php class Foo { private CONST BAR = 9000; }',
+                '<?php class Foo { private  CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { private CONST BAR = 9000; }',
+                '<?php class Foo { private
+
+CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { private /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { private/* foo */CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { private /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { private  /* foo */CONST BAR = 9000; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithProtectedCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithProtected($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'protected',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithProtectedCases()
+    {
+        return [
+            [
+                '<?php class Foo { protected $bar; }',
+                '<?php class Foo { protected$bar; }',
+            ],
+            [
+                '<?php class Foo { protected $bar; }',
+                '<?php class Foo { protected  $bar; }',
+            ],
+            [
+                '<?php class Foo { protected $bar; }',
+                '<?php class Foo { protected
+
+$bar; }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */$bar; }',
+                '<?php class Foo { protected/* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */$bar; }',
+                '<?php class Foo { protected  /* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { protected function bar() {} }',
+                '<?php class Foo { protected  function bar() {} }',
+            ],
+            [
+                '<?php class Foo { protected function bar() {} }',
+                '<?php class Foo { protected
+
+function bar() {} }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */function bar() {} }',
+                '<?php class Foo { protected/* foo */function bar() {} }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */function bar() {} }',
+                '<?php class Foo { protected  /* foo */function bar() {} }',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.1
+     *
+     * @dataProvider provideFixWithProtectedPhp71Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithProtectedPhp71($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'protected',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithProtectedPhp71Cases()
+    {
+        return [
+            [
+                '<?php class Foo { protected CONST BAR = 9000; }',
+                '<?php class Foo { protected  CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { protected CONST BAR = 9000; }',
+                '<?php class Foo { protected
+
+CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { protected/* foo */CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { protected /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { protected  /* foo */CONST BAR = 9000; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithPublicCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPublic($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'public',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPublicCases()
+    {
+        return [
+            [
+                '<?php class Foo { public $bar; }',
+                '<?php class Foo { public$bar; }',
+            ],
+            [
+                '<?php class Foo { public $bar; }',
+                '<?php class Foo { public  $bar; }',
+            ],
+            [
+                '<?php class Foo { public $bar; }',
+                '<?php class Foo { public
+
+$bar; }',
+            ],
+            [
+                '<?php class Foo { public /* foo */$bar; }',
+                '<?php class Foo { public/* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { public /* foo */$bar; }',
+                '<?php class Foo { public  /* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { public function bar() {} }',
+                '<?php class Foo { public  function bar() {} }',
+            ],
+            [
+                '<?php class Foo { public function bar() {} }',
+                '<?php class Foo { public
+
+function bar() {} }',
+            ],
+            [
+                '<?php class Foo { public /* foo */function bar() {} }',
+                '<?php class Foo { public/* foo */function bar() {} }',
+            ],
+            [
+                '<?php class Foo { public /* foo */function bar() {} }',
+                '<?php class Foo { public  /* foo */function bar() {} }',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.1
+     *
+     * @dataProvider provideFixWithPublicPhp71Cases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPublicPhp71($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'public',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPublicPhp71Cases()
+    {
+        return [
+            [
+                '<?php class Foo { public CONST BAR = 9000; }',
+                '<?php class Foo { public  CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { public CONST BAR = 9000; }',
+                '<?php class Foo { public
+
+CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { public /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { public/* foo */CONST BAR = 9000; }',
+            ],
+            [
+                '<?php class Foo { public /* foo */CONST BAR = 9000; }',
+                '<?php class Foo { public  /* foo */CONST BAR = 9000; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithRequireCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithRequire($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'require',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithRequireCases()
+    {
+        return [
+            [
+                '<?php require "vendor/autoload.php";',
+                '<?php require"vendor/autoload.php";',
+            ],
+            [
+                '<?php require "vendor/autoload.php";',
+                '<?php require  "vendor/autoload.php";',
+            ],
+            [
+                '<?php require "vendor/autoload.php";',
+                '<?php require
+
+"vendor/autoload.php";',
+            ],
+            [
+                '<?php require /* foo */"vendor/autoload.php";',
+                '<?php require/* foo */"vendor/autoload.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithRequireOnceCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithRequireOnce($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'require_once',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithRequireOnceCases()
+    {
+        return [
+            [
+                '<?php require_once "vendor/autoload.php";',
+                '<?php require_once"vendor/autoload.php";',
+            ],
+            [
+                '<?php require_once "vendor/autoload.php";',
+                '<?php require_once  "vendor/autoload.php";',
+            ],
+            [
+                '<?php require_once "vendor/autoload.php";',
+                '<?php require_once
+
+"vendor/autoload.php";',
+            ],
+            [
+                '<?php require_once /* foo */"vendor/autoload.php";',
+                '<?php require_once/* foo */"vendor/autoload.php";',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithReturnCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithReturn($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'return',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithReturnCases()
+    {
+        return [
+            [
+                '<?php return;',
+            ],
+            [
+                '<?php return /* foo */;',
+                '<?php return/* foo */;',
+            ],
+            [
+                '<?php return /* foo */;',
+                '<?php return  /* foo */;',
+            ],
+            [
+                '<?php return $foo;',
+                '<?php return$foo;',
+            ],
+            [
+                '<?php return 9000;',
+                '<?php return  9000;',
+            ],
+            [
+                '<?php return 9000;',
+                '<?php return
+
+9000;',
+            ],
+            [
+                '<?php return /* */ 9000 + 1 /* foo */       ?>',
+                '<?php return
+
+
+
+
+
+/* */ 9000 + 1 /* foo */       ?>',
+            ],
+            [
+                '<?php return /* foo */9000;',
+                '<?php return/* foo */9000;',
+            ],
+            [
+                '<?php return $foo && $bar || $baz;',
+                '<?php return
+
+$foo && $bar || $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo
+    && $bar
+    || $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo &&
+    $bar ||
+    $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo
+    + $bar
+    - $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo +
+    $bar -
+    $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo ?
+    $bar :
+    $baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo
+    ? $bar
+    : baz;',
+            ],
+            [
+                '<?php
+
+return
+    $foo ?:
+    $bar;',
+            ],
+            [
+                '<?php
+
+return
+    $foo
+    ?: $bar;',
+            ],
+            [
+                '<?php
+
+return
+    $foo
+    ?: $bar?>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithStaticCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithStatic($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'static',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithStaticCases()
+    {
+        return [
+            [
+                '<?php function foo() { static $bar; }',
+                '<?php function foo() { static$bar; }',
+            ],
+            [
+                '<?php function foo() { static $bar; }',
+                '<?php function foo() { static  $bar; }',
+            ],
+            [
+                '<?php function foo() { static $bar; }',
+                '<?php function foo() { static
+
+$bar; }',
+            ],
+            [
+                '<?php function foo() { static /* foo */$bar; }',
+                '<?php function foo() { static/* foo */$bar; }',
+            ],
+            [
+                '<?php function foo() { static /* foo */$bar; }',
+                '<?php function foo() { static  /* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { static function bar() {} }',
+                '<?php class Foo { static  function bar() {} }',
+            ],
+            [
+                '<?php class Foo { static function bar() {} }',
+                '<?php class Foo { static
+
+function bar() {} }',
+            ],
+            [
+                '<?php class Foo { static /* foo */function bar() {} }',
+                '<?php class Foo { static/* foo */function bar() {} }',
+            ],
+            [
+                '<?php class Foo { static /* foo */function bar() {} }',
+                '<?php class Foo { static  /* foo */function bar() {} }',
+            ],
+            [
+                '<?php class Foo { function bar() { return new static(); } }',
+            ],
+            [
+                '<?php class Foo { function bar() { return static::class; } }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithThrowCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithThrow($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'throw',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithThrowCases()
+    {
+        return [
+            [
+                '<?php throw $foo;',
+                '<?php throw$foo;',
+            ],
+            [
+                '<?php throw new Exception();',
+                '<?php throw  new Exception();',
+            ],
+            [
+                '<?php throw new Exception();',
+                '<?php throw
+
+new Exception();',
+            ],
+            [
+                '<?php throw /* foo */new Exception();',
+                '<?php throw/* foo */new Exception();',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithTraitCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithTrait($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'trait',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithTraitCases()
+    {
+        return [
+            [
+                '<?php trait Foo {}',
+                '<?php trait  Foo {}',
+            ],
+            [
+                '<?php trait Foo {}',
+                '<?php trait
+
+Foo {}',
+            ],
+            [
+                '<?php trait /* foo */Foo {}',
+                '<?php trait  /* foo */Foo {}',
+            ],
+            [
+                '<?php trait /* foo */Foo {}',
+                '<?php trait/* foo */Foo {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithTryCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithTry($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'try',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithTryCases()
+    {
+        return [
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try{} catch (\Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try  {} catch (\Exception $exception) {}',
+            ],
+            [
+                '<?php try {} catch (\Exception $exception) {}',
+                '<?php try
+
+{} catch (\Exception $exception) {}',
+            ],
+            [
+                '<?php try /* foo */{} catch (\Exception $exception) {}',
+                '<?php try/* foo */{} catch (\Exception $exception) {}',
+            ],
+            [
+                '<?php try /* foo */{} catch (\Exception $exception) {}',
+                '<?php try  /* foo */{} catch (\Exception $exception) {}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithUseCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithUse($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'use',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithUseCases()
+    {
+        return [
+            [
+                '<?php use Foo\Bar;',
+                '<?php use  Foo\Bar;',
+            ],
+            [
+                '<?php use Foo\Bar;',
+                '<?php use
+
+Foo\Bar;',
+            ],
+            [
+                '<?php use /* foo */Foo\Bar;',
+                '<?php use/* foo */Foo\Bar;',
+            ],
+            [
+                '<?php use /* foo */Foo\Bar;',
+                '<?php use  /* foo */Foo\Bar;',
+            ],
+            [
+                '<?php use const Foo\BAR;',
+                '<?php use  const Foo\BAR;',
+            ],
+            [
+                '<?php use const Foo\BAR;',
+                '<?php use
+
+const Foo\BAR;',
+            ],
+            [
+                '<?php use /* foo */const Foo\BAR;',
+                '<?php use/* foo */const Foo\BAR;',
+            ],
+            [
+                '<?php use /* foo */const Foo\BAR;',
+                '<?php use/* foo */const Foo\BAR;',
+            ],
+            [
+                '<?php use function Foo\bar;',
+                '<?php use  function Foo\bar;',
+            ],
+            [
+                '<?php use function Foo\bar;',
+                '<?php use
+
+function Foo\bar;',
+            ],
+            [
+                '<?php use /* foo */function Foo\bar;',
+                '<?php use/* foo */function Foo\bar;',
+            ],
+            [
+                '<?php use /* foo */function Foo\bar;',
+                '<?php use/* foo */function Foo\bar;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithUseLambdaCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithUseLambda($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'use_lambda',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithUseLambdaCases()
+    {
+        return [
+            [
+                '<?php $foo = function () use ($bar) {};',
+                '<?php $foo = function () use($bar) {};',
+            ],
+            [
+                '<?php $foo = function () use ($bar) {};',
+                '<?php $foo = function () use  ($bar) {};',
+            ],
+            [
+                '<?php $foo = function () use ($bar) {};',
+                '<?php $foo = function () use
+
+($bar) {};',
+            ],
+            [
+                '<?php $foo = function () use /* foo */($bar) {};',
+                '<?php $foo = function () use/* foo */($bar) {};',
+            ],
+            [
+                '<?php $foo = function () use /* foo */($bar) {};',
+                '<?php $foo = function () use  /* foo */($bar) {};',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithUseTraitCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithUseTrait($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'use_trait',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithUseTraitCases()
+    {
+        return [
+            [
+                '<?php class Foo { use Bar; }',
+                '<?php class Foo { use  Bar; }',
+            ],
+            [
+                '<?php class Foo { use Bar; }',
+                '<?php class Foo { use
+
+Bar; }',
+            ],
+            [
+                '<?php class Foo { use /* foo */Bar; }',
+                '<?php class Foo { use/* foo */Bar; }',
+            ],
+            [
+                '<?php class Foo { use /* foo */Bar; }',
+                '<?php class Foo { use  /* foo */Bar; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithVarCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithVar($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'var',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithVarCases()
+    {
+        return [
+            [
+                '<?php class Foo { var $bar; }',
+                '<?php class Foo { var$bar; }',
+            ],
+            [
+                '<?php class Foo { var $bar; }',
+                '<?php class Foo { var  $bar; }',
+            ],
+            [
+                '<?php class Foo { var $bar; }',
+                '<?php class Foo { var
+
+$bar; }',
+            ],
+            [
+                '<?php class Foo { var /* foo */$bar; }',
+                '<?php class Foo { var/* foo */$bar; }',
+            ],
+            [
+                '<?php class Foo { var /* foo */$bar; }',
+                '<?php class Foo { var  /* foo */$bar; }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithWhileCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithWhile($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'while',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithWhileCases()
+    {
+        return [
+            [
+                '<?php do {} while (true);',
+                '<?php do {} while(true);',
+            ],
+            [
+                '<?php do {} while (true);',
+                '<?php do {} while  (true);',
+            ],
+            [
+                '<?php do {} while (true);',
+                '<?php do {} while
+
+(true);',
+            ],
+            [
+                '<?php do {} while /* foo */(true);',
+                '<?php do {} while/* foo */(true);',
+            ],
+            [
+                '<?php do {} while /* foo */(true);',
+                '<?php do {} while  /* foo */(true);',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithYieldCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithYield($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'yield',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithYieldCases()
+    {
+        return [
+            [
+                '<?php function foo() { yield $foo; }',
+                '<?php function foo() { yield$foo; }',
+            ],
+            [
+                '<?php function foo() { yield "Foo"; }',
+                '<?php function foo() { yield  "Foo"; }',
+            ],
+            [
+                '<?php function foo() { yield "Foo"; }',
+                '<?php function foo() { yield
+
+"Foo"; }',
+            ],
+            [
+                '<?php function foo() { yield /* foo */"Foo"; }',
+                '<?php function foo() { yield/* foo */"Foo"; }',
+            ],
+        ];
+    }
+
+    /**
+     * @requires PHP 7.0
+     *
+     * @dataProvider provideFixWithYieldFromCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithYieldFrom($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'yield_from',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithYieldFromCases()
+    {
+        return [
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield  from baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from $foo; }',
+                '<?php function foo() { yield from$foo; }',
+            ],
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield from  baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield  from  baz(); }',
+            ],
+            [
+                '<?php function foo() { yIeLd fRoM baz(); }',
+                '<?php function foo() { yIeLd  fRoM  baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield
+
+from baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield from
+
+baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from baz(); }',
+                '<?php function foo() { yield
+
+from
+
+baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from /* foo */baz(); }',
+                '<?php function foo() { yield from/* foo */baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from /* foo */baz(); }',
+                '<?php function foo() { yield from  /* foo */baz(); }',
+            ],
+            [
+                '<?php function foo() { yield from /* foo */baz(); }',
+                '<?php function foo() { yield from
+
+/* foo */baz(); }',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFixWithPhpOpenCases
+     *
+     * @param string      $expected
+     * @param null|string $input
+     */
+    public function testFixWithPhpOpen($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'constructs' => [
+                'php_open',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithPhpOpenCases()
+    {
+        return [
+            [
+                '<?php echo 1;',
+                '<?php    echo 1;',
+            ],
+            [
+                "<?php\necho 1;",
+            ],
+            [
+                "<?php\n   echo 1;",
+            ],
+            [
+                '<?php ',
+            ],
+            [
+                "<?php\n",
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR

* [x] introduces a `SingleSpaceAfterConstructFixer`
* [x] adds the `single_space_after_construct` fixer to the `@PhpCsFixer` rule set

Fixes #3981.

💁‍♂ Not sure about this one, there are a quite a bunch of fixers which are dealing with spaces themselves, what do you think?

### Handles

* [x] `abstract`
* [x] `as`
* [x] `break`
* [x] `case`
* [x] `catch`
* [x] `class` (when declaring classes)
* [x] `clone`
* [x] `const`
* [x] `const_import`
* [x] `continue`
* [x] `do`
* [x] `echo` 
* [x] `else` 
* [x] `elseif` 
* [x] `extends`
* [x] `final`
* [x] `finally`
* [x] `for`
* [x] `foreach`
* [x] `function`
* [x] `function_import`
* [x] `global`
* [x] `goto` 
* [x] `if`
* [x] `implements`
* [x] `include`
* [x] `include_once`
* [x] `instanceof`
* [x] `insteadof`
* [x] `interface`
* [x] `new`
* [x] `php_open`
* [x] `open_tag_with_echo`  
* [x] `print` 
* [x] `private`
* [x] `protected`
* [x] `public`
* [x] `require`
* [x] `require_once`
* [x] `return` 
* [x] `static` (when referring to variables, fields, functions, methods)
* [x] `switch` 
* [x] `throw`
* [x] `trait`
* [x] `try`
* [x] `use`
* [x] `use_lambda`
* [x] `use_trait`
* [x] `var`
* [x] `while`
* [x] `yield`
* [x] `yield from`

## What about these?

* [ ] parameter type declaration
* [ ] property type declaration

## Wait until PHP 8 has been released and we started supporting it

* [ ] `match`
