### PR TITLE
BracesFixer - fix invalid code generation on alternative syntax

### DIFF
--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5263,4 +5263,83 @@ function example()
 }'
         );
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixAlternativeSyntaxCases
+     */
+    public function testFixAlternativeSyntax($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixAlternativeSyntaxCases()
+    {
+        yield [
+            '<?php if (foo()) {
+    while (bar()) {
+    }
+}',
+            '<?php if (foo()) while (bar()) {}',
+        ];
+
+        yield [
+            '<?php if ($a) {
+    foreach ($b as $c) {
+    }
+}',
+            '<?php if ($a) foreach ($b as $c) {}',
+        ];
+
+        yield [
+            '<?php if ($a) foreach ($b as $c): ?> X <?php endforeach; ?>',
+        ];
+
+        yield [
+            '<?php if ($a) while ($b): ?> X <?php endwhile; ?>',
+        ];
+
+        yield [
+            '<?php if ($a) for (;;): ?> X <?php endfor; ?>',
+        ];
+
+        yield [
+            '<?php if ($a) switch ($a): case 1: ?> X <?php endswitch; ?>',
+        ];
+
+        yield [
+            '<?php if ($a): elseif ($b): for (;;): ?> X <?php endfor; endif; ?>',
+        ];
+
+        yield [
+            '<?php switch ($a): case 1: for (;;): ?> X <?php endfor; endswitch; ?>,',
+        ];
+
+        yield [
+            '<?php
+if ($a) foreach ($b as $c): ?>
+    <?php if ($a) for (;;): ?>
+        <?php if ($a) foreach ($b as $c): ?>
+            <?php if ($a) for (;;): ?>
+                <?php if ($a) while ($b): ?>
+                    <?php if ($a) while ($b): ?>
+                        <?php if ($a) foreach ($b as $c): ?>
+                            <?php if ($a) for (;;): ?>
+                                <?php if ($a) while ($b): ?>
+                                    <?php if ($a) while ($b): ?>
+
+                                    <?php endwhile; ?>
+                                <?php endwhile; ?>
+                            <?php endfor; ?>
+                        <?php endforeach; ?>
+                    <?php endwhile; ?>
+                <?php endwhile; ?>
+            <?php endfor; ?>
+        <?php endforeach; ?>
+    <?php endfor; ?>
+<?php endforeach; ?>',
+        ];
+    }
 }


### PR DESCRIPTION
Fixes #4811 

Basically this skips some edge cases when using alternative syntax. For now I don't want to add a lot of logic to support this case fully as we are splitting this fixer in the future anyway. Secondly we don't support alternative syntax in a lot of cases in the project.

For those interested; `BracesFixer::findStatementEnd` doesn't find the correct index for some of the alternative syntax expressions (see utests)