### PR TITLE
PhpUnitNoExpectationAnnotationFixer - fix handling expect empty exception message

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -264,8 +264,12 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         $tag = $annotation->getTag()->getName();
 
-        Preg::match('/@'.$tag.'\s+(.+)$/s', $annotation->getContent(), $matches);
+        if (1 !== Preg::match('/@'.$tag.'\s+(.+)$/s', $annotation->getContent(), $matches)) {
+            return '';
+        }
+
         $content = $matches[1];
+
         if (Preg::match('/\R/u', $content)) {
             $content = Preg::replace('/\s*\R+\s*\*\s*/u', ' ', $content);
         }

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -41,6 +41,32 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
     public function provideTestFixCases()
     {
         return [
+            'empty exception message' => [
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         */
+        public function testFnc()
+        {
+            $this->setExpectedException(\FooException::class, \'\');
+
+            aaa();
+        }
+    }',
+                '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * @expectedException FooException
+         * @expectedExceptionMessage
+         */
+        public function testFnc()
+        {
+            aaa();
+        }
+    }',
+            ],
             'expecting exception' => [
                 '<?php
     final class MyTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
An edge case I had with an empty @expectedExceptionMessage annotation
uncovered an unchecked return resulting in the undefined offset.

Fix is to fall-back to empty string which also solves the fixer for
me.