### PR TITLE
Enhancement: Use default name property to configure command names

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -48,7 +48,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class DescribeCommand extends Command
 {
-    const COMMAND_NAME = 'describe';
+    protected static $defaultName = 'describe';
 
     /**
      * @var string[]
@@ -86,7 +86,6 @@ final class DescribeCommand extends Command
     protected function configure()
     {
         $this
-            ->setName(self::COMMAND_NAME)
             ->setDefinition(
                 [
                     new InputArgument('name', InputArgument::REQUIRED, 'Name of rule / set.'),

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -41,7 +41,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 final class FixCommand extends Command
 {
-    const COMMAND_NAME = 'fix';
+    protected static $defaultName = 'fix';
 
     /**
      * @var EventDispatcherInterface
@@ -95,7 +95,6 @@ final class FixCommand extends Command
     protected function configure()
     {
         $this
-            ->setName(self::COMMAND_NAME)
             ->setDefinition(
                 [
                     new InputArgument('path', InputArgument::IS_ARRAY, 'The path.'),

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -41,7 +41,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class HelpCommand extends BaseHelpCommand
 {
-    const COMMAND_NAME = 'help';
+    protected static $defaultName = 'help';
 
     /**
      * Returns help-copy suitable for console output.

--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -25,17 +25,14 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class ReadmeCommand extends Command
 {
-    const COMMAND_NAME = 'readme';
+    protected static $defaultName = 'readme';
 
     /**
      * {@inheritdoc}
      */
     protected function configure()
     {
-        $this
-            ->setName(self::COMMAND_NAME)
-            ->setDescription('Generates the README content, based on the fix command help.')
-        ;
+        $this->setDescription('Generates the README content, based on the fix command help.');
     }
 
     /**

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -32,7 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class SelfUpdateCommand extends Command
 {
-    const COMMAND_NAME = 'self-update';
+    protected static $defaultName = 'self-update';
 
     /**
      * @var NewVersionCheckerInterface
@@ -67,7 +67,6 @@ final class SelfUpdateCommand extends Command
     protected function configure()
     {
         $this
-            ->setName(self::COMMAND_NAME)
             ->setAliases(['selfupdate'])
             ->setDefinition(
                 [

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -34,7 +34,7 @@ final class CommandTest extends TestCase
      */
     public function testCommandHasNameConst(Command $command)
     {
-        static::assertSame($command->getName(), \constant(\get_class($command).'::COMMAND_NAME'));
+        static::assertNotNull($command->getDefaultName());
     }
 
     public function provideCommandHasNameConstCases()


### PR DESCRIPTION
This PR

* [x] uses the `$defaultName` property to configure command names

Fixes #4539.