### PR TITLE
ClassKeywordRemoveFixer: Add support of namespaces

### DIFF
--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -226,7 +226,7 @@ $className = Baz::class;
                     continue;
                 }
 
-                $classImport = $namespace->getFullName()."\\".$classString;
+                $classImport = $namespace->getFullName().'\\'.$classString;
             }
         }
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -226,7 +226,7 @@ $className = Baz::class;
                     continue;
                 }
 
-                $classImport = $namespace->getFullName().'\\'.$classString;
+                $classString = $namespace->getFullName().'\\'.$classString;
             }
         }
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\LanguageConstruct;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -211,6 +212,21 @@ $className = Baz::class;
                 $classImport = $import;
 
                 break;
+            }
+        }
+
+        if ($classImport === false) {
+            $namespaces = (new NamespacesAnalyzer())->getDeclarations($tokens);
+            foreach ($namespaces as $namespace) {
+                if ('' === $namespace->getFullName()) {
+                    continue;
+                }
+
+                if ($classIndex < $namespace->getScopeStartIndex() || $classIndex > $namespace->getScopeEndIndex()) {
+                    continue;
+                }
+
+                $classImport = $namespace->getFullName() . "\\" . $classString;
             }
         }
 

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -215,7 +215,7 @@ $className = Baz::class;
             }
         }
 
-        if ($classImport === false) {
+        if (false === $classImport) {
             $namespaces = (new NamespacesAnalyzer())->getDeclarations($tokens);
             foreach ($namespaces as $namespace) {
                 if ('' === $namespace->getFullName()) {
@@ -226,7 +226,7 @@ $className = Baz::class;
                     continue;
                 }
 
-                $classImport = $namespace->getFullName() . "\\" . $classString;
+                $classImport = $namespace->getFullName()."\\".$classString;
             }
         }
 

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -245,6 +245,16 @@ DateTime:: # a
                 }
                 ',
             ],
+            [
+                '<?php
+                namespace Foo;
+                var_dump(\'Foo\\Bar\\Baz\');
+                ',
+                '<?php
+                namespace Foo;
+                var_dump(Bar\Baz::class);
+                ',
+            ],
         ];
     }
 

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -218,11 +218,31 @@ DateTime:: # a
             [
                 '<?php
                 namespace Foo\\Bar;
-                var_dump(Foo\\Bar\\Baz);
+                var_dump(\'Foo\\Bar\\Baz\');
                 ',
                 '<?php
                 namespace Foo\Bar;
                 var_dump(Baz::class);
+                '
+            ],
+            [
+                '<?php
+                namespace Space1 {
+                    var_dump(\'Space1\\Baz\');
+                }
+                
+                namespace Space2 {
+                    var_dump(\'Space2\\Baz\');
+                }
+                ',
+                '<?php
+                namespace Space1 {
+                    var_dump(Baz::class);
+                }
+                
+                namespace Space2 {
+                    var_dump(Baz::class);
+                }
                 '
             ]
         ];

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -215,6 +215,16 @@ DateTime:: # a
                 }
                 ',
             ],
+            [
+                '<?php
+                namespace Foo\\Bar;
+                var_dump(Foo\\Bar\\Baz);
+                ',
+                '<?php
+                namespace Foo\Bar;
+                var_dump(Baz::class);
+                '
+            ]
         ];
     }
 

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -223,7 +223,7 @@ DateTime:: # a
                 '<?php
                 namespace Foo\Bar;
                 var_dump(Baz::class);
-                '
+                ',
             ],
             [
                 '<?php
@@ -243,8 +243,8 @@ DateTime:: # a
                 namespace Space2 {
                     var_dump(Baz::class);
                 }
-                '
-            ]
+                ',
+            ],
         ];
     }
 

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -255,6 +255,16 @@ DateTime:: # a
                 var_dump(Bar\Baz::class);
                 ',
             ],
+            [
+                '<?php
+                namespace Foo\\Bar;
+                var_dump(\'Foo\\Bar\\Baz\');
+                ',
+                '<?php
+                namespace Foo\Bar;
+                var_dump(Baz::class);
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #4555

The modification is about validating 2 test cases:

**Case 1**:
Before:
```php
<?php
namespace Foo\Bar;
var_dump(Baz::class);
```

After:
```php
<?php
namespace Foo\Bar;
var_dump('Foo\Bar\Baz');
```

**Case 2**:

Before:
```php
<?php
namespace Space1 {
  var_dump(Baz::class);
}

namespace Space2 {
  var_dump(Baz::class);
}
```
After:
```php
<?php
namespace Space1 {
  var_dump('Space1\Baz');
}

namespace Space2 {
  var_dump('Space2\Baz');
}
```