### PR TITLE
MethodArgumentSpaceFixer - Regression

### DIFF
--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -341,6 +341,16 @@ EOTXTb
 $a#
 );',
             ],
+            'with_random_comments and config' => [
+                '<?php xyz#
+ (#
+""#
+,#
+$a#
+);',
+                null,
+                ['on_multiline' => 'ensure_fully_multiline'],
+            ],
             'keep_multiple_spaces_after_comma_with_newlines' => [
                 "<?php xyz(\$a=10,\n\$b=20);",
                 "<?php xyz(\$a=10,   \n\$b=20);",


### PR DESCRIPTION
bug is in the current 2.12 branch, but is not released yet

I think this is regression after https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/75b55b529e09b32f3d3215b4429939154e0c5fab

causes 3.0 currently to fail as well

ping @keradus 