### PR TITLE
PhpdocToCommentFixer - Ignore annotations

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -88,6 +88,10 @@ foreach($connections as $key => $sqlite) {
                 continue;
             }
 
+            if ($commentsAnalyzer->isAnnotation($token)) {
+                continue;
+            }
+
             $tokens[$index] = new Token([T_COMMENT, '/*'.ltrim($token->getContent(), '/*')]);
         }
     }

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -92,6 +92,11 @@ final class CommentsAnalyzer
         return false;
     }
 
+    public function isAnnotation(Token $token)
+    {
+        return 1 === Preg::match('#\/\*{2}\s+.*@\w+#m', $token->getContent());
+    }
+
     /**
      * Return array of indices that are part of a comment started at given index.
      *

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -552,6 +552,17 @@ $loader = require __DIR__.\'/../vendor/autoload.php\';
 ',
         ];
 
+        $cases[] = [
+            '<?php
+
+foreach ($this->subscribers[$eventClassName] as $subscriber) {
+    /** @noinspection PhpParamsInspection */
+    /** @psalm-suppress UndefinedInterfaceMethod */
+    $subscriber->notify($event);
+}
+',
+        ];
+
         return $cases;
     }
 

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -302,4 +302,121 @@ $bar;',
             ['<?php /* Before anonymous function */ $fn = fn($x) => $x + 1;'],
         ];
     }
+
+    /**
+     * @dataProvider provideAnnotationCases
+     *
+     * @param string $code
+     */
+    public function testIsAnnotation($code)
+    {
+        $tokens = Tokens::fromCode($code);
+
+        $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
+
+        $token = $tokens[$index];
+
+        $analyzer = new CommentsAnalyzer();
+
+        static::assertTrue($analyzer->isAnnotation($token));
+    }
+
+    public function provideAnnotationCases()
+    {
+        return [
+            [
+                '<?php
+
+/**
+ * @var int $foo
+ */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/** @var int $foo */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/**
+ * @noinspection PhpParamsInspection
+ */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/** @noinspection PhpParamsInspection */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/** @psalm-suppress hmmm */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/**
+ * @psalm-suppress hmmm
+ */
+$foo = 900;
+',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideNotAnnotationCases
+     *
+     * @param string $code
+     */
+    public function testIsNotAnnotation($code)
+    {
+        $tokens = Tokens::fromCode($code);
+
+        $index = $tokens->getNextTokenOfKind(0, [[T_COMMENT], [T_DOC_COMMENT]]);
+
+        $token = $tokens[$index];
+
+        $analyzer = new CommentsAnalyzer();
+
+        static::assertFalse($analyzer->isAnnotation($token));
+    }
+
+    public function provideNotAnnotationCases()
+    {
+        return [
+            [
+                '<?php
+
+/* @var int $foo */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/* @noinspection PhpParamsInspection */
+$foo = 900;
+',
+            ],
+            [
+                '<?php
+
+/* @psalm-suppress hmmm */
+#foo = 900;
+',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
This PR

* [x] adds a failing test case
* [x] adjusts `PhpDocToComment` fixer to ignore annotations

💁‍♂ For reference, see https://github.com/vimeo/psalm/issues/2344.

/cc @theseer

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4446