### PR TITLE
ArrayPushFixer - introduction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,12 @@ Choose from the list of available rules:
 
   Each element of an array must be indented exactly once.
 
+* **array_push** [@Symfony:risky, @PhpCsFixer:risky]
+
+  Converts simple usages of ``array_push($x, $y);`` to ``$x[] = $y;``.
+
+  *Risky rule: risky when the function ``array_push`` is overridden.*
+
 * **array_syntax** [@Symfony, @PhpCsFixer]
 
   PHP arrays should be declared using the configured syntax.

--- a/src/Fixer/Alias/ArrayPushFixer.php
+++ b/src/Fixer/Alias/ArrayPushFixer.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Alias;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class ArrayPushFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`.',
+            [new VersionSpecificCodeSample("<?php\narray_push(\$x, \$y);\n", new VersionSpecification(70000))],
+            null,
+            'Risky when the function `array_push` is overridden.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return \PHP_VERSION_ID >= 70000 && $tokens->isTokenKindFound(T_STRING) && $tokens->count() > 7;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $functionsAnalyzer = new FunctionsAnalyzer();
+
+        for ($index = $tokens->count() - 7; $index > 0; --$index) {
+            if (!$tokens[$index]->equals([T_STRING, 'array_push'], false)) {
+                continue;
+            }
+
+            if (!$functionsAnalyzer->isGlobalFunctionCall($tokens, $index)) {
+                continue; // redeclare/override
+            }
+
+            // meaningful before must be `<?php`, `{`, `}` or `;`
+
+            $callIndex = $index;
+            $index = $tokens->getPrevMeaningfulToken($index);
+            $namespaceSeparatorIndex = null;
+
+            if ($tokens[$index]->isGivenKind(T_NS_SEPARATOR)) {
+                $namespaceSeparatorIndex = $index;
+                $index = $tokens->getPrevMeaningfulToken($index);
+            }
+
+            if (!$tokens[$index]->equalsAny([';', '{', '}', ')', [T_OPEN_TAG]])) {
+                continue;
+            }
+
+            // figure out where the arguments list opens
+
+            $openBraceIndex = $tokens->getNextMeaningfulToken($callIndex);
+            $blockType = Tokens::detectBlockType($tokens[$openBraceIndex]);
+
+            if (null === $blockType || Tokens::BLOCK_TYPE_PARENTHESIS_BRACE !== $blockType['type']) {
+                continue;
+            }
+
+            // figure out where the arguments list closes
+
+            $closeBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openBraceIndex);
+
+            // meaningful after `)` must be `;`, `? >` or nothing
+
+            $afterCloseBraceIndex = $tokens->getNextMeaningfulToken($closeBraceIndex);
+
+            if (null !== $afterCloseBraceIndex && !$tokens[$afterCloseBraceIndex]->equalsAny([';', [T_CLOSE_TAG]])) {
+                continue;
+            }
+
+            // must have 2 arguments
+
+            // first argument must be a variable (with possibly array indexing etc.),
+            // after that nothing meaningful should be there till the next `,` or `)`
+            // if `)` than we cannot fix it (it is a single argument call)
+
+            $firstArgumentStop = $this->getFirstArgumentEnd($tokens, $openBraceIndex);
+            $firstArgumentStop = $tokens->getNextMeaningfulToken($firstArgumentStop);
+
+            if (!$tokens[$firstArgumentStop]->equals(',')) {
+                return;
+            }
+
+            // second argument can be about anything but ellipsis, we must make sure there is not
+            // a third argument (or more) passed to `array_push`
+
+            $secondArgumentStart = $tokens->getNextMeaningfulToken($firstArgumentStop);
+            $secondArgumentStop = $this->getSecondArgumentEnd($tokens, $secondArgumentStart, $closeBraceIndex);
+
+            if (null === $secondArgumentStop) {
+                continue;
+            }
+
+            // candidate is valid, replace tokens
+
+            $tokens->clearTokenAndMergeSurroundingWhitespace($closeBraceIndex);
+            $tokens->clearTokenAndMergeSurroundingWhitespace($firstArgumentStop);
+            $tokens->insertAt(
+                $firstArgumentStop,
+                [
+                    new Token('['),
+                    new Token(']'),
+                    new Token([T_WHITESPACE, ' ']),
+                    new Token('='),
+                ]
+            );
+            $tokens->clearTokenAndMergeSurroundingWhitespace($openBraceIndex);
+            $tokens->clearTokenAndMergeSurroundingWhitespace($callIndex);
+
+            if (null !== $namespaceSeparatorIndex) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($namespaceSeparatorIndex);
+            }
+        }
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return int
+     */
+    private function getFirstArgumentEnd(Tokens $tokens, $index)
+    {
+        $nextIndex = $tokens->getNextMeaningfulToken($index);
+        $nextToken = $tokens[$nextIndex];
+
+        while ($nextToken->equalsAny([
+            '$',
+            '[',
+            '(',
+            [CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN],
+            [CT::T_DYNAMIC_PROP_BRACE_OPEN],
+            [CT::T_DYNAMIC_VAR_BRACE_OPEN],
+            [CT::T_NAMESPACE_OPERATOR],
+            [T_NS_SEPARATOR],
+            [T_STATIC],
+            [T_STRING],
+            [T_VARIABLE],
+        ])) {
+            $blockType = Tokens::detectBlockType($nextToken);
+
+            if (null !== $blockType) {
+                $nextIndex = $tokens->findBlockEnd($blockType['type'], $nextIndex);
+            }
+
+            $index = $nextIndex;
+            $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
+            $nextToken = $tokens[$nextIndex];
+        }
+
+        if ($nextToken->isGivenKind(T_OBJECT_OPERATOR)) {
+            return $this->getFirstArgumentEnd($tokens, $nextIndex);
+        }
+
+        if ($nextToken->isGivenKind(T_PAAMAYIM_NEKUDOTAYIM)) {
+            return $this->getFirstArgumentEnd($tokens, $tokens->getNextMeaningfulToken($nextIndex));
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param int $index
+     * @param int $endIndex boundary, i.e. tokens index of `)`
+     *
+     * @return null|int
+     */
+    private function getSecondArgumentEnd(Tokens $tokens, $index, $endIndex)
+    {
+        if ($tokens[$index]->isGivenKind(T_ELLIPSIS)) {
+            return null;
+        }
+
+        $index = $tokens->getNextMeaningfulToken($index);
+
+        for (; $index <= $endIndex; ++$index) {
+            $blockType = Tokens::detectBlockType($tokens[$index]);
+
+            while (null !== $blockType && $blockType['isStart']) {
+                $index = $tokens->findBlockEnd($blockType['type'], $index);
+                $index = $tokens->getNextMeaningfulToken($index);
+                $blockType = Tokens::detectBlockType($tokens[$index]);
+            }
+
+            if ($tokens[$index]->equals(',') || $tokens[$index]->isGivenKind([T_YIELD, T_YIELD_FROM, T_LOGICAL_AND, T_LOGICAL_OR, T_LOGICAL_XOR])) {
+                return null;
+            }
+        }
+
+        return $endIndex;
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
@@ -247,7 +247,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 ];
 
                 if ($isMultilineWhitespace) {
-                    array_push($tokensOverrideArgStart, new Token([T_WHITESPACE, $indent.$this->whitespacesConfig->getIndent()]));
+                    $tokensOverrideArgStart[] = new Token([T_WHITESPACE, $indent.$this->whitespacesConfig->getIndent()]);
                     array_unshift($tokensOverrideArgBefore, new Token([T_WHITESPACE, $indent]));
                 }
 

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -201,6 +201,7 @@ final class RuleSet implements RuleSetInterface
         ],
         '@Symfony:risky' => [
             '@PHP56Migration:risky' => true,
+            'array_push' => true,
             'combine_nested_dirname' => true,
             'dir_constant' => true,
             'ereg_to_preg' => true,

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Alias;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Alias\ArrayPushFixer
+ */
+final class ArrayPushFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     * @requires PHP 7.0
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        yield 'minimal' => [
+            '<?php $a[] =$b;',
+            '<?php array_push($a,$b);',
+        ];
+
+        yield 'simple' => [
+            '<?php $a[] = $b;',
+            '<?php array_push($a, $b);',
+        ];
+
+        yield 'simple, spaces' => [
+            '<?php  $a   [] =$b ;',
+            '<?php array_push( $a ,  $b );',
+        ];
+
+        yield 'simple 25x times' => [
+            '<?php '.str_repeat('$a[] = $b;', 25),
+            '<?php '.str_repeat('array_push($a, $b);', 25),
+        ];
+
+        yield 'simple namespaced' => [
+            '<?php $a[] = $b1;',
+            '<?php \array_push($a, $b1);',
+        ];
+
+        yield '; before' => [
+            '<?php ; $a1[] = $b2 ?>',
+            '<?php ; array_push($a1, $b2) ?>',
+        ];
+
+        yield ') before' => [
+            '<?php
+                if ($c) $a[] = $b;
+
+                while (--$c > 0) $a[] = $c;
+            ',
+            '<?php
+                if ($c) array_push($a, $b);
+
+                while (--$c > 0) array_push($a, $c);
+            ',
+        ];
+
+        yield '} before' => [
+            '<?php $b3 = []; { $a = 1; } $b5[] = 1;',
+            '<?php $b3 = []; { $a = 1; } \array_push($b5, 1);',
+        ];
+
+        yield '{ before' => [
+            '<?php { $a[] = $b8; }',
+            '<?php { array_push($a, $b8); }',
+        ];
+
+        yield 'comments and PHPDoc' => [
+            '<?php /* */ $a2[] = $b3 /** */;',
+            '<?php /* */ array_push($a2, $b3) /** */;',
+        ];
+
+        yield [
+            '<?php $a5{1*3}[2+1][] = $b4{2+1};',
+            '<?php array_push($a5{1*3}[2+1], $b4{2+1});',
+        ];
+
+        yield [
+            '<?php $a4[1][] = $b6[2];',
+            '<?php array_push($a4[1], $b6[2]);',
+        ];
+
+        yield [
+            '<?php $a5{1*3}[2+1][] = $b7{2+1};',
+            '<?php array_push($a5{1*3}[2+1], $b7{2+1});',
+        ];
+
+        yield 'case insensitive and precedence' => [
+            '<?php
+                $a[] = $b--;
+                $a[] = ++$b;
+                $a[] = !$b;
+                $a[] = $b + $c;
+                $a[] = 1 ** $c / 2 || !b && c(1,2,3) ^ $a{1};
+            ',
+            '<?php
+                array_push($a, $b--);
+                ARRAY_push($a, ++$b);
+                array_PUSH($a, !$b);
+                ARRAY_PUSH($a, $b + $c);
+                \array_push($a, 1 ** $c / 2 || !b && c(1,2,3) ^ $a{1});
+            ',
+        ];
+
+        yield [
+            '<?php $a::$c[] = $b;',
+            '<?php array_push($a::$c, $b);',
+        ];
+
+        yield [
+            '<?php $a[foo(1,2,3)][] = $b[foo(1,2,3)];',
+            '<?php array_push($a[foo(1,2,3)], $b[foo(1,2,3)]);',
+        ];
+
+        yield [
+            '<?php \A\B::$foo[] = 1;',
+            '<?php array_push(\A\B::$foo, 1);',
+        ];
+
+        yield [
+            '<?php static::$foo[] = 1;',
+            '<?php array_push(static::$foo, 1);',
+        ];
+
+        yield [
+            '<?php namespace\A::$foo[] = 1;',
+            '<?php array_push(namespace\A::$foo, 1);',
+        ];
+
+        yield [
+            '<?php foo()->bar[] = 1;',
+            '<?php array_push(foo()->bar, 1);',
+        ];
+
+        yield [
+            '<?php foo()[] = 1;',
+            '<?php array_push(foo(), 1);',
+        ];
+
+        yield [
+            '<?php $a->$c[] = $b;', // invalid on PHP5.6
+            '<?php array_push($a->$c, $b);',
+        ];
+
+        yield [
+            '<?php $a->$c[1]->$d{$a--}->$a[7][] = $b;', // invalid on PHP5.6
+            '<?php array_push($a->$c[1]->$d{$a--}->$a[7], $b);',
+        ];
+
+        yield 'push multiple' => [
+            '<?php array_push($a6, $b9, $c);',
+        ];
+
+        yield 'push multiple II' => [
+            '<?php ; array_push($a6a, $b9->$a(1,2), $c);',
+        ];
+
+        yield 'returns number of elements in the array I' => [
+            '<?php foo(array_push($a7, $b10)); // ;array_push($a, $b);',
+        ];
+
+        yield 'returns number of elements in the array II' => [
+            '<?php $a = 3 * array_push($a8, $b11);',
+        ];
+
+        yield 'returns number of elements in the array III' => [
+            '<?php $a = foo($z, array_push($a9, $b12));',
+        ];
+
+        yield 'returns number of elements in the array IV' => [
+            '<?php $z = array_push($a00, $b13);',
+        ];
+
+        yield 'function declare in different namespace' => [
+            '<?php namespace Foo; function array_push($a11, $b14){};',
+        ];
+
+        yield 'overridden detect I' => [
+            '<?php namespace Foo; array_push(1, $a15);',
+        ];
+
+        yield 'overridden detect II' => [
+            '<?php namespace Foo; array_push($a + 1, $a16);',
+        ];
+
+        yield [
+            '<?php
+                array_push(++foo()->bar, 1);
+                array_push(foo()->bar + 1, 1);
+            ',
+        ];
+
+        yield 'different namespace and not a function call' => [
+            '<?php
+                A\array_push($a, $b17);
+                A::array_push($a, $b18);
+                $a->array_push($a, $b19);
+            ',
+        ];
+
+        yield 'open echo' => [
+            '<?= array_push($a, $b20) ?> <?= array_push($a, $b20); ?>',
+        ];
+
+        yield 'ellipsis' => [
+            '<?php array_push($a, ...$b21);',
+        ];
+
+        $precedenceCases = [
+            '$b = yield $c',
+            '$b = yield from $c',
+            '$b and $c',
+            '$b or $c',
+            '$b xor $c',
+        ];
+
+        foreach ($precedenceCases as $precedenceCase) {
+            yield [
+                sprintf(
+                    '<?php array_push($a, %s);',
+                    $precedenceCase
+                ),
+            ];
+        }
+
+        yield [
+            '<?php
+                while (foo()) $a[] = $b;
+                foreach (foo() as $C) $a[] = $b;
+                if (foo()) $a[] = $b;
+                if ($b) {} elseif (foo()) $a[] = $b;
+            ',
+            '<?php
+                while (foo()) array_push($a, $b);
+                foreach (foo() as $C) array_push($a, $b);
+                if (foo()) array_push($a, $b);
+                if ($b) {} elseif (foo()) array_push($a, $b);
+            ',
+        ];
+    }
+}


### PR DESCRIPTION
```
possum@aquarium:/home/possum/work/PHP-CS-Fixer$ php php-cs-fixer describe array_push
Description of array_push rule.
Converts simple usages of ``array_push($x, $y);`` to ``$x[] = $y;``.

Fixer applying this rule is risky.
Risky when the function `array_push` is overridden.

Fixing examples:
 * Example #1.
```
```diff
--- Original
+++ New
@@ -1,2 +1,2 @@
 <?php
-array_push($x, $y);
+$x[] = $y;
```

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3483