### PR TITLE
LambdaNotUsedImportFixer - introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -845,6 +845,10 @@ Choose from the list of available rules:
   - ``use_yoda_style`` (``bool``): whether Yoda style conditions should be used;
     defaults to ``true``. DEPRECATED: use ``yoda_style`` fixer instead
 
+* **lambda_not_used_import**
+
+  Lambda must not import variables it doesn't use.
+
 * **line_ending** [@PSR2, @Symfony, @PhpCsFixer]
 
   All PHP files must use same line ending.

--- a/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
+++ b/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
@@ -1,0 +1,353 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\FunctionNotation;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * @author SpacePossum
+ */
+final class LambdaNotUsedImportFixer extends AbstractFixer
+{
+    /**
+     * @var ArgumentsAnalyzer
+     */
+    private $argumentsAnalyzer;
+
+    /**
+     * @var FunctionsAnalyzer
+     */
+    private $functionAnalyzer;
+
+    /**
+     * @var TokensAnalyzer
+     */
+    private $tokensAnalyzer;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Lambda must not import variables it doesn\'t use.',
+            [new CodeSample("<?php\n\$foo = function() use (\$bar) {};\n")]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before NoSpacesInsideParenthesisFixer.
+     */
+    public function getPriority()
+    {
+        return 3;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isAllTokenKindsFound([T_FUNCTION, CT::T_USE_LAMBDA]);
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $this->argumentsAnalyzer = new ArgumentsAnalyzer();
+        $this->functionAnalyzer = new FunctionsAnalyzer();
+        $this->tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        for ($index = $tokens->count() - 4; $index > 0; --$index) {
+            $lambdaUseIndex = $this->getLambdaUseIndex($tokens, $index);
+
+            if (false !== $lambdaUseIndex) {
+                $this->fixLambda($tokens, $lambdaUseIndex);
+            }
+        }
+    }
+
+    /**
+     * @param int $lambdaUseIndex
+     */
+    private function fixLambda(Tokens $tokens, $lambdaUseIndex)
+    {
+        $lambdaUseOpenBraceIndex = $tokens->getNextTokenOfKind($lambdaUseIndex, ['(']);
+        $lambdaUseCloseBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $lambdaUseOpenBraceIndex);
+        $arguments = $this->argumentsAnalyzer->getArguments($tokens, $lambdaUseOpenBraceIndex, $lambdaUseCloseBraceIndex);
+
+        $imports = $this->filterArguments($tokens, $arguments);
+
+        if (0 === \count($imports)) {
+            return; // no imports to remove
+        }
+
+        $notUsedImports = $this->findNotUsedLambdaImports($tokens, $imports, $lambdaUseCloseBraceIndex);
+        $notUsedImportsCount = \count($notUsedImports);
+
+        if (0 === $notUsedImportsCount) {
+            return; // no not used imports found
+        }
+
+        if ($notUsedImportsCount === \count($arguments)) {
+            $this->clearImportsAndUse($tokens, $lambdaUseIndex, $lambdaUseCloseBraceIndex); // all imports are not used
+
+            return;
+        }
+
+        $this->clearImports($tokens, array_reverse($notUsedImports));
+    }
+
+    /**
+     * @param int $lambdaUseCloseBraceIndex
+     *
+     * @return array
+     */
+    private function findNotUsedLambdaImports(Tokens $tokens, array $imports, $lambdaUseCloseBraceIndex)
+    {
+        static $riskyKinds = [
+            CT::T_DYNAMIC_VAR_BRACE_OPEN,
+            T_EVAL,
+            T_INCLUDE,
+            T_INCLUDE_ONCE,
+            T_REQUIRE,
+            T_REQUIRE_ONCE,
+        ];
+
+        // figure out where the lambda starts ...
+        $lambdaOpenIndex = $tokens->getNextTokenOfKind($lambdaUseCloseBraceIndex, ['{']);
+        $curlyBracesLevel = 0;
+
+        for ($index = $lambdaOpenIndex;; ++$index) { // go through the body of the lambda and keep count of the (possible) usages of the imported variables
+            $token = $tokens[$index];
+
+            if ($token->equals('{')) {
+                ++$curlyBracesLevel;
+
+                continue;
+            }
+
+            if ($token->equals('}')) {
+                --$curlyBracesLevel;
+
+                if (0 === $curlyBracesLevel) {
+                    break;
+                }
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_STRING) && 'compact' === strtolower($token->getContent()) && $this->functionAnalyzer->isGlobalFunctionCall($tokens, $index)) {
+                return []; // wouldn't touch it with a ten-foot pole
+            }
+
+            if ($token->isGivenKind($riskyKinds)) {
+                return [];
+            }
+
+            if ($token->equals('$')) {
+                $nextIndex = $tokens->getNextMeaningfulToken($index);
+
+                if ($tokens[$nextIndex]->isGivenKind(T_VARIABLE)) {
+                    return []; // "$$a" case
+                }
+            }
+
+            if ($token->isGivenKind(T_VARIABLE)) {
+                $content = $token->getContent();
+
+                if (isset($imports[$content])) {
+                    unset($imports[$content]);
+
+                    if (0 === \count($imports)) {
+                        return $imports;
+                    }
+                }
+            }
+
+            if ($token->isClassy()) { // is anonymous class
+                // check if used as argument in the constructor of the anonymous class
+                $index = $tokens->getNextTokenOfKind($index, ['(', '{']);
+
+                if ($tokens[$index]->equals('(')) {
+                    $closeBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+                    $arguments = $this->argumentsAnalyzer->getArguments($tokens, $index, $closeBraceIndex);
+
+                    $imports = $this->countImportsUsedAsArgument($tokens, $imports, $arguments);
+
+                    $index = $tokens->getNextTokenOfKind($closeBraceIndex, ['{']);
+                }
+
+                // skip body
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+
+            if ($token->isGivenKind(T_FUNCTION)) {
+                // check if used as argument
+                $lambdaUseOpenBraceIndex = $tokens->getNextTokenOfKind($index, ['(']);
+                $lambdaUseCloseBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $lambdaUseOpenBraceIndex);
+                $arguments = $this->argumentsAnalyzer->getArguments($tokens, $lambdaUseOpenBraceIndex, $lambdaUseCloseBraceIndex);
+
+                $imports = $this->countImportsUsedAsArgument($tokens, $imports, $arguments);
+
+                // check if used as import
+                $index = $tokens->getNextTokenOfKind($index, [[CT::T_USE_LAMBDA], '{']);
+
+                if ($tokens[$index]->isGivenKind(CT::T_USE_LAMBDA)) {
+                    $lambdaUseOpenBraceIndex = $tokens->getNextTokenOfKind($index, ['(']);
+                    $lambdaUseCloseBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $lambdaUseOpenBraceIndex);
+                    $arguments = $this->argumentsAnalyzer->getArguments($tokens, $lambdaUseOpenBraceIndex, $lambdaUseCloseBraceIndex);
+
+                    $imports = $this->countImportsUsedAsArgument($tokens, $imports, $arguments);
+
+                    $index = $tokens->getNextTokenOfKind($lambdaUseCloseBraceIndex, ['{']);
+                }
+
+                // skip body
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+        }
+
+        return $imports;
+    }
+
+    /**
+     * @return array
+     */
+    private function countImportsUsedAsArgument(Tokens $tokens, array $imports, array $arguments)
+    {
+        foreach ($arguments as $start => $end) {
+            $info = $this->argumentsAnalyzer->getArgumentInfo($tokens, $start, $end);
+            $content = $info->getName();
+
+            if (isset($imports[$content])) {
+                unset($imports[$content]);
+
+                if (0 === \count($imports)) {
+                    return $imports;
+                }
+            }
+        }
+
+        return $imports;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return false|int
+     */
+    private function getLambdaUseIndex(Tokens $tokens, $index)
+    {
+        if (!$tokens[$index]->isGivenKind(T_FUNCTION) || !$this->tokensAnalyzer->isLambda($index)) {
+            return false;
+        }
+
+        $lambdaUseIndex = $tokens->getNextMeaningfulToken($index); // we are @ '(' or '&' after this
+
+        if ($tokens[$lambdaUseIndex]->isGivenKind(CT::T_RETURN_REF)) {
+            $lambdaUseIndex = $tokens->getNextMeaningfulToken($lambdaUseIndex);
+        }
+
+        $lambdaUseIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $lambdaUseIndex); // we are @ ')' after this
+        $lambdaUseIndex = $tokens->getNextMeaningfulToken($lambdaUseIndex);
+
+        if (!$tokens[$lambdaUseIndex]->isGivenKind(CT::T_USE_LAMBDA)) {
+            return false;
+        }
+
+        return $lambdaUseIndex;
+    }
+
+    /**
+     * @return array
+     */
+    private function filterArguments(Tokens $tokens, array $arguments)
+    {
+        $imports = [];
+
+        foreach ($arguments as $start => $end) {
+            $info = $this->argumentsAnalyzer->getArgumentInfo($tokens, $start, $end);
+            $argument = $info->getNameIndex();
+
+            if ($tokens[$tokens->getPrevMeaningfulToken($argument)]->equals('&')) {
+                continue;
+            }
+
+            $argumentCandidate = $tokens[$argument];
+
+            if ('$this' === $argumentCandidate->getContent()) {
+                continue;
+            }
+
+            if ($this->tokensAnalyzer->isSuperGlobal($argument)) {
+                continue;
+            }
+
+            $imports[$argumentCandidate->getContent()] = $argument;
+        }
+
+        return $imports;
+    }
+
+    private function clearImports(Tokens $tokens, array $imports)
+    {
+        foreach ($imports as $content => $removeIndex) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($removeIndex);
+            $previousRemoveIndex = $tokens->getPrevMeaningfulToken($removeIndex);
+
+            if ($tokens[$previousRemoveIndex]->equals(',')) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($previousRemoveIndex);
+            } elseif ($tokens[$previousRemoveIndex]->equals('(')) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($tokens->getNextMeaningfulToken($removeIndex)); // next is always ',' here
+            }
+        }
+    }
+
+    /**
+     * Remove `use` and all imported variables.
+     *
+     * @param int $lambdaUseIndex
+     * @param int $lambdaUseCloseBraceIndex
+     */
+    private function clearImportsAndUse(Tokens $tokens, $lambdaUseIndex, $lambdaUseCloseBraceIndex)
+    {
+        for ($i = $lambdaUseCloseBraceIndex; $i >= $lambdaUseIndex; --$i) {
+            if ($tokens[$i]->isComment()) {
+                continue;
+            }
+
+            if ($tokens[$i]->isWhitespace()) {
+                $previousIndex = $tokens->getPrevNonWhitespace($i);
+
+                if ($tokens[$previousIndex]->isComment()) {
+                    continue;
+                }
+            }
+
+            $tokens->clearTokenAndMergeSurroundingWhitespace($i);
+        }
+    }
+}

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -18,12 +18,18 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
 /**
  * @author SpacePossum
  */
 final class ReturnAssignmentFixer extends AbstractFixer
 {
+    /**
+     * @var TokensAnalyzer
+     */
+    private $tokensAnalyzer;
+
     /**
      * {@inheritdoc}
      */
@@ -60,6 +66,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $tokenCount = \count($tokens);
+        $this->tokensAnalyzer = new TokensAnalyzer($tokens);
 
         for ($index = 1; $index < $tokenCount; ++$index) {
             if (!$tokens[$index]->isGivenKind(T_FUNCTION)) {
@@ -183,7 +190,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
                 }
             }
 
-            if ($this->isSuperGlobal($tokens[$index])) {
+            if ($this->tokensAnalyzer->isSuperGlobal($index)) {
                 $isRisky = true;
 
                 continue;
@@ -331,29 +338,5 @@ final class ReturnAssignmentFixer extends AbstractFixer
         }
 
         $tokens->clearTokenAndMergeSurroundingWhitespace($index);
-    }
-
-    /**
-     * @return bool
-     */
-    private function isSuperGlobal(Token $token)
-    {
-        static $superNames = [
-            '$_COOKIE' => true,
-            '$_ENV' => true,
-            '$_FILES' => true,
-            '$_GET' => true,
-            '$_POST' => true,
-            '$_REQUEST' => true,
-            '$_SERVER' => true,
-            '$_SESSION' => true,
-            '$GLOBALS' => true,
-        ];
-
-        if (!$token->isGivenKind(T_VARIABLE)) {
-            return false;
-        }
-
-        return isset($superNames[strtoupper($token->getContent())]);
     }
 }

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -48,7 +48,7 @@ function foo( \$bar, \$baz )
      * {@inheritdoc}
      *
      * Must run before FunctionToConstantFixer.
-     * Must run after CombineConsecutiveIssetsFixer, CombineNestedDirnameFixer, PowToExponentiationFixer.
+     * Must run after CombineConsecutiveIssetsFixer, CombineNestedDirnameFixer, LambdaNotUsedImportFixer, PowToExponentiationFixer.
      */
     public function getPriority()
     {

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -610,6 +610,34 @@ final class TokensAnalyzer
     }
 
     /**
+     * @param int $index
+     *
+     * @return bool
+     */
+    public function isSuperGlobal($index)
+    {
+        static $superNames = [
+            '$_COOKIE' => true,
+            '$_ENV' => true,
+            '$_FILES' => true,
+            '$_GET' => true,
+            '$_POST' => true,
+            '$_REQUEST' => true,
+            '$_SERVER' => true,
+            '$_SESSION' => true,
+            '$GLOBALS' => true,
+        ];
+
+        $token = $this->tokens[$index];
+
+        if (!$token->isGivenKind(T_VARIABLE)) {
+            return false;
+        }
+
+        return isset($superNames[strtoupper($token->getContent())]);
+    }
+
+    /**
      * Find classy elements.
      *
      * Searches in tokens from the classy (start) index till the end (index) of the classy.

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -111,6 +111,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['implode_call'], $fixers['method_argument_space']],
             [$fixers['indentation_type'], $fixers['phpdoc_indent']],
             [$fixers['is_null'], $fixers['yoda_style']],
+            [$fixers['lambda_not_used_import'], $fixers['no_spaces_inside_parenthesis']],
             [$fixers['line_ending'], $fixers['braces']],
             [$fixers['list_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']],

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer
+ */
+final class LambdaNotUsedImportFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            'simple' => [
+                '<?php $foo = function() {};',
+                '<?php $foo = function() use ($bar) {};',
+            ],
+            'simple, one of two' => [
+                '<?php $foo = function & () use ( $foo) { echo $foo; };',
+                '<?php $foo = function & () use ($bar, $foo) { echo $foo; };',
+            ],
+            'simple, one used, one reference, two not used' => [
+                '<?php $foo = function() use ($bar, &$foo  ) { echo $bar; };',
+                '<?php $foo = function() use ($bar, &$foo, $not1, $not2) { echo $bar; };',
+            ],
+            'simple, but witch comments' => [
+                '<?php $foo = function()
+# 1
+#2
+# 3
+#4
+# 5
+ #6
+{};',
+                '<?php $foo = function()
+use
+# 1
+( #2
+# 3
+$bar #4
+# 5
+) #6
+{};',
+            ],
+            'nested lambda I' => [
+                '<?php
+
+$f = function() {
+    return function ($d) use ($c) {
+        $b = 1; echo $c;
+    };
+};
+',
+                '<?php
+
+$f = function() use ($b) {
+    return function ($d) use ($c) {
+        $b = 1; echo $c;
+    };
+};
+',
+            ],
+            'nested lambda II' => [
+                '<?php
+// do not fix
+$f = function() use ($a) { return function() use ($a) { return function() use ($a) { return function() use ($a) { echo $a; }; }; }; };
+$f = function() use ($b) { return function($b) { return function($b) { return function($b) { echo $b; }; }; }; };
+
+// do fix
+$f = function() { return function() { return function() { return function() { }; }; }; };
+                ',
+                '<?php
+// do not fix
+$f = function() use ($a) { return function() use ($a) { return function() use ($a) { return function() use ($a) { echo $a; }; }; }; };
+$f = function() use ($b) { return function($b) { return function($b) { return function($b) { echo $b; }; }; }; };
+
+// do fix
+$f = function() use ($a) { return function() use ($a) { return function() use ($a) { return function() use ($a) { }; }; }; };
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @requires PHP 7.0
+     * @dataProvider providePhp70Cases
+     */
+    public function testFixPhp70($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function providePhp70Cases()
+    {
+        return [
+            'anonymous class' => [
+                '<?php
+$a = function() use ($b) { new class($b){}; }; // do not fix
+$a = function() { new class(){ public function foo($b){echo $b;}}; }; // do fix
+',
+                '<?php
+$a = function() use ($b) { new class($b){}; }; // do not fix
+$a = function() use ($b) { new class(){ public function foo($b){echo $b;}}; }; // do fix
+',
+            ],
+            [
+                '<?php $fn = function() use ($this) {} ?>',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideDoNotFixCases
+     */
+    public function testDoNotFix($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideDoNotFixCases()
+    {
+        return [
+            'reference' => [
+                '<?php $fn = function() use(&$b) {} ?>',
+            ],
+            'super global, invalid from PHP7.1' => [
+                '<?php $fn = function() use($_COOKIE) {} ?>',
+            ],
+            'compact 1' => [
+                '<?php $foo = function() use ($b) { return compact(\'b\'); };',
+            ],
+            'compact 2' => [
+                '<?php $foo = function() use ($b) { return \compact(\'b\'); };',
+            ],
+            'eval' => [
+                '<?php $foo = function($c) use ($b) { eval($c); };',
+            ],
+            'super global' => [
+                '<?php $foo = function($c) use ($_COOKIE) {};',
+            ],
+            'include' => [
+                '<?php $foo = function($c) use ($b) { include __DIR__."/test3.php"; };',
+            ],
+            'include_once' => [
+                '<?php $foo = function($c) use ($b) { include_once __DIR__."/test3.php"; };',
+            ],
+            'require' => [
+                '<?php $foo = function($c) use ($b) { require __DIR__."/test3.php"; };',
+            ],
+            'require_once' => [
+                '<?php $foo = function($c) use ($b) { require_once __DIR__."/test3.php"; };',
+            ],
+            '${X}' => [
+                '<?php $foo = function($g) use ($b) { $h = ${$g}; };',
+            ],
+            '$$c' => [
+                '<?php $foo = function($g) use ($b) { $h = $$g; };',
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/priority/lambda_not_used_import,no_spaces_inside_parenthesis.test
+++ b/tests/Fixtures/Integration/priority/lambda_not_used_import,no_spaces_inside_parenthesis.test
@@ -1,0 +1,9 @@
+--TEST--
+Integration of fixers: lambda_not_used_import,no_spaces_inside_parenthesis.
+--RULESET--
+{"lambda_not_used_import": true, "no_spaces_inside_parenthesis": true}
+--EXPECT--
+<?php $foo = function() use ($bar, &$foo) { echo $bar; };
+
+--INPUT--
+<?php $foo = function() use ($bar, &$foo, $not1, $not2) { echo $bar; };


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4652

```
$ php php-cs-fixer describe lambda_not_used_import
Description of lambda_not_used_import rule.
Lambda must not import variables it doesn't use.

Fixing examples:
 * Example #1.
```

```diff
--- Original
+++ New
@@ -1,2 +1,2 @@
 <?php
-$foo = function() use ($bar) {};
+$foo = function() {};
```

Found some valid cases on SF, happy to make adjustments based on reviews :)