### PR TITLE
Don't use deprecated fixer in integration tests

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -125,7 +125,7 @@ class Foo
      * {@inheritdoc}
      *
      * Must run before ArrayIndentationFixer, MethodChainingIndentationFixer.
-     * Must run after ClassAttributesSeparationFixer, ElseifFixer, LineEndingFixer, MethodSeparationFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleTraitInsertPerStatementFixer.
+     * Must run after ClassAttributesSeparationFixer, ElseifFixer, LineEndingFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleTraitInsertPerStatementFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -211,7 +211,7 @@ class Example
     /**
      * {@inheritdoc}
      *
-     * Must run before ClassAttributesSeparationFixer, MethodSeparationFixer, NoBlankLinesAfterClassOpeningFixer, SpaceAfterSemicolonFixer.
+     * Must run before ClassAttributesSeparationFixer, NoBlankLinesAfterClassOpeningFixer, SpaceAfterSemicolonFixer.
      * Must run after NoPhp4ConstructorFixer, ProtectedToPrivateFixer.
      */
     public function getPriority()

--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -42,8 +42,6 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Dep
 
     /**
      * {@inheritdoc}
-     *
-     * Must run after NoUselessReturnFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -55,7 +55,7 @@ function example($b) {
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeReturnFixer, BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer.
+     * Must run before BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer.
      * Must run after NoEmptyStatementFixer, NoUnneededCurlyBracesFixer, NoUselessElseFixer, SimplifiedNullReturnFixer.
      */
     public function getPriority()

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -49,7 +49,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
      * {@inheritdoc}
      *
      * Must run before PhpdocIndentFixer.
-     * Must run after ClassAttributesSeparationFixer, MethodSeparationFixer.
+     * Must run after ClassAttributesSeparationFixer.
      */
     public function getPriority()
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\AutoReview;
 
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Tests\Test\IntegrationCaseFactory;
@@ -47,6 +48,16 @@ final class FixerFactoryTest extends TestCase
     public function testFixersPriority(FixerInterface $first, FixerInterface $second)
     {
         static::assertLessThan($first->getPriority(), $second->getPriority(), sprintf('"%s" should have less priority than "%s"', \get_class($second), \get_class($first)));
+    }
+
+    /**
+     * @dataProvider provideFixersPriorityCases
+     * @dataProvider provideFixersPrioritySpecialPhpdocCases
+     */
+    public function testFixersAreNotDeprecated(FixerInterface $first, FixerInterface $second)
+    {
+        static::assertNotInstanceOf(DeprecatedFixerInterface::class, $first);
+        static::assertNotInstanceOf(DeprecatedFixerInterface::class, $second);
     }
 
     public function provideFixersPriorityCases()
@@ -108,8 +119,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['list_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']],
             [$fixers['method_chaining_indentation'], $fixers['array_indentation']],
-            [$fixers['method_separation'], $fixers['braces']],
-            [$fixers['method_separation'], $fixers['indentation_type']],
             [$fixers['multiline_whitespace_before_semicolons'], $fixers['space_after_semicolon']],
             [$fixers['no_alias_functions'], $fixers['implode_call']],
             [$fixers['no_alias_functions'], $fixers['php_unit_dedicate_assert']],
@@ -160,12 +169,10 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_else'], $fixers['no_trailing_whitespace']],
             [$fixers['no_useless_else'], $fixers['no_useless_return']],
             [$fixers['no_useless_else'], $fixers['no_whitespace_in_blank_line']],
-            [$fixers['no_useless_return'], $fixers['blank_line_before_return']],
             [$fixers['no_useless_return'], $fixers['blank_line_before_statement']],
             [$fixers['no_useless_return'], $fixers['no_extra_blank_lines']],
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']],
             [$fixers['ordered_class_elements'], $fixers['class_attributes_separation']],
-            [$fixers['ordered_class_elements'], $fixers['method_separation']],
             [$fixers['ordered_class_elements'], $fixers['no_blank_lines_after_class_opening']],
             [$fixers['ordered_class_elements'], $fixers['space_after_semicolon']],
             [$fixers['php_unit_construct'], $fixers['php_unit_dedicate_assert']],

--- a/tests/Fixtures/Integration/priority/class_attributes_separation,braces_2.test
+++ b/tests/Fixtures/Integration/priority/class_attributes_separation,braces_2.test
@@ -1,7 +1,7 @@
 --TEST--
-Integration of fixers: method_separation,braces.
+Integration of fixers: class_attributes_separation,braces.
 --RULESET--
-{"method_separation": true, "braces": true}
+{"class_attributes_separation": {"elements": ["method"]}, "braces": true}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/class_attributes_separation,indentation_type_2.test
+++ b/tests/Fixtures/Integration/priority/class_attributes_separation,indentation_type_2.test
@@ -1,7 +1,7 @@
 --TEST--
-Integration of fixers: method_separation,indentation_type.
+Integration of fixers: class_attributes_separation,indentation_type.
 --RULESET--
-{"method_separation": true, "indentation_type": true}
+{"class_attributes_separation": {"elements": ["method"]}, "indentation_type": true}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/no_useless_return,blank_line_before_statement_2.test
+++ b/tests/Fixtures/Integration/priority/no_useless_return,blank_line_before_statement_2.test
@@ -1,7 +1,7 @@
 --TEST--
-Integration of fixers: no_useless_return,blank_line_before_return.
+Integration of fixers: no_useless_return,blank_line_before_statement.
 --RULESET--
-{"no_useless_return": true, "blank_line_before_return": true}
+{"no_useless_return": true, "blank_line_before_statement": {"statements": ["return"]}}
 --EXPECT--
 <?php
 class Test {

--- a/tests/Fixtures/Integration/priority/ordered_class_elements,class_attributes_separation_2.test
+++ b/tests/Fixtures/Integration/priority/ordered_class_elements,class_attributes_separation_2.test
@@ -1,7 +1,7 @@
 --TEST--
-Integration of fixers: ordered_class_elements,method_separation.
+Integration of fixers: ordered_class_elements,class_attributes_separation.
 --RULESET--
-{"ordered_class_elements": true, "method_separation": true}
+{"ordered_class_elements": true, "class_attributes_separation": {"elements": ["method"]}}
 --EXPECT--
 <?php
 


### PR DESCRIPTION
I've spotted [this](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3419), so this one is to update integration tests.

@keradus @SpacePossum @julienfalque WDYT?