### PR TITLE
Verify PCRE pattern before use

### DIFF
--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -27,7 +27,7 @@ final class PregTest extends TestCase
     public function testMatchFailing()
     {
         $this->expectException(PregException::class);
-        $this->expectExceptionMessage('Error occurred when calling preg_match.');
+        $this->expectExceptionMessage('Preg::match(): Invalid PCRE pattern ""');
 
         Preg::match('', 'foo', $matches);
     }
@@ -47,10 +47,113 @@ final class PregTest extends TestCase
         static::assertSame($expectedMatches, $actualMatches);
     }
 
+    public function providePatternValidationCases()
+    {
+        return [
+            'invalid_blank' => ['', null, PregException::class],
+            'invalid_open' => ["\1", null, PregException::class, "'\1' found"],
+            'valid_control_character_delimiter' => ["\1\1", 1],
+            'invalid_control_character_modifier' => ["\1\1\1", null, PregException::class, ' Unknown modifier '],
+            'valid_slate' => ['//', 1],
+            'valid_paired' => ['()', 1],
+            'null_byte_injection' => ['()'."\0", null, PregException::class, ' Null byte in regex '],
+            'paired_non_utf8_only' => ["((*UTF8)\xFF)", null, PregException::class, 'UTF-8'],
+            'valid_paired_non_utf8_only' => ["(\xFF)", 1],
+            'php_version_dependent' => ['([\\R])', 0, PregException::class, 'Compilation failed: escape sequence is invalid '],
+        ];
+    }
+
+    /**
+     * @dataProvider providePatternValidationCases
+     *
+     * @param $pattern
+     * @param null|int    $expected
+     * @param null|string $expectedException
+     * @param null|string $expectedMessage
+     */
+    public function testPatternValidation($pattern, $expected = null, $expectedException = null, $expectedMessage = null)
+    {
+        $setup = function () use ($expectedException, $expectedMessage) {
+            $i = 0;
+
+            if (null !== $expectedException) {
+                ++$i;
+                $this->expectException($expectedException);
+            }
+
+            if (null !== $expectedMessage) {
+                ++$i;
+                $this->expectExceptionMessage($expectedMessage);
+            }
+
+            return (bool) $i;
+        };
+
+        try {
+            $actual = Preg::match($pattern, "The quick brown \xFF\x00\\xXX jumps over the lazy dog\n");
+        } catch (\Exception $ex) {
+            $setup();
+
+            throw $ex;
+        }
+
+        if (null !== $expected) {
+            static::assertSame($expected, $actual);
+
+            return;
+        }
+
+        $setup() || $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider providePatternValidationCases
+     *
+     * @param string      $pattern
+     * @param null|int    $expected
+     * @param null|string $expectedException
+     * @param null|string $expectedMessage
+     */
+    public function testPatternsValidation($pattern, $expected = null, $expectedException = null, $expectedMessage = null)
+    {
+        $setup = function () use ($expectedException, $expectedMessage) {
+            $i = 0;
+
+            if (null !== $expectedException) {
+                ++$i;
+                $this->expectException($expectedException);
+            }
+
+            if (null !== $expectedMessage) {
+                ++$i;
+                $this->expectExceptionMessage($expectedMessage);
+            }
+
+            return (bool) $i;
+        };
+
+        try {
+            $buffer = "The quick brown \xFF\x00\\xXX jumps over the lazy dog\n";
+            $actual = $buffer !== Preg::replace((array) $pattern, 'abc', $buffer);
+        } catch (\Exception $ex) {
+            $setup();
+
+            throw $ex;
+        }
+
+        if (null !== $expected) {
+            static::assertSame((bool) $expected, $actual);
+
+            return;
+        }
+
+        $setup() || $this->addToAssertionCount(1);
+    }
+
     public function testMatchAllFailing()
     {
         $this->expectException(PregException::class);
-        $this->expectExceptionMessage('Error occurred when calling preg_match_all.');
+        $this->expectExceptionMessage('Preg::matchAll(): Invalid PCRE pattern ""');
 
         Preg::matchAll('', 'foo', $matches);
     }
@@ -73,7 +176,7 @@ final class PregTest extends TestCase
     public function testReplaceFailing()
     {
         $this->expectException(PregException::class);
-        $this->expectExceptionMessage('Error occurred when calling preg_replace.');
+        $this->expectExceptionMessageRegExp('~\Q\Preg::replace()\E: Invalid PCRE pattern "": \(code: \d+\) [^(]+ \(version: \d+~');
 
         Preg::replace('', 'foo', 'bar');
     }
@@ -96,7 +199,7 @@ final class PregTest extends TestCase
     public function testReplaceCallbackFailing()
     {
         $this->expectException(PregException::class);
-        $this->expectExceptionMessage('Error occurred when calling preg_replace_callback.');
+        $this->expectExceptionMessage('Preg::replaceCallback(): Invalid PCRE pattern ""');
 
         Preg::replaceCallback('', 'sort', 'foo');
     }
@@ -140,7 +243,7 @@ final class PregTest extends TestCase
     public function testSplitFailing()
     {
         $this->expectException(PregException::class);
-        $this->expectExceptionMessage('Error occurred when calling preg_split.');
+        $this->expectExceptionMessage('Preg::split(): Invalid PCRE pattern ""');
 
         Preg::split('', 'foo');
     }


### PR DESCRIPTION
To give a detailed PregException message making any problems w/ the
pattern visible.

Add to all the Preg::...($pattern, ....) methods as getting details of any
pattern related errors later on is not easily possible b/c of multi-
matching w/ and w/o UTF-8 mode (see b29848e).

NOTE: Replacement parameters are not checked.

Related: #4406
Reference: b29848ed609c652150e0a2813cefe5b9b70a9e1d