### PR TITLE
Improve Symfony 5 compatibility

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -12,10 +12,13 @@
 
 namespace PhpCsFixer\Event;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
 // Since PHP-CS-FIXER is PHP 5.6 compliant we can't always use Symfony Contracts (currently needs PHP ^7.1.3)
-// This conditionnal inheritance will be useless when PHP-CS-FIXER no longer supports PHP versions
+// This conditional inheritance will be useless when PHP-CS-FIXER no longer supports PHP versions
 // inferior to Symfony/Contracts PHP minimal version
-if (class_exists(\Symfony\Contracts\EventDispatcher\Event::class)) {
+if (is_subclass_of(EventDispatcher::class, EventDispatcherInterface::class)) {
     class Event extends \Symfony\Contracts\EventDispatcher\Event
     {
     }


### PR DESCRIPTION
Closes #4684

one can install contract on his own, even if he is using Sf version that does not rely on contracts,
for that, we need to check if actually Sf component relies on contract, not only the fact that contract exists.

TODO:
- [x] look for other places when we check that contract exists and nothing more (edit by @julienfalque: only found one in the related test, not sure it's worth the hassle)