### PR TITLE
SimpleToComplexStringVariableFixer - Fix $ bug

### DIFF
--- a/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+++ b/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
@@ -93,7 +93,16 @@ EOT
                 continue;
             }
 
-            $tokens->overrideRange($index, $index + 2, [
+            $tokenOfStringBeforeToken = $tokens[$index - 1];
+            $stringContent = $tokenOfStringBeforeToken->getContent();
+
+            if ('$' === substr($stringContent, -1) && '\\$' !== substr($stringContent, -2)) {
+                $newContent = substr($stringContent, 0, -1).'\\$';
+                $tokenOfStringBeforeToken = new Token([T_ENCAPSED_AND_WHITESPACE, $newContent]);
+            }
+
+            $tokens->overrideRange($index - 1, $index + 2, [
+                $tokenOfStringBeforeToken,
                 new Token([T_CURLY_OPEN, '{']),
                 new Token([T_VARIABLE, '$'.$varnameToken->getContent()]),
                 new Token([CT::T_CURLY_CLOSE, '}']),

--- a/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
@@ -98,6 +98,48 @@ echo "Hello \${name}";
 EXPECTED
                 ,
             ],
+            'double dollar' => [
+                <<<'EXPECTED'
+<?php
+$name = 'World';
+echo "Hello \${$name}";
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+$name = 'World';
+echo "Hello $${name}";
+INPUT
+                ,
+            ],
+            'double dollar heredoc' => [
+                <<<'EXPECTED'
+<?php
+$name = 'World';
+echo <<<TEST
+Hello \${$name}!
+TEST;
+
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+$name = 'World';
+echo <<<TEST
+Hello $${name}!
+TEST;
+
+INPUT
+                ,
+            ],
+            'double dollar single quote' => [
+                <<<'EXPECTED'
+<?php
+$name = 'World';
+echo 'Hello $${name}';
+EXPECTED
+                ,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Account for $ being the last character of the encapsulating string, it needs to be escaped in order to not form a new simple string variable.