### PR TITLE
NativeConstantInvocationFixer - add "strict" flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -970,6 +970,8 @@ Choose from the list of available rules:
   - ``include`` (``array``): list of additional constants to fix; defaults to ``[]``
   - ``scope`` (``'all'``, ``'namespaced'``): only fix constant invocations that are made
     within a namespace or fix all; defaults to ``'all'``
+  - ``strict`` (``bool``): whether leading ``\`` of constant invocation not meant to
+    have it should be removed; defaults to ``false``
 
 * **native_function_casing** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
+++ b/src/Fixer/PhpTag/EchoTagSyntaxFixer.php
@@ -93,10 +93,10 @@ EOT
     public function isCandidate(Tokens $tokens)
     {
         if (self::FORMAT_SHORT === $this->configuration[self::OPTION_FORMAT]) {
-            return $tokens->isAnyTokenKindsFound([\T_ECHO, \T_PRINT]);
+            return $tokens->isAnyTokenKindsFound([T_ECHO, T_PRINT]);
         }
 
-        return $tokens->isTokenKindFound(\T_OPEN_TAG_WITH_ECHO);
+        return $tokens->isTokenKindFound(T_OPEN_TAG_WITH_ECHO);
     }
 
     /**
@@ -137,14 +137,14 @@ EOT
         $skipWhenComplexCode = $this->configuration[self::OPTION_SHORTEN_SIMPLE_STATEMENTS_ONLY];
         $count = $tokens->count();
         for ($index = 0; $index < $count; ++$index) {
-            if (!$tokens[$index]->isGivenKind(\T_OPEN_TAG)) {
+            if (!$tokens[$index]->isGivenKind(T_OPEN_TAG)) {
                 continue;
             }
             $nextMeaningful = $tokens->getNextMeaningfulToken($index);
             if (null === $nextMeaningful) {
                 return;
             }
-            if (!$tokens[$nextMeaningful]->isGivenKind([\T_ECHO, \T_PRINT])) {
+            if (!$tokens[$nextMeaningful]->isGivenKind([T_ECHO, T_PRINT])) {
                 $index = $nextMeaningful;
 
                 continue;
@@ -163,19 +163,19 @@ EOT
     private function shortToLong(Tokens $tokens)
     {
         if (self::LONG_FUNCTION_PRINT === $this->configuration[self::OPTION_LONG_FUNCTION]) {
-            $echoToken = [\T_PRINT, 'print'];
+            $echoToken = [T_PRINT, 'print'];
         } else {
-            $echoToken = [\T_ECHO, 'echo'];
+            $echoToken = [T_ECHO, 'echo'];
         }
         $index = -1;
         for (;;) {
-            $index = $tokens->getNextTokenOfKind($index, [[\T_OPEN_TAG_WITH_ECHO]]);
+            $index = $tokens->getNextTokenOfKind($index, [[T_OPEN_TAG_WITH_ECHO]]);
             if (null === $index) {
                 return;
             }
-            $replace = [new Token([\T_OPEN_TAG, '<?php ']), new Token($echoToken)];
+            $replace = [new Token([T_OPEN_TAG, '<?php ']), new Token($echoToken)];
             if (!$tokens[$index + 1]->isWhitespace()) {
-                $replace[] = new Token([\T_WHITESPACE, ' ']);
+                $replace[] = new Token([T_WHITESPACE, ' ']);
             }
             $tokens->overrideRange($index, $index, $replace);
             ++$index;
@@ -202,7 +202,7 @@ EOT
         $semicolonFound = false;
         for ($count = $tokens->count(); $index < $count; ++$index) {
             $token = $tokens[$index];
-            if ($token->isGivenKind(\T_CLOSE_TAG)) {
+            if ($token->isGivenKind(T_CLOSE_TAG)) {
                 return false;
             }
             if (';' === $token->getContent()) {
@@ -225,7 +225,7 @@ EOT
      */
     private function buildLongToShortTokens(Tokens $tokens, $openTagIndex, $echoTagIndex)
     {
-        $result = [new Token([\T_OPEN_TAG_WITH_ECHO, '<?='])];
+        $result = [new Token([T_OPEN_TAG_WITH_ECHO, '<?='])];
 
         $start = $tokens->getNextNonWhitespace($openTagIndex);
 

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -112,7 +112,7 @@ EOT
 
                 ++$nextIndex;
             }
-            krsort($variableTokens, \SORT_NUMERIC);
+            krsort($variableTokens, SORT_NUMERIC);
 
             foreach ($variableTokens as $distinctVariableSet) {
                 if (1 === \count($distinctVariableSet['tokens'])) {

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -190,6 +190,7 @@ final class RuleSet implements RuleSetInterface
                     'PHP_VERSION_ID',
                 ],
                 'scope' => 'namespaced',
+                'strict' => true,
             ],
             'native_function_invocation' => [
                 'include' => [NativeFunctionInvocationFixer::SET_COMPILER_OPTIMIZED],

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -535,4 +535,22 @@ EOT;
 
         $this->doTest($expected);
     }
+
+    public function testFixStrictOption()
+    {
+        $this->fixer->configure(['strict' => true]);
+
+        $this->doTest(
+            '<?php
+                echo \PHP_VERSION . \PHP_EOL; // built-in constants to have backslash
+                echo MY_FRAMEWORK_MAJOR_VERSION . MY_FRAMEWORK_MINOR_VERSION; // non-built-in constants not to have backslash
+                echo \Dont\Touch\Namespaced\CONSTANT;
+            ',
+            '<?php
+                echo \PHP_VERSION . PHP_EOL; // built-in constants to have backslash
+                echo \MY_FRAMEWORK_MAJOR_VERSION . MY_FRAMEWORK_MINOR_VERSION; // non-built-in constants not to have backslash
+                echo \Dont\Touch\Namespaced\CONSTANT;
+            '
+        );
+    }
 }


### PR DESCRIPTION
@nicolas-grekas is it OK to add it to `@Symfony` rule set (I did it as it is very similar "strict" as for `NativeFunctionInvocationFixer`)?