### PR TITLE
FinalClassFixer - Doctrine\ORM\Mapping as ORM alias should not be required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -656,7 +656,7 @@ Choose from the list of available rules:
   - ``annotation-black-list`` (``array``): class level annotations tags that must be
     omitted to fix the class, even if all of the white list ones are used
     as well. (case insensitive); defaults to ``['@final', '@Entity',
-    '@ORM\\Entity']``
+    '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity']``
   - ``annotation-white-list`` (``array``): class level annotations tags that must be
     set in order to fix the class. (case insensitive); defaults to
     ``['@internal']``

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -154,7 +154,13 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
             (new FixerOptionBuilder('annotation-black-list', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues($annotationsAsserts)
-                ->setDefault(['@final', '@Entity', '@ORM\Entity'])
+                ->setDefault([
+                    '@final',
+                    '@Entity',
+                    '@ORM\Entity',
+                    '@ORM\Mapping\Entity',
+                    '@Mapping\Entity',
+                ])
                 ->setNormalizer($annotationsNormalizer)
                 ->getOption(),
             (new FixerOptionBuilder('consider-absent-docblock-as-internal-class', 'Should classes without any DocBlock be fixed to final?'))

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -39,6 +39,8 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
         return [
             ['<?php /** @Entity */ class MyEntity {}'],
             ['<?php use Doctrine\ORM\Mapping as ORM; /** @ORM\Entity */ class MyEntity {}'],
+            ['<?php use Doctrine\ORM\Mapping; /** @Mapping\Entity */ class MyEntity {}'],
+            ['<?php use Doctrine\ORM; /** @ORM\Mapping\Entity */ class MyEntity {}'],
             ['<?php /** @entity */ class MyEntity {}'],
             ['<?php use Doctrine\ORM\Mapping as ORM; /** @orm\entity */ class MyEntity {}'],
             ['<?php abstract class MyAbstract {}'],


### PR DESCRIPTION
This PR

* [x] adjusts the `FinalInternalClassFixer` (which is proxied to from the `FinalClassFixer`) to also ignore entities when the namespace `Doctrine\ORM\Mapping` is not aliased to `ORM`

💁‍♂ While it's suggested by literally all examples for Doctrine entity mapping, using the alias is not a requirement.