### PR TITLE
DX: removing unnecessary variable initialization

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
@@ -88,8 +88,6 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             : '';
 
         $prevIndex = $tokens->getPrevNonWhitespace($index);
-        $doc = null;
-        $docIndex = null;
 
         if ($tokens[$prevIndex]->isGivenKind(T_DOC_COMMENT)) {
             $docIndex = $prevIndex;


### PR DESCRIPTION
Spotted when working on https://github.com/kubawerlos/php-cs-fixer-custom-fixers/pull/132

Both variables will be initialized in `if` and in `else`.