### PR TITLE
Remove workaround for dev-tools install reg. Phive

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -21,15 +21,6 @@ cd "$(dirname "$0")"
 
 mkdir -p bin
 
-###
-# temporary work-around: phive expects gpg2 as gpg, build box has gpg1 as gpg
-#   phive/phive:208 <https://github.com/phar-io/phive/issues/208>
-if [ "${TRAVIS-}" = true ]; then
-  sudo apt-get install dirmngr --install-recommends
-  [ ! -f "/usr/bin/gpg1"  ] && sudo mv -- "/usr/bin/gpg" "/usr/bin/gpg1"
-  sudo ln -sfT "/usr/bin/gpg2" "/usr/bin/gpg"
-fi
-
 VERSION_CB="2.0.0.2"
 VERSION_SC="stable"
 
@@ -65,6 +56,4 @@ composer info -D | sort
 
 echo λλλ phive packages
 
-# echo "debug: #phive/phive:208"
-# see above
 ./bin/phive install --trust-gpg-keys D2CCAC42F6295E7D,8E730BA25823D8B5


### PR DESCRIPTION
Removal of the temporary work-around to make Phive work on Travis. 2dadad5 (https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/2dadad5eb75eec98c8ccca4bb6f2668afae1038b#diff-3948854d59731218a3ce36138a86bcc3R24-R32).

Phive has been updated (0.13.2) to work in the Travis build of PHP-CS-Fixer.

NOTE: This was previously WIP, after updating / running w/ the fixed version problems to install Phive in the build can be seen for key download as keyservers are often down. This makes the build to fail early.

Phive-Issue: phar-io/phive#208 <https://github.com/phar-io/phive/issues/208>
Related-To: #4550 
Ref: 2dadad5eb75eec98c8ccca4bb6f2668afae1038b