### PR TITLE
Run Travis CI on stable PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
     include:
         -
             stage: Static Code Analysis
-            php: 7.3
+            php: 7.4
             env: COMPOSER_FLAGS="--prefer-stable"
             install:
                 - travis_retry ./dev-tools/install.sh
@@ -81,12 +81,14 @@ jobs:
             <<: *STANDARD_TEST_JOB
             stage: Test
             php: 7.1
+            name: 7.1 | Symfony 4.1
             env: SYMFONY_DEPRECATIONS_HELPER=disabled PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="~4.1.0"
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
             php: 7.2
+            name: 7.2 | Symfony 5.0
             env: SYMFONY_DEPRECATIONS_HELPER=disabled PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER=1 SYMFONY_VERSION="^5.0"
 
         -
@@ -95,13 +97,13 @@ jobs:
             php: 7.3
             name: 7.3 | With migration rules
             before_script:
-                - php php-cs-fixer fix --rules @PHP71Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q || travis_terminate 1
+                - php php-cs-fixer fix --rules @PHP73Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q || travis_terminate 1
 
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.3
-            name: 7.3 | Collect coverage
+            php: 7.4
+            name: 7.4 | Collect coverage
             before_install:
                 # for building a tag release we don't need to collect code coverage
                 - if [ $TRAVIS_TAG ]; then travis_terminate 0; fi
@@ -118,7 +120,7 @@ jobs:
 
                 # Install PCOV
                 - |
-                    git clone --single-branch --branch=v1.0.2 --depth=1 https://github.com/krakjoe/pcov
+                    git clone --single-branch --branch=v1.0.6 --depth=1 https://github.com/krakjoe/pcov
                     cd pcov
                     phpize
                     ./configure
@@ -135,12 +137,12 @@ jobs:
         -
             <<: *STANDARD_TEST_JOB
             stage: Test
-            php: 7.4snapshot
+            php: nightly
             env: COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 SYMFONY_DEPRECATIONS_HELPER=weak
 
         -
             stage: Deployment
-            php: 7.3
+            php: 7.4
             install: ./dev-tools/build.sh
             script:
                 - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 vendor/bin/phpunit tests/Smoke/
@@ -159,3 +161,6 @@ jobs:
                     tags: true
             after_deploy:
                 - ./dev-tools/trigger-website.sh ${TRAVIS_TOKEN} ${TRAVIS_TAG}
+
+    allow_failures:
+        - php: nightly

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -3,7 +3,7 @@
         "php": "^7.1"
     },
     "require-dev": {
-        "humbug/box": "~3.7.0",
+        "humbug/box": "^3.8",
         "localheinz/composer-normalize": "^1.1",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.6",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,4 @@ parameters:
     ignoreErrors:
         - '/^.+::__construct\(\) does not call parent constructor from SplFileInfo\.$/'
         - '/^Return typehint of method PhpCsFixer\\Tests\\Test\\.+::createIsIdenticalStringConstraint\(\) has invalid type PHPUnit_Framework_Constraint_IsIdentical\.$/'
-        ## cannot analyse out of PHP 7.4
-        - '/^Constant T_FN not found\.$/'
         - '/^Class (Symfony\\Contracts\\EventDispatcher\\Event|Symfony\\Component\\EventDispatcher\\Event) not found.$/'


### PR DESCRIPTION
- "Static Code Analysis" and "Fast Test" to be run on PHP 7.4
- each standard job to be run on different PHP (previously "Collect coverage" and "With migration rules" were run on the same PHP version)
- `nightly` instead of `7.4snapshot` as `assertUpcomingPhpVersionIsCoveredByCiJob`
- allow nightly to fail
- update `humbug/box` due to it's dependency `nikic/iter` having the [problem](https://github.com/nikic/iter/blob/v1.6.0/src/iter.fn.php#L3) with PHP 7.4

Needs https://travis-ci.community/t/some-extensions-are-missing-in-php-7-4-0-zip-gmp-sodium/6320 to be fixed
