### PR TITLE
DX: travis_retry for dev-tools install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
             php: 7.2
             env: COMPOSER_FLAGS="--prefer-stable"
             install:
-                - ./dev-tools/install.sh
+                - travis_retry ./dev-tools/install.sh
 
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -1,42 +1,70 @@
 #!/bin/sh
-
+#
+# dev-tools install
+#
+# installation script for dev-tool utilities (phive, checkbashisms,
+# etc.) but not composer.
+#
+# script must be idempotent as to continue retrying in case of failure
+# (e.g. network timed out) when invoking again so that temporary i/o or
+# network problems can be dealt with by invoking the script again (and
+# again) until success. required for unattended build.
+#
+# usage: ./dev-tools/install.sh
+#    or: travis_retry ./dev-tools/install.sh
+#    or: ./install.sh
+#    or: ./install.sh || ./install.sh || ./install.sh
+#
 set -eu
 
 cd "$(dirname "$0")"
 
 mkdir -p bin
 
+###
+# temporary work-around: phive expects gpg2 as gpg, build box has gpg1 as gpg
+#   phive/phive:208 <https://github.com/phar-io/phive/issues/208>
+if [ "${TRAVIS-}" = true ]; then
+  sudo apt-get install dirmngr --install-recommends
+  [ ! -f "/usr/bin/gpg1"  ] && sudo mv -- "/usr/bin/gpg" "/usr/bin/gpg1"
+  sudo ln -sfT "/usr/bin/gpg2" "/usr/bin/gpg"
+fi
+
 VERSION_CB="2.0.0.2"
 VERSION_SC="stable"
 
 echo λλλ phive
-if [ ! -f bin/phive ]; then
-    wget --no-clobber --output-document=bin/phive https://phar.io/releases/phive.phar
-    wget --no-clobber --output-document=bin/phive.asc https://phar.io/releases/phive.phar.asc
+if [ ! -x bin/phive ]; then
+    wget -Obin/phive https://phar.io/releases/phive.phar
+    wget -Obin/phive.asc https://phar.io/releases/phive.phar.asc
     gpg --keyserver pool.sks-keyservers.net --recv-keys 0x9D8A98B29B2D5D79
     gpg --verify bin/phive.asc bin/phive
     chmod u+x bin/phive
-    bin/phive --version
 fi
+bin/phive --version
 
 echo λλλ checkbashisms
-if [ ! -f bin/checkbashisms ]; then
-    wget --no-clobber --output-document=bin/checkbashisms https://sourceforge.net/projects/checkbaskisms/files/${VERSION_CB}/checkbashisms/download
+if [ ! -x bin/checkbashisms ]; then
+    wget -Obin/checkbashisms https://sourceforge.net/projects/checkbaskisms/files/${VERSION_CB}/checkbashisms/download
     chmod u+x bin/checkbashisms
-    bin/checkbashisms --version
 fi
+bin/checkbashisms --version
 
 echo λλλ shellcheck
-if [ ! -f bin/shellcheck ]; then
-    wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${VERSION_SC}.linux.x86_64.tar.xz" | tar -xJv --directory bin shellcheck-${VERSION_SC}/shellcheck
-    mv "bin/shellcheck-${VERSION_SC}/shellcheck" bin/
-    rmdir "bin/shellcheck-${VERSION_SC}/"
-    bin/shellcheck --version
+if [ ! -x bin/shellcheck ]; then
+    wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${VERSION_SC}.linux.x86_64.tar.xz" \
+        | tar -xJv -O shellcheck-${VERSION_SC}/shellcheck \
+        > bin/shellcheck
+    chmod u+x bin/shellcheck
 fi
+bin/shellcheck --version
 
 echo λλλ composer packages
 composer update
 composer info -D | sort
 
 echo λλλ phive packages
+
+# echo "debug: #phive/phive:208"
+# see above
 ./bin/phive install --trust-gpg-keys D2CCAC42F6295E7D,8E730BA25823D8B5


### PR DESCRIPTION
in Travis seeing errors like:

	gpg: keyserver timed out
	gpg: keyserver receive failed: keyserver error
	The command "./dev-tools/install.sh" failed and exited with 2 during .

which is doing GPG verification of the downloaded Phive utility and then
failing due to network failures w/ GPG key-servers.

a work-around is to retry done by travis_retry (retries 3 times by default
on failure).

this is also true for other network operations during dev-tools install.

as the install.sh script only installs by testing for files if already
installed the installation of each utility forms a transaction of its own.

to establish transaction behavior for the Phive installation, files are
now re-downloaded (unless Phive was already installed) and only after
successful GPG verification the Phive utility is installed as bin/phive.

for better verification of each utility installation per potential retry,
the installation check is done always (most often by invoking each utility
and displaying the version information). previously this was not necessary
as the script was not expected to be called over and over again.

change for all wget operations having the --no-clobber argument while
using the --output-document with a pathname to a regular file are not safe
any longer as wget exits w/ non-zero status when the file already exists.
therefore wget writes the file to stdout that is redirected to the target
file to make the operation fail-safe in context of an unattended build
that re-tries on failure.

utilities are now tested for being executable as only testing for being a
file as done previously is not enough as installation requires modifying
the execution bit.

additionally a minor improvement in extracting the single shellcheck file
from the tar archive by directly extracting the file removing the
management of the temporary directory that previously was an intermediate
temporary result of tar-file extraction.

these changes should also benefit calling the script again in interactive
use (e.g. $ ./install.sh).