### PR TITLE
Rename simple_lambda_call to regular_callable_call

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1786,6 +1786,12 @@ Choose from the list of available rules:
     ones; defaults to ``['getrandmax' => 'mt_getrandmax', 'rand' =>
     'mt_rand', 'srand' => 'mt_srand']``
 
+* **regular_callable_call**
+
+  Callables must be called without using ``call_user_func*`` when possible.
+
+  *Risky rule: risky when the ``call_user_func`` or ``call_user_func_array`` function is overridden.*
+
 * **return_assignment** [@PhpCsFixer]
 
   Local, dynamic and directly referenced variables should not be assigned
@@ -1835,12 +1841,6 @@ Choose from the list of available rules:
   ``error_suppression`` instead.
 
   *Risky rule: silencing of deprecation errors might cause changes to code behaviour.*
-
-* **simple_lambda_call**
-
-  Calling lambdas without using ``call_user_func*``, when possible.
-
-  *Risky rule: risky when the ``call_user_func`` or ``call_user_func_array`` function is overridden.*
 
 * **simple_to_complex_string_variable** [@PhpCsFixer]
 

--- a/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
+++ b/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
-final class SimpleLambdaCallFixer extends AbstractFixer
+final class RegularCallableCallFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}
@@ -33,7 +33,7 @@ final class SimpleLambdaCallFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Calling lambdas without using `call_user_func*`, when possible.',
+            'Callables must be called without using `call_user_func*` when possible.',
             [
                 new CodeSample(
                     '<?php

--- a/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
@@ -19,9 +19,9 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @covers \PhpCsFixer\Fixer\FunctionNotation\SimpleLambdaCallFixer
+ * @covers \PhpCsFixer\Fixer\FunctionNotation\RegularCallableCallFixer
  */
-final class SimpleLambdaCallFixerTest extends AbstractFixerTestCase
+final class RegularCallableCallFixerTest extends AbstractFixerTestCase
 {
     /**
      * @param string      $expected


### PR DESCRIPTION
Reasoning:
* not all callables are lambdas;
* _simple_ is confusing IMO.