### PR TITLE
NoSuperfluousPhpdocTags - Add remove_inheritdoc option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1122,6 +1122,7 @@ Choose from the list of available rules:
 
   - ``allow_mixed`` (``bool``): whether type ``mixed`` without description is allowed
     (``true``) or considered superfluous (``false``); defaults to ``false``
+  - ``remove_inheritdoc`` (``bool``): remove ``@inheritDoc`` tags; defaults to ``false``
 
 * **no_trailing_comma_in_list_call** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -67,6 +67,14 @@ class Foo {
     public function doFoo(Bar $bar, $baz): Baz {}
 }
 ', new VersionSpecification(70000)),
+                new CodeSample('<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    public function doFoo(Bar $bar, $baz) {}
+}
+', ['remove_inheritdoc' => true]),
             ]
         );
     }
@@ -105,46 +113,27 @@ class Foo {
                 continue;
             }
 
-            $functionIndex = $this->findDocumentedFunction($tokens, $index);
-            if (null === $functionIndex) {
+            $content = $initialContent = $token->getContent();
+
+            $documentedElementIndex = $this->findDocumentedElement($tokens, $index);
+
+            if (null === $documentedElementIndex) {
                 continue;
             }
 
-            $docBlock = new DocBlock($token->getContent());
+            $token = $tokens[$documentedElementIndex];
 
-            $openingParenthesisIndex = $tokens->getNextTokenOfKind($functionIndex, ['(']);
-            $closingParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openingParenthesisIndex);
-
-            $argumentsInfo = $this->getArgumentsInfo(
-                $tokens,
-                $openingParenthesisIndex + 1,
-                $closingParenthesisIndex - 1
-            );
-
-            foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
-                if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
-                    continue;
-                }
-
-                $argumentName = $matches[1];
-
-                if (
-                    !isset($argumentsInfo[$argumentName])
-                    || $this->annotationIsSuperfluous($annotation, $argumentsInfo[$argumentName], $shortNames)
-                ) {
-                    $annotation->remove();
-                }
+            if ($token->isGivenKind(T_FUNCTION)) {
+                $content = $this->fixFunctionDocComment($content, $tokens, $index, $shortNames);
             }
 
-            $returnTypeInfo = $this->getReturnTypeInfo($tokens, $closingParenthesisIndex);
-
-            foreach ($docBlock->getAnnotationsOfType('return') as $annotation) {
-                if ($this->annotationIsSuperfluous($annotation, $returnTypeInfo, $shortNames)) {
-                    $annotation->remove();
-                }
+            if ($this->configuration['remove_inheritdoc']) {
+                $content = $this->removeSuperfluousInheritDoc($content);
             }
 
-            $tokens[$index] = new Token([T_DOC_COMMENT, $docBlock->getContent()]);
+            if ($content !== $initialContent) {
+                $tokens[$index] = new Token([T_DOC_COMMENT, $content]);
+            }
         }
     }
 
@@ -158,20 +147,95 @@ class Foo {
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
+            (new FixerOptionBuilder('remove_inheritdoc', 'Remove `@inheritDoc` tags'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
         ]);
     }
 
-    private function findDocumentedFunction(Tokens $tokens, $index)
+    /**
+     * @param Tokens $tokens
+     * @param int    $docCommentIndex
+     *
+     * @return null|int
+     */
+    private function findDocumentedElement(Tokens $tokens, $docCommentIndex)
     {
+        $index = $docCommentIndex;
+
         do {
             $index = $tokens->getNextMeaningfulToken($index);
 
-            if (null === $index || $tokens[$index]->isGivenKind(T_FUNCTION)) {
+            if (null === $index || $tokens[$index]->isGivenKind([T_FUNCTION, T_CLASS, T_INTERFACE])) {
                 return $index;
             }
         } while ($tokens[$index]->isGivenKind([T_ABSTRACT, T_FINAL, T_STATIC, T_PRIVATE, T_PROTECTED, T_PUBLIC]));
 
+        $index = $tokens->getNextMeaningfulToken($docCommentIndex);
+
+        $kindsBeforeProperty = [T_STATIC, T_PRIVATE, T_PROTECTED, T_PUBLIC];
+
+        if (!$tokens[$index]->isGivenKind($kindsBeforeProperty)) {
+            return null;
+        }
+
+        do {
+            $index = $tokens->getNextMeaningfulToken($index);
+
+            if ($tokens[$index]->isGivenKind(T_VARIABLE)) {
+                return $index;
+            }
+        } while ($tokens[$index]->isGivenKind($kindsBeforeProperty));
+
         return null;
+    }
+
+    /**
+     * @param string $content
+     * @param Tokens $tokens
+     * @param int    $functionIndex
+     * @param array  $shortNames
+     *
+     * @return string
+     */
+    private function fixFunctionDocComment($content, Tokens $tokens, $functionIndex, array $shortNames)
+    {
+        $docBlock = new DocBlock($content);
+
+        $openingParenthesisIndex = $tokens->getNextTokenOfKind($functionIndex, ['(']);
+        $closingParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openingParenthesisIndex);
+
+        $argumentsInfo = $this->getArgumentsInfo(
+            $tokens,
+            $openingParenthesisIndex + 1,
+            $closingParenthesisIndex - 1
+        );
+
+        foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
+            if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
+                continue;
+            }
+
+            $argumentName = $matches[1];
+
+            if (
+                !isset($argumentsInfo[$argumentName])
+                || $this->annotationIsSuperfluous($annotation, $argumentsInfo[$argumentName], $shortNames)
+            ) {
+                $annotation->remove();
+            }
+        }
+
+        $returnTypeInfo = $this->getReturnTypeInfo($tokens, $closingParenthesisIndex);
+
+        foreach ($docBlock->getAnnotationsOfType('return') as $annotation) {
+            if ($this->annotationIsSuperfluous($annotation, $returnTypeInfo, $shortNames)) {
+                $annotation->remove();
+            }
+        }
+
+        return $docBlock->getContent();
     }
 
     /**
@@ -326,5 +390,61 @@ class Foo {
         sort($normalized);
 
         return $normalized;
+    }
+
+    /**
+     * @param string $docComment
+     *
+     * @return string
+     */
+    private function removeSuperfluousInheritDoc($docComment)
+    {
+        return Preg::replace('~
+            # $1: before @inheritDoc tag
+            (
+                # beginning of comment or a PHPDoc tag
+                (?:
+                    ^/\*\*
+                    (?:
+                        \R
+                        [ \t]*(?:\*[ \t]*)?
+                    )*?
+                    |
+                    @\N+
+                )
+
+                # empty comment lines
+                (?:
+                    \R
+                    [ \t]*(?:\*[ \t]*?)?
+                )*
+            )
+
+            # spaces before @inheritDoc tag
+            [ \t]*
+
+            # @inheritDoc tag
+            (?:@inheritDocs?|\{@inheritDocs?\})
+
+            # $2: after @inheritDoc tag
+            (
+                # empty comment lines
+                (?:
+                    \R
+                    [ \t]*(?:\*[ \t]*)?
+                )*
+
+                # a PHPDoc tag or end of comment
+                (?:
+                    @\N+
+                    |
+                    (?:
+                        \R
+                        [ \t]*(?:\*[ \t]*)?
+                    )*
+                    [ \t]*\*/$
+                )
+            )
+        ~ix', '$1$2', $docComment);
     }
 }

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -303,6 +303,701 @@ class Foo {
     public function doFoo($foo) {}
 }',
             ],
+            'inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'inline_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'dont_remove_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'dont_remove_inline_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'remove_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inline_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdoc_when_surrounded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDoc
+     *
+     * Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdoc_when_preceded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdoc_when_followed_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     *
+     * Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inline_inheritdoc_inside_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo {@inheritDoc} Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'inline_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'dont_remove_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'dont_remove_inline_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'remove_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inline_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdocs_when_surrounded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDocs
+     *
+     * Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdocs_when_preceded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDocs
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdocs_when_followed_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     *
+     * Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inline_inheritdocs_inside_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo {@inheritDocs} Bar.
+     */
+    public function doFoo($foo) {}
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    private $foo;
+}',
+            ],
+            'inline_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    private $foo;
+}',
+            ],
+            'dont_remove_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'dont_remove_property_inline_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'remove_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    private $foo;
+}',
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    private $foo;
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inline_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    private $foo;
+}',
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    private $foo;
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdoc_when_surrounded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDoc
+     *
+     * Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdoc_when_preceded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDoc
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdoc_when_followed_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     *
+     * Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inline_inheritdoc_inside_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo {@inheritDoc} Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    private $foo;
+}',
+            ],
+            'inline_property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    private $foo;
+}',
+            ],
+            'dont_remove_property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'dont_remove_inline_property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'remove_property_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    private $foo;
+}',
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    private $foo;
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inline_property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     *
+     */
+    private $foo;
+}',
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    private $foo;
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdocs_when_surrounded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDocs
+     *
+     * Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdocs_when_preceded_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo.
+     *
+     * @inheritDocs
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_property_inheritdocs_when_followed_by_text' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     *
+     * Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inline_property_inheritdocs_inside_text' => [
+                '<?php
+class Foo {
+    /**
+     * Foo {@inheritDocs} Bar.
+     */
+    private $foo;
+}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'class_inheritdoc' => [
+                '<?php
+/**
+ * @inheritDoc
+ */
+class Foo {}',
+            ],
+            'dont_remove_class_inheritdoc' => [
+                '<?php
+/**
+ * @inheritDoc
+ */
+class Foo {}',
+                null,
+                ['remove_inheritdoc' => false],
+            ],
+            'remove_class_inheritdoc' => [
+                '<?php
+/**
+ *
+ */
+class Foo {}',
+                '<?php
+/**
+ * @inheritDoc
+ */
+class Foo {}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_interface_inheritdoc' => [
+                '<?php
+/**
+ *
+ */
+interface Foo {}',
+                '<?php
+/**
+ * @inheritDoc
+ */
+interface Foo {}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_class_inheritdoc_when_surrounded_by_text' => [
+                '<?php
+/**
+ * Foo.
+ *
+ * @inheritDoc
+ *
+ * Bar.
+ */
+class Foo {}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_class_inheritdoc_when_preceded_by_text' => [
+                '<?php
+/**
+ * Foo.
+ *
+ * @inheritDoc
+ */
+class Foo {}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_class_inheritdoc_when_followed_by_text' => [
+                '<?php
+/**
+ * @inheritDoc
+ *
+ * Bar.
+ */
+class Foo {}',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inheritdoc_after_other_tag' => [
+                '<?php
+class Foo {
+    /**
+     * @param int $foo an integer
+     *
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @param int $foo an integer
+     *
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_only_inheritdoc_line' => [
+                '<?php
+class Foo {
+    /**
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     *
+     *
+     *
+     *
+     *
+     *
+     * @inheritDoc
+     *
+     *
+     *
+     *
+     *
+     *
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_single_line_inheritdoc' => [
+                '<?php
+class Foo {
+    /** */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /** @inheritDoc */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inheritdoc_on_first_line' => [
+                '<?php
+class Foo {
+    /**
+     */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /** @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'remove_inheritdoc_on_last_line' => [
+                '<?php
+class Foo {
+    /**
+     * */
+    public function doFoo($foo) {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc */
+    public function doFoo($foo) {}
+}',
+                ['remove_inheritdoc' => true],
+            ],
+            'dont_remove_inheritdoc_non_structural_element' => [
+                '<?php
+/**
+ * @inheritDoc
+ */
+$foo = 1;',
+                null,
+                ['remove_inheritdoc' => true],
+            ],
         ];
     }
 


### PR DESCRIPTION
`@inheritDoc` is superfluous when not surrounded by text because it is already the default behavior.