### PR TITLE
DX: move all dev dependencies to dev-tools

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,6 +35,7 @@ install:
 
 before_test:
     - cd C:\projects\php-cs-fixer
+    - php C:\tools\composer.phar remove --dev --no-update --working-dir=./dev-tools humbug/box localheinz/composer-normalize phpstan/phpstan-phpunit
     - php C:\tools\composer.phar update --no-ansi --no-interaction --no-progress --optimize-autoloader --prefer-stable --working-dir=dev-tools
     - php C:\tools\composer.phar info --direct --working-dir=dev-tools | sort
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,11 +35,11 @@ install:
 
 before_test:
     - cd C:\projects\php-cs-fixer
-    - php C:\tools\composer.phar update --optimize-autoloader --no-interaction --no-progress --prefer-stable --no-ansi
-    - php C:\tools\composer.phar info -D | sort
+    - php C:\tools\composer.phar update --no-ansi --no-interaction --no-progress --optimize-autoloader --prefer-stable --working-dir=dev-tools
+    - php C:\tools\composer.phar info --direct --working-dir=dev-tools | sort
 
 test_script:
     - cd C:\projects\php-cs-fixer
-    - vendor\bin\phpunit
+    - dev-tools\vendor\bin\phpunit
     - set PHP_CS_FIXER_FUTURE_MODE=1
     - php php-cs-fixer --diff --dry-run -v fix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
             - run: echo "memory_limit = 512M" > $(brew --prefix)/etc/php/7.2/conf.d/memory.ini
             - run: curl -sS https://getcomposer.org/installer | php
             - run: php composer.phar global show hirak/prestissimo -q || php composer.phar global require --no-interaction --no-progress --optimize-autoloader hirak/prestissimo
-            - run: php composer.phar install --optimize-autoloader --no-interaction --no-progress --no-suggest
-            - run: php composer.phar info -D | sort
+            - run: php composer.phar update --no-interaction --no-progress --no-suggest --optimize-autoloader --working-dir=./dev-tools
+            - run: php composer.phar info --direct --working-dir=./dev-tools | sort
 
             - save_cache:
                 key: cache-{{ checksum "composer.json" }}
@@ -27,5 +27,5 @@ jobs:
                     - ~/.composer
                     - ~/Library/Caches/Homebrew
 
-            - run: vendor/bin/phpunit
+            - run: ./dev-tools/vendor/bin/phpunit
             - run: PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer --diff --dry-run -v fix

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
         - COMPOSER_FLAGS=""
 
 before_install:
-    # turn off XDebug
+    # turn off Xdebug
     - phpenv config-rm xdebug.ini || return 0
 
     # Composer: boost installation
@@ -78,7 +78,7 @@ jobs:
             php: '5.6'
             env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             before_install:
-                # turn off XDebug
+                # turn off Xdebug
                 - phpenv config-rm xdebug.ini || return 0
 
                 # Composer: boost installation
@@ -93,7 +93,7 @@ jobs:
             php: '7.0'
             env: SYMFONY_DEPRECATIONS_HELPER=disabled PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="~4.1.0"
             before_install:
-                # turn off XDebug
+                # turn off Xdebug
                 - phpenv config-rm xdebug.ini || return 0
 
                 # Composer: boost installation
@@ -107,7 +107,7 @@ jobs:
             stage: Test
             php: '7.1'
             before_install:
-                # turn off XDebug
+                # turn off Xdebug
                 - phpenv config-rm xdebug.ini || return 0
 
                 # Composer: boost installation
@@ -139,7 +139,7 @@ jobs:
                 - if [ $COLLECT_COVERAGE == 0 ]; then travis_terminate 0; fi
 
                 ## regular `before_install`
-                # turn off XDebug
+                # turn off Xdebug
                 - phpenv config-rm xdebug.ini || return 0
 
                 # Composer: boost installation

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,15 @@ jobs:
             stage: Test
             php: 5.6
             env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+            before_install:
+                # turn off XDebug
+                - phpenv config-rm xdebug.ini || return 0
+
+                # Composer: boost installation
+                - composer global show hirak/prestissimo --quiet || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
+
+                # Require PHPUnit 8
+                - composer remove --dev --no-update --working-dir=./dev-tools humbug/box phpstan/phpstan-phpunit
 
         -
             <<: *STANDARD_TEST_JOB

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
 
         - &STANDARD_TEST_JOB
             stage: Fast Test
-            php: 7.3
+            php: 7.2
             install:
                 # Composer: enforce given Symfony components version
                 - if [ "$SYMFONY_VERSION" != "" ]; then composer global show symfony/flex -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS symfony/flex; fi
@@ -81,13 +81,13 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.1
+            php: 7.0
             env: SYMFONY_DEPRECATIONS_HELPER=disabled PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="~4.1.0"
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.2
+            php: 7.1
 
         -
             <<: *STANDARD_TEST_JOB

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
                 - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
             script:
-                - vendor/bin/phpunit || travis_terminate 1
+                - ./dev-tools/vendor/bin/phpunit || travis_terminate 1
                 - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer --diff --dry-run -v fix
 
         -
@@ -134,8 +134,8 @@ jobs:
                 # Make code compatible with PHPUnit 8
                 - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer fix --rules=void_return -q tests || return 0
             script:
-                - vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
-                - php vendor/bin/php-coveralls -v
+                - ./dev-tools/vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
+                - ./dev-tools/vendor/bin/php-coveralls -v
 
         -
             <<: *STANDARD_TEST_JOB
@@ -148,7 +148,7 @@ jobs:
             php: 7.3
             install: ./dev-tools/build.sh
             script:
-                - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 vendor/bin/phpunit tests/Smoke/
+                - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 ./dev-tools/vendor/bin/phpunit tests/Smoke/
 
             before_deploy:
                 # ensure that deployment is happening only if tag matches version of PHP CS Fixer

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
 
         - &STANDARD_TEST_JOB
             stage: Fast Test
-            php: 7.0
+            php: 7.3
             install:
                 # Composer: enforce given Symfony components version
                 - if [ "$SYMFONY_VERSION" != "" ]; then composer global show symfony/flex -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS symfony/flex; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
                 - if [ "$SYMFONY_VERSION" != "" ]; then composer global show symfony/flex -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS symfony/flex; fi
                 - if [ "$SYMFONY_VERSION" != "" ]; then composer config extra.symfony.require $SYMFONY_VERSION || true; fi
 
-                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - travis_retry composer update --working-dir=./dev-tools $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
                 - composer info -D | sort
             script:
                 - ./dev-tools/vendor/bin/phpunit || travis_terminate 1
@@ -119,7 +119,7 @@ jobs:
                 - composer global show hirak/prestissimo -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
 
                 # Require PHPUnit 8
-                - composer require --dev --no-update phpunit/phpunit:^8
+                - composer require --dev --no-update --working-dir=./dev-tools phpunit/phpunit:^8
 
                 # Install PCOV
                 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
     include:
         -
             stage: Static Code Analysis
-            php: 7.3
+            php: '7.3'
             env: COMPOSER_FLAGS="--prefer-stable"
             install:
                 - travis_retry ./dev-tools/install.sh
@@ -60,7 +60,7 @@ jobs:
 
         - &STANDARD_TEST_JOB
             stage: Fast Test
-            php: 7.2
+            php: '7.2'
             install:
                 # Composer: enforce given Symfony components version
                 - if [ "$SYMFONY_VERSION" != "" ]; then composer global show symfony/flex -q || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS symfony/flex; fi
@@ -75,7 +75,7 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 5.6
+            php: '5.6'
             env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
             before_install:
                 # turn off XDebug
@@ -85,30 +85,48 @@ jobs:
                 - composer global show hirak/prestissimo --quiet || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
 
                 # Require PHPUnit 8
-                - composer remove --dev --no-update --working-dir=./dev-tools humbug/box phpstan/phpstan-phpunit
+                - composer remove --dev --no-update --working-dir=./dev-tools humbug/box localheinz/composer-normalize phpstan/phpstan-phpunit
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.0
+            php: '7.0'
             env: SYMFONY_DEPRECATIONS_HELPER=disabled PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="~4.1.0"
+            before_install:
+                # turn off XDebug
+                - phpenv config-rm xdebug.ini || return 0
+
+                # Composer: boost installation
+                - composer global show hirak/prestissimo --quiet || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
+
+                # Require PHPUnit 8
+                - composer remove --dev --no-update --working-dir=./dev-tools humbug/box localheinz/composer-normalize phpstan/phpstan-phpunit
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.1
+            php: '7.1'
+            before_install:
+                # turn off XDebug
+                - phpenv config-rm xdebug.ini || return 0
+
+                # Composer: boost installation
+                - composer global show hirak/prestissimo --quiet || travis_retry composer global require $DEFAULT_COMPOSER_FLAGS hirak/prestissimo
+
+                # Require PHPUnit 8
+                - composer remove --dev --no-update --working-dir=./dev-tools humbug/box
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.3
+            php: '7.3'
             before_script:
                 - php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q || travis_terminate 1
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.3
+            php: '7.3'
             env: COLLECT_COVERAGE=1
             before_install:
                 # check phpdbg
@@ -149,12 +167,12 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.4snapshot
+            php: '7.4snapshot'
             env: COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 SYMFONY_DEPRECATIONS_HELPER=weak
 
         -
             stage: Deployment
-            php: 7.3
+            php: '7.3'
             install: ./dev-tools/build.sh
             script:
                 - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 ./dev-tools/vendor/bin/phpunit tests/Smoke/
@@ -175,4 +193,4 @@ jobs:
                 - ./dev-tools/trigger-website.sh ${TRAVIS_TOKEN} ${TRAVIS_TAG}
 
     allow_failures:
-        - php: 7.4snapshot
+        - php: '7.4snapshot'

--- a/composer.json
+++ b/composer.json
@@ -31,20 +31,6 @@
         "symfony/process": "^3.0 || ^4.0",
         "symfony/stopwatch": "^3.0 || ^4.0"
     },
-    "require-dev": {
-        "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
-        "justinrainbow/json-schema": "^5.0",
-        "keradus/cli-executor": "^1.2",
-        "mikey179/vfsstream": "^1.6",
-        "php-coveralls/php-coveralls": "^2.1",
-        "php-cs-fixer/accessible-object": "^1.0",
-        "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
-        "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
-        "phpunitgoodpractices/traits": "^1.8",
-        "symfony/phpunit-bridge": "^4.3",
-        "symfony/yaml": "^3.0 || ^4.0"
-    },
     "suggest": {
         "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
@@ -69,11 +55,6 @@
             "tests/Test/InternalIntegrationCaseFactory.php",
             "tests/TestCase.php"
         ]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "PhpCsFixer\\Tests\\": "tests/"
-        }
     },
     "bin": [
         "php-cs-fixer"

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -3,9 +3,9 @@
         "hhvm": "*"
     },
     "require-dev": {
-        "humbug/box": "^2.7. || ^3.8",
+        "humbug/box": "^3.8",
         "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
-        "justinrainbow/json-schema": "~1.3 || ^5.0",
+        "justinrainbow/json-schema": "^5.0",
         "keradus/cli-executor": "^1.2",
         "localheinz/composer-normalize": "^1.1",
         "mi-schi/phpmd-extension": "^4.3",
@@ -15,6 +15,7 @@
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
         "phpmd/phpmd": "^2.6",
+        "phpstan/phpstan-phpunit": "^0.11.2",
         "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
         "phpunitgoodpractices/traits": "^1.8",
         "symfony/phpunit-bridge": "^4.3",

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,14 +1,11 @@
 {
-    "require": {
-        "php": "^7.1"
-    },
     "conflict": {
         "hhvm": "*"
     },
     "require-dev": {
-        "humbug/box": "~3.7.0",
+        "humbug/box": "^2.7. || ^3.8",
         "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
-        "justinrainbow/json-schema": "^5.0",
+        "justinrainbow/json-schema": "~1.3 || ^5.0",
         "keradus/cli-executor": "^1.2",
         "localheinz/composer-normalize": "^1.1",
         "mi-schi/phpmd-extension": "^4.3",
@@ -18,7 +15,6 @@
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
         "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan-phpunit": "^0.11.2",
         "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
         "phpunitgoodpractices/traits": "^1.8",
         "symfony/phpunit-bridge": "^4.3",

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -2,18 +2,43 @@
     "require": {
         "php": "^7.1"
     },
-    "require-dev": {
-        "humbug/box": "~3.7.0",
-        "localheinz/composer-normalize": "^1.1",
-        "mi-schi/phpmd-extension": "^4.3",
-        "phpmd/phpmd": "^2.6",
-        "phpstan/phpstan-phpunit": "^0.11.2"
-    },
     "conflict": {
         "hhvm": "*"
+    },
+    "require-dev": {
+        "humbug/box": "~3.7.0",
+        "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
+        "justinrainbow/json-schema": "^5.0",
+        "keradus/cli-executor": "^1.2",
+        "localheinz/composer-normalize": "^1.1",
+        "mi-schi/phpmd-extension": "^4.3",
+        "mikey179/vfsstream": "^1.6",
+        "php-coveralls/php-coveralls": "^2.1",
+        "php-cs-fixer/accessible-object": "^1.0",
+        "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+        "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
+        "phpmd/phpmd": "^2.6",
+        "phpstan/phpstan-phpunit": "^0.11.2",
+        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+        "phpunitgoodpractices/traits": "^1.8",
+        "symfony/phpunit-bridge": "^4.3",
+        "symfony/yaml": "^3.0 || ^4.0",
+        "wikimedia/composer-merge-plugin": "^1.4"
     },
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true
+    },
+    "extra": {
+        "merge-plugin": {
+            "require": [
+                "../composer.json"
+            ]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PhpCsFixer\\Tests\\": "../tests/"
+        }
     }
 }

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -56,7 +56,7 @@ if (class_exists('Phar')) {
 
 if ($require) {
     // OK, it's not, let give Composer autoloader a try!
-    $possibleFiles = [__DIR__.'/../../autoload.php', __DIR__.'/../autoload.php', __DIR__.'/vendor/autoload.php'];
+    $possibleFiles = [__DIR__.'/../../autoload.php', __DIR__.'/../autoload.php', __DIR__.'/vendor/autoload.php', __DIR__.'/dev-tools/vendor/autoload.php'];
     $file = null;
     foreach ($possibleFiles as $possibleFile) {
         if (file_exists($possibleFile)) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,14 +2,14 @@
 
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="./dev-tools/vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"
-    bootstrap="./vendor/autoload.php"
+    bootstrap="./dev-tools/vendor/autoload.php"
     colors="true"
     columns="max"
     convertErrorsToExceptions="true"

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -75,6 +75,9 @@ final class InstallViaComposerTest extends AbstractSmokeTest
                 [
                     'type' => 'path',
                     'url' => __DIR__.'/../..',
+                    'options' => [
+                        'symlink' => false,
+                    ],
                 ],
             ],
             'require' => [


### PR DESCRIPTION
This PR extracts `dev-require` and `dev-autoload` from `composer.json`, but also:

- cleans up AppVeyor, CircleCI and TravisCI configurations
- update TravisCI fast test to run PHP 7.2 instead of PHP 7.0
- updates `InstallViaComposerTest`, so it makes the copy for testing, not symlink

Should those 3 be extracted to separate PRs?