### PR TITLE
PhpdocToReturnType - Add support for Foo[][]

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -36,7 +36,7 @@ class Annotation
     (?<types>
         (?<type>
             (?<array>
-                (?&simple)\[\]
+                (?&simple)(\[\])*
             )
             |
             (?<simple>

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -234,6 +234,10 @@ final class AnnotationTest extends TestCase
                 ['int'],
             ],
             [
+                ' * @method Foo[][] method()',
+                ['Foo[][]'],
+            ],
+            [
                 ' * @method int[] method()',
                 ['int[]'],
             ],

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -217,8 +217,10 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @return Foo[] */ function my_foo(): array {}',
                 '<?php /** @return Foo[] */ function my_foo() {}',
             ],
-            'skip array of array of types' => [
+            'array of array of types' => [
+                '<?php /** @return Foo[][] */ function my_foo(): array {}',
                 '<?php /** @return Foo[][] */ function my_foo() {}',
+                70000,
             ],
             'nullable array of types' => [
                 '<?php /** @return null|Foo[] */ function my_foo(): ?array {}',


### PR DESCRIPTION
fixes point two of https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4511

backport of fixes done in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4583 by @jg-development , thanks!