### PR TITLE
Improve static analysis

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -24,6 +24,8 @@ use PhpCsFixer\Utils;
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
+ * @extends \SplFixedArray<Token>
+ *
  * @method Token current()
  * @method Token offsetGet($index)
  */


### PR DESCRIPTION
In my project I implemented a custom fixer. When scanning the project with the latest phpstan I'm getting errors like this:

```
Method App\Module\Core\PhpCsFixer\MyCustomFixer::isCandidate() has parameter $tokens with no value type specified in iterable type PhpCsFixer\Tokenizer\Tokens.
```

The correct fix for this is to make phpstan aware that the `Tokens` class only contains `Token` instances using this annotation.