### PR TITLE
NoSuperfluousPhpdocTagsFixer - Remove for typed properties (PHP 7.4)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1112,8 +1112,8 @@ Choose from the list of available rules:
 
 * **no_superfluous_phpdoc_tags** [@Symfony, @PhpCsFixer]
 
-  Removes ``@param`` and ``@return`` tags that don't provide any useful
-  information.
+  Removes ``@param``, ``@return`` and ``@var`` tags that don't provide any
+  useful information.
 
   Configuration options:
 

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -36,7 +36,7 @@ final class NoSuperfluousPhpdocTagsFixer extends AbstractFixer implements Config
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Removes `@param` and `@return` tags that don\'t provide any useful information.',
+            'Removes `@param`, `@return` and `@var` tags that don\'t provide any useful information.',
             [
                 new CodeSample('<?php
 class Foo {
@@ -67,6 +67,14 @@ class Foo {
     public function doFoo(Bar $bar, $baz): Baz {}
 }
 ', new VersionSpecification(70000)),
+                new VersionSpecificCodeSample('<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    private Bar $bar;
+}
+', new VersionSpecification(70400)),
             ]
         );
     }
@@ -106,46 +114,25 @@ class Foo {
                 continue;
             }
 
-            $functionIndex = $this->findDocumentedFunction($tokens, $index);
-            if (null === $functionIndex) {
+            $content = $initialContent = $token->getContent();
+
+            $documentedElementIndex = $this->findDocumentedElement($tokens, $index);
+
+            if (null === $documentedElementIndex) {
                 continue;
             }
 
-            $docBlock = new DocBlock($token->getContent());
+            $token = $tokens[$documentedElementIndex];
 
-            $openingParenthesisIndex = $tokens->getNextTokenOfKind($functionIndex, ['(']);
-            $closingParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openingParenthesisIndex);
-
-            $argumentsInfo = $this->getArgumentsInfo(
-                $tokens,
-                $openingParenthesisIndex + 1,
-                $closingParenthesisIndex - 1
-            );
-
-            foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
-                if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
-                    continue;
-                }
-
-                $argumentName = $matches[1];
-
-                if (
-                    !isset($argumentsInfo[$argumentName])
-                    || $this->annotationIsSuperfluous($annotation, $argumentsInfo[$argumentName], $shortNames)
-                ) {
-                    $annotation->remove();
-                }
+            if ($token->isGivenKind(T_FUNCTION)) {
+                $content = $this->fixFunctionDocComment($content, $tokens, $index, $shortNames);
+            } elseif ($token->isGivenKind(T_VARIABLE)) {
+                $content = $this->fixPropertyDocComment($content, $tokens, $index, $shortNames);
             }
 
-            $returnTypeInfo = $this->getReturnTypeInfo($tokens, $closingParenthesisIndex);
-
-            foreach ($docBlock->getAnnotationsOfType('return') as $annotation) {
-                if ($this->annotationIsSuperfluous($annotation, $returnTypeInfo, $shortNames)) {
-                    $annotation->remove();
-                }
+            if ($content !== $initialContent) {
+                $tokens[$index] = new Token([T_DOC_COMMENT, $content]);
             }
-
-            $tokens[$index] = new Token([T_DOC_COMMENT, $docBlock->getContent()]);
         }
     }
 
@@ -162,17 +149,114 @@ class Foo {
         ]);
     }
 
-    private function findDocumentedFunction(Tokens $tokens, $index)
+    /**
+     * @param int $docCommentIndex
+     *
+     * @return null|int
+     */
+    private function findDocumentedElement(Tokens $tokens, $docCommentIndex)
     {
+        $index = $docCommentIndex;
+
         do {
             $index = $tokens->getNextMeaningfulToken($index);
 
-            if (null === $index || $tokens[$index]->isGivenKind(T_FUNCTION)) {
+            if (null === $index || $tokens[$index]->isGivenKind([T_FUNCTION, T_CLASS, T_INTERFACE])) {
                 return $index;
             }
         } while ($tokens[$index]->isGivenKind([T_ABSTRACT, T_FINAL, T_STATIC, T_PRIVATE, T_PROTECTED, T_PUBLIC]));
 
+        $index = $tokens->getNextMeaningfulToken($docCommentIndex);
+
+        $kindsBeforeProperty = [T_STATIC, T_PRIVATE, T_PROTECTED, T_PUBLIC, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, T_STRING, T_NS_SEPARATOR];
+
+        if (!$tokens[$index]->isGivenKind($kindsBeforeProperty)) {
+            return null;
+        }
+
+        do {
+            $index = $tokens->getNextMeaningfulToken($index);
+
+            if ($tokens[$index]->isGivenKind(T_VARIABLE)) {
+                return $index;
+            }
+        } while ($tokens[$index]->isGivenKind($kindsBeforeProperty));
+
         return null;
+    }
+
+    /**
+     * @param string $content
+     * @param int    $functionIndex
+     *
+     * @return string
+     */
+    private function fixFunctionDocComment($content, Tokens $tokens, $functionIndex, array $shortNames)
+    {
+        $docBlock = new DocBlock($content);
+
+        $openingParenthesisIndex = $tokens->getNextTokenOfKind($functionIndex, ['(']);
+        $closingParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openingParenthesisIndex);
+
+        $argumentsInfo = $this->getArgumentsInfo(
+            $tokens,
+            $openingParenthesisIndex + 1,
+            $closingParenthesisIndex - 1
+        );
+
+        foreach ($docBlock->getAnnotationsOfType('param') as $annotation) {
+            if (0 === Preg::match('/@param(?:\s+[^\$]\S+)?\s+(\$\S+)/', $annotation->getContent(), $matches)) {
+                continue;
+            }
+
+            $argumentName = $matches[1];
+
+            if (!isset($argumentsInfo[$argumentName]) || $this->annotationIsSuperfluous($annotation, $argumentsInfo[$argumentName], $shortNames)) {
+                $annotation->remove();
+            }
+        }
+
+        $returnTypeInfo = $this->getReturnTypeInfo($tokens, $closingParenthesisIndex);
+
+        foreach ($docBlock->getAnnotationsOfType('return') as $annotation) {
+            if ($this->annotationIsSuperfluous($annotation, $returnTypeInfo, $shortNames)) {
+                $annotation->remove();
+            }
+        }
+
+        return $docBlock->getContent();
+    }
+
+    /**
+     * @param string $content
+     * @param int    $docCommentIndex
+     *
+     * @return string
+     */
+    private function fixPropertyDocComment($content, Tokens $tokens, $docCommentIndex, array $shortNames)
+    {
+        $docBlock = new DocBlock($content);
+
+        $index = $tokens->getNextMeaningfulToken($docCommentIndex);
+
+        $kindsBeforeProperty = [T_STATIC, T_PRIVATE, T_PROTECTED, T_PUBLIC];
+
+        if (!$tokens[$index]->isGivenKind($kindsBeforeProperty)) {
+            return $content;
+        }
+
+        do {
+            $index = $tokens->getNextMeaningfulToken($index);
+
+            $propertyTypeInfo = $this->parseTypeHint($tokens, $index);
+            foreach ($docBlock->getAnnotationsOfType('var') as $annotation) {
+                if ($this->annotationIsSuperfluous($annotation, $propertyTypeInfo, $shortNames)) {
+                    $annotation->remove();
+                }
+            }
+        } while ($tokens[$index]->isGivenKind($kindsBeforeProperty));
+
+        return $docBlock->getContent();
     }
 
     /**
@@ -254,7 +338,7 @@ class Foo {
         }
 
         return [
-            'type' => $type,
+            'type' => '' === $type ? null : $type,
             'allows_null' => $allowsNull,
         ];
     }
@@ -268,6 +352,8 @@ class Foo {
     {
         if ('param' === $annotation->getTag()->getName()) {
             $regex = '/@param\s+(?:\S|\s(?!\$))+\s\$\S+\s+\S/';
+        } elseif ('var' === $annotation->getTag()->getName()) {
+            $regex = '/@var\s+\S+(\s+\$\S+)?(\s+)([^$\s]+)/';
         } else {
             $regex = '/@return\s+\S+\s+\S/';
         }

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -116,6 +116,49 @@ class Foo {
                 null,
                 ['allow_mixed' => true],
             ],
+            'allow_mixed=>false on property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var mixed
+     */
+    private $bar;
+}',
+                ['allow_mixed' => false],
+            ],
+            'allow_mixed=>false on property with var' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var mixed $bar
+     */
+    private $bar;
+}',
+                ['allow_mixed' => false],
+            ],
+            'allow_mixed=>false on property but with comment' => [
+                '<?php
+class Foo {
+    /**
+     * @var mixed comment
+     */
+    private $bar;
+}',
+                null,
+                ['allow_mixed' => false],
+            ],
             'multiple different types' => [
                 '<?php
 class Foo {
@@ -300,6 +343,69 @@ class Foo {
      * @return null
      */
     public function doFoo($foo) {}
+}',
+            ],
+            'inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'inline_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDocs
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'inline_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    public function doFoo($foo) {}
+}',
+            ],
+            'property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * @inheritDoc
+     */
+    private $foo;
+}',
+            ],
+            'inline_property_inheritdoc' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdoc}
+     */
+    private $foo;
+}',
+            ],
+            'inline_property_inheritdocs' => [
+                '<?php
+class Foo {
+    /**
+     * {@inheritdocs}
+     */
+    private $foo;
 }',
             ],
         ];
@@ -621,6 +727,251 @@ class Foo {
      * @return array|null
      */
     public function doFoo(iterable $bar, ?int $baz): ?array {}
+}',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp74Cases
+     * @requires PHP 7.4
+     */
+    public function testFixPhp74($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixPhp74Cases()
+    {
+        return [
+            'some typed static public property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    static public Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    static public Bar $bar;
+}',
+            ],
+            'some typed public static property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    public static Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    public static Bar $bar;
+}',
+            ],
+            'some typed public property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    public Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    public Bar $bar;
+}',
+            ],
+            'some typed protected property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    protected Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    protected Bar $bar;
+}',
+            ],
+            'some typed private property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var Bar
+     */
+    private Bar $bar;
+}',
+            ],
+            'some typed nullable private property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private ?Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var null|Bar
+     */
+    private ?Bar $bar;
+}',
+            ],
+            'some typed nullable property with name declared in phpdoc' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private ?Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var null|Bar $bar
+     */
+    private ?Bar $bar;
+}',
+            ],
+            'some array property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private array $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var array
+     */
+    private array $bar;
+}',
+            ],
+            'some nullable array property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private ?array $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var array|null
+     */
+    private ?array $bar;
+}',
+            ],
+            'some object property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    private object $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var object
+     */
+    private object $bar;
+}',
+            ],
+            'phpdoc does not match property typehint' => [
+                '<?php
+class Foo {
+    /**
+     * @var FooImplementation1|FooImplementation2
+     */
+    private FooInterface $bar;
+}',
+            ],
+            'allow_mixed=>false but with description' => [
+                '<?php
+class Foo {
+    /**
+     * @var mixed description
+     */
+    private $bar;
+}',
+                null,
+                ['allow_mixed' => false],
+            ],
+            'allow_mixed=>false but with description and var name' => [
+                '<?php
+class Foo {
+    /**
+     * @var mixed $bar description
+     */
+    private $bar;
+}',
+                null,
+                ['allow_mixed' => false],
+            ],
+            'allow_mixed=>true' => [
+                '<?php
+class Foo {
+    /**
+     * @var mixed
+     */
+    private $bar;
+}',
+                null,
+                ['allow_mixed' => true],
+            ],
+            'some fully qualified typed property' => [
+                '<?php
+class Foo {
+    /**
+     */
+    protected \Foo\Bar $bar;
+}',
+                '<?php
+class Foo {
+    /**
+     * @var \Foo\Bar
+     */
+    protected \Foo\Bar $bar;
+}',
+            ],
+            'some fully qualified imported typed property' => [
+                '<?php
+namespace App;
+use Foo\Bar;
+class Foo {
+    /**
+     */
+    protected Bar $bar;
+}',
+                '<?php
+namespace App;
+use Foo\Bar;
+class Foo {
+    /**
+     * @var \Foo\Bar
+     */
+    protected Bar $bar;
 }',
             ],
         ];


### PR DESCRIPTION
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4713

This one targets 2.15. I hope I did it correctly. If not, then https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4713 still has the 2.16 version.