### PR TITLE
Fixed the unit tests

### DIFF
--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -613,7 +613,7 @@ EOT
             ],
             [
                 '<?php
-    final class MyTest extends \PHPUnit_Framework_TestCase
+    abstract class MyTest extends \PHPUnit_Framework_TestCase
     {
         /**
          * @expectedException FooException


### PR DESCRIPTION
The tokenising linter doesn't say this is a syntax error, which is why the PHP 7.x tests were passing, but the PHP 5.6 linter doesn't like this.