### PR TITLE
Configure no_superfluous_phpdoc_tags for Symfony

### DIFF
--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -103,7 +103,7 @@ final class RuleSet implements RuleSetInterface
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
             'no_spaces_around_offset' => true,
-            'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
+            'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'allow_unused_params' => true],
             'no_trailing_comma_in_list_call' => true,
             'no_trailing_comma_in_singleline_array' => true,
             'no_unneeded_control_parentheses' => true,


### PR DESCRIPTION
Continuation of #4505 

Depends on:
- [x] #4606

Ref:
- https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4566#issuecomment-540728366

this PR is a placeholder.
codebase needs to be adjusted

cc @azjezz @nicolas-grekas