### PR TITLE
ClassAttributesSeparationFixer - add option for no new lines between properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -364,14 +364,14 @@ Choose from the list of available rules:
 
 * **class_attributes_separation** [@Symfony, @PhpCsFixer]
 
-  Class, trait and interface elements must be separated with one blank
-  line.
+  Class, trait and interface elements must be separated with one or no
+  blank line.
 
   Configuration options:
 
-  - ``elements`` (a subset of ``['const', 'method', 'property']``): list of classy
-    elements; 'const', 'method', 'property'; defaults to ``['const',
-    'method', 'property']``
+  - ``elements`` (``array``): dictionary of ``const|method|property`` => ``one|none``
+    values; defaults to ``['const' => 'one', 'property' => 'one', 'method' =>
+    'one']``
 
 * **class_definition** [@PSR2, @Symfony, @PhpCsFixer]
 

--- a/README.rst
+++ b/README.rst
@@ -369,7 +369,7 @@ Choose from the list of available rules:
 
   Configuration options:
 
-  - ``elements`` (``array``): dictionary of ``const|method|property`` => ``one|none``
+  - ``elements`` (``array``): dictionary of ``const|method|property`` => ``none|one``
     values; defaults to ``['const' => 'one', 'method' => 'one', 'property' =>
     'one']``
 

--- a/README.rst
+++ b/README.rst
@@ -364,13 +364,13 @@ Choose from the list of available rules:
 
 * **class_attributes_separation** [@Symfony, @PhpCsFixer]
 
-  Class, trait and interface elements must be separated with one or no
+  Class, trait and interface elements must be separated with one or none
   blank line.
 
   Configuration options:
 
   - ``elements`` (``array``): dictionary of ``const|method|property`` => ``one|none``
-    values; defaults to ``['const' => 'one', 'property' => 'one', 'method' =>
+    values; defaults to ``['const' => 'one', 'method' => 'one', 'property' =>
     'one']``
 
 * **class_definition** [@PSR2, @Symfony, @PhpCsFixer]

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -36,15 +36,30 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
  */
 final class ClassAttributesSeparationFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface, WhitespacesAwareFixerInterface
 {
+    /**
+     * @internal
+     */
     const SPACING_NONE = 'none';
+
+    /**
+     * @internal
+     */
     const SPACING_ONE = 'one';
+
+    /**
+     * @internal
+     */
+    const SUPPORTED_SPACINGS = [self::SPACING_NONE, self::SPACING_ONE];
+
+    /**
+     * @internal
+     */
+    const SUPPORTED_TYPES = ['const', 'method', 'property'];
 
     /**
      * @var array<string, true>
      */
     private $classElementTypes = [];
-    private static $supportedSpacings = [self::SPACING_NONE, self::SPACING_ONE];
-    private static $supportedTypes = ['const', 'method', 'property'];
 
     /**
      * {@inheritdoc}
@@ -174,26 +189,26 @@ class Sample
     protected function createConfigurationDefinition()
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property` => `one|none` values.'))
+            (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property` => `none|one` values.'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function ($option) {
                     foreach ($option as $type => $spacing) {
-                        if (!\in_array($type, self::$supportedTypes, true)) {
+                        if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
                                     'Unexpected element type, expected any of "%s", got "%s".',
-                                    implode('", "', self::$supportedTypes),
+                                    implode('", "', self::SUPPORTED_TYPES),
                                     \is_object($type) ? \get_class($type) : \gettype($type).'#'.$type
                                 )
                             );
                         }
 
-                        if (!\in_array($spacing, self::$supportedSpacings, true)) {
+                        if (!\in_array($spacing, self::SUPPORTED_SPACINGS, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
                                     'Unexpected spacing for element type "%s", expected any of "%s", got "%s".',
                                     $spacing,
-                                    implode('", "', self::$supportedSpacings),
+                                    implode('", "', self::SUPPORTED_SPACINGS),
                                     \is_object($spacing) ? \get_class($spacing) : (null === $spacing ? 'null' : \gettype($spacing).'#'.$spacing)
                                 )
                             );

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -157,14 +157,14 @@ class Sample
                 ;
 
                 $this->fixSpaceBelowClassMethod($tokens, $classEnd, $methodEnd);
-                $this->fixSpaceAboveClassElement($tokens, $classStart, $index);
+                $this->fixSpaceAboveClassElement($tokens, $classStart, $index, $spacing);
 
                 continue;
             }
 
             // `const`, `property` or `method` of an `interface`
             $this->fixSpaceBelowClassElement($tokens, $classEnd, $tokens->getNextTokenOfKind($index, [';']), $spacing);
-            $this->fixSpaceAboveClassElement($tokens, $classStart, $index);
+            $this->fixSpaceAboveClassElement($tokens, $classStart, $index, $spacing);
         }
     }
 
@@ -266,10 +266,11 @@ class Sample
      * Deals with comments, PHPDocs and spaces above the element with respect to the position of the
      * element within the class, interface or trait.
      *
-     * @param int $classStartIndex index of the class Token the element is in
-     * @param int $elementIndex    index of the element to fix
+     * @param int    $classStartIndex index of the class Token the element is in
+     * @param int    $elementIndex    index of the element to fix
+     * @param string $spacing
      */
-    private function fixSpaceAboveClassElement(Tokens $tokens, $classStartIndex, $elementIndex)
+    private function fixSpaceAboveClassElement(Tokens $tokens, $classStartIndex, $elementIndex, $spacing)
     {
         static $methodAttr = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT];
 
@@ -324,7 +325,7 @@ class Sample
 
         // deal with element without a PHPDoc above it
         if (false === $tokens[$nonWhiteAbove]->isGivenKind(T_DOC_COMMENT)) {
-            $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, $nonWhiteAbove === $classStartIndex ? 1 : 2);
+            $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, $nonWhiteAbove === $classStartIndex || self::SPACING_NONE === $spacing ? 1 : 2);
 
             return;
         }

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -172,7 +172,7 @@ class Sample
                     : $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($index, ['{']))
                 ;
 
-                $this->fixSpaceBelowClassMethod($tokens, $classEnd, $methodEnd);
+                $this->fixSpaceBelowClassMethod($tokens, $classEnd, $methodEnd, $spacing);
                 $this->fixSpaceAboveClassElement($tokens, $classStart, $index, $spacing);
 
                 continue;
@@ -282,14 +282,15 @@ class Sample
      * Deals with comments, PHPDocs and spaces above the method with respect to the position of the
      * method within the class or trait.
      *
-     * @param int $classEndIndex
-     * @param int $elementEndIndex
+     * @param int    $classEndIndex
+     * @param int    $elementEndIndex
+     * @param string $spacing
      */
-    private function fixSpaceBelowClassMethod(Tokens $tokens, $classEndIndex, $elementEndIndex)
+    private function fixSpaceBelowClassMethod(Tokens $tokens, $classEndIndex, $elementEndIndex, $spacing)
     {
         $nextNotWhite = $tokens->getNextNonWhitespace($elementEndIndex);
 
-        $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, $nextNotWhite === $classEndIndex ? 1 : 2);
+        $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, $nextNotWhite === $classEndIndex || self::SPACING_NONE === $spacing ? 1 : 2);
     }
 
     /**

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -36,15 +36,15 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
  */
 final class ClassAttributesSeparationFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface, WhitespacesAwareFixerInterface
 {
-    const SPACING_ONE = 'one';
     const SPACING_NONE = 'none';
+    const SPACING_ONE = 'one';
 
     /**
      * @var array<string, true>
      */
     private $classElementTypes = [];
     private static $supportedSpacings = [self::SPACING_NONE, self::SPACING_ONE];
-    private static $supportedTypes = ['const', 'property', 'method'];
+    private static $supportedTypes = ['const', 'method', 'property'];
 
     /**
      * {@inheritdoc}
@@ -65,7 +65,7 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Class, trait and interface elements must be separated with one or no blank line.',
+            'Class, trait and interface elements must be separated with one or none blank line.',
             [
                 new CodeSample(
                     '<?php
@@ -204,8 +204,8 @@ class Sample
                 }])
                 ->setDefault([
                     'const' => self::SPACING_ONE,
-                    'property' => self::SPACING_ONE,
                     'method' => self::SPACING_ONE,
+                    'property' => self::SPACING_ONE,
                 ])
                 ->getOption(),
         ]);
@@ -217,9 +217,9 @@ class Sample
      * Deals with comments, PHPDocs and spaces above the element with respect to the position of the
      * element within the class, interface or trait.
      *
-     * @param int   $classEndIndex
-     * @param int   $elementEndIndex
-     * @param mixed $spacing
+     * @param int    $classEndIndex
+     * @param int    $elementEndIndex
+     * @param string $spacing
      */
     private function fixSpaceBelowClassElement(Tokens $tokens, $classEndIndex, $elementEndIndex, $spacing)
     {

--- a/src/Fixer/ClassNotation/MethodSeparationFixer.php
+++ b/src/Fixer/ClassNotation/MethodSeparationFixer.php
@@ -77,7 +77,7 @@ final class Sample
     protected function createProxyFixers()
     {
         $fixer = new ClassAttributesSeparationFixer();
-        $fixer->configure(['elements' => ['method']]);
+        $fixer->configure(['elements' => ['method' => ClassAttributesSeparationFixer::SPACING_ONE]]);
 
         return [$fixer];
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -70,7 +70,7 @@ final class RuleSet implements RuleSetInterface
                 'allow_single_line_closure' => true,
             ],
             'cast_spaces' => true,
-            'class_attributes_separation' => ['elements' => ['method']],
+            'class_attributes_separation' => ['elements' => ['method' => 'one']],
             'class_definition' => ['single_line' => true],
             'concat_space' => true,
             'declare_equal_normalize' => true,

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -992,6 +992,90 @@ class ezcReflectionMethod extends ReflectionMethod {
      * @param string      $expected
      * @param null|string $input
      *
+     * @dataProvider provideDeprecatedConfigCases
+     * @group legacy
+     * @expectedDeprecation A list of elements is deprecated, use a dictionary of `const|method|property` => `none|one` instead.
+     */
+    public function testWithDeprecatedConfig($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideDeprecatedConfigCases()
+    {
+        return [
+            [
+                '<?php
+                    class A
+                    {
+                        private $a = null;
+
+                        public $b = 1;
+
+                        function A() {}
+                     }
+                ',
+                '<?php
+                    class A
+                    {
+                        private $a = null;
+                        public $b = 1;
+
+
+
+                        function A() {}
+                     }
+                ',
+                ['elements' => ['property']],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        function A() {}
+
+                        function B() {}
+                    }
+                ',
+                '<?php
+                    class A
+                    {
+                        function A() {}
+                        function B() {}
+                    }
+                ',
+                ['elements' => ['method']],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        const A = 1;
+
+                        const THREE = ONE + self::TWO; /* test */ # test
+
+                        const B = 2;
+                    }
+                ',
+                '<?php
+                    class A
+                    {
+
+                        const A = 1;
+                        const THREE = ONE + self::TWO; /* test */ # test
+                        const B = 2;
+                    }
+                ',
+                ['elements' => ['const']],
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
      * @dataProvider provideFix70Cases
      * @requires PHP 7.0
      */

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\ClassNotation;
 
+use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\WhitespacesFixerConfig;
@@ -936,7 +937,29 @@ class ezcReflectionMethod extends ReflectionMethod {
 
                     function A(){}}
                 ',
-                ['elements' => ['property']],
+                ['elements' => ['property' => ClassAttributesSeparationFixer::SPACING_ONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        private $a = null;
+                        public $b = 1;
+
+                    function A(){}}
+                ',
+                '<?php
+                    class A
+                    {
+                        private $a = null;
+
+                        public $b = 1;
+
+
+
+                    function A(){}}
+                ',
+                ['elements' => ['property' => ClassAttributesSeparationFixer::SPACING_NONE]],
             ],
             [
                 '<?php
@@ -957,7 +980,7 @@ class ezcReflectionMethod extends ReflectionMethod {
                         const THREE = ONE + self::TWO; /* test */ # test
                         const B = 2;}
                 ',
-                ['elements' => ['const']],
+                ['elements' => ['const' => 'one']],
             ],
         ];
     }
@@ -1044,7 +1067,7 @@ private $d = 123;
     public function testFix71($expected, $input = null)
     {
         $this->fixer->configure([
-            'elements' => ['method', 'const'],
+            'elements' => ['method' => ClassAttributesSeparationFixer::SPACING_ONE, 'const' => ClassAttributesSeparationFixer::SPACING_ONE],
         ]);
         $this->doTest($expected, $input);
     }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -980,7 +980,7 @@ class ezcReflectionMethod extends ReflectionMethod {
                         const THREE = ONE + self::TWO; /* test */ # test
                         const B = 2;}
                 ',
-                ['elements' => ['const' => 'one']],
+                ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_ONE]],
             ],
         ];
     }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -985,6 +985,63 @@ class ezcReflectionMethod extends ReflectionMethod {
                 ',
                 ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_ONE]],
             ],
+            [
+                '<?php
+                    class A
+                    {
+                        const A = 1;
+                        const THREE = ONE + self::TWO;
+                        const B = 2;
+                    }
+                ',
+                '<?php
+                    class A
+                    {
+                        const A = 1;
+
+                        const THREE = ONE + self::TWO;
+
+                        const B = 2;
+                    }
+                ',
+                ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_NONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        function A() {}
+
+                        function B() {}
+                    }
+                ',
+                '<?php
+                    class A
+                    {
+                        function A() {}
+                        function B() {}
+                    }
+                ',
+                ['elements' => ['method' => ClassAttributesSeparationFixer::SPACING_ONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        function A() {}
+                        function B() {}
+                    }
+                ',
+                '<?php
+                    class A
+                    {
+                        function A() {}
+
+                        function B() {}
+                    }
+                ',
+                ['elements' => ['method' => ClassAttributesSeparationFixer::SPACING_NONE]],
+            ],
         ];
     }
 

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -925,7 +925,8 @@ class ezcReflectionMethod extends ReflectionMethod {
 
                         public $b = 1;
 
-                    function A(){}}
+                        function A() {}
+                     }
                 ',
                 '<?php
                     class A
@@ -935,7 +936,8 @@ class ezcReflectionMethod extends ReflectionMethod {
 
 
 
-                    function A(){}}
+                        function A() {}
+                     }
                 ',
                 ['elements' => ['property' => ClassAttributesSeparationFixer::SPACING_ONE]],
             ],
@@ -946,7 +948,8 @@ class ezcReflectionMethod extends ReflectionMethod {
                         private $a = null;
                         public $b = 1;
 
-                    function A(){}}
+                        function A() {}
+                    }
                 ',
                 '<?php
                     class A
@@ -955,9 +958,8 @@ class ezcReflectionMethod extends ReflectionMethod {
 
                         public $b = 1;
 
-
-
-                    function A(){}}
+                        function A() {}
+                    }
                 ',
                 ['elements' => ['property' => ClassAttributesSeparationFixer::SPACING_NONE]],
             ],
@@ -970,7 +972,7 @@ class ezcReflectionMethod extends ReflectionMethod {
                         const THREE = ONE + self::TWO; /* test */ # test
 
                         const B = 2;
-}
+                    }
                 ',
                 '<?php
                     class A
@@ -978,7 +980,8 @@ class ezcReflectionMethod extends ReflectionMethod {
 
                         const A = 1;
                         const THREE = ONE + self::TWO; /* test */ # test
-                        const B = 2;}
+                        const B = 2;
+                    }
                 ',
                 ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_ONE]],
             ],


### PR DESCRIPTION
Implementation for https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4755

Changes the `class_attributes_separation` option to take options for each type (`const`, `method` or `property`. The options can be either `one` or `none`, indicating one or no spaces between the types.
 
## Example

A configuration like this:
```php
'class_attributes_separation' => ['elements' => ['property' => 'none']],
```

Would change this example code:

```php
<?php
class A
{
    private $a = null;

    public $b = 1;

    function A() {}
}
```

to this:

```php
<?php
class A
{
    private $a = null;
    public $b = 1;

    function A() {}
}
```
