### PR TITLE
Deprecate Config::create()

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,7 +16,7 @@ $finder = PhpCsFixer\Finder::create()
     ->append([__DIR__.'/php-cs-fixer'])
 ;
 
-$config = PhpCsFixer\Config::create()
+$config = (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PHP56Migration' => true,

--- a/README.rst
+++ b/README.rst
@@ -2095,7 +2095,7 @@ The example below will add two rules to the default list of PSR2 set rules:
         ->in(__DIR__)
     ;
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setRules([
             '@PSR2' => true,
             'strict_param' => true,
@@ -2122,7 +2122,7 @@ The following example shows how to use all ``Symfony`` rules but the ``full_open
         ->in(__DIR__)
     ;
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setRules([
             '@Symfony' => true,
             'full_opening_tag' => false,
@@ -2137,7 +2137,7 @@ configure them in your config file.
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setIndent("\t")
         ->setLineEnding("\r\n")
     ;
@@ -2160,7 +2160,7 @@ Cache can be disabled via ``--using-cache`` option or config file:
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setUsingCache(false)
     ;
 
@@ -2170,7 +2170,7 @@ Cache file can be specified via ``--cache-file`` option or config file:
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setCacheFile(__DIR__.'/.php_cs.cache')
     ;
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -170,7 +170,7 @@ $config = Symfony\CS\Config\Config::create()
 ```
 <?php
 // phpcs-fixer v2.*
-$config = PhpCsFixer\Config::create()
+$config = (new PhpCsFixer\Config())
     ->registerCustomFixers([
         new ShopSys\CodingStandards\CsFixer\MissingButtonTypeFixer(),
         new ShopSys\CodingStandards\CsFixer\OrmJoinColumnRequireNullableFixer(),

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,9 +41,13 @@ class Config implements ConfigInterface
 
     /**
      * @return static
+     *
+     * @deprecated since 2.17
      */
     public static function create()
     {
+        @trigger_error(__METHOD__.' is deprecated since 2.17 and will be removed in 3.0.', E_USER_DEPRECATED);
+
         return new static();
     }
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -167,7 +167,7 @@ The example below will add two rules to the default list of PSR2 set rules:
         ->in(__DIR__)
     ;
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setRules([
             '@PSR2' => true,
             'strict_param' => true,
@@ -194,7 +194,7 @@ The following example shows how to use all ``Symfony`` rules but the ``full_open
         ->in(__DIR__)
     ;
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setRules([
             '@Symfony' => true,
             'full_opening_tag' => false,
@@ -209,7 +209,7 @@ configure them in your config file.
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setIndent("\t")
         ->setLineEnding("\r\n")
     ;
@@ -232,7 +232,7 @@ Cache can be disabled via ``--using-cache`` option or config file:
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setUsingCache(false)
     ;
 
@@ -242,7 +242,7 @@ Cache file can be specified via ``--cache-file`` option or config file:
 
     <?php
 
-    return PhpCsFixer\Config::create()
+    return (new PhpCsFixer\Config())
         ->setCacheFile(__DIR__.'/.php_cs.cache')
     ;
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -134,7 +134,7 @@ final class ConfigTest extends TestCase
         $finder = new Finder();
         $finder->in(__DIR__.'/Fixtures/FinderDirectory');
 
-        $config = Config::create()->setFinder($finder);
+        $config = (new Config())->setFinder($finder);
 
         $items = iterator_to_array(
             $config->getFinder(),
@@ -150,7 +150,7 @@ final class ConfigTest extends TestCase
         $finder = new SymfonyFinder();
         $finder->in(__DIR__.'/Fixtures/FinderDirectory');
 
-        $config = Config::create()->setFinder($finder);
+        $config = (new Config())->setFinder($finder);
 
         $items = iterator_to_array(
             $config->getFinder(),
@@ -222,5 +222,23 @@ final class ConfigTest extends TestCase
             [$fixers, $fixers],
             [$fixers, new \ArrayIterator($fixers)],
         ];
+    }
+
+    public function testConfigConstructorWithName()
+    {
+        $anonymousConfig = new Config();
+        $namedConfig = new Config('foo');
+
+        static::assertSame($anonymousConfig->getName(), 'default');
+        static::assertSame($namedConfig->getName(), 'foo');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation PhpCsFixer\Config::create is deprecated since 2.17 and will be removed in 3.0.
+     */
+    public function testDeprecatedConstructor()
+    {
+        Config::create();
     }
 }

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_1/.php_cs.dist
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_1/.php_cs.dist
@@ -4,4 +4,4 @@ if (!class_exists('Test1Config')) {
     class Test1Config extends PhpCsFixer\Config {}
 }
 
-return Test1Config::create();
+return new Test1Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_2/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_2/.php_cs
@@ -4,4 +4,4 @@ if (!class_exists('Test2Config')) {
     class Test2Config extends PhpCsFixer\Config {}
 }
 
-return Test2Config::create();
+return new Test2Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_3/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_3/.php_cs
@@ -4,4 +4,4 @@ if (!class_exists('Test3Config')) {
     class Test3Config extends PhpCsFixer\Config {}
 }
 
-return Test3Config::create();
+return new Test3Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_3/.php_cs.dist
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_3/.php_cs.dist
@@ -1,3 +1,3 @@
 <?php
 
-return PhpCsFixer\Config::create();
+return new PhpCsFixer\Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_4/my.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_4/my.php_cs
@@ -4,4 +4,4 @@ if (!class_exists('Test4Config')) {
     class Test4Config extends PhpCsFixer\Config {}
 }
 
-return Test4Config::create();
+return new Test4Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_6/.php_cs.dist
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_6/.php_cs.dist
@@ -4,4 +4,4 @@ if (!class_exists('Test6Config')) {
     class Test6Config extends PhpCsFixer\Config {}
 }
 
-return Test6Config::create();
+return new Test6Config();

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_7/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_7/.php_cs
@@ -1,3 +1,3 @@
 <?php
 
-return PhpCsFixer\Config::create()->setFormat('xls');
+return (new PhpCsFixer\Config())->setFormat('xls');

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_8/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_8/.php_cs
@@ -1,6 +1,6 @@
 <?php
 
-$config = PhpCsFixer\Config::create();
+$config = new PhpCsFixer\Config();
 $config->setRiskyAllowed(true);
 $config->setRules(array('php_unit_construct' => true));
 $config->setUsingCache(false);

--- a/tests/Fixtures/ConfigurationResolverConfigFile/case_9/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverConfigFile/case_9/.php_cs
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->filter(function ($x) { return true; })

--- a/tests/Fixtures/ConfigurationResolverPathsIntersection/d/.php_cs
+++ b/tests/Fixtures/ConfigurationResolverPathsIntersection/d/.php_cs
@@ -16,7 +16,7 @@ if (!class_exists('ConfigurationResolverPathsIntersection_d_Config')) {
     }
 }
 
-return ConfigurationResolverPathsIntersection_d_Config::create()
+return (new ConfigurationResolverPathsIntersection_d_Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__.'/..')

--- a/tests/Fixtures/FixCommand/.phpcs
+++ b/tests/Fixtures/FixCommand/.phpcs
@@ -1,6 +1,6 @@
 <?php
 
-$config = PhpCsFixer\Config::create();
+$config = new PhpCsFixer\Config();
 
 $finder = $config->getFinder()->in(__DIR__);
 

--- a/tests/Fixtures/ci-integration/.php_cs.dist
+++ b/tests/Fixtures/ci-integration/.php_cs.dist
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules(array(
         '@Symfony' => true,
     ))


### PR DESCRIPTION
[Config] Add the complete use of config name  with:
- static constructor (passing name to __construct())
- default safe name on static constructor as well
- setter in ConfigInterface.php
- setter in Config.php

Instead of forcing "default".