### PR TITLE
Allow PHP-CS-Fixer/diff dependency 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "composer/semver": "^1.4",
         "composer/xdebug-handler": "^1.2",
         "doctrine/annotations": "^1.2",
-        "php-cs-fixer/diff": "^1.3",
+        "php-cs-fixer/diff": "^1.3 || ^2.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
         "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
         "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",


### PR DESCRIPTION
Important, if `php-cs-fixer/diff` package of version 2.0 is required in custom project with CS fixer also required.