### PR TITLE
ExplicitStringVariableFixer - variables pair if one is already explicit

### DIFF
--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -92,7 +92,9 @@ EOT
             $nextIndex = $index + 1;
             $squareBracketCount = 0;
             while (!$this->isStringPartToken($tokens[$nextIndex])) {
-                if ($tokens[$nextIndex]->isGivenKind(T_VARIABLE) && 1 !== $squareBracketCount) {
+                if ($tokens[$nextIndex]->isGivenKind(T_CURLY_OPEN)) {
+                    $nextIndex = $tokens->getNextTokenOfKind($nextIndex, [[CT::T_CURLY_CLOSE]]);
+                } elseif ($tokens[$nextIndex]->isGivenKind(T_VARIABLE) && 1 !== $squareBracketCount) {
                     $distinctVariableIndex = $nextIndex;
                     $variableTokens[$distinctVariableIndex] = [
                         'tokens' => [$nextIndex => $tokens[$nextIndex]],

--- a/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
+++ b/tests/Fixer/StringNotation/ExplicitStringVariableFixerTest.php
@@ -208,6 +208,14 @@ EOF;
                 '<?php $mobileNumberVisible = "***-***-{$last4Digits[0]}{$last4Digits[1]}-{$last4Digits[2]}{$last4Digits[3]}";',
                 '<?php $mobileNumberVisible = "***-***-$last4Digits[0]$last4Digits[1]-$last4Digits[2]$last4Digits[3]";',
             ],
+            [
+                '<?php $pair = "${foo} {$bar[0]}";',
+                '<?php $pair = "$foo {$bar[0]}";',
+            ],
+            [
+                '<?php $pair = "${foo}{$bar[0]}";',
+                '<?php $pair = "$foo{$bar[0]}";',
+            ],
         ];
     }
 


### PR DESCRIPTION
1st added test case works fine, 2nd one (when space between is removed) is failing.

Ping @Slamdunk for review.