### PR TITLE
Refactor conversion of PHPDoc to type declarations

### DIFF
--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -13,11 +13,26 @@ accordingly the function signature. Requires PHP >= 7.0.
    be fixed. [3] Manual actions are required if inherited signatures are not
    properly documented.
 
+Configuration
+-------------
+
+``scalar_types``
+~~~~~~~~~~~~~~~~
+
+Fix also scalar types; may have unexpected behaviour due to PHP bad type
+coercion system.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -33,6 +48,8 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
+*Default* configuration.
+
 .. code-block:: diff
 
    --- Original
@@ -43,3 +60,19 @@ Example #2
    -function my_foo($bar)
    +function my_foo(?string $bar)
     {}
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['scalar_types' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /** @param Foo $foo */
+   -function foo($foo) {}
+   +function foo(Foo $foo) {}
+    /** @param string $foo */
+    function bar($foo) {}

--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -12,17 +12,209 @@
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @internal
  */
-abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer
+abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
 {
+    /**
+     * @var string
+     */
+    private $classRegex = '/^\\\\?[a-zA-Z_\\x7f-\\xff](?:\\\\?[a-zA-Z0-9_\\x7f-\\xff]+)*$/';
+
+    /**
+     * @var array<string, int>
+     */
+    private $versionSpecificTypes = [
+        'void' => 70100,
+        'iterable' => 70100,
+        'object' => 70200,
+        'mixed' => 80000,
+    ];
+
+    /**
+     * @var array<string, bool>
+     */
+    private $scalarTypes = [
+        'bool' => true,
+        'float' => true,
+        'int' => true,
+        'string' => true,
+    ];
+
     /**
      * @var array<string, bool>
      */
     private static $syntaxValidationCache = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return bool
+     */
+    abstract protected function isSkippedType($type);
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('scalar_types', 'Fix also scalar types; may have unexpected behaviour due to PHP bad type coercion system.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true)
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * Find all the annotations of given type in the function's PHPDoc comment.
+     *
+     * @param string $name
+     * @param int    $index The index of the function token
+     *
+     * @return Annotation[]
+     */
+    protected function findAnnotations($name, Tokens $tokens, $index)
+    {
+        do {
+            $index = $tokens->getPrevNonWhitespace($index);
+        } while ($tokens[$index]->isGivenKind([
+            T_COMMENT,
+            T_ABSTRACT,
+            T_FINAL,
+            T_PRIVATE,
+            T_PROTECTED,
+            T_PUBLIC,
+            T_STATIC,
+        ]));
+
+        if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
+            return [];
+        }
+
+        $namespacesAnalyzer = new NamespacesAnalyzer();
+        $namespace = $namespacesAnalyzer->getNamespaceAt($tokens, $index);
+
+        $namespaceUsesAnalyzer = new NamespaceUsesAnalyzer();
+        $namespaceUses = $namespaceUsesAnalyzer->getDeclarationsInNamespace($tokens, $namespace);
+
+        $doc = new DocBlock(
+            $tokens[$index]->getContent(),
+            $namespace,
+            $namespaceUses
+        );
+
+        return $doc->getAnnotationsOfType($name);
+    }
+
+    /**
+     * @param string $type
+     * @param bool   $isNullable
+     *
+     * @return Token[]
+     */
+    protected function createTypeDeclarationTokens($type, $isNullable)
+    {
+        static $specialTypes = [
+            'array' => [CT::T_ARRAY_TYPEHINT, 'array'],
+            'callable' => [T_CALLABLE, 'callable'],
+            'static' => [T_STATIC, 'static'],
+        ];
+
+        $newTokens = [];
+
+        if (true === $isNullable && 'mixed' !== $type) {
+            $newTokens[] = new Token([CT::T_NULLABLE_TYPE, '?']);
+        }
+
+        if (isset($specialTypes[$type])) {
+            $newTokens[] = new Token($specialTypes[$type]);
+        } else {
+            $typeUnqualified = ltrim($type, '\\');
+
+            if (isset($this->scalarTypes[$typeUnqualified]) || isset($this->versionSpecificTypes[$typeUnqualified])) {
+                // 'scalar's, 'void', 'iterable' and 'object' must be unqualified
+                $newTokens[] = new Token([T_STRING, $typeUnqualified]);
+            } else {
+                foreach (explode('\\', $type) as $nsIndex => $value) {
+                    if (0 === $nsIndex && '' === $value) {
+                        continue;
+                    }
+
+                    if (0 < $nsIndex) {
+                        $newTokens[] = new Token([T_NS_SEPARATOR, '\\']);
+                    }
+
+                    $newTokens[] = new Token([T_STRING, $value]);
+                }
+            }
+        }
+
+        return $newTokens;
+    }
+
+    /**
+     * @param bool $isReturnType
+     *
+     * @return null|array
+     */
+    protected function getCommonTypeFromAnnotation(Annotation $annotation, $isReturnType)
+    {
+        $typesExpression = $annotation->getTypeExpression();
+
+        $commonType = $typesExpression->getCommonType();
+        $isNullable = $typesExpression->allowsNull();
+
+        if (null === $commonType) {
+            return null;
+        }
+
+        if ($isNullable && (\PHP_VERSION_ID < 70100 || 'void' === $commonType)) {
+            return null;
+        }
+
+        if ('static' === $commonType && (!$isReturnType || \PHP_VERSION_ID < 80000)) {
+            $commonType = 'self';
+        }
+
+        if ($this->isSkippedType($commonType)) {
+            return null;
+        }
+
+        if (isset($this->versionSpecificTypes[$commonType]) && \PHP_VERSION_ID < $this->versionSpecificTypes[$commonType]) {
+            return null;
+        }
+
+        if (isset($this->scalarTypes[$commonType])) {
+            if (false === $this->configuration['scalar_types']) {
+                return null;
+            }
+        } elseif (1 !== Preg::match($this->classRegex, $commonType)) {
+            return null;
+        }
+
+        return [$commonType, $isNullable];
+    }
 
     final protected function isValidSyntax($code)
     {

--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -13,6 +13,8 @@
 namespace PhpCsFixer\DocBlock;
 
 use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 
 /**
  * This class represents a docblock.
@@ -40,15 +42,30 @@ class DocBlock
     private $annotations;
 
     /**
+     * @var null|NamespaceAnalysis
+     */
+    private $namespace;
+
+    /**
+     * @var NamespaceUseAnalysis[]
+     */
+    private $namespaceUses;
+
+    /**
      * Create a new docblock instance.
      *
-     * @param string $content
+     * @param string                 $content
+     * @param null|NamespaceAnalysis $namespace
+     * @param NamespaceUseAnalysis[] $namespaceUses
      */
-    public function __construct($content)
+    public function __construct($content, $namespace = null, array $namespaceUses = [])
     {
         foreach (Preg::split('/([^\n\r]+\R*)/', $content, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $line) {
             $this->lines[] = new Line($line);
         }
+
+        $this->namespace = $namespace;
+        $this->namespaceUses = $namespaceUses;
     }
 
     /**
@@ -101,7 +118,7 @@ class DocBlock
             if ($this->lines[$index]->containsATag()) {
                 // get all the lines that make up the annotation
                 $lines = \array_slice($this->lines, $index, $this->findAnnotationLength($index), true);
-                $annotation = new Annotation($lines);
+                $annotation = new Annotation($lines, $this->namespace, $this->namespaceUses);
                 // move the index to the end of the annotation to avoid
                 // checking it again because we know the lines inside the
                 // current annotation cannot be part of another annotation

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\DocBlock;
+
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
+
+/**
+ * @internal
+ */
+final class TypeExpression
+{
+    /**
+     * Regex to match any types, shall be used with `x` modifier.
+     */
+    const REGEX_TYPES = '
+    # <simple> is any non-array, non-generic, non-alternated type, eg `int` or `\Foo`
+    # <array> is array of <simple>, eg `int[]` or `\Foo[]`
+    # <generic> is generic collection type, like `array<string, int>`, `Collection<Item>` and more complex like `Collection<int, \null|SubCollection<string>>`
+    # <type> is <simple>, <array> or <generic> type, like `int`, `bool[]` or `Collection<ItemKey, ItemVal>`
+    # <types> is one or more types alternated via `|`, like `int|bool[]|Collection<ItemKey, ItemVal>`
+    (?<types>
+        (?<type>
+            (?<array>
+                (?&simple)(\[\])*
+            )
+            |
+            (?<simple>
+                [@$?]?[\\\\\w]+
+            )
+            |
+            (?<generic>
+                (?&simple)
+                <
+                    (?:(?&types),\s*)?(?:(?&types)|(?&generic))
+                >
+            )
+        )
+        (?:
+            \|
+            (?:(?&simple)|(?&array)|(?&generic))
+        )*
+    )
+    ';
+
+    /**
+     * @var string[]
+     */
+    private $types = [];
+
+    /**
+     * @var null|NamespaceAnalysis
+     */
+    private $namespace;
+
+    /**
+     * @var NamespaceUseAnalysis[]
+     */
+    private $namespaceUses;
+
+    /**
+     * @param string                 $value
+     * @param null|NamespaceAnalysis $namespace
+     * @param NamespaceUseAnalysis[] $namespaceUses
+     */
+    public function __construct($value, $namespace, array $namespaceUses)
+    {
+        while ('' !== $value && false !== $value) {
+            Preg::match(
+                '{^'.self::REGEX_TYPES.'$}x',
+                $value,
+                $matches
+            );
+
+            $this->types[] = $matches['type'];
+            $value = substr($value, \strlen($matches['type']) + 1);
+        }
+
+        $this->namespace = $namespace;
+        $this->namespaceUses = $namespaceUses;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getTypes()
+    {
+        return $this->types;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getCommonType()
+    {
+        $aliases = [
+            'true' => 'bool',
+            'false' => 'bool',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'double' => 'float',
+            'real' => 'float',
+            'callback' => 'callable',
+        ];
+
+        $mainType = null;
+
+        foreach ($this->types as $type) {
+            if ('null' === $type) {
+                continue;
+            }
+
+            if (isset($aliases[$type])) {
+                $type = $aliases[$type];
+            } elseif (1 === Preg::match('/\[\]$/', $type)) {
+                $type = 'array';
+            } elseif (1 === Preg::match('/^(.+?)</', $type, $matches)) {
+                $type = $matches[1];
+            }
+
+            if (null === $mainType || $type === $mainType) {
+                $mainType = $type;
+
+                continue;
+            }
+
+            $mainType = $this->getParentType($type, $mainType);
+
+            if (null === $mainType) {
+                return null;
+            }
+        }
+
+        return $mainType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function allowsNull()
+    {
+        foreach ($this->types as $type) {
+            if (\in_array($type, ['null', 'mixed'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getParentType($type1, $type2)
+    {
+        $types = [
+            $this->normalize($type1),
+            $this->normalize($type2),
+        ];
+        natcasesort($types);
+        $types = implode('|', $types);
+
+        $parents = [
+            'array|iterable' => 'iterable',
+            'array|Traversable' => 'iterable',
+            'iterable|Traversable' => 'iterable',
+            'self|static' => 'self',
+        ];
+
+        if (isset($parents[$types])) {
+            return $parents[$types];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return string
+     */
+    private function normalize($type)
+    {
+        $aliases = [
+            'true' => 'bool',
+            'false' => 'bool',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'double' => 'float',
+            'real' => 'float',
+            'callback' => 'callable',
+        ];
+
+        if (isset($aliases[$type])) {
+            return $aliases[$type];
+        }
+
+        if (\in_array($type, [
+            'void',
+            'null',
+            'bool',
+            'int',
+            'float',
+            'string',
+            'array',
+            'iterable',
+            'object',
+            'callable',
+            'resource',
+            'mixed',
+        ], true)) {
+            return $type;
+        }
+
+        if (1 === Preg::match('/\[\]$/', $type)) {
+            return 'array';
+        }
+
+        if (1 === Preg::match('/^(.+?)</', $type, $matches)) {
+            return $matches[1];
+        }
+
+        if (0 === strpos($type, '\\')) {
+            return substr($type, 1);
+        }
+
+        foreach ($this->namespaceUses as $namespaceUse) {
+            if ($namespaceUse->getShortName() === $type) {
+                return $namespaceUse->getFullName();
+            }
+        }
+
+        if (null === $this->namespace || '' === $this->namespace->getShortName()) {
+            return $type;
+        }
+
+        return "{$this->namespace->getFullName()}\\{$type}";
+    }
+}

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -13,15 +13,9 @@
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
-use PhpCsFixer\DocBlock\Annotation;
-use PhpCsFixer\DocBlock\DocBlock;
-use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
-use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
-use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
 use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
-use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -29,7 +23,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  */
-final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer implements ConfigurationDefinitionFixerInterface
+final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
 {
     /**
      * @var array<int, array<int, int|string>>
@@ -41,39 +35,13 @@ final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
     ];
 
     /**
-     * @var array<string, int>
-     */
-    private $versionSpecificTypes = [
-        'void' => 70100,
-        'iterable' => 70100,
-        'object' => 70200,
-    ];
-
-    /**
-     * @var array<string, string>
-     */
-    private $scalarTypes = [
-        'bool' => 'bool',
-        'true' => 'bool',
-        'false' => 'bool',
-        'float' => 'float',
-        'int' => 'int',
-        'string' => 'string',
-    ];
-
-    /**
-     * @var array<string, bool>
+     * @var array<string, true>
      */
     private $skippedTypes = [
         'mixed' => true,
         'resource' => true,
         'null' => true,
     ];
-
-    /**
-     * @var string
-     */
-    private $classRegex = '/^\\\\?[a-zA-Z_\\x7f-\\xff](?:\\\\?[a-zA-Z0-9_\\x7f-\\xff]+)*(?<array>\[\])*$/';
 
     /**
      * {@inheritdoc}
@@ -162,25 +130,9 @@ final class Foo {
         return 13;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isRisky()
+    protected function isSkippedType($type)
     {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function createConfigurationDefinition()
-    {
-        return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('scalar_types', 'Fix also scalar types; may have unexpected behaviour due to PHP bad type coercion system.'))
-                ->setAllowedTypes(['bool'])
-                ->setDefault(true)
-                ->getOption(),
-        ]);
+        return isset($this->skippedTypes[$type]);
     }
 
     /**
@@ -206,73 +158,19 @@ final class Foo {
                 continue;
             }
 
-            $returnTypeAnnotation = $this->findReturnAnnotations($tokens, $index);
+            $returnTypeAnnotation = $this->findAnnotations('return', $tokens, $index);
 
             if (1 !== \count($returnTypeAnnotation)) {
                 continue;
             }
 
-            $returnTypeAnnotation = current($returnTypeAnnotation);
-            $types = array_values($returnTypeAnnotation->getTypes());
-            $typesCount = \count($types);
+            $typeInfo = $this->getCommonTypeFromAnnotation(current($returnTypeAnnotation), true);
 
-            if (1 > $typesCount || 2 < $typesCount) {
+            if (null === $typeInfo) {
                 continue;
             }
 
-            $isNullable = false;
-            $returnType = current($types);
-
-            if (2 === $typesCount) {
-                $null = $types[0];
-                $returnType = $types[1];
-                if ('null' !== $null) {
-                    $null = $types[1];
-                    $returnType = $types[0];
-                }
-
-                if ('null' !== $null) {
-                    continue;
-                }
-
-                $isNullable = true;
-
-                if (\PHP_VERSION_ID < 70100) {
-                    continue;
-                }
-
-                if ('void' === $returnType) {
-                    continue;
-                }
-            }
-
-            if ('static' === $returnType) {
-                $returnType = \PHP_VERSION_ID < 80000 ? 'self' : 'static';
-            }
-
-            if (isset($this->skippedTypes[$returnType])) {
-                continue;
-            }
-
-            if (isset($this->versionSpecificTypes[$returnType]) && \PHP_VERSION_ID < $this->versionSpecificTypes[$returnType]) {
-                continue;
-            }
-
-            if (isset($this->scalarTypes[$returnType])) {
-                if (false === $this->configuration['scalar_types']) {
-                    continue;
-                }
-
-                $returnType = $this->scalarTypes[$returnType];
-            } else {
-                if (1 !== Preg::match($this->classRegex, $returnType, $matches)) {
-                    continue;
-                }
-
-                if (isset($matches['array'])) {
-                    $returnType = 'array';
-                }
-            }
+            list($returnType, $isNullable) = $typeInfo;
 
             $startIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
 
@@ -284,7 +182,18 @@ final class Foo {
                 continue;
             }
 
-            $this->fixFunctionDefinition($tokens, $startIndex, $isNullable, $returnType);
+            $endFuncIndex = $tokens->getPrevTokenOfKind($startIndex, [')']);
+
+            $tokens->insertAt(
+                $endFuncIndex + 1,
+                array_merge(
+                    [
+                        new Token([CT::T_TYPE_COLON, ':']),
+                        new Token([T_WHITESPACE, ' ']),
+                    ],
+                    $this->createTypeDeclarationTokens($returnType, $isNullable)
+                )
+            );
         }
     }
 
@@ -301,84 +210,5 @@ final class Foo {
         $nextIndex = $tokens->getNextMeaningfulToken($endFuncIndex);
 
         return $tokens[$nextIndex]->isGivenKind(CT::T_TYPE_COLON);
-    }
-
-    /**
-     * @param int    $index      The index of the end of the function definition line, EG at { or ;
-     * @param bool   $isNullable
-     * @param string $returnType
-     */
-    private function fixFunctionDefinition(Tokens $tokens, $index, $isNullable, $returnType)
-    {
-        static $specialTypes = [
-            'array' => [CT::T_ARRAY_TYPEHINT, 'array'],
-            'callable' => [T_CALLABLE, 'callable'],
-            'static' => [T_STATIC, 'static'],
-        ];
-
-        $newTokens = [
-            new Token([CT::T_TYPE_COLON, ':']),
-            new Token([T_WHITESPACE, ' ']),
-        ];
-
-        if (true === $isNullable) {
-            $newTokens[] = new Token([CT::T_NULLABLE_TYPE, '?']);
-        }
-
-        if (isset($specialTypes[$returnType])) {
-            $newTokens[] = new Token($specialTypes[$returnType]);
-        } else {
-            $returnTypeUnqualified = ltrim($returnType, '\\');
-
-            if (isset($this->scalarTypes[$returnTypeUnqualified]) || isset($this->versionSpecificTypes[$returnTypeUnqualified])) {
-                // 'scalar's, 'void', 'iterable' and 'object' must be unqualified
-                $newTokens[] = new Token([T_STRING, $returnTypeUnqualified]);
-            } else {
-                foreach (explode('\\', $returnType) as $nsIndex => $value) {
-                    if (0 === $nsIndex && '' === $value) {
-                        continue;
-                    }
-
-                    if (0 < $nsIndex) {
-                        $newTokens[] = new Token([T_NS_SEPARATOR, '\\']);
-                    }
-
-                    $newTokens[] = new Token([T_STRING, $value]);
-                }
-            }
-        }
-
-        $endFuncIndex = $tokens->getPrevTokenOfKind($index, [')']);
-        $tokens->insertAt($endFuncIndex + 1, $newTokens);
-    }
-
-    /**
-     * Find all the return annotations in the function's PHPDoc comment.
-     *
-     * @param int $index The index of the function token
-     *
-     * @return Annotation[]
-     */
-    private function findReturnAnnotations(Tokens $tokens, $index)
-    {
-        do {
-            $index = $tokens->getPrevNonWhitespace($index);
-        } while ($tokens[$index]->isGivenKind([
-            T_COMMENT,
-            T_ABSTRACT,
-            T_FINAL,
-            T_PRIVATE,
-            T_PROTECTED,
-            T_PUBLIC,
-            T_STATIC,
-        ]));
-
-        if (!$tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
-            return [];
-        }
-
-        $doc = new DocBlock($tokens[$index]->getContent());
-
-        return $doc->getAnnotationsOfType('return');
     }
 }

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -232,11 +232,11 @@ class Foo {
         );
 
         foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
-            if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
+            $argumentName = $annotation->getVariableName();
+
+            if (null === $argumentName) {
                 continue;
             }
-
-            $argumentName = $matches[1];
 
             if (!isset($argumentsInfo[$argumentName]) && $this->configuration['allow_unused_params']) {
                 continue;

--- a/src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+++ b/src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tokenizer\Analyzer;
 
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -31,6 +32,22 @@ final class NamespaceUsesAnalyzer
         $useIndexes = $tokenAnalyzer->getImportUseIndexes();
 
         return $this->getDeclarations($tokens, $useIndexes);
+    }
+
+    /**
+     * @return NamespaceUseAnalysis[]
+     */
+    public function getDeclarationsInNamespace(Tokens $tokens, NamespaceAnalysis $namespace)
+    {
+        $namespaceUses = [];
+
+        foreach ($this->getDeclarationsFromTokens($tokens) as $namespaceUse) {
+            if ($namespaceUse->getStartIndex() >= $namespace->getScopeStartIndex() && $namespaceUse->getStartIndex() <= $namespace->getScopeEndIndex()) {
+                $namespaceUses[] = $namespaceUse;
+            }
+        }
+
+        return $namespaceUses;
     }
 
     /**

--- a/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+++ b/src/Tokenizer/Analyzer/NamespacesAnalyzer.php
@@ -68,4 +68,24 @@ final class NamespacesAnalyzer
 
         return $namespaces;
     }
+
+    /**
+     * @param int $index
+     *
+     * @return NamespaceAnalysis
+     */
+    public function getNamespaceAt(Tokens $tokens, $index)
+    {
+        if (!$tokens->offsetExists($index)) {
+            throw new \InvalidArgumentException("Token index {$index} does not exist.");
+        }
+
+        foreach ($this->getDeclarations($tokens) as $namespace) {
+            if ($namespace->getScopeStartIndex() <= $index && $namespace->getScopeEndIndex() >= $index) {
+                return $namespace;
+            }
+        }
+
+        throw new \LogicException("Unable to get the namespace at index {$index}.");
+    }
 }

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\DocBlock;
+
+use PhpCsFixer\DocBlock\TypeExpression;
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
+
+/**
+ * @covers \PhpCsFixer\DocBlock\TypeExpression
+ *
+ * @internal
+ */
+final class TypeExpressionTest extends TestCase
+{
+    /**
+     * @param string   $typesExpression
+     * @param string[] $expectedTypes
+     *
+     * @dataProvider provideGetTypesCases
+     */
+    public function testGetTypes($typesExpression, $expectedTypes)
+    {
+        $expression = new TypeExpression($typesExpression, null, []);
+        static::assertSame($expectedTypes, $expression->getTypes());
+    }
+
+    public function provideGetTypesCases()
+    {
+        yield ['int', ['int']];
+        yield ['Foo[][]', ['Foo[][]']];
+        yield ['int[]', ['int[]']];
+        yield ['int[]|null', ['int[]', 'null']];
+        yield ['int[]|null|?int|array', ['int[]', 'null', '?int', 'array']];
+        yield ['null|Foo\Bar|\Baz\Bax|int[]', ['null', 'Foo\Bar', '\Baz\Bax', 'int[]']];
+        yield ['gen<int>', ['gen<int>']];
+        yield ['int|gen<int>', ['int', 'gen<int>']];
+        yield ['\int|\gen<\int, \bool>', ['\int', '\gen<\int, \bool>']];
+        yield ['gen<int,  int>', ['gen<int,  int>']];
+        yield ['gen<int,  bool|string>', ['gen<int,  bool|string>']];
+        yield ['gen<int,  string[]>', ['gen<int,  string[]>']];
+        yield ['gen<int,  gener<string, bool>>', ['gen<int,  gener<string, bool>>']];
+        yield ['gen<int,  gener<string, null|bool>>', ['gen<int,  gener<string, null|bool>>']];
+        yield ['null|gen<int,  gener<string, bool>>|int|string[]', ['null', 'gen<int,  gener<string, bool>>', 'int', 'string[]']];
+        yield ['null|gen<int,  gener<string, bool>>|int|array<int, string>|string[]', ['null', 'gen<int,  gener<string, bool>>', 'int', 'array<int, string>', 'string[]']];
+        yield ['this', ['this']];
+        yield ['@this', ['@this']];
+        yield ['$SELF|int', ['$SELF', 'int']];
+        yield ['array<string|int, string>', ['array<string|int, string>']];
+    }
+
+    /**
+     * @param string                 $typesExpression
+     * @param null|string            $expectedCommonType
+     * @param NamespaceUseAnalysis[] $namespaceUses
+     *
+     * @dataProvider provideCommonTypeCases
+     */
+    public function testGetCommonType($typesExpression, $expectedCommonType, NamespaceAnalysis $namespace = null, array $namespaceUses = [])
+    {
+        $expression = new TypeExpression($typesExpression, $namespace, $namespaceUses);
+        static::assertSame($expectedCommonType, $expression->getCommonType());
+    }
+
+    public function provideCommonTypeCases()
+    {
+        $globalNamespace = new NamespaceAnalysis('', '', 0, 999, 0, 999);
+        $appNamespace = new NamespaceAnalysis('App', 'App', 0, 999, 0, 999);
+
+        $useTraversable = new NamespaceUseAnalysis('Traversable', 'Traversable', false, 0, 0, NamespaceUseAnalysis::TYPE_CLASS);
+        $useObjectAsTraversable = new NamespaceUseAnalysis('Foo', 'Traversable', false, 0, 0, NamespaceUseAnalysis::TYPE_CLASS);
+
+        yield ['true', 'bool'];
+        yield ['false', 'bool'];
+        yield ['bool', 'bool'];
+        yield ['int', 'int'];
+        yield ['float', 'float'];
+        yield ['string', 'string'];
+        yield ['array', 'array'];
+        yield ['object', 'object'];
+        yield ['self', 'self'];
+        yield ['static', 'static'];
+        yield ['bool[]', 'array'];
+        yield ['int[]', 'array'];
+        yield ['float[]', 'array'];
+        yield ['string[]', 'array'];
+        yield ['array[]', 'array'];
+        yield ['bool[][]', 'array'];
+        yield ['int[][]', 'array'];
+        yield ['float[][]', 'array'];
+        yield ['string[][]', 'array'];
+        yield ['array[][]', 'array'];
+        yield ['array|iterable', 'iterable'];
+        yield ['iterable|array', 'iterable'];
+        yield ['array|Traversable', 'iterable'];
+        yield ['array|\Traversable', 'iterable'];
+        yield ['array|Traversable', 'iterable', $globalNamespace];
+        yield ['iterable|Traversable', 'iterable'];
+        yield ['array<string>', 'array'];
+        yield ['array<int, string>', 'array'];
+        yield ['iterable<string>', 'iterable'];
+        yield ['iterable<int, string>', 'iterable'];
+        yield ['\Traversable<string>', '\Traversable'];
+        yield ['Traversable<int, string>', 'Traversable'];
+        yield ['Collection<string>', 'Collection'];
+        yield ['Collection<int, string>', 'Collection'];
+        yield ['array<int, string>|iterable<int, string>', 'iterable'];
+        yield ['int[]|string[]', 'array'];
+        yield ['int|null', 'int'];
+        yield ['null|int', 'int'];
+        yield ['void', 'void'];
+        yield ['array|Traversable', 'iterable', null, [$useTraversable]];
+        yield ['array|Traversable', 'iterable', $globalNamespace, [$useTraversable]];
+        yield ['array|Traversable', 'iterable', $appNamespace, [$useTraversable]];
+        yield ['self|static', 'self'];
+
+        yield ['array|Traversable', null, null, [$useObjectAsTraversable]];
+        yield ['array|Traversable', null, $globalNamespace, [$useObjectAsTraversable]];
+        yield ['array|Traversable', null, $appNamespace, [$useObjectAsTraversable]];
+        yield ['bool|int', null];
+        yield ['string|bool', null];
+        yield ['array<int, string>|Collection<int, string>', null];
+    }
+
+    /**
+     * @param string $typesExpression
+     * @param bool   $expectNullAllowed
+     *
+     * @dataProvider provideAllowsNullCases
+     */
+    public function testAllowsNull($typesExpression, $expectNullAllowed)
+    {
+        $expression = new TypeExpression($typesExpression, null, []);
+        static::assertSame($expectNullAllowed, $expression->allowsNull());
+    }
+
+    public function provideAllowsNullCases()
+    {
+        yield ['null', true];
+        yield ['mixed', true];
+        yield ['null|mixed', true];
+        yield ['int|bool|null', true];
+        yield ['int|bool|mixed', true];
+
+        yield ['int', false];
+        yield ['bool', false];
+        yield ['string', false];
+    }
+}

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -34,8 +34,11 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
     public function testFix($expected, $input = null, $versionSpecificFix = null, $config = null)
     {
         if (
-            (null !== $input && \PHP_VERSION_ID < 70000)
-            || (null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix)
+            null !== $input
+            && (
+                \PHP_VERSION_ID < 70000
+                || (null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix)
+            )
         ) {
             $expected = $input;
             $input = null;
@@ -221,7 +224,12 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                     }
                 ',
             ],
-            'static is skipped' => [
+            'report static as self' => [
+                '<?php
+                    class Foo {
+                        /** @param static $foo */ function my_foo(self $foo) {}
+                    }
+                ',
                 '<?php
                     class Foo {
                         /** @param static $foo */ function my_foo($foo) {}
@@ -303,7 +311,7 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                 70100,
             ],
             'array and iterable param' => [
-                '<?php /** @param Foo[]|iterable $foo */ function my_foo(array $foo) {}',
+                '<?php /** @param Foo[]|iterable $foo */ function my_foo(iterable $foo) {}',
                 '<?php /** @param Foo[]|iterable $foo */ function my_foo($foo) {}',
                 70100,
             ],
@@ -317,10 +325,12 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @param null|object $foo */ function my_foo($foo) {}',
                 70200,
             ],
-            'generics with single type is not supported' => [
+            'generics with single type' => [
+                '<?php /** @param array<foo> $foo */ function my_foo(array $foo) {}',
                 '<?php /** @param array<foo> $foo */ function my_foo($foo) {}',
             ],
-            'generics with multiple types are not supported' => [
+            'generics with multiple types' => [
+                '<?php /** @param array<int, string> $foo */ function my_foo(array $foo) {}',
                 '<?php /** @param array<int, string> $foo */ function my_foo($foo) {}',
             ],
             'stop searching last token' => [
@@ -337,6 +347,81 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
             ],
             'void as type in phpdoc' => [
                 '<?php /** @param void $bar */ function foo($bar) {}',
+            ],
+            'array and traversable' => [
+                '<?php /** @param array|Traversable $foo */ function my_foo(iterable $foo) {}',
+                '<?php /** @param array|Traversable $foo */ function my_foo($foo) {}',
+                70100,
+            ],
+            'array and traversable with leading slash' => [
+                '<?php /** @param array|\Traversable $foo */ function my_foo(iterable $foo) {}',
+                '<?php /** @param array|\Traversable $foo */ function my_foo($foo) {}',
+                70100,
+            ],
+            'array and traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     /** @param array|Traversable $foo */
+                     function my_foo($foo) {}
+                ',
+            ],
+            'array and traversable with leading slash in a namespace' => [
+                '<?php
+                     namespace App;
+                     /** @param array|\Traversable $foo */
+                     function my_foo(iterable $foo) {}
+                ',
+                '<?php
+                     namespace App;
+                     /** @param array|\Traversable $foo */
+                     function my_foo($foo) {}
+                ',
+                70100,
+            ],
+            'array and imported traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     use Traversable;
+                     /** @param array|Traversable $foo */
+                     function my_foo(iterable $foo) {}
+                ',
+                '<?php
+                     namespace App;
+                     use Traversable;
+                     /** @param array|Traversable $foo */
+                     function my_foo($foo) {}
+                ',
+                70100,
+            ],
+            'array and object aliased as traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     use Foo as Traversable;
+                     /** @param array|Traversable $foo */
+                     function my_foo($foo) {}
+                ',
+                null,
+                70100,
+            ],
+            'array of object and traversable' => [
+                '<?php /** @param Foo[]|Traversable $foo */ function my_foo(iterable $foo) {}',
+                '<?php /** @param Foo[]|Traversable $foo */ function my_foo($foo) {}',
+                70100,
+            ],
+            'array of object and iterable' => [
+                '<?php /** @param Foo[]|iterable $foo */ function my_foo(iterable $foo) {}',
+                '<?php /** @param Foo[]|iterable $foo */ function my_foo($foo) {}',
+                70100,
+            ],
+            'array of string and array of int' => [
+                '<?php /** @param string[]|int[] $foo */ function my_foo(array $foo) {}',
+                '<?php /** @param string[]|int[] $foo */ function my_foo($foo) {}',
+            ],
+            'do not fix scalar types when configured as such' => [
+                '<?php /** @param int $foo */ function my_foo($foo) {}',
+                null,
+                null,
+                ['scalar_types' => false],
             ],
         ];
     }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -33,7 +33,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
      */
     public function testFix($expected, $input = null, $versionSpecificFix = null, array $config = [])
     {
-        if (null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix) {
+        if (null !== $input && null !== $versionSpecificFix && \PHP_VERSION_ID < $versionSpecificFix) {
             $expected = $input;
             $input = null;
         }
@@ -219,7 +219,8 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             'skip mixed nullable types' => [
                 '<?php /** @return null|Foo|Bar */ function my_foo() {}',
             ],
-            'skip generics' => [
+            'generics' => [
+                '<?php /** @return array<int, bool> */ function my_foo(): array {}',
                 '<?php /** @return array<int, bool> */ function my_foo() {}',
             ],
             'array of types' => [
@@ -255,6 +256,75 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                         } // comment 3
                     }
                 ',
+            ],
+            'array and traversable' => [
+                '<?php /** @return array|Traversable */ function my_foo(): iterable {}',
+                '<?php /** @return array|Traversable */ function my_foo() {}',
+                70100,
+            ],
+            'array and traversable with leading slash' => [
+                '<?php /** @return array|\Traversable */ function my_foo(): iterable {}',
+                '<?php /** @return array|\Traversable */ function my_foo() {}',
+                70100,
+            ],
+            'array and traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     /** @return array|Traversable */
+                     function my_foo() {}
+                ',
+            ],
+            'array and traversable with leading slash in a namespace' => [
+                '<?php
+                     namespace App;
+                     /** @return array|\Traversable */
+                     function my_foo(): iterable {}
+                ',
+                '<?php
+                     namespace App;
+                     /** @return array|\Traversable */
+                     function my_foo() {}
+                ',
+                70100,
+            ],
+            'array and imported traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     use Traversable;
+                     /** @return array|Traversable */
+                     function my_foo(): iterable {}
+                ',
+                '<?php
+                     namespace App;
+                     use Traversable;
+                     /** @return array|Traversable */
+                     function my_foo() {}
+                ',
+                70100,
+            ],
+            'array and object aliased as traversable in a namespace' => [
+                '<?php
+                     namespace App;
+                     use Foo as Traversable;
+                     /** @return array|Traversable */
+                     function my_foo() {}
+                ',
+                null,
+                70100,
+            ],
+            'array of object and traversable' => [
+                '<?php /** @return Foo[]|Traversable */ function my_foo(): iterable {}',
+                '<?php /** @return Foo[]|Traversable */ function my_foo() {}',
+                70100,
+            ],
+            'array of object and iterable' => [
+                '<?php /** @return Foo[]|iterable */ function my_foo(): iterable {}',
+                '<?php /** @return Foo[]|iterable */ function my_foo() {}',
+                70100,
+            ],
+            'array of string and array of int' => [
+                '<?php /** @return string[]|int[] */ function my_foo(): array {}',
+                '<?php /** @return string[]|int[] */ function my_foo() {}',
             ],
         ];
 

--- a/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
@@ -37,7 +37,10 @@ final class NamespacesAnalyzerTest extends TestCase
         $tokens = Tokens::fromCode($code);
         $analyzer = new NamespacesAnalyzer();
 
-        static::assertSame(serialize($expected), serialize(($analyzer->getDeclarations($tokens))));
+        static::assertSame(
+            serialize($expected),
+            serialize($analyzer->getDeclarations($tokens))
+        );
     }
 
     public function provideNamespacesCases()
@@ -81,6 +84,77 @@ final class NamespacesAnalyzerTest extends TestCase
                     17
                 ),
             ]],
+        ];
+    }
+
+    /**
+     * @param string $code
+     * @param int    $index
+     *
+     * @dataProvider provideGetNamespaceAtCases
+     */
+    public function testGetNamespaceAt($code, $index, NamespaceAnalysis $expected)
+    {
+        $tokens = Tokens::fromCode($code);
+        $analyzer = new NamespacesAnalyzer();
+
+        static::assertSame(
+            serialize($expected),
+            serialize($analyzer->getNamespaceAt($tokens, $index))
+        );
+    }
+
+    public function provideGetNamespaceAtCases()
+    {
+        return [
+            [
+                '<?php // no namespaces',
+                1,
+                new NamespaceAnalysis(
+                    '',
+                    '',
+                    0,
+                    0,
+                    0,
+                    1
+                ),
+            ],
+            [
+                '<?php namespace Foo\Bar;',
+                5,
+                new NamespaceAnalysis(
+                    'Foo\Bar',
+                    'Bar',
+                    1,
+                    6,
+                    1,
+                    6
+                ),
+            ],
+            [
+                '<?php namespace Foo\Bar{}; namespace Foo\Baz {};',
+                5,
+                new NamespaceAnalysis(
+                    'Foo\Bar',
+                    'Bar',
+                    1,
+                    6,
+                    1,
+                    7
+                ),
+            ],
+            [
+                '<?php namespace Foo\Bar{}; namespace Foo\Baz {};',
+                13,
+                new NamespaceAnalysis(
+                    'Foo\Baz',
+                    'Baz',
+                    10,
+                    16,
+                    10,
+                    17
+                ),
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR:
* refactors parts of `PhpdocToParamTypeFixer` and `PhpdocToReturnTypeFixer` to ease sharing common logic.
* implements some points of #4511