### PR TITLE
README - Mark up as code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -679,13 +679,13 @@ Choose from the list of available rules:
 
 * **final_public_method_for_abstract_class**
 
-  All public methods of abstract classes should be final.
+  All ``public`` methods of ``abstract`` classes should be ``final``.
 
-  *Risky rule: risky when overriding public methods of abstract classes.*
+  *Risky rule: risky when overriding ``public`` methods of ``abstract`` classes.*
 
 * **final_static_access**
 
-  Converts ``static`` access to ``self`` access in final classes.
+  Converts ``static`` access to ``self`` access in ``final`` classes.
 
 * **fopen_flag_order** [@Symfony:risky, @PhpCsFixer:risky]
 
@@ -1775,7 +1775,7 @@ Choose from the list of available rules:
 
 * **self_static_accessor**
 
-  Inside a final class or anonymous class ``self`` should be preferred to
+  Inside a ``final`` class or anonymous class ``self`` should be preferred to
   ``static``.
 
 * **semicolon_after_instruction** [@Symfony, @PhpCsFixer]

--- a/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
@@ -50,7 +50,7 @@ final class FinalPublicMethodForAbstractClassFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'All public methods of abstract classes should be final.',
+            'All `public` methods of `abstract` classes should be `final`.',
             [
                 new CodeSample(
                     '<?php
@@ -65,7 +65,7 @@ abstract class AbstractMachine
             ],
             'Enforce API encapsulation in an inheritance architecture. '
             .'If you want to override a method, use the Template method pattern.',
-            'Risky when overriding public methods of abstract classes'
+            'Risky when overriding `public` methods of `abstract` classes'
         );
     }
 

--- a/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
+++ b/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
@@ -29,7 +29,7 @@ final class FinalStaticAccessFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Converts `static` access to `self` access in final classes.',
+            'Converts `static` access to `self` access in `final` classes.',
             [
                 new CodeSample(
                     '<?php

--- a/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
@@ -34,7 +34,7 @@ final class SelfStaticAccessorFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Inside a final class or anonymous class `self` should be preferred to `static`.',
+            'Inside a `final` class or anonymous class `self` should be preferred to `static`.',
             [
                 new CodeSample(
                     '<?php


### PR DESCRIPTION
This PR

* [x] marks up parts of fixer descriptions as code where it makes sense

Follows #3928, #4000.