### PR TITLE
HeredocIndentationFixer - config option for indentation level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -814,6 +814,12 @@ Choose from the list of available rules:
 
   Heredoc/nowdoc content must be properly indented. Requires PHP >= 7.3.
 
+  Configuration options:
+
+  - ``indentation`` (``'same_as_start'``, ``'start_plus_one'``): whether the indentation
+    should be the same as in the start token line or one level more;
+    defaults to ``'start_plus_one'``
+
 * **heredoc_to_nowdoc** [@PhpCsFixer]
 
   Convert ``heredoc`` to ``nowdoc`` where possible.

--- a/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
@@ -48,8 +48,9 @@ TEST
      * @dataProvider provideFixCases
      * @requires PHP 7.3
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -257,6 +258,52 @@ EOD
 );
 INPUT
                 ,
+            ],
+            [
+                <<<'EXPECTED'
+<?php
+    foo(<<<EOD
+    abc
+
+        def
+    EOD
+    );
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+    foo(<<<EOD
+abc
+
+    def
+EOD
+    );
+INPUT
+                ,
+                ['indentation' => 'same_as_start'],
+            ],
+            [
+                <<<'EXPECTED'
+<?php
+    foo(<<<EOD
+    abc
+
+        def
+    EOD
+    );
+EXPECTED
+                ,
+                <<<'INPUT'
+<?php
+    foo(<<<EOD
+        abc
+
+            def
+        EOD
+    );
+INPUT
+                ,
+                ['indentation' => 'same_as_start'],
             ],
         ];
     }


### PR DESCRIPTION
We discussed the best indentation level for the HeredocIndentationFixer [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3697#issuecomment-396066783) and [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3915).

But now since I'm actually using it, I changed my mind.
I would like to write code like this:

```php
    public function foo() 
    {
        return $this->createQuery(<<<'DQL'
            SELECT foo
            FROM App\Entity\Foo foo
            WHERE ...
        DQL)->getResult();
    }
```

and NOT:

```php
    public function foo() 
    {
        return $this->createQuery(<<<'DQL'
            SELECT foo
            FROM App\Entity\Foo foo
            WHERE ...
            DQL)->getResult();
    }
```

So I suggest to add a config option `indentation` with possible values `start_plus_one` (default; same as current behavior) and `same_as_start` (new behavior). (Ideas for better names?)

The fixer will remain non-risky, so it does not change the actual string result.
This input:

```php
    $dql = <<<'DQL'
SELECT foo
FROM App\Entity\Foo foo
DQL;
```

will be changed with the new behavior (`same_as_start`) to:

```php
    $dql = <<<'DQL'
    SELECT foo
    FROM App\Entity\Foo foo
    DQL;
```

Adding one more indentation level inside string content is not part of this fixer (as it would be risky). 