### PR TITLE
Added additional phpdoc separation cases

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -618,6 +618,11 @@ EOF;
         $this->doTest("<?php\n    /**\n     * Foo\n     */");
     }
 
+    public function testWithSingleLineDescription()
+    {
+        $this->doTest("<?php\n    /** Foo */");
+    }
+
     public function testWithEmptyDoc()
     {
         $this->doTest("<?php\n    /**\n     */");

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -612,4 +612,14 @@ EOF;
 
         $this->doTest($expected, $input);
     }
+
+    public function testWithOnlyDescription()
+    {
+        $this->doTest("<?php\n    /**\n     * Foo\n     */");
+    }
+
+    public function testWithEmptyDoc()
+    {
+        $this->doTest("<?php\n    /**\n     */");
+    }
 }


### PR DESCRIPTION
Hopefully, this will demonstrate that the phpdoc separation fixer crashes. Related to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4869.