### PR TITLE
Increase Travis CI Git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 git:
-    depth: 1
+    depth: 10
 
 cache:
     directories:


### PR DESCRIPTION
When merging a PR while there is a Travis CI build running, jobs of that build that didn't start yet will fail as a new commit has been added on the target branch.