### PR TITLE
LineEndingFixer - T_CLOSE_TAG support, StringLineEndingFixer - T_INLI…

### DIFF
--- a/src/Fixer/StringNotation/StringLineEndingFixer.php
+++ b/src/Fixer/StringNotation/StringLineEndingFixer.php
@@ -32,7 +32,7 @@ final class StringLineEndingFixer extends AbstractFixer implements WhitespacesAw
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAnyTokenKindsFound([T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE]);
+        return $tokens->isAnyTokenKindsFound([T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML]);
     }
 
     /**
@@ -68,7 +68,7 @@ final class StringLineEndingFixer extends AbstractFixer implements WhitespacesAw
         $ending = $this->whitespacesConfig->getLineEnding();
 
         foreach ($tokens as $tokenIndex => $token) {
-            if (!$token->isGivenKind([T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE])) {
+            if (!$token->isGivenKind([T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML])) {
                 continue;
             }
 

--- a/src/Fixer/Whitespace/LineEndingFixer.php
+++ b/src/Fixer/Whitespace/LineEndingFixer.php
@@ -87,7 +87,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
                 continue;
             }
 
-            if ($token->isGivenKind([T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_START_HEREDOC])) {
+            if ($token->isGivenKind([T_CLOSE_TAG, T_COMMENT, T_DOC_COMMENT, T_OPEN_TAG, T_START_HEREDOC, T_WHITESPACE])) {
                 $tokens[$index] = new Token([
                     $token->getId(),
                     Preg::replace(

--- a/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
+++ b/tests/Fixer/StringNotation/StringLineEndingFixerTest.php
@@ -93,6 +93,10 @@ final class StringLineEndingFixerTest extends AbstractFixerTestCase
                 sprintf(str_replace('<<<', 'B<<<', $heredocTemplate), $input),
                 sprintf(str_replace('<<<', 'B<<<', $heredocTemplate), str_replace("\n", "\r\n", $input)),
             ],
+            'not T_CLOSE_TAG, do T_INLINE_HTML' => [
+                "<?php foo(); ?>\r\nA\n\n",
+                "<?php foo(); ?>\r\nA\r\n\r\n",
+            ],
         ];
     }
 

--- a/tests/Fixer/Whitespace/LineEndingFixerTest.php
+++ b/tests/Fixer/Whitespace/LineEndingFixerTest.php
@@ -50,19 +50,27 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
             "<?php \$b = \" \$a \r\n 123\"; \$a = <<<TEST\r\nAAAAA \n |\r\nTEST;\r\n", // both cases
         ];
 
-        // !T_INLINE_HTML
-        $cases[] = [
-            "<?php ?>\r\n<?php ?>\r\n",
+        $cases['T_INLINE_HTML'] = [
+            "<?php ?>\nZ\r\n<?php ?>\nZ\r\n",
         ];
 
-        // !T_CONSTANT_ENCAPSED_STRING
-        $cases[] = [
+        $cases['!T_CONSTANT_ENCAPSED_STRING'] = [
             "<?php \$a=\"a\r\n\";",
         ];
 
         $cases[] = [
             "<?php echo 'foo',\n\n'bar';",
             "<?php echo 'foo',\r\r\n'bar';",
+        ];
+
+        $cases['T_CLOSE_TAG'] = [
+            "<?php\n?>\n<?php\n",
+            "<?php\n?>\r\n<?php\n",
+        ];
+
+        $cases['T_CLOSE_TAG II'] = [
+            "<?php\n?>\n<?php\n?>\n<?php\n",
+            "<?php\n?>\r\n<?php\n?>\r\n<?php\n",
         ];
 
         return $cases;
@@ -103,28 +111,23 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
     private function provideCommonCases()
     {
         return [
-            // T_OPEN_TAG
-            [
+            'T_OPEN_TAG' => [
                 "<?php\n \$a = 1;",
                 "<?php\r\n \$a = 1;",
             ],
-            // T_WHITESPACE
-            [
+            'T_WHITESPACE' => [
                 "<?php \n \$a\n= 1;\n",
                 "<?php \r\n \$a\r\n= 1;\r\n",
             ],
-            // T_COMMENT
-            [
+            'T_COMMENT' => [
                 "<?php /*\n*/",
                 "<?php /*\r\n*/",
             ],
-            // T_DOC_COMMENT
-            [
+            'T_DOC_COMMENT' => [
                 "<?php /**\n*/",
                 "<?php /**\r\n*/",
             ],
-            // T_START_HEREDOC
-            [
+            'T_START_HEREDOC' => [
                 "<?php \$a = <<<'TEST'\nAA\nTEST;\n",
                 "<?php \$a = <<<'TEST'\r\nAA\r\nTEST;\r\n",
             ],
@@ -132,8 +135,7 @@ final class LineEndingFixerTest extends AbstractFixerTestCase
                 "<?php \$a = <<<TEST\nAAA\nTEST;\n",
                 "<?php \$a = <<<TEST\r\nAAA\r\nTEST;\r\n",
             ],
-            // T_ENCAPSED_AND_WHITESPACE
-            [
+            'T_ENCAPSED_AND_WHITESPACE' => [
                 "<?php \$a = <<<'TEST'\nAAAA 1\n \$b\nTEST;\n",
                 "<?php \$a = <<<'TEST'\r\nAAAA 1\r\n \$b\r\nTEST;\r\n",
             ],


### PR DESCRIPTION
…NE_HTML support

Fixes #4812 

Fixes two issues of the line ending fixers. For reference https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/2224 and https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3452