### PR TITLE
Remove superfluous leading backslash, closes 4520

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -245,9 +245,10 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $doc->getContent()]);
             $tokens->insertAt($braceIndex + 1, $newMethods);
 
-            $tokens[$braceIndex + $newMethods->getSize() + 1] = new Token([
+            $whitespaceIndex = $braceIndex + $newMethods->getSize() + 1;
+            $tokens[$whitespaceIndex] = new Token([
                 T_WHITESPACE,
-                $this->whitespacesConfig->getLineEnding().$tokens[$braceIndex + $newMethods->getSize() + 1]->getContent(),
+                $this->whitespacesConfig->getLineEnding().$tokens[$whitespaceIndex]->getContent(),
             ]);
 
             $i = $docBlockIndex;
@@ -275,10 +276,10 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     private function annotationsToParamList(array $annotations)
     {
         $params = [];
-        $exceptionClass = '\\'.ltrim($annotations['expectedException'], '\\');
+        $exceptionClass = ltrim($annotations['expectedException'], '\\');
 
         if ($this->configuration['use_class_const']) {
-            $params[] = $exceptionClass.'::class';
+            $params[] = "\\{$exceptionClass}::class";
         } else {
             $params[] = "'{$exceptionClass}'";
         }

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -221,7 +221,7 @@ final class PhpUnitNoExpectationAnnotationFixerTest extends AbstractFixerTestCas
          */
         public function testFnc()
         {
-            $this->setExpectedException(\'\FooException\');
+            $this->setExpectedException(\'FooException\');
 
             aaa();
         }


### PR DESCRIPTION
In string context, there is no need to prefix the exception class-name
of the exception with any backslashes as these are always in the global
name-space.

Looks like the prefix is only useful for verbatim class names which is not
addressed in this issue (see #4068 for more details on verbatim class-
names and also a generic resolution suggestion for many fixers).

Additionally minor changes regarding standard (Phpstorm) inspections.

Closes: #4520
Related: #4068