### PR TITLE
MethodArgumentSpaceFixerTest - make explicit configuration to prevent fail on configuration change

### DIFF
--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -333,13 +333,40 @@ EOTXTb
     );
 ",
             ],
-            'with_random_comments' => [
+            'with_random_comments on_multiline:ignore' => [
                 '<?php xyz#
  (#
 ""#
 ,#
 $a#
 );',
+                null,
+                ['on_multiline' => 'ignore'],
+            ],
+            'with_random_comments on_multiline:ensure_single_line' => [
+                '<?php xyz#
+ (#
+""#
+,#
+$a#
+);',
+                null,
+                ['on_multiline' => 'ensure_single_line'],
+            ],
+            'with_random_comments on_multiline:ensure_fully_multiline' => [
+                '<?php xyz#
+ (#
+""#
+,#
+$a#
+ );',
+                '<?php xyz#
+ (#
+""#
+,#
+$a#
+);',
+                ['on_multiline' => 'ensure_fully_multiline'],
             ],
             'keep_multiple_spaces_after_comma_with_newlines' => [
                 "<?php xyz(\$a=10,\n\$b=20);",


### PR DESCRIPTION
let's see if it would fix 3.0 branch, if so, lets merge PR to 2.12 and sync other branches

basically, we changed the default value of option and then we merged new test case, that was relying on previous default value of that option