### PR TITLE
NoUnneededFinalMethodFixer - update description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1153,7 +1153,8 @@ Choose from the list of available rules:
 
 * **no_unneeded_final_method** [@Symfony, @PhpCsFixer]
 
-  A final class must not have final methods.
+  A ``final`` class must not have ``final`` methods and ``private`` method must
+  not be ``final``.
 
 * **no_unreachable_default_argument_value** [@PhpCsFixer:risky]
 

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -28,7 +28,7 @@ final class NoUnneededFinalMethodFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'A final class must not have final methods.',
+            'A `final` class must not have `final` methods and `private` method must not be `final`.',
             [
                 new CodeSample(
                     '<?php


### PR DESCRIPTION
Follow up to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3093.

Pinging @localheinz (as author of mentionend PR), @Slamdunk (as author of the fixer) and @peter-gribanov (as reporter od the [issue](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4771)) for review.