### PR TITLE
Command::execute() should always return an integer

### DIFF
--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -106,7 +106,7 @@ final class DescribeCommand extends Command
             if ('@' === $name[0]) {
                 $this->describeSet($output, $name);
 
-                return null;
+                return 0;
             }
 
             $this->describeRule($output, $name);
@@ -126,6 +126,8 @@ final class DescribeCommand extends Command
                 null === $alternative ? '' : ' Did you mean "'.$alternative.'"?'
             ));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Console/Command/ReadmeCommand.php
+++ b/src/Console/Command/ReadmeCommand.php
@@ -287,5 +287,7 @@ EOF;
         $footer = str_replace('%download.url%', $downloadUrl, $footer);
 
         $output->write($header."\n".$help."\n".$footer);
+
+        return 0;
     }
 }

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -171,5 +171,7 @@ EOT
         rename($tempFilename, $localFilename);
 
         $output->writeln(sprintf('<info>php-cs-fixer updated</info> (<comment>%s</comment>)', $remoteTag));
+
+        return 0;
     }
 }


### PR DESCRIPTION
In Symfony 4.4, a deprecation error is triggered if `Command::execute()` does not return an integer, see symfony/symfony#33747. This PR adds the necessary `return` statements.