### PR TITLE
DX: PhpdocToParamTypeFixer - improve typing

### DIFF
--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -38,7 +38,7 @@ final class PhpdocToParamTypeFixer extends AbstractFixer implements Configuratio
     const MINIMUM_PHP_VERSION = 70000;
 
     /**
-     * @var array
+     * @var array{int, string}[]
      */
     private $blacklistFuncNames = [
         [T_STRING, '__clone'],


### PR DESCRIPTION
type before #4850 was not proper, but if we can say more than `array`, let's do so