### PR TITLE
NonPrintableCharacterFixer - fix for backslash and quotes when changing to escape sequences

### DIFF
--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -141,6 +141,7 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
 
                 $previousToken = $tokens[$index - 1];
                 $stringTypeChanged = false;
+                $swapQuotes = false;
 
                 if ($previousToken->isGivenKind(T_START_HEREDOC)) {
                     $previousTokenContent = $previousToken->getContent();
@@ -150,12 +151,20 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
                         $stringTypeChanged = true;
                     }
                 } elseif ("'" === $content[0]) {
-                    $content = Preg::replace('/^\'(.*)\'$/', '"$1"', $content);
                     $stringTypeChanged = true;
+                    $swapQuotes = true;
                 }
 
+                if ($swapQuotes) {
+                    $content = str_replace("\\'", "'", $content);
+                }
                 if ($stringTypeChanged) {
-                    $content = Preg::replace('/([\\\\$])/', '\\\\$1', $content);
+                    $content = Preg::replace('/(\\\\{1,2})/', '\\\\\\\\', $content);
+                    $content = str_replace('$', '\$', $content);
+                }
+                if ($swapQuotes) {
+                    $content = str_replace('"', '\"', $content);
+                    $content = Preg::replace('/^\'(.*)\'$/', '"$1"', $content);
                 }
 
                 $tokens[$index] = new Token([$token->getId(), strtr($content, $escapeSequences)]);

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -198,6 +198,102 @@ TXT;
             [
                 '<?php echo \'。\';',
             ],
+            [
+                <<<'EXPECTED'
+<?php echo "Double \" quote \u{200b} inside";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Double " quote %s inside';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "Single ' quote \u{200b} inside";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Single \' quote %s inside';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo <<<STRING
+    Quotes ' and " to be handled \u{200b} properly \\' and \\"
+STRING
+;
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo <<<'STRING'
+    Quotes ' and " to be handled %s properly \' and \"
+STRING
+;
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "\\\u{200b}\"";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo '\\%s"';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "\\\u{200b}'";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo '\\%s\'';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "Backslash 1 \\ \u{200b}";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Backslash 1 \ %s';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "Backslash 2 \\ \u{200b}";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Backslash 2 \\ %s';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "Backslash 3 \\\\ \u{200b}";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Backslash 3 \\\ %s';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
+            [
+                <<<'EXPECTED'
+<?php echo "Backslash 4 \\\\ \u{200b}";
+EXPECTED
+                ,
+                sprintf(<<<'INPUT'
+<?php echo 'Backslash 4 \\\\ %s';
+INPUT
+                 , pack('H*', 'e2808b')),
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #4663 and replaces #4664.

Ping @mvorisek as reporter and @ivan1986 as the original author for review.