### PR TITLE
Braces - do while loop gets broken

### DIFF
--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5246,6 +5246,18 @@ function foo()
 }
 ',
             ],
+            [
+                '<?php
+
+function f()
+{
+    do {
+        foo();
+    } //
+    while (false);
+}
+',
+            ]
         ];
     }
 


### PR DESCRIPTION
The braces fixer is fixing:

```php
<?php
function f()
{
    do {
        foo();
    } //
    while (false);
}
```

to:

```php
<?php
function f()
{
    do {
        foo();
    } // while (false);
}
```

which is invalid syntax.

---

By comparison, the braces fixer leaves the following unchanged:

```php
<?php

do {
    foo();
} //
while (false);
```