### PR TITLE
FullyQualifiedStrictTypesFixer - Ignore partial class names which look like FQCNs

### DIFF
--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -152,6 +152,11 @@ class SomeClass
         }
 
         $typeName = $type->getName();
+
+        if (0 !== strpos($typeName, '\\')) {
+            return;
+        }
+
         $shortType = (new TypeShortNameResolver())->resolve($tokens, $typeName);
         if ($shortType === $typeName) {
             return;

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -113,6 +113,27 @@ class SomeClass
     }
 }',
             ],
+            'Partial class name looks like FQCN' => [
+                '<?php
+
+namespace One;
+
+use Two\Three;
+
+class Two
+{
+    /**
+     * Note that for this example, the following classes exist:
+     *
+     * - One\Two
+     * - One\Two\Three
+     * - Two\Three\Four
+     */
+    public function three(Three\Four $four): Two\Three
+    {
+    }
+}',
+            ],
             'Test multi namespace fixes' => [
                 '<?php
 namespace Foo\Other {
@@ -247,6 +268,28 @@ class SomeClass
     }
 }',
             ],
+            'Partial class name looks like FQCN' => [
+                '<?php
+
+namespace One;
+
+use Two\Three;
+
+class Two
+{
+    /**
+     * Note that for this example, the following classes exist:
+     *
+     * - One\Two
+     * - One\Two\Three
+     * - Two\Three
+     */
+    public function three(Two\Three $three, Three $other)
+    {
+    }
+}',
+            ],
+
             'Test multi namespace fixes' => [
                 '<?php
 namespace Foo\Other {
@@ -405,6 +448,27 @@ use Foo\Bar\Baz;
 class SomeClass
 {
     public function doSomething(\Foo\Bar\SomeClass $foo, \Foo\Bar\Buz $buz, ?\Foo\Bar\Zoof\Buz $barbuz): ?\Foo\Bar\Baz
+    {
+    }
+}',
+            ],
+            'Partial class name looks like FQCN' => [
+                '<?php
+
+namespace One;
+
+use Two\Three;
+
+class Two
+{
+    /**
+     * Note that for this example, the following classes exist:
+     *
+     * - One\Two
+     * - One\Two\Three
+     * - Two\Three\Four
+     */
+    public function three(Three\Four $four): ?Two\Three
     {
     }
 }',


### PR DESCRIPTION
This PR

* [x] adds a failing test case
* [x] ignores types when they are not references relative to the root namespace