### PR TITLE
ClassKeywordRemoveFixer - fix for self,static and parent keywords

### DIFF
--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -161,9 +161,8 @@ $className = Baz::class;
     private function replaceClassKeywordsSection(Tokens $tokens, $startIndex, $endIndex)
     {
         $ctClassTokens = $tokens->findGivenKind(CT::T_CLASS_CONSTANT, $startIndex, $endIndex);
-        if (!empty($ctClassTokens)) {
-            $this->replaceClassKeyword($tokens, current(array_keys($ctClassTokens)));
-            $this->replaceClassKeywordsSection($tokens, $startIndex, $endIndex);
+        foreach (array_reverse(array_keys($ctClassTokens)) as $classIndex) {
+            $this->replaceClassKeyword($tokens, $classIndex);
         }
     }
 
@@ -175,6 +174,10 @@ $className = Baz::class;
     {
         $classEndIndex = $tokens->getPrevMeaningfulToken($classIndex);
         $classEndIndex = $tokens->getPrevMeaningfulToken($classEndIndex);
+
+        if ($tokens[$classEndIndex]->equalsAny([[T_STRING, 'self'], [T_STATIC, 'static'], [T_STRING, 'parent']], false)) {
+            return;
+        }
 
         $classBeginIndex = $classEndIndex;
         while (true) {

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -199,6 +199,22 @@ DateTime:: # a
                 }
                 ',
             ],
+            [
+                '<?php
+                namespace Foo;
+                class Bar extends Baz {
+                    public function a() {
+                        return self::class;
+                    }
+                    public function b() {
+                        return static::class;
+                    }
+                    public function c() {
+                        return parent::class;
+                    }
+                }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4554 (Travis failure is not related to the fix)

Pinging @soullivaneuh (as original author) and @lukasbestle (as bug reporter) for review.