### PR TITLE
NoBlankLinesAfterPhpdocFixer — Do not strip newline between docblock and use statements

### DIFF
--- a/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
@@ -79,6 +79,7 @@ class Bar {}
             T_CONTINUE,
             T_BREAK,
             T_DECLARE,
+            T_USE,
         ];
 
         foreach ($tokens as $index => $token) {

--- a/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixerTest.php
@@ -144,6 +144,20 @@ EOF;
         $this->doTest($expected);
     }
 
+    public function testLineBeforeUseStatementIsNotRemoved()
+    {
+        $expected = <<<'EOF'
+<?php
+/**
+ * This is some license header.
+ */
+
+use Foo\Bar;
+EOF;
+
+        $this->doTest($expected);
+    }
+
     public function testLineWithSpacesIsRemovedWhenNextTokenIsIndented()
     {
         $this->doTest(


### PR DESCRIPTION
When a docblock is followed by a use statement, it is most likely a file-level docblock. File-level docblocks should be followed by a newline as per the phpDoc standard: https://docs.phpdoc.org/getting-started/your-first-set-of-documentation.html

Example:

```
<?php
/**
 * Some license info.
 */

use Foo\Bar;

/**
 * My class.
 */
class MyClass
...
```