### PR TITLE
julienfalque:deprecate-final-static-access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -686,6 +686,7 @@ Choose from the list of available rules:
 * **final_static_access**
 
   Converts ``static`` access to ``self`` access in ``final`` classes.
+  DEPRECATED: use ``self_static_accessor`` instead.
 
 * **fopen_flag_order** [@Symfony:risky, @PhpCsFixer:risky]
 


### PR DESCRIPTION
Should be deprecated in v2.16 & v3.0 & master?
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4673

> **julienfalque** commented on 28 Nov
> 
> In v2.16, we added rules ``final_static_access`` and ``self_static_accessor`` but they almost do the same thing so we can actually drop one. 
> 
> I chose to deprecate ``final_static_access`` in favor of ``self_static_accessor`` because the former does not support anonymous classes while the latter does.