### PR TITLE
Disallow PHP 7.4 failures on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,3 @@ jobs:
                     tags: true
             after_deploy:
                 - ./dev-tools/trigger-website.sh ${TRAVIS_TOKEN} ${TRAVIS_TAG}
-
-    allow_failures:
-        - php: 7.4snapshot


### PR DESCRIPTION
[PHP bug](https://bugs.php.net/bug.php?id=78575) has been closed. Looks like the actual bug was in `mikey179/vfsstream` (https://github.com/bovigo/vfsStream/pull/204). The fix has been merged and released so we can now disallow Travis CI failures.