### PR TITLE
FinalStaticAccessFixer - deprecate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -701,6 +701,7 @@ Choose from the list of available rules:
 * **final_static_access**
 
   Converts ``static`` access to ``self`` access in ``final`` classes.
+  DEPRECATED: use ``self_static_accessor`` instead.
 
 * **fopen_flag_order** [@Symfony:risky, @PhpCsFixer:risky]
 

--- a/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
+++ b/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
@@ -12,16 +12,17 @@
 
 namespace PhpCsFixer\Fixer\ClassNotation;
 
-use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\AbstractProxyFixer;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\Tokenizer\Token;
-use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @author ntzm
+ *
+ * @deprecated in 2.17
  */
-final class FinalStaticAccessFixer extends AbstractFixer
+final class FinalStaticAccessFixer extends AbstractProxyFixer implements DeprecatedFixerInterface
 {
     /**
      * {@inheritdoc}
@@ -49,105 +50,16 @@ final class Sample
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getSuccessorsNames()
     {
-        // Should be run after FinalInternalClass and PhpUnitTestCaseStaticMethodCalls
-        return -1;
+        return array_keys($this->proxyFixers);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function isCandidate(Tokens $tokens)
+    protected function createProxyFixers()
     {
-        return $tokens->isAllTokenKindsFound([T_FINAL, T_CLASS, T_STATIC]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
-    {
-        for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
-            if (!$tokens[$index]->isGivenKind(T_FINAL)) {
-                continue;
-            }
-
-            $classTokenIndex = $tokens->getNextMeaningfulToken($index);
-
-            if (!$tokens[$classTokenIndex]->isGivenKind(T_CLASS)) {
-                continue;
-            }
-
-            $startClassIndex = $tokens->getNextTokenOfKind(
-                $classTokenIndex,
-                ['{']
-            );
-
-            $endClassIndex = $tokens->findBlockEnd(
-                Tokens::BLOCK_TYPE_CURLY_BRACE,
-                $startClassIndex
-            );
-
-            $this->replaceStaticAccessWithSelfAccessBetween(
-                $tokens,
-                $startClassIndex,
-                $endClassIndex
-            );
-        }
-    }
-
-    /**
-     * @param int $startIndex
-     * @param int $endIndex
-     */
-    private function replaceStaticAccessWithSelfAccessBetween(
-        Tokens $tokens,
-        $startIndex,
-        $endIndex
-    ) {
-        for ($index = $startIndex; $index <= $endIndex; ++$index) {
-            if ($tokens[$index]->isGivenKind(T_CLASS)) {
-                $index = $this->getEndOfAnonymousClass($tokens, $index);
-
-                continue;
-            }
-
-            if (!$tokens[$index]->isGivenKind(T_STATIC)) {
-                continue;
-            }
-
-            $doubleColonIndex = $tokens->getNextMeaningfulToken($index);
-
-            if (!$tokens[$doubleColonIndex]->isGivenKind(T_DOUBLE_COLON)) {
-                continue;
-            }
-
-            $tokens[$index] = new Token([T_STRING, 'self']);
-        }
-    }
-
-    /**
-     * @param int $index
-     *
-     * @return int
-     */
-    private function getEndOfAnonymousClass(Tokens $tokens, $index)
-    {
-        $instantiationBraceStart = $tokens->getNextMeaningfulToken($index);
-
-        if ($tokens[$instantiationBraceStart]->equals('(')) {
-            $index = $tokens->findBlockEnd(
-                Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
-                $instantiationBraceStart
-            );
-        }
-
-        $bodyBraceStart = $tokens->getNextTokenOfKind($index, ['{']);
-
-        return $tokens->findBlockEnd(
-            Tokens::BLOCK_TYPE_CURLY_BRACE,
-            $bodyBraceStart
-        );
+        return [new SelfStaticAccessorFixer()];
     }
 }

--- a/tests/Fixer/ClassNotation/FinalStaticAccessFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalStaticAccessFixerTest.php
@@ -137,7 +137,8 @@ final class FinalStaticAccessFixerTest extends AbstractFixerTestCase
             'does not change non-final classes' => [
                 '<?php class A { public $b = static::class; }',
             ],
-            'does not change anonymous classes' => [
+            'changes anonymous classes' => [
+                '<?php $a = new class { public $b = self::class; };',
                 '<?php $a = new class { public $b = static::class; };',
             ],
             'handles comments' => [
@@ -145,23 +146,23 @@ final class FinalStaticAccessFixerTest extends AbstractFixerTestCase
                 '<?php /*a*/final/*b*/class/*c*/A { public $b = /*1*/static/*2*/::/*3*/class; }',
             ],
             'property and nested anonymous class' => [
-                '<?php final class A { public $b = self::class; public function foo(){ return new class { public $b = static::class; }; }}',
+                '<?php final class A { public $b = self::class; public function foo(){ return new class { public $b = self::class; }; }}',
                 '<?php final class A { public $b = static::class; public function foo(){ return new class { public $b = static::class; }; }}',
             ],
             'property and nested anonymous class with set function' => [
-                '<?php final class A { public $b = self::class; public function foo(){ return new class ($a = function () {}) { public $b = static::class; }; }}',
+                '<?php final class A { public $b = self::class; public function foo(){ return new class ($a = function () {}) { public $b = self::class; }; }}',
                 '<?php final class A { public $b = static::class; public function foo(){ return new class ($a = function () {}) { public $b = static::class; }; }}',
             ],
             'property and nested anonymous class with set anonymous class' => [
-                '<?php final class A { public $b = self::class; public function foo(){ return new class ($a = new class {}) { public $b = static::class; }; }}',
+                '<?php final class A { public $b = self::class; public function foo(){ return new class ($a = new class {}) { public $b = self::class; }; }}',
                 '<?php final class A { public $b = static::class; public function foo(){ return new class ($a = new class {}) { public $b = static::class; }; }}',
             ],
             'property and nested anonymous class with change after' => [
-                '<?php final class A { public function foo(){ return new class { public $b = static::class; }; } public $b = self::class; }',
+                '<?php final class A { public function foo(){ return new class { public $b = self::class; }; } public $b = self::class; }',
                 '<?php final class A { public function foo(){ return new class { public $b = static::class; }; } public $b = static::class; }',
             ],
             'property and nested anonymous class with extends' => [
-                '<?php final class A { public $b = self::class; public function foo(){ return new class extends X implements Y { public $b = static::class; }; }}',
+                '<?php final class A { public $b = self::class; public function foo(){ return new class extends X implements Y { public $b = self::class; }; }}',
                 '<?php final class A { public $b = static::class; public function foo(){ return new class extends X implements Y { public $b = static::class; }; }}',
             ],
         ];


### PR DESCRIPTION
In v2.16, we added rules `final_static_access` and `self_static_accessor` but they almost do the same thing so we can actually drop one. I chose to deprecate `final_static_access` in favor of `self_static_accessor` because the former does not support anonymous classes while the latter does.

/cc @ntzm @SpacePossum as authors of the rules.