### PR TITLE
SwitchContinueToBreakFixer - Introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1954,6 +1954,10 @@ Choose from the list of available rules:
 
   Removes extra spaces between colon and case value.
 
+* **switch_continue_to_break** [@Symfony, @PhpCsFixer, @PHP73Migration]
+
+  Switch case must not be ended with ``continue`` but with ``break``.
+
 * **ternary_operator_spaces** [@Symfony, @PhpCsFixer]
 
   Standardize spaces around ternary operator.

--- a/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
+++ b/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
@@ -1,0 +1,259 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ControlStructure;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class SwitchContinueToBreakFixer extends AbstractFixer
+{
+    private $switchLevels = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Switch case must not be ended with `continue` but with `break`.',
+            [
+                new CodeSample(
+                    '<?php
+switch ($foo) {
+    case 1:
+        continue;
+}
+'
+                ),
+                new CodeSample(
+                    '<?php
+switch ($foo) {
+    case 1:
+        while($bar) {
+            do {
+                continue 3;
+            } while(false);
+
+            if ($foo + 1 > 3) {
+                continue;
+            }
+
+            continue 2;
+        }
+}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_SWITCH, T_CONTINUE, T_LNUMBER]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $count = \count($tokens);
+
+        for ($index = 1; $index < $count - 1; ++$index) {
+            $index = $this->doFix($tokens, $index, 0, false);
+        }
+    }
+
+    /**
+     * @param int  $index
+     * @param int  $depth      >= 0
+     * @param bool $isInSwitch
+     *
+     * @return int
+     */
+    private function doFix(Tokens $tokens, $index, $depth, $isInSwitch)
+    {
+        $token = $tokens[$index];
+
+        if ($token->isGivenKind([T_FOREACH, T_FOR, T_WHILE])) {
+            // go to first `(`, go to its close ')', go to first of '{', ';', '? >'
+            $index = $tokens->getNextTokenOfKind($index, ['(']);
+            $index = $tokens->getNextTokenOfKind($index, [')']);
+            $index = $tokens->getNextTokenOfKind($index, ['{', ';', [T_CLOSE_TAG]]);
+
+            if (!$tokens[$index]->equals('{')) {
+                return $index;
+            }
+
+            return $this->fixInLoop($tokens, $index, $depth + 1);
+        }
+
+        if ($token->isGivenKind([T_DO])) {
+            return $this->fixInLoop($tokens, $tokens->getNextTokenOfKind($index, ['{']), $depth + 1);
+        }
+
+        if ($token->isGivenKind(T_SWITCH)) {
+            return $this->fixInSwitch($tokens, $index, $depth + 1);
+        }
+
+        if ($token->isGivenKind(T_CONTINUE)) {
+            return $this->fixContinueWhenActsAsBreak($tokens, $index, $isInSwitch, $depth);
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param int $switchIndex
+     * @param int $depth
+     *
+     * @return int
+     */
+    private function fixInSwitch(Tokens $tokens, $switchIndex, $depth)
+    {
+        $this->switchLevels[] = $depth;
+
+        // figure out where the switch starts
+        $openIndex = $tokens->getNextTokenOfKind($switchIndex, ['{']);
+
+        // figure out where the switch ends
+        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openIndex);
+
+        for ($index = $openIndex + 1; $index < $closeIndex; ++$index) {
+            $index = $this->doFix($tokens, $index, $depth, true);
+        }
+
+        array_pop($this->switchLevels);
+
+        return $closeIndex;
+    }
+
+    /**
+     * @param int $openIndex
+     * @param int $depth
+     *
+     * @return int
+     */
+    private function fixInLoop(Tokens $tokens, $openIndex, $depth)
+    {
+        $openCount = 1;
+
+        do {
+            ++$openIndex;
+            $token = $tokens[$openIndex];
+
+            if ($token->equals('{')) {
+                ++$openCount;
+
+                continue;
+            }
+
+            if ($token->equals('}')) {
+                --$openCount;
+
+                if (0 === $openCount) {
+                    break;
+                }
+
+                continue;
+            }
+
+            $openIndex = $this->doFix($tokens, $openIndex, $depth, false);
+        } while (true);
+
+        return $openIndex;
+    }
+
+    /**
+     * @param int  $continueIndex
+     * @param bool $isInSwitch
+     * @param int  $depth
+     *
+     * @return int
+     */
+    private function fixContinueWhenActsAsBreak(Tokens $tokens, $continueIndex, $isInSwitch, $depth)
+    {
+        $followingContinueIndex = $tokens->getNextMeaningfulToken($continueIndex);
+        $followingContinueToken = $tokens[$followingContinueIndex];
+
+        if ($isInSwitch && $followingContinueToken->equals(';')) {
+            $this->replaceContinueWithBreakToken($tokens, $continueIndex); // short continue 1 notation
+
+            return $followingContinueIndex;
+        }
+
+        if (!$followingContinueToken->isGivenKind(T_LNUMBER)) {
+            return $followingContinueIndex;
+        }
+
+        $afterFollowingContinueIndex = $tokens->getNextMeaningfulToken($followingContinueIndex);
+
+        if (!$tokens[$afterFollowingContinueIndex]->equals(';')) {
+            return $afterFollowingContinueIndex; // if next not is `;` return without fixing, for example `continue 1 ? ><?php + $a;`
+        }
+
+        // check if continue {jump} targets a switch statement and if so fix it
+
+        $jump = $followingContinueToken->getContent();
+        $jump = str_replace('_', '', $jump); // support for numeric_literal_separator
+
+        if (\strlen($jump) > 2 && 'x' === $jump[1]) {
+            $jump = hexdec($jump); // hexadecimal - 0x1
+        } elseif (\strlen($jump) > 2 && 'b' === $jump[1]) {
+            $jump = bindec($jump); // binary - 0b1
+        } elseif (\strlen($jump) > 1 && '0' === $jump[0]) {
+            $jump = octdec($jump); // octal 01
+        } elseif (1 === Preg::match('#^\d+$#', $jump)) { // positive int
+            $jump = (float) $jump; // cast to float, might be a number bigger than PHP max. int value
+        } else {
+            return $afterFollowingContinueIndex; // cannot process value, ignore
+        }
+
+        if ($jump > PHP_INT_MAX) {
+            return $afterFollowingContinueIndex; // cannot process value, ignore
+        }
+
+        $jump = (int) $jump;
+
+        if ($isInSwitch && (1 === $jump || 0 === $jump)) {
+            $this->replaceContinueWithBreakToken($tokens, $continueIndex); // long continue 0/1 notation
+
+            return $afterFollowingContinueIndex;
+        }
+
+        $jumpDestination = $depth - $jump + 1;
+
+        if (\in_array($jumpDestination, $this->switchLevels, true)) {
+            $this->replaceContinueWithBreakToken($tokens, $continueIndex);
+
+            return $afterFollowingContinueIndex;
+        }
+
+        return $afterFollowingContinueIndex;
+    }
+
+    /**
+     * @param int $index
+     */
+    private function replaceContinueWithBreakToken(Tokens $tokens, $index)
+    {
+        $tokens[$index] = new Token([T_BREAK, 'break']);
+    }
+}

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -165,6 +165,7 @@ final class RuleSet implements RuleSetInterface
             ],
             'standardize_increment' => true,
             'standardize_not_equals' => true,
+            'switch_continue_to_break' => true,
             'ternary_operator_spaces' => true,
             'trailing_comma_in_multiline_array' => true,
             'trim_array_spaces' => true,
@@ -327,6 +328,7 @@ final class RuleSet implements RuleSetInterface
         '@PHP73Migration' => [
             '@PHP71Migration' => true,
             'heredoc_indentation' => true,
+            'switch_continue_to_break' => true,
         ],
         '@PHPUnit30Migration:risky' => [
             'php_unit_dedicate_assert' => ['target' => PhpUnitTargetVersion::VERSION_3_0],

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -1,0 +1,569 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ControlStructure;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ControlStructure\SwitchContinueToBreakFixer
+ */
+final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestFixCases()
+    {
+        return [
+            'simple case' => [
+                '<?php
+switch($a) {
+    case 1:
+        echo 1;
+
+        break;
+    case 2:
+        echo 2;
+
+        if ($z) break 1;
+
+        break 1;
+    case 3:
+        echo 2;
+
+        continue 2;
+    case 4:
+        continue 12;
+}
+',
+                '<?php
+switch($a) {
+    case 1:
+        echo 1;
+
+        continue;
+    case 2:
+        echo 2;
+
+        if ($z) continue 1;
+
+        continue 1;
+    case 3:
+        echo 2;
+
+        continue 2;
+    case 4:
+        continue 12;
+}
+',
+            ],
+            'nested switches' => [
+                '<?php
+switch($z) {
+    case 1:
+        switch($x) {
+            case 2:
+                switch($y) {
+                    case 3:
+                        switch($z) {
+                            case 4:
+                                break; // z.1
+                        }
+                        break; // z
+                }
+                break; // y
+        }
+        break; // x
+}
+',
+                '<?php
+switch($z) {
+    case 1:
+        switch($x) {
+            case 2:
+                switch($y) {
+                    case 3:
+                        switch($z) {
+                            case 4:
+                                continue; // z.1
+                        }
+                        continue; // z
+                }
+                continue; // y
+        }
+        continue; // x
+}
+',
+            ],
+            'nested 1' => [
+                '<?php
+    while($a) {
+        switch($b) {
+            case 1:
+                break 1;
+            case 2:
+                break 1;
+            case 3:
+                continue 2;
+            case 4:
+                continue 3;
+        }
+    }
+
+    switch($b) {
+        case 1:
+            switch($c) {
+                case 1:
+                    break 2;
+        }
+    }
+',
+                '<?php
+    while($a) {
+        switch($b) {
+            case 1:
+                continue 1;
+            case 2:
+                continue 1;
+            case 3:
+                continue 2;
+            case 4:
+                continue 3;
+        }
+    }
+
+    switch($b) {
+        case 1:
+            switch($c) {
+                case 1:
+                    continue 2;
+        }
+    }
+',
+            ],
+            'nested 2' => [
+                '<?php
+while ($foo) {
+    switch ($bar) {
+        case "baz":
+            while ($xyz) {
+                switch($zA) {
+                    case 1:
+                        break 3; // fix
+                }
+
+                if ($z) continue;
+                if ($zz){ continue; }
+
+                if ($zzz) continue 3;
+                if ($zzz){ continue 3; }
+
+                if ($b) break 2; // fix
+            }
+
+            switch($zG) {
+                case 1:
+                    switch($zF) {
+                        case 1:
+                            break 1; // fix
+                        case 2:
+                            break 2; // fix
+                        case 3:
+                            break 3; // fix
+                        case 4:
+                            while($a){
+                                while($a){
+                                    while($a){
+                                        if ($a) {
+                                            break 4; // fix
+                                        } elseif($z) {
+                                            break 5; // fix
+                                        } else {
+                                            break 6; // fix
+                                        }
+
+                                        continue 7;
+                                    }
+                                }
+                            }
+
+                            continue 4;
+                    }
+
+                    break 2; // fix
+            }
+    }
+}
+',
+                '<?php
+while ($foo) {
+    switch ($bar) {
+        case "baz":
+            while ($xyz) {
+                switch($zA) {
+                    case 1:
+                        continue 3; // fix
+                }
+
+                if ($z) continue;
+                if ($zz){ continue; }
+
+                if ($zzz) continue 3;
+                if ($zzz){ continue 3; }
+
+                if ($b) continue 2; // fix
+            }
+
+            switch($zG) {
+                case 1:
+                    switch($zF) {
+                        case 1:
+                            continue 1; // fix
+                        case 2:
+                            continue 2; // fix
+                        case 3:
+                            continue 3; // fix
+                        case 4:
+                            while($a){
+                                while($a){
+                                    while($a){
+                                        if ($a) {
+                                            continue 4; // fix
+                                        } elseif($z) {
+                                            continue 5; // fix
+                                        } else {
+                                            continue 6; // fix
+                                        }
+
+                                        continue 7;
+                                    }
+                                }
+                            }
+
+                            continue 4;
+                    }
+
+                    continue 2; // fix
+            }
+    }
+}
+',
+            ],
+            'nested do while' => [
+                '<?php
+switch ($a) {
+    case 1:
+        do {
+            switch ($a) {
+                case 1:
+                    do {
+                        switch ($a) {
+                            case 1:
+                                do {
+                                    continue;
+                                } while (false);
+
+                            break;
+                        }
+
+                        continue;
+                    } while (false);
+
+                break;
+            }
+            continue;
+        } while (false);
+
+    break;
+}
+',
+                '<?php
+switch ($a) {
+    case 1:
+        do {
+            switch ($a) {
+                case 1:
+                    do {
+                        switch ($a) {
+                            case 1:
+                                do {
+                                    continue;
+                                } while (false);
+
+                            continue;
+                        }
+
+                        continue;
+                    } while (false);
+
+                continue;
+            }
+            continue;
+        } while (false);
+
+    continue;
+}
+',
+            ],
+            [
+                '<?php
+switch(foo()) {
+    case 1: while(bar($i))continue;break;
+    default: echo 7;
+}
+',
+                '<?php
+switch(foo()) {
+    case 1: while(bar($i))continue;continue;
+    default: echo 7;
+}
+',
+            ],
+            'do not fix cases' => [
+                '<?php
+switch($a) {
+    case 1:
+        while (false) {
+            continue;
+        }
+
+        while (false) continue 2;
+
+        do {
+            continue;
+        } while (false);
+
+        for ($a = 0; $a < 1; ++$a) {
+            continue;
+        }
+
+        foreach ($a as $b) continue;
+        for (; $i < 1; ++$i) continue 7; echo $i;
+        for (;;) continue;
+        while(false) continue;
+        while(false) continue?><?php
+
+        // so bad and such a mess, not worth adding a ton of logic to fix this
+        switch($z) {
+            case 1:
+                continue ?>   <?php 23;
+            case 2:
+                continue 1?>   <?php + $a;
+        }
+}
+',
+            ],
+            'nested while, do not fix' => [
+                '<?php
+switch(foo()) {
+    case 1: while(bar($i)){ --$i; echo 1; continue;}break;
+    default: echo 8;
+}',
+            ],
+            'not int cases' => [
+                '<?php
+while($b) {
+switch($a) {
+case 1:
+    break 01;
+case 2:
+    break 0x1;
+case 22:
+    break 0x01;
+case 3:
+    break 0b1;
+case 32:
+    break 0b0001;
+case 4:
+    break 0b000001;
+// do not fix
+case 1:
+    continue 02;
+case 2:
+    continue 0x2;
+case 3:
+    continue 0b10;
+}
+}',
+                '<?php
+while($b) {
+switch($a) {
+case 1:
+    continue 01;
+case 2:
+    continue 0x1;
+case 22:
+    continue 0x01;
+case 3:
+    continue 0b1;
+case 32:
+    continue 0b0001;
+case 4:
+    continue 0b000001;
+// do not fix
+case 1:
+    continue 02;
+case 2:
+    continue 0x2;
+case 3:
+    continue 0b10;
+}
+}',
+            ],
+            'deep nested case' => [
+                '<?php
+switch ($a) {
+case $b:
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    switch ($a) {
+        case 1:
+            echo 1;
+
+            break 10;
+}}}}}}}}}}',
+                '<?php
+switch ($a) {
+case $b:
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    switch ($a) {
+        case 1:
+            echo 1;
+
+            continue 10;
+}}}}}}}}}}',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestFixPhp70Cases
+     * @requires PHP 7.0
+     */
+    public function testFixPhp70($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestFixPhp70Cases()
+    {
+        return [
+            [
+                sprintf('<?php switch($a){ case 1: continue 1%d;}', PHP_INT_MAX),
+            ],
+            [
+                '<?php
+switch($a) {
+    case 1:
+        continue $a;
+    case 2:
+        break 0;
+    case 3:
+        continue 1.2;
+}
+',
+                '<?php
+switch($a) {
+    case 1:
+        continue $a;
+    case 2:
+        continue 0;
+    case 3:
+        continue 1.2;
+}
+',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.4
+     *
+     * @dataProvider provideFix74Cases
+     */
+    public function testFix74($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix74Cases()
+    {
+        return [
+            'numeric literal separator' => [
+                '<?php
+switch ($a) {
+case $b:
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    switch ($a) {
+        case 1:
+            echo 1;
+
+            break 1_0;
+}}}}}}}}}}',
+                '<?php
+switch ($a) {
+case $b:
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    while (false) {
+    switch ($a) {
+        case 1:
+            echo 1;
+
+            continue 1_0;
+}}}}}}}}}}',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Description of switch_continue_to_break rule.
Switch case must not be ended with `continue` but with `break`.


```diff
--- Original
+++ New
@@ -1,5 +1,5 @@
<?php
    switch ($foo) {
        case 1:
-           continue;
+           break;
    }
```

```diff
--- Original
+++ New
@@ -1,15 +1,15 @@
<?php
switch ($foo) {
    case 1:
        while($bar) {
            do {
-                continue 3;
+                break 3;
            } while(false);
            
            if ($foo + 1 > 3) {
                continue;
            }
            
-            continue 2;
+            break 2;
        }
}
```

@ see https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch

https://wiki.php.net/rfc/continue_on_switch_deprecation

https://github.com/php/php-src/pull/3364
