### PR TITLE
Configurable fixers code sample

### DIFF
--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -52,6 +52,17 @@ switch ($foo) {
 }
 '
                 ),
+                new CodeSample(
+                    '<?php
+switch ($foo) {
+    case 1:
+        foo();
+    case 2:
+        foo();
+}
+',
+                    ['comment_text' => 'some comment']
+                ),
             ],
             'Adds a "no break" comment before fall-through cases, and removes it if there is no fall-through.'
         );

--- a/src/Fixer/FunctionNotation/FopenFlagsFixer.php
+++ b/src/Fixer/FunctionNotation/FopenFlagsFixer.php
@@ -33,7 +33,10 @@ final class FopenFlagsFixer extends AbstractFopenFlagFixer implements Configurat
     {
         return new FixerDefinition(
             'The flags in `fopen` calls must omit `t`, and `b` must be omitted or included consistently.',
-            [new CodeSample("<?php\n\$a = fopen(\$foo, 'rwt');\n")],
+            [
+                new CodeSample("<?php\n\$a = fopen(\$foo, 'rwt');\n"),
+                new CodeSample("<?php\n\$a = fopen(\$foo, 'rwt');\n", ['b_mode' => false]),
+            ],
             null,
             'Risky when the function `fopen` is overridden.'
         );

--- a/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
@@ -39,7 +39,10 @@ final class PhpUnitSizeClassFixer extends AbstractFixer implements WhitespacesAw
     {
         return new FixerDefinition(
             'All PHPUnit test cases should have `@small`, `@medium` or `@large` annotation to enable run time limits.',
-            [new CodeSample("<?php\nclass MyTest extends TestCase {}\n")],
+            [
+                new CodeSample("<?php\nclass MyTest extends TestCase {}\n"),
+                new CodeSample("<?php\nclass MyTest extends TestCase {}\n", ['group' => 'medium']),
+            ],
             'The special groups [small, medium, large] provides a way to identify tests that are taking long to be executed.'
         );
     }

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -131,6 +131,29 @@ final class FixerTest extends TestCase
                 static::assertArrayHasKey($fixerName, $this->allowedRequiredOptions, sprintf('[%s] Has no sample for default configuration.', $fixerName));
             }
 
+            $fixerNamesWithKnownMissingSamplesWithConfig = [
+                'doctrine_annotation_spaces',
+                'general_phpdoc_annotation_remove',
+                'is_null',
+                'php_unit_dedicate_assert_internal_type',
+                'php_unit_internal_class',
+                'php_unit_namespaced',
+                'php_unit_test_case_static_method_calls',
+                'phpdoc_scalar',
+                'phpdoc_to_return_type',
+                'phpdoc_types',
+            ];
+
+            if (\count($configSamplesProvided) < 2) {
+                if (\in_array($fixerName, $fixerNamesWithKnownMissingSamplesWithConfig, true)) {
+                    static::markTestIncomplete(sprintf('[%s] Configurable fixer only provides a default configuration sample and none for its configuration options, please help and add it.', $fixerName));
+                }
+
+                static::fail(sprintf('[%s] Configurable fixer only provides a default configuration sample and none for its configuration options.', $fixerName));
+            } elseif (\in_array($fixerName, $fixerNamesWithKnownMissingSamplesWithConfig, true)) {
+                static::fail(sprintf('[%s] Invalid listed as missing code samples, please update the list.', $fixerName));
+            }
+
             $options = $fixer->getConfigurationDefinition()->getOptions();
 
             foreach ($options as $option) {

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -624,7 +624,7 @@ final class RuleSetTest extends TestCase
             $message = '';
 
             foreach ($duplicates as $setName => $r) {
-                $message .= sprintf("\n%s defines rules the same as it extends from:", $setName);
+                $message .= sprintf("\n\"%s\" defines rules the same as it extends from:", $setName);
 
                 foreach ($duplicates[$setName] as $ruleName => $otherSets) {
                     $message .= sprintf("\n- \"%s\" is also in \"%s\"", $ruleName, implode(', ', $otherSets));
@@ -650,7 +650,7 @@ final class RuleSetTest extends TestCase
                 break; // do not check below, config for the rule has been changed
             }
 
-            if (\count($setRules['sets']) > 0) {
+            if (isset($setRules['sets']) && \count($setRules['sets']) > 0) {
                 $subSetDuplicates = $this->findInSets($setRules['sets'], $ruleName, $config);
 
                 if (\count($subSetDuplicates) > 0) {


### PR DESCRIPTION
Configurable fixers must have at least one code sample with configuration (so other than the default).
Found during some housekeeping