### PR TITLE
Two new fixers: Blank line before else/elseif and before catch/finally

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,10 @@ Choose from the list of available rules:
   Ensure there is no code on the same line as the PHP open tag and it is
   followed by a blank line.
 
+* **blank_line_before_else_block**
+
+  An empty line feed must precede any else or elseif codeblock.
+
 * **blank_line_before_return**
 
   An empty line feed should precede a return statement. DEPRECATED: use

--- a/README.rst
+++ b/README.rst
@@ -304,6 +304,10 @@ Choose from the list of available rules:
   Ensure there is no code on the same line as the PHP open tag and it is
   followed by a blank line.
 
+* **blank_line_before_catch_block**
+
+  An empty line feed must precede any catch or finally codeblock.
+
 * **blank_line_before_else_block**
 
   An empty line feed must precede any else or elseif codeblock.

--- a/src/Fixer/Whitespace/BlankLineBeforeCatchBlockFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeCatchBlockFixer.php
@@ -19,7 +19,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-final class BlankLineBeforeElseBlockFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
+final class BlankLineBeforeCatchBlockFixer extends AbstractFixer implements WhitespacesAwareFixerInterface
 {
     /**
      * {@inheritdoc}
@@ -27,17 +27,17 @@ final class BlankLineBeforeElseBlockFixer extends AbstractFixer implements White
     public function getDefinition()
     {
         return new FixerDefinition(
-            'An empty line feed must precede any else or elseif codeblock.',
+            'An empty line feed must precede any catch or finally codeblock.',
             [
                 new CodeSample(
                     '<?php
-if ($a) {
+try {
     foo();
 
-} elseif ($b) {
+} catch (\Exception $b) {
     bar();
 
-} else {
+} finally {
     baz();
 }
 '
@@ -60,7 +60,7 @@ if ($a) {
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_ELSEIF) || $tokens->isTokenKindFound(T_ELSE);
+        return $tokens->isTokenKindFound(T_CATCH) || $tokens->isTokenKindFound(T_FINALLY);
     }
 
     /**
@@ -73,7 +73,7 @@ if ($a) {
 
         foreach ($tokens as $index => $token) {
             /** @var Token $token */
-            if ($token->isGivenKind([T_ELSE, T_ELSEIF])) {
+            if ($token->isGivenKind([T_CATCH, T_FINALLY])) {
                 $index = $tokens->getPrevMeaningfulToken($index);
 
                 if ($tokens[$index]->equals('}')) {

--- a/src/Fixer/Whitespace/BlankLineBeforeElseBlockFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeElseBlockFixer.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Whitespace;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class BlankLineBeforeElseBlockFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'An empty line feed must precede any else or elseif codeblock.',
+            [
+                new CodeSample(
+                    '<?php
+if ($a) {
+    foo();
+
+} elseif ($b) {
+    bar();
+
+} else {
+    baz();
+}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority()
+    {
+        // should run after no_blank_lines_after_phpdoc
+        return -26;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_ELSEIF) || $tokens->isTokenKindFound(T_ELSE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        foreach ($tokens as $index => $token) {
+            /** @var Token $token */
+            if ($token->isGivenKind([T_ELSE, T_ELSEIF])) {
+                $index = $tokens->getPrevMeaningfulToken($index);
+
+                if ($tokens[$index]->equals('}')) {
+                    --$index;
+
+                    while ($tokens[$index]->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                        --$index;
+                    }
+
+                    /** @var Token $whitespace */
+                    $whitespace = $tokens[$index];
+
+                    /** @var int $presentNewlines */
+                    $presentNewlines = substr_count($whitespace->getContent(), "\n");
+
+                    if ($whitespace->isWhitespace() && $presentNewlines < 2) {
+                        $tokens[$index] = $this->convertWhitespaceToken($whitespace);
+                    }
+                }
+            }
+        }
+    }
+
+    private function convertWhitespaceToken(Token $whitespace): Token
+    {
+        return new Token([
+            $whitespace->getId(),
+            substr_replace(
+                $whitespace->getContent(),
+                "\n\n",
+                strpos($whitespace->getContent(), "\n"),
+                1
+            ),
+        ]);
+    }
+}

--- a/tests/Fixer/Whitespace/BlankLineBeforeCatchBlockFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeCatchBlockFixerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Whitespace;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class BlankLineBeforeCatchBlockFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+try {
+    foo();
+
+} catch (\Exception $b) {
+    bar();
+
+} finally {
+    baz();
+}',
+            ],
+            [
+                '<?php
+try {
+    foo();
+
+} catch (\Exception $b) {
+    bar();
+
+} finally {
+    baz();
+}',
+                '<?php
+try {
+    foo();
+} catch (\Exception $b) {
+    bar();
+} finally {
+    baz();
+}',
+            ],
+            [
+                '<?php
+    try {
+        foo();
+
+    } catch (\Exception $b) {
+        bar();
+
+    } finally {
+        baz();
+    }',
+                '<?php
+    try {
+        foo();
+    } catch (\Exception $b) {
+        bar();
+    } finally {
+        baz();
+    }',
+            ],
+            [
+                '<?php
+try {
+    foo();
+
+/* Lorem ipsum */} catch (\Exception $b) {
+    bar();
+
+} finally {
+    baz();
+}',
+                '<?php
+try {
+    foo();
+/* Lorem ipsum */} catch (\Exception $b) {
+    bar();
+} finally {
+    baz();
+}',
+            ],
+            [
+                '<?php try {foo();} catch (\Exception $b) {bar();} finally {baz();}',
+            ],
+        ];
+    }
+}

--- a/tests/Fixer/Whitespace/BlankLineBeforeElseBlockFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeElseBlockFixerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Whitespace;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class BlankLineBeforeElseBlockFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+if ($a) {
+    foo();
+
+} elseif ($b) {
+    bar();
+
+} else {
+    baz();
+}',
+            ],
+            [
+                '<?php
+if ($a) {
+    foo();
+
+} elseif ($b) {
+    bar();
+
+} else {
+    baz();
+}',
+                '<?php
+if ($a) {
+    foo();
+} elseif ($b) {
+    bar();
+} else {
+    baz();
+}',
+            ],
+            [
+                '<?php
+    if ($a) {
+        foo();
+
+    } elseif ($b) {
+        bar();
+
+    } else {
+        baz();
+    }',
+                '<?php
+    if ($a) {
+        foo();
+    } elseif ($b) {
+        bar();
+    } else {
+        baz();
+    }',
+            ],
+            [
+                '<?php
+if ($a) {
+    foo();
+
+/* Lorem ipsum */} elseif ($b) {
+    bar();
+
+} else {
+    baz();
+}',
+                '<?php
+if ($a) {
+    foo();
+/* Lorem ipsum */} elseif ($b) {
+    bar();
+} else {
+    baz();
+}',
+            ],
+            [
+                '<?php if ($a) {foo();} elseif ($b) {bar();} else {baz();}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR add's two similar fixers:
 - Blank line before else and elseif code-blocks
 - Blank line before catch and finally code-blocks

The first fixer (blank_line_before_else_block) turns this:
```php
if ($a) {
    foo();
} elseif ($b) {
    bar();
} else {
    baz();
}
```
... into this:
```php
if ($a) {
    foo();

} elseif ($b) {
    bar();

} else {
    baz();
}
```
And the second fixer (blank_line_before_catch_block) turns this:
```php
try {
    foo();
} catch (\Exception $e) {
    bar();
} finally {
    baz();
}
```
... into this:
```php
try {
    foo();

} catch (\Exception $e) {
    bar();

} finally {
    baz();
}
```

The reasoning on why someone (including me) might want this is relatively simple: Statements in a conditional code-block is more closely related to the condition of said code-block then to the condition of the next code-block or the previous code-block, so they (IMO) should be separated by a blank line.

I thought about merging these two very similar fixers into one fixer because the reasoning is the same for both cases: To group code-blocks by explicitly separating them from other blocks with a blank line. But these two fixers concern two different types of code-blocks (conditional and exception-handling), so a user may want to use one but not the other, even if i do not see the reasoning for that yet.
Instead of using two separate fixers i could also have used one and made it configurable, but that seems more complicated then just having two fixers and they *do* concern two different use-cases, so they could become different in the future.