### PR TITLE
HeaderCommentFixer - do not remove class docs

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -238,7 +238,29 @@ echo 1;
     {
         $index = $tokens->getNextNonWhitespace($headerNewIndex);
 
-        return null === $index || !$tokens[$index]->isComment() ? null : $index;
+        if (null === $index || !$tokens[$index]->isComment()) {
+            return null;
+        }
+
+        $next = $index + 1;
+
+        if (!isset($tokens[$next]) || \in_array($this->configuration['separate'], ['top', 'none'], true) || !$tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
+            return $index;
+        }
+
+        if ($tokens[$next]->isWhitespace()) {
+            if (!Preg::match('/^\h*\R\h*$/D', $tokens[$next]->getContent())) {
+                return $index;
+            }
+
+            ++$next;
+        }
+
+        if (!isset($tokens[$next]) || !$tokens[$next]->isClassy() && !$tokens[$next]->isGivenKind(T_FUNCTION)) {
+            return $index;
+        }
+
+        return $this->getHeaderAsComment() === $tokens[$index]->getContent() ? $index : null;
     }
 
     /**

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -384,6 +384,99 @@ class Bar
 {
 }',
             ],
+            [
+                ['header' => 'tmp'],
+                '<?php
+
+/*
+ * tmp
+ */
+
+/**
+ * Foo class doc.
+ */
+class Foo {}',
+                '<?php
+
+/**
+ * Foo class doc.
+ */
+class Foo {}',
+            ],
+            [
+                ['header' => 'tmp'],
+                '<?php
+
+/*
+ * tmp
+ */
+
+class Foo {}',
+                '<?php
+
+/*
+ * Foo class doc.
+ */
+class Foo {}',
+            ],
+            [
+                [
+                    'header' => 'tmp',
+                    'comment_type' => 'PHPDoc',
+                ],
+                '<?php
+
+/**
+ * tmp
+ */
+
+/**
+ * Foo class doc.
+ */
+class Foo {}',
+                '<?php
+
+/**
+ * Foo class doc.
+ */
+class Foo {}',
+            ],
+            [
+                [
+                    'header' => 'tmp',
+                    'comment_type' => 'PHPDoc',
+                ],
+                '<?php
+
+/**
+ * tmp
+ */
+
+class Foo {}',
+                '<?php
+
+/**
+ * tmp
+ */
+class Foo {}',
+            ],
+            [
+                [
+                    'header' => 'tmp',
+                    'separate' => 'top',
+                ],
+                '<?php
+
+/*
+ * tmp
+ */
+class Foo {}',
+                '<?php
+/**
+ * Foo class doc.
+ */
+class Foo {}',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR tries to fix #4067.

It is difficult to find the correct/best behavior.

My proposal follows these rules:

1) A comment is a class doc comment, if it is a `T_DOC_COMMENT` (not a `T_COMMENT`) and if there is no blank line between the comment and the class/interface/trait/function:

```php
/**
 * this is a class doc comment
 * header comment will be added above
 */
class Foo {}

/**
 * this is NOT a class doc comment (blank line)
 * will be replaced by header comment
 */

class Foo {}

/*
 * this is NOT a class doc comment (no T_DOC_COMMENT)
 * will be replaced by header comment
 */
class Foo {}
```

2) If configuration for `separate` is `top` or `none`, the behavior does not change with this pr, because it is not possible then to make the decision by the blank line after the comment.

3) If `separate` is `both`/`bottom` and `comment_type` is `PHPDoc` and the comment looks like a class doc comment (see 1.), but the content is the same as the expected header, then it is considered as the header comment, and only the missing blank line is added.