### PR TITLE
Import cannot be used after `::` so can be removed

### DIFF
--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -90,7 +90,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         foreach ((new NamespacesAnalyzer())->getDeclarations($tokens) as $namespace) {
             $currentNamespaceUseDeclarations = array_filter(
                 $useDeclarations,
-                function (NamespaceUseAnalysis $useDeclaration) use ($namespace) {
+                static function (NamespaceUseAnalysis $useDeclaration) use ($namespace) {
                     return
                         $useDeclaration->getStartIndex() >= $namespace->getScopeStartIndex()
                         && $useDeclaration->getEndIndex() <= $namespace->getScopeEndIndex()
@@ -143,7 +143,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
                 if (
                     0 === strcasecmp($shortName, $token->getContent())
-                    && !$prevMeaningfulToken->isGivenKind([T_NS_SEPARATOR, T_CONST, T_OBJECT_OPERATOR])
+                    && !$prevMeaningfulToken->isGivenKind([T_NS_SEPARATOR, T_CONST, T_OBJECT_OPERATOR, T_DOUBLE_COLON])
                 ) {
                     return true;
                 }
@@ -151,10 +151,12 @@ final class NoUnusedImportsFixer extends AbstractFixer
                 continue;
             }
 
-            if ($token->isComment() && Preg::match(
-                '/(?<![[:alnum:]])(?<!\\\\)'.$shortName.'(?![[:alnum:]])/i',
-                $token->getContent()
-            )) {
+            if ($token->isComment()
+                && Preg::match(
+                    '/(?<![[:alnum:]])(?<!\\\\)'.$shortName.'(?![[:alnum:]])/i',
+                    $token->getContent()
+                )
+            ) {
                 return true;
             }
         }

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -506,12 +506,15 @@ $bar = null;
 EOF
                 ,
             ],
-            'property_name' => [
+            'property name, method name, static method call, static property' => [
                 <<<'EOF'
 <?php
 
 
 $foo->bar = null;
+$foo->bar();
+$foo::bar();
+$foo::bar;
 EOF
                 ,
                 <<<'EOF'
@@ -520,6 +523,9 @@ EOF
 use Foo\Bar;
 
 $foo->bar = null;
+$foo->bar();
+$foo::bar();
+$foo::bar;
 EOF
                 ,
             ],


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4582