### PR TITLE
PhpUnitOrderedCoversFixer - stop using deprecated fixer

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -173,7 +173,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['php_unit_construct'], $fixers['php_unit_dedicate_assert']],
             [$fixers['php_unit_fqcn_annotation'], $fixers['no_unused_imports']],
             [$fixers['php_unit_internal_class'], $fixers['final_internal_class']],
-            [$fixers['php_unit_fqcn_annotation'], $fixers['php_unit_ordered_covers']],
+            [$fixers['php_unit_fqcn_annotation'], $fixers['phpdoc_order_by_value']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['no_empty_phpdoc']],
             [$fixers['php_unit_no_expectation_annotation'], $fixers['php_unit_expectation']],
             [$fixers['php_unit_dedicate_assert'], $fixers['php_unit_dedicate_assert_internal_type']],

--- a/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
+++ b/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
@@ -1,7 +1,7 @@
 --TEST--
-Integration of fixers: php_unit_fqcn_annotation,php_unit_ordered_covers.
+Integration of fixers: php_unit_fqcn_annotation,phpdoc_order_by_value.
 --RULESET--
-{"php_unit_fqcn_annotation": true, "php_unit_ordered_covers": true}
+{"php_unit_fqcn_annotation": true, "phpdoc_order_by_value": ['annotations' => [ 'covers' ]]}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
+++ b/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: php_unit_fqcn_annotation,phpdoc_order_by_value.
 --RULESET--
-{"php_unit_fqcn_annotation": true, "phpdoc_order_by_value": ['annotations' => [ 'covers' ]]}
+{"php_unit_fqcn_annotation": true, "phpdoc_order_by_value": ['annotations': ['covers']]}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
+++ b/tests/Fixtures/Integration/priority/php_unit_fqcn_annotation,phpdoc_order_by_value.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: php_unit_fqcn_annotation,phpdoc_order_by_value.
 --RULESET--
-{"php_unit_fqcn_annotation": true, "phpdoc_order_by_value": ['annotations': ['covers']]}
+{"php_unit_fqcn_annotation": true, "phpdoc_order_by_value": {"annotations": ["covers"]}}
 --EXPECT--
 <?php
 /**


### PR DESCRIPTION
appendix for #4569

cc @localheinz 