### PR TITLE
FinalPublicMethodForAbstractClassFixer - Do not attempt to mark abstract public methods as final

### DIFF
--- a/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php
@@ -149,8 +149,8 @@ abstract class AbstractMachine
                 $prevIndex = $tokens->getPrevMeaningfulToken($index);
                 $prevToken = $tokens[$prevIndex];
             }
-            // skip already final methods
-            if ($prevToken->isGivenKind([T_FINAL])) {
+            // skip abstract or already final methods
+            if ($prevToken->isGivenKind([T_ABSTRACT, T_FINAL])) {
                 $index = $prevIndex;
 
                 continue;

--- a/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
@@ -93,6 +93,12 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
                 "<?php abstract class MyClass { {$fixed} }",
                 "<?php abstract class MyClass { {$original} }",
             ],
+            'abstract-class-with-abstract-public-methods' => [
+                '<?php abstract class MyClass {
+                    abstract public function foo();
+                    abstract public static function bar();
+                }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] asserts that the `FinalPublicMethodForAbstractClassFixer` does not mark an `abstract public`  method as `final`
* [x] adjusts the `FinalPublicMethodForAbstractClassFixer` to ignore `abstract public` methods

Follows #3928.