### PR TITLE
Fix: Do not import functions when in root namespace

### DIFF
--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -270,12 +270,10 @@ function foo() {}
 \Foo();
 EXPECTED
             ],
-            'without namespace / only import once' => [
+            'without namespace / do not import, but remove leading slash' => [
                 <<<'EXPECTED'
 <?php
 
-use function bar;
-use function foo;
 foo();
 bar();
 Foo();


### PR DESCRIPTION
This PR

* [x] adds a failing test case
* [ ] stops importing functions when in root namespace

Fixes #4776.