### PR TITLE
DX: Lock binary SCA tools versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ jobs:
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
 
-                - wget --no-clobber --output-document=$HOME/bin/checkbashisms https://sourceforge.net/projects/checkbaskisms/files/2.0.0.2/checkbashisms/download || true
-                - chmod +x $HOME/bin/checkbashisms
+                - ./dev-tools/bin-download.sh
             before_script:
                 - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then COMMIT_RANGE=$TRAVIS_COMMIT_RANGE; else COMMIT_RANGE="HEAD~..HEAD"; fi;
                 - export COMMIT_SCA_FILES=`git diff --name-only --diff-filter=ACMRTUXB $COMMIT_RANGE`

--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -5,6 +5,7 @@ files_with_trailing_spaces=$(
     find . \
         -type f \
         -not -path "./.git/*" \
+        -not -path "./dev-tools/bin/*" \
         -not -path "./dev-tools/vendor/*" \
         -not -path "./vendor/*" \
         -not -path "./tests/Fixtures/*" \

--- a/dev-tools/.gitignore
+++ b/dev-tools/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
+/bin/
 /vendor/

--- a/dev-tools/bin-download.sh
+++ b/dev-tools/bin-download.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+cd "$(dirname "$0")"
+
+mkdir -p bin
+
+VERSION_CB="2.0.0.2"
+VERSION_SC="stable"
+
+if [ ! -f bin/checkbashisms ]; then
+    wget --no-clobber --output-document=bin/checkbashisms https://sourceforge.net/projects/checkbaskisms/files/${VERSION_CB}/checkbashisms/download
+    chmod u+x bin/checkbashisms
+    bin/checkbashisms --version
+fi
+
+if [ ! -f bin/shellcheck ]; then
+    wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${VERSION_SC}.linux.x86_64.tar.xz" | tar -xJv --directory bin shellcheck-${VERSION_SC}/shellcheck
+    mv "bin/shellcheck-${VERSION_SC}/shellcheck" bin/
+    rmdir "bin/shellcheck-${VERSION_SC}/"
+    bin/shellcheck --version
+fi

--- a/dev-tools/check-shell-scripts.sh
+++ b/dev-tools/check-shell-scripts.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+cd "$(dirname "$0")"
+
 IFS='
 '
 
@@ -9,14 +11,11 @@ SHELL_SCRIPTS=$(
     find ./ \
     -type f \
     -not -path '*/vendor/*' \
-    -not -path './dev-tools/ci-integration.sh' \
     -iname '*.sh'
 )
 
 # shellcheck disable=SC2086
-checkbashisms $SHELL_SCRIPTS
+bin/checkbashisms $SHELL_SCRIPTS
 
 # shellcheck disable=SC2086
-shellcheck $SHELL_SCRIPTS
-
-shellcheck --exclude=SC2086 ./dev-tools/ci-integration.sh
+bin/shellcheck $SHELL_SCRIPTS


### PR DESCRIPTION
Travis is red for all branches - I can confirm that it's due to Travis unattended update of some libraries, let's lock them.

#4494 was fixing the symptom (already merged), but let us not have same issue again