### PR TITLE
NoSuperfluousPhpdocTagsFixer - allow params that aren't on the signature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1133,6 +1133,9 @@ Choose from the list of available rules:
 
   - ``allow_mixed`` (``bool``): whether type ``mixed`` without description is allowed
     (``true``) or considered superfluous (``false``); defaults to ``false``
+  - ``allow_unused_params`` (``bool``): whether ``param`` annontation without actual
+    signature is allowed (``true``) or considered superfluous (``false``);
+    defaults to ``false``
   - ``remove_inheritdoc`` (``bool``): remove ``@inheritDoc`` tags; defaults to ``false``
 
 * **no_trailing_comma_in_list_call** [@Symfony, @PhpCsFixer]

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -117,6 +117,17 @@ class Foo {
                 null,
                 ['allow_mixed' => true],
             ],
+            'allow_unused_params=>true' => [
+                '<?php
+class Foo {
+    /**
+     * @param string|int $c
+     */
+    public function doFoo($bar /*, $c = 0 */) {}
+}',
+                null,
+                ['allow_unused_params' => true],
+            ],
             'multiple different types' => [
                 '<?php
 class Foo {


### PR DESCRIPTION
fixes #4504
fixes #3933