### PR TITLE
FixerTest - yield the data in AutoReview

### DIFF
--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -236,9 +236,9 @@ final class FixerTest extends TestCase
 
     public function provideFixerDefinitionsCases()
     {
-        return array_map(static function (FixerInterface $fixer) {
-            return [$fixer];
-        }, $this->getAllFixers());
+        foreach ($this->getAllFixers() as $fixer) {
+            yield $fixer->getName() => [$fixer];
+        }
     }
 
     /**
@@ -280,9 +280,9 @@ final class FixerTest extends TestCase
             return $fixer instanceof ConfigurationDefinitionFixerInterface;
         });
 
-        return array_map(static function (FixerInterface $fixer) {
-            return [$fixer];
-        }, $fixers);
+        foreach ($fixers as $fixer) {
+            yield $fixer->getName() => [$fixer];
+        }
     }
 
     /**


### PR DESCRIPTION
This allows use of PHPUnit's `--filter` to only test one Fixer by its name.