### PR TITLE
LineEndingFixer - handle "\r\r\n"

### DIFF
--- a/src/Fixer/Whitespace/LineEndingFixer.php
+++ b/src/Fixer/Whitespace/LineEndingFixer.php
@@ -67,7 +67,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
                     $tokens[$index] = new Token([
                         $token->getId(),
                         Preg::replace(
-                            "#\r\n|\n#",
+                            '#\R#',
                             $ending,
                             $token->getContent()
                         ),
@@ -81,7 +81,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
                 $tokens[$index] = new Token([
                     $token->getId(),
                     Preg::replace(
-                        "#\r\n|\n#",
+                        '#\R#',
                         $ending,
                         $token->getContent()
                     ),

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -60,6 +60,11 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
             "<?php \$a=\"a\r\n\";",
         ];
 
+        $cases[] = [
+            "<?php echo 'foo',\n\n'bar';",
+            "<?php echo 'foo',\r\r\n'bar';",
+        ];
+
         return $cases;
     }
 


### PR DESCRIPTION
The added test is converting the input to expected, but it fails because:

> Code build on input code must match expected code.

We have two ways to fix it:
1. Update the RegEx `#\r\n|\n#` to `#\r+\n|\n#`
2. Update the RegEx `#\r\n|\n#` to `#\r\n|\r|\n#` and test case to:
```php
        $cases[] = [
            "<?php echo 'foo',\n\n'bar';",
            "<?php echo 'foo',\r\r\n'bar';",
        ];
```

Option 2 seems more right as the original `\r\r\n` is treated (at least in PHPStorm) as 2 line endings.

Ping @fabpot, @SpacePossum and @keradus as authors for opinion.