### PR TITLE
Increase PHPStan level to 8 with strict rules

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -8,7 +8,8 @@
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.6",
         "phpstan/phpstan": "0.12.18",
-        "phpstan/phpstan-phpunit": "^0.12"
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12"
     },
     "conflict": {
         "hhvm": "*"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,14372 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 1
+			path: src/AbstractAlignFixerHelper.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: src/AbstractAlignFixerHelper.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\AbstractDoctrineAnnotationFixer\\:\\:\\$classyElements type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Offset 'ignored_tags' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Cannot assign offset \\(int\\|string\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\AbstractDoctrineAnnotationFixer\\:\\:fixAnnotations\\(\\) has parameter \\$doctrineAnnotationTokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/AbstractDoctrineAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/AbstractFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\AbstractFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/AbstractFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 2
+			path: src/AbstractFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\) has parameter \\$argumentEndIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/AbstractFopenFlagFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\) has parameter \\$argumentStartIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/AbstractFopenFlagFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/AbstractLinesBeforeNamespaceFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/AbstractLinesBeforeNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/AbstractLinesBeforeNamespaceFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: src/AbstractLinesBeforeNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 10
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\AbstractNoUselessElseFixer\\:\\:getPreviousBlock\\(\\) should return array\\<int\\> but returns array\\<int, int\\|null\\>\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 2
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/AbstractNoUselessElseFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/AbstractPhpdocTypesFixer.php
+
+		-
+			message: "#^Cannot call method getPriority\\(\\) on PhpCsFixer\\\\Fixer\\\\FixerInterface\\|false\\.$#"
+			count: 1
+			path: src/AbstractProxyFixer.php
+
+		-
+			message: "#^Cannot call method isKeyword\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractPsrAutoloadingFixer.php
+
+		-
+			message: "#^Cannot call method isMagicConstant\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/AbstractPsrAutoloadingFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/AbstractPsrAutoloadingFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of static method PhpCsFixer\\\\Preg\\:\\:match\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/AbstractPsrAutoloadingFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Cache\\\\Cache\\:\\:\\$hashes type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/Cache.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\Cache\\:\\:toJson\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Cache/Cache.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Cache/Cache.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\Directory\\:\\:normalizePath\\(\\) has parameter \\$path with no typehint specified\\.$#"
+			count: 1
+			path: src/Cache/Directory.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Cache/FileCacheManager.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, PhpCsFixer\\\\Cache\\\\CacheInterface\\|null given\\.$#"
+			count: 1
+			path: src/Cache/FileCacheManager.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\FileCacheManager\\:\\:calcHash\\(\\) has parameter \\$content with no typehint specified\\.$#"
+			count: 1
+			path: src/Cache/FileCacheManager.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of static method PhpCsFixer\\\\Cache\\\\Cache\\:\\:fromJson\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Cache/FileHandler.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Cache\\\\Signature\\:\\:\\$rules type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\Signature\\:\\:__construct\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\Signature\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\Signature\\:\\:utf8Encode\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: src/Cache/Signature.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Cache\\\\SignatureInterface\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Cache/SignatureInterface.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$cacheFile has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$customFixers has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$finder has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$format has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$hideProgress has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$indent has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$isRiskyAllowed has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$lineEnding has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$name has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$phpExecutable has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$rules has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Config\\:\\:\\$usingCache has no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Config\\:\\:__construct\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Config\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Instanceof between Traversable and Traversable will always evaluate to true\\.$#"
+			count: 2
+			path: src/Config.php
+
+		-
+			message: "#^Call to function is_object\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
+			count: 2
+			path: src/Config.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Config\\:\\:setRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Config.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\ConfigInterface\\:\\:getFinder\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: src/ConfigInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\ConfigInterface\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ConfigInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\ConfigInterface\\:\\:setRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ConfigInterface.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: src/Console/Application.php
+
+		-
+			message: "#^Offset 0 does not exist on array\\<string\\>\\|string\\|null\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method PhpCsFixer\\\\Console\\\\Command\\\\DescribeCommand\\:\\:describeSet\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$name of method PhpCsFixer\\\\Console\\\\Command\\\\DescribeCommand\\:\\:describeRule\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$needle of method PhpCsFixer\\\\WordMatcher\\:\\:match\\(\\) expects string, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
+			count: 3
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$messages of method Symfony\\\\Component\\\\Console\\\\Output\\\\OutputInterface\\:\\:writeln\\(\\) expects iterable\\|string, string\\|null given\\.$#"
+			count: 3
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$input1 of function array_map expects array, array\\<string\\>\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and array will always evaluate to true\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function lcfirst expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\. \\<error\\>DEPRECATED…' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, array\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Binary operation \"\\+\" between int\\|string and 1 results in an error\\.$#"
+			count: 3
+			path: src/Console/Command/DescribeCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$cwd of class PhpCsFixer\\\\Console\\\\ConfigurationResolver constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Console/Command/FixCommand.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: src/Console/Command/FixCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_file expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/FixCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$time of class PhpCsFixer\\\\Report\\\\ReportSummary constructor expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Console/Command/FixCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$input1 of function array_map expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 3
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_slice expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Command\\\\HelpCommand\\:\\:toString\\(\\) should return string but returns array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Command\\\\HelpCommand\\:\\:getDisplayableAllowedValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 3
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string, int\\|string\\>\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of static method PhpCsFixer\\\\Console\\\\Command\\\\HelpCommand\\:\\:wordwrap\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function lcfirst expects string, array\\<string\\>\\|string given\\.$#"
+			count: 3
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of static method PhpCsFixer\\\\Preg\\:\\:replace\\(\\) expects array\\<string\\>\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$input1 of function array_map expects array, array\\<string\\>\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and array will always evaluate to true\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\: ' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\. DEPRECATED\\: ' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Foreach overwrites \\$line with its value variable\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Command\\\\HelpCommand\\:\\:getFixersHelp\\(\\) should return string but returns array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Console/Command/HelpCommand.php
+
+		-
+			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Binary operation \"\\.\" between string and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Command\\\\ReadmeCommand\\:\\:header\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Command\\\\ReadmeCommand\\:\\:header\\(\\) has parameter \\$underline with no typehint specified\\.$#"
+			count: 1
+			path: src/Console/Command/ReadmeCommand.php
+
+		-
+			message: "#^Cannot call method getVersion\\(\\) on Symfony\\\\Component\\\\Console\\\\Application\\|null\\.$#"
+			count: 1
+			path: src/Console/Command/SelfUpdateCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$versionA of method PhpCsFixer\\\\Console\\\\SelfUpdate\\\\NewVersionCheckerInterface\\:\\:compareVersions\\(\\) expects string, string\\|null given\\.$#"
+			count: 2
+			path: src/Console/Command/SelfUpdateCommand.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Console/Command/SelfUpdateCommand.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$cacheFile has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$cacheManager has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$differ has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$directory has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$finder has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$format has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$linter has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$path has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$progress has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$ruleSet has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:\\$usingCache has no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of class PhpCsFixer\\\\Cache\\\\FileHandler constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"PhpCsFixer\\\\Differ\\\\NullDiffer\"\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"PhpCsFixer\\\\Differ\\\\SebastianBergmannDiffer\"\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"PhpCsFixer\\\\Differ\\\\UnifiedDiffer\"\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 5
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Cannot call method getIndent\\(\\) on PhpCsFixer\\\\ConfigInterface\\|null\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Cannot call method getLineEnding\\(\\) on PhpCsFixer\\\\ConfigInterface\\|null\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 2
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:configFinderIsOverridden\\(\\) should return bool but returns bool\\|null\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Only booleans are allowed in &&, string given on the right side\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:iterableToTraversable\\(\\) has parameter \\$iterable with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:iterableToTraversable\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:parseRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:validateRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\ConfigurationResolver\\:\\:separatedContextLessInclude\\(\\) has parameter \\$path with no typehint specified\\.$#"
+			count: 1
+			path: src/Console/ConfigurationResolver.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Console/Output/ErrorOutput.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\Output\\\\ErrorOutput\\:\\:outputTrace\\(\\) has parameter \\$trace with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/Output/ErrorOutput.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Console\\\\Output\\\\ProcessOutput\\:\\:\\$eventStatusMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/Output/ProcessOutput.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Console/Output/ProcessOutput.php
+
+		-
+			message: "#^Only numeric types are allowed in %, int\\|null given on the right side\\.$#"
+			count: 1
+			path: src/Console/Output/ProcessOutput.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Console/Output/ProcessOutput.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\SelfUpdate\\\\GithubClient\\:\\:getTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/SelfUpdate/GithubClient.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Console\\\\SelfUpdate\\\\GithubClientInterface\\:\\:getTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Console/SelfUpdate/GithubClientInterface.php
+
+		-
+			message: "#^Offset 0 does not exist on array\\<string\\>\\|null\\.$#"
+			count: 1
+			path: src/Console/SelfUpdate/NewVersionChecker.php
+
+		-
+			message: "#^Argument of an invalid type array\\<string\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Console/SelfUpdate/NewVersionChecker.php
+
+		-
+			message: "#^Parameter \\#1 \\$versions of static method Composer\\\\Semver\\\\Semver\\:\\:rsort\\(\\) expects array, array\\<int, mixed\\>\\|null given\\.$#"
+			count: 1
+			path: src/Console/SelfUpdate/NewVersionChecker.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Console/WarningsDetector.php
+
+		-
+			message: "#^Parameter \\#1 \\$format of function sprintf expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Differ/DiffConsoleFormatter.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: src/Differ/DiffConsoleFormatter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Differ/DiffConsoleFormatter.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Differ/DiffConsoleFormatter.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\DocBlock\\\\Annotation\\:\\:\\$end \\(int\\) does not accept int\\|string\\|false\\.$#"
+			count: 1
+			path: src/DocBlock/Annotation.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between false and string will always evaluate to true\\.$#"
+			count: 1
+			path: src/DocBlock/Annotation.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method PhpCsFixer\\\\DocBlock\\\\Line\\:\\:setContent\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 3
+			path: src/DocBlock/Annotation.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/DocBlock/Annotation.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\DocBlock\\\\DocBlock\\:\\:findAnnotationLength\\(\\) has parameter \\$start with no typehint specified\\.$#"
+			count: 1
+			path: src/DocBlock/DocBlock.php
+
+		-
+			message: "#^Parameter \\#1 \\$pos of method PhpCsFixer\\\\DocBlock\\\\DocBlock\\:\\:getLine\\(\\) expects int, float\\|int given\\.$#"
+			count: 2
+			path: src/DocBlock/DocBlock.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method PhpCsFixer\\\\DocBlock\\\\Line\\:\\:setContent\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/DocBlock/Tag.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\DocBlock\\\\TagComparator\\:\\:\\$groups type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/DocBlock/TagComparator.php
+
+		-
+			message: "#^Class PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens extends generic class SplFixedArray but does not specify its types\\: TValue$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\:\\:createFromDocComment\\(\\) return type has no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int, float\\|int\\<1, max\\>\\|int\\<min, \\-1\\> given\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int, float\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Offset 'position' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Offset 'value' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Variable \\$token might not be defined\\.$#"
+			count: 2
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\:\\:offsetSet\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\:\\:offsetSet\\(\\) has parameter \\$token with no typehint specified\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\:\\:offsetUnset\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Doctrine/Annotation/Tokens.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Error\\\\Error\\:\\:\\$appliedFixers type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Error/Error.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Error\\\\Error\\:\\:__construct\\(\\) has parameter \\$appliedFixers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Error/Error.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Error\\\\Error\\:\\:getAppliedFixers\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Error/Error.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 3
+			path: src/Error/ErrorsManager.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Error/ErrorsManager.php
+
+		-
+			message: "#^Call to function is_subclass_of\\(\\) with 'Symfony\\\\\\\\Component…' and 'Symfony\\\\\\\\Contracts…' will always evaluate to true\\.$#"
+			count: 1
+			path: src/Event/Event.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string, int\\|string\\>\\|null given\\.$#"
+			count: 1
+			path: src/FileReader.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FileRemoval\\:\\:\\$files type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FileRemoval.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FileRemoval\\:\\:unlink\\(\\) has parameter \\$path with no typehint specified\\.$#"
+			count: 1
+			path: src/FileRemoval.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/BacktickToShellExecFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\BacktickToShellExecFixer\\:\\:fixBackticks\\(\\) has parameter \\$backtickTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/BacktickToShellExecFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/BacktickToShellExecFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$indexStart of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/BacktickToShellExecFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indexEnd of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/BacktickToShellExecFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Alias\\\\EregToPregFixer\\:\\:\\$functions type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Alias\\\\EregToPregFixer\\:\\:\\$delimiters type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\EregToPregFixer\\:\\:getBestDelimiter\\(\\) should return string but returns int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/EregToPregFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Alias\\\\MbStrFunctionsFixer\\:\\:\\$functionsMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/MbStrFunctionsFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Alias/MbStrFunctionsFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/Alias/MbStrFunctionsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\NoAliasFunctionsFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
+
+		-
+			message: "#^Offset 'sets' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
+
+		-
+			message: "#^Cannot assign offset \\(int\\|string\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoAliasFunctionsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Alias\\\\NoMixedEchoPrintFixer\\:\\:\\$defaultConfig has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\NoMixedEchoPrintFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Offset 'use' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Alias\\\\NoMixedEchoPrintFixer\\)\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/NoMixedEchoPrintFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/PowToExponentiationFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Alias\\\\RandomApiMigrationFixer\\:\\:\\$argumentCounts type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/RandomApiMigrationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Alias\\\\RandomApiMigrationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Alias/RandomApiMigrationFixer.php
+
+		-
+			message: "#^Offset 'replacements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Alias/RandomApiMigrationFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/Alias/RandomApiMigrationFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Alias/RandomApiMigrationFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$firstArgumentStart of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:removeSettypeCall\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#6 \\$secondArgumentStart of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:removeSettypeCall\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$argumentToken of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:findSettypeNullCall\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$argumentToken of method PhpCsFixer\\\\Fixer\\\\Alias\\\\SetTypeToCastFixer\\:\\:fixSettypeCall\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Alias/SetTypeToCastFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\ArraySyntaxFixer\\:\\:\\$candidateTokenKind has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\ArraySyntaxFixer\\:\\:\\$fixCallback has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\ArraySyntaxFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\ArraySyntaxFixer\\)\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Offset 'syntax' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Offset 'after_heredoc' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\NoWhitespaceBeforeCommaInArrayFixer\\:\\:skipNonArrayElements\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Offset 'after_heredoc' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/TrimArraySpacesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ArrayNotation\\\\WhitespaceAfterCommaInArrayFixer\\:\\:skipNonArrayElements\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 34
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 20
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 21
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 13
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 14
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 4
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 15
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Offset 'position_after…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 9
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 7
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Offset 'allow_single_line…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 13
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:isCommentWithFixableIndentation\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Variable \\$i might not be defined\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isWhilePartOfDoWhile\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|string and string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$structureTokenIndex of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:findParenthesisEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:findStatementEnd\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:getControlContinuationTokensForOpeningToken\\(\\) has parameter \\$openingTokenKind with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:getFinalControlContinuationTokensForOpeningToken\\(\\) has parameter \\$openingTokenKind with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startBraceIndex of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:fixSingleLineWhitespaceForDeclare\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Basic\\\\BracesFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '\\$1' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/BracesFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Basic\\\\EncodingFixer\\:\\:\\$BOM has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Basic/EncodingFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/EncodingFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/EncodingFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Basic\\\\NonPrintableCharacterFixer\\:\\:\\$symbolsReplace has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Basic\\\\NonPrintableCharacterFixer\\:\\:\\$tokens has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Offset 'use_escape…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtr expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/NonPrintableCharacterFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$start of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:generatePartialCode\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 2
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Offset 'dir' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr0Fixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr4Fixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Basic/Psr4Fixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 2
+			path: src/Fixer/Basic/Psr4Fixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/Basic/Psr4Fixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Casing\\\\LowercaseConstantsFixer\\:\\:isNeighbourAccepted\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Casing/LowercaseConstantsFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/LowercaseConstantsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/LowercaseConstantsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Casing\\\\LowercaseKeywordsFixer\\:\\:\\$excludedTokens has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Casing/LowercaseKeywordsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Casing\\\\MagicMethodCasingFixer\\:\\:\\$magicNames has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/MagicMethodCasingFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionCasingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+
+		-
+			message: "#^Offset 'space' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/CastSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/CastNotation/CastSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/LowercaseCastFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/LowercaseCastFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/LowercaseCastFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
+
+		-
+			message: "#^Variable \\$i might not be defined\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/NoShortBoolCastFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/NoUnsetCastFixer.php
+
+		-
+			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/CastNotation/ShortScalarCastFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Offset 'elements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classEndIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceBelowClassMethod\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$elementEndIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceBelowClassMethod\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classStartIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceAboveClassElement\\(\\) expects int, int\\|false\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classEndIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceBelowClassElement\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$elementEndIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:fixSpaceBelowClassElement\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Variable \\$nextNotWhite might not be defined\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:correctLineBreaks\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:correctLineBreaks\\(\\) expects int, int\\|null given\\.$#"
+			count: 8
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$commentIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixer\\:\\:findCommentBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNonWhitespaceSibling\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionExtends\\(\\) has parameter \\$classExtendsInfo with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionExtends\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Offset 'single_line' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:makeClassyDefinitionSingleLine\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Offset 'single_item_single…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Offset 'multi_line_extends…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:makeClassyInheritancePartMultiLine\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionImplements\\(\\) has parameter \\$classImplementsInfo with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionImplements\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionOpenSpacing\\(\\) has parameter \\$classDefInfo with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 6
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:fixClassyDefinitionOpenSpacing\\(\\) should return int but returns int\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:getClassyDefinitionInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, int given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:getClassyInheritanceInfo\\(\\) expects int, int\\|string given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:getClassyInheritanceInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, bool\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, bool\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixer\\:\\:makeClassyDefinitionSingleLine\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ClassDefinitionFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\FinalInternalClassFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Offset 'annotation\\-white…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Offset 'annotation\\-black…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Offset 'consider\\-absent…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/FinalInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$classStart of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoPhp4ConstructorFixer\\:\\:fixConstructor\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classStart of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoPhp4ConstructorFixer\\:\\:fixParent\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoPhp4ConstructorFixer\\:\\:getWrapperMethodSequence\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoPhp4ConstructorFixer\\:\\:findFunction\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\NoUnneededFinalMethodFixer\\:\\:fixClass\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:\\$typeHierarchy type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:\\$specialTypes type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:\\$typePosition type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Offset 'order' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Foreach overwrites \\$pos with its value variable\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:getElements\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:sortTokens\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Offset 'end' does not exist on array\\('start' \\=\\> int, 'visibility' \\=\\> string, 'static' \\=\\> bool, \\?'type' \\=\\> mixed, \\?'end' \\=\\> int, \\?'name' \\=\\> mixed\\)\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:detectElementType\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:sortGroupElements\\(\\) has parameter \\$a with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixer\\:\\:sortGroupElements\\(\\) has parameter \\$b with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Offset 'sortAlgorithm' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Foreach overwrites \\$interfaceIndex with its key variable\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:offsetExists\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Offset 'order' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Offset 'direction' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Offset 'originalIndex' does not exist on array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Offset 'tokens' does not exist on null\\|array\\('tokens' \\=\\> array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>, \\?'normalized' \\=\\> string, \\?'originalIndex' \\=\\> int\\)\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indexEnd of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/OrderedInterfacesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ProtectedToPrivateFixer\\:\\:skipClass\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\ProtectedToPrivateFixer\\:\\:fixClass\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 9
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SelfAccessorFixer\\:\\:replaceNameOccurrences\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SelfAccessorFixer\\:\\:getClassStart\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SelfAccessorFixer\\:\\:getClassStart\\(\\) has parameter \\$namespace with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SelfAccessorFixer.php
+
+		-
+			message: "#^Offset 'elements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isArray\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixer\\:\\:expandElement\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixer\\:\\:expandElement\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixer\\:\\:getModifiersSequences\\(\\) should return array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 3
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ClassNotation\\\\SingleTraitInsertPerStatementFixer\\:\\:getCandidates\\(\\) should return array\\<int\\> but returns array\\<int, int\\|null\\>\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+
+		-
+			message: "#^Offset 'elements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 11
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isHeaderComment\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isBeforeStructuralElement\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:getCommentBlockIndices\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indices of method PhpCsFixer\\\\Fixer\\\\Comment\\\\CommentToPhpdocFixer\\:\\:isCommentCandidate\\(\\) expects array\\<int\\>, array\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indices of method PhpCsFixer\\\\Fixer\\\\Comment\\\\CommentToPhpdocFixer\\:\\:fixComment\\(\\) expects array\\<int\\>, array\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$arg1 of function max expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|false given\\.$#"
+			count: 2
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Comment\\\\CommentToPhpdocFixer\\:\\:getMessage\\(\\) has parameter \\$content with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Comment/CommentToPhpdocFixer.php
+
+		-
+			message: "#^Offset 'location' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Offset 'header' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Offset 'comment_type' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Offset 'separate' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Comment\\\\HeaderCommentFixer\\:\\:removeHeader\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot assign offset \\(float\\|int\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 3
+			path: src/Fixer/Comment/HeaderCommentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Comment\\\\NoEmptyCommentFixer\\:\\:getCommentBlock\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Comment\\\\NoEmptyCommentFixer\\:\\:getCommentBlock\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Comment/NoEmptyCommentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Comment\\\\SingleLineCommentStyleFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Comment/SingleLineCommentStyleFixer.php
+
+		-
+			message: "#^Offset 'comment_types' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Comment/SingleLineCommentStyleFixer.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Fixer/Comment/SingleLineCommentStyleFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between '// ' and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Comment/SingleLineCommentStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ConfigurableFixerInterface\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ConfigurableFixerInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Offset 'exclude' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Offset 'include' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Offset 'fix_built_in' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Offset 'scope' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/ElseifFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\IncludeFixer\\:\\:clearIncludies\\(\\) has parameter \\$includies with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/IncludeFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixElseif\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixElse\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:fixOpenCloseControls\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:findParenthesisEnd\\(\\) has parameter \\$structureTokenIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$colonIndex of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoAlternativeSyntaxFixer\\:\\:addBraces\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 5
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 17
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoBreakCommentFixer\\:\\:isNoBreakComment\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Offset 'comment_text' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 16
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoBreakCommentFixer\\:\\:getStructureEnd\\(\\) should return int but returns int\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoBreakCommentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\NoUnneededControlParenthesesFixer\\:\\:\\$loops has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Offset 'statements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+
+		-
+			message: "#^Offset 'namespaces' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/NoUselessElseFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+
+		-
+			message: "#^Variable \\$colonIndex might not be defined\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 23
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:isOfLowerPrecedence\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:findComparisonEnd\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:findComparisonStart\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 9
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$yoda of method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:getCompareFixableInfo\\(\\) expects bool, bool\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:getCompareFixableInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Offset 'always_move_variable' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:getLeftSideCompareFixableInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:getRightSideCompareFixableInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method isCast\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 6
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isEmptyAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:isConstant\\(\\) has parameter \\$end with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixer\\:\\:isConstant\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Offset 'equal' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Offset 'identical' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Offset 'less_and_greater' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ControlStructure/YodaStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationArrayAssignmentFixer\\:\\:fixAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
+
+		-
+			message: "#^Offset 'operator' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationBracesFixer\\:\\:fixAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixer.php
+
+		-
+			message: "#^Offset 'syntax' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationBracesFixer\\:\\:addBracesToAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationBracesFixer\\:\\:removesBracesFromAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixer\\:\\:fixAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Offset 'indent_mixed_lines' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixer\\:\\:getLineBracesCount\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixer\\:\\:isClosingLineWithMeaningfulContent\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixer\\:\\:indentationCanBeFixed\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'around_argument…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 2
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$search of function array_key_exists expects array, array\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'around_array…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:fixAnnotations\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'around_parentheses' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 2
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'around_commas' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'before_argument…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'after_argument…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'before_array…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 4
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Offset 'after_array…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 4
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:fixSpacesAroundParentheses\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:fixSpacesAroundCommas\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:fixAroundAssignments\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:updateSpacesAfter\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:updateSpacesBefore\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixer\\:\\:updateSpacesAt\\(\\) has parameter \\$tokens with no value type specified in iterable type PhpCsFixer\\\\Doctrine\\\\Annotation\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\|bool given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot access offset 'indexes' on \\(array\\)\\|true\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 9
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot access offset 'end' on \\(array\\)\\|true\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\CombineNestedDirnameFixer\\:\\:getDirnameInfo\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\CombineNestedDirnameFixer\\:\\:getDirnameInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Implicit array creation is not allowed \\- variable \\$info does not exist\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 5
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, array\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\CombineNestedDirnameFixer\\:\\:combineDirnames\\(\\) has parameter \\$dirnameInfoArray with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$argumentStartIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagOrderFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentStartIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$argumentEndIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagOrderFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentEndIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagOrderFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$argumentStartIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagsFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentStartIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$argumentEndIndex \\(int\\) of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FopenFlagsFixer\\:\\:fixFopenFlagToken\\(\\) should be contravariant with parameter \\$argumentEndIndex \\(mixed\\) of method PhpCsFixer\\\\AbstractFopenFlagFixer\\:\\:fixFopenFlagToken\\(\\)$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Offset 'b_mode' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FopenFlagsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixer\\:\\:\\$supportedSpacings has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixer\\:\\:\\$singleLineWhitespaceOptions has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 7
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Offset 'closure_function…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixer\\:\\:fixParenthesisInnerEdge\\(\\) has parameter \\$end with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixer\\:\\:fixParenthesisInnerEdge\\(\\) has parameter \\$start with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:getArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\ImplodeCallFixer\\:\\:getArgumentIndices\\(\\) should return array\\<int, int\\> but returns array\\<int\\|string, int\\|null\\>\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ImplodeCallFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Offset 'ensure_fully…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Offset 'on_multiline' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 4
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 10
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isKeyword\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixer\\:\\:isNewline\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:ensureWhitespaceAtIndex\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Offset 'after_heredoc' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, mixed given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Offset 'keep_multiple…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of static method PhpCsFixer\\\\Preg\\:\\:match\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function ltrim expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Offset 'scope' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 6
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Offset 'strict' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Offset 'exclude' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Offset 'include' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 4
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtolower expects string, string\\|true given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixer\\:\\:normalizeFunctionNames\\(\\) should return array\\<string, true\\> but returns array\\<string\\|true\\>\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 4
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixer\\:\\:fixFunctionDefinition\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixer\\:\\:removeDefaultArgument\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixer\\:\\:clearWhitespacesBeforeIndex\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Offset 'scalar_types' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\PhpdocToReturnTypeFixer\\:\\:hasReturnTypeHint\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\PhpdocToReturnTypeFixer\\:\\:fixFunctionDefinition\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+
+		-
+			message: "#^Offset 'space_before' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\StaticLambdaFixer\\:\\:hasPossibleReferenceToThis\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\StaticLambdaFixer\\:\\:hasPossibleReferenceToThis\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/StaticLambdaFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\VoidReturnFixer\\:\\:hasReturnTypeHint\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\VoidReturnFixer\\:\\:fixFunctionDefinition\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of method PhpCsFixer\\\\Fixer\\\\FunctionNotation\\\\VoidReturnFixer\\:\\:hasVoidReturn\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/FunctionNotation/VoidReturnFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$type of method PhpCsFixer\\\\Fixer\\\\Import\\\\FullyQualifiedStrictTypesFixer\\:\\:detectAndReplaceTypeWithShortType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis, PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, array\\<int\\>\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Import\\\\NoLeadingImportSlashFixer\\:\\:removeLeadingImportSlash\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoLeadingImportSlashFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\NoUnusedImportsFixer\\:\\:removeUsesInSameNamespace\\(\\) has parameter \\$useDeclarations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Import/NoUnusedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of function array_reverse expects array, array\\<int\\>\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 3
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$namespace of method PhpCsFixer\\\\Fixer\\\\Import\\\\OrderedImportsFixer\\:\\:prepareNamespace\\(\\) expects string, bool\\|int\\|string given\\.$#"
+			count: 4
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\OrderedImportsFixer\\:\\:getNewOrder\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Offset 'sort_algorithm' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Binary operation \"\\+\" between int\\|string and 1 results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Variable \\$k might not be defined\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Variable \\$k2 might not be defined\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getTokenNotOfKindSibling\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Offset 'imports_order' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Foreach overwrites \\$indexes with its value variable\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\OrderedImportsFixer\\:\\:sortByAlgorithm\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Import/OrderedImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, array\\<int\\>\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:fixGroupUse\\(\\) expects int, array\\<int\\>\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:fixGroupUse\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:fixMultipleUse\\(\\) expects int, array\\<int\\>\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:fixMultipleUse\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Import\\\\SingleImportPerStatementFixer\\:\\:getGroupDeclaration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 3
+			path: src/Fixer/Import/SingleImportPerStatementFixer.php
+
+		-
+			message: "#^Binary operation \"\\+\\=\" between array\\<int\\>\\|int and int results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Import/SingleLineAfterImportsFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$start of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:generatePartialCode\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$end of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:generatePartialCode\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|false given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:getIssetInfo\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indexes of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:clearTokens\\(\\) expects array\\<int\\>, array\\<int\\|string, int\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:getIssetInfo\\(\\) should return array\\<int\\> but returns array\\<int, int\\|null\\>\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveIssetsFixer\\:\\:getTokenClones\\(\\) should return array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\> but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveUnsetsFixer\\:\\:moveTokens\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$indices of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\CombineConsecutiveUnsetsFixer\\:\\:clearOffsetTokens\\(\\) expects array\\<int\\>, array\\<int, int\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Cannot clone PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\DeclareEqualNormalizeFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Offset 'space' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\DeclareEqualNormalizeFixer\\)\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/DirConstantFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Offset 'noise_remaining…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, mixed given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Offset 'mute_deprecation…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Offset 'functions' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:getReplaceCandidate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$braceOpenIndex of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:getReplacementTokenClones\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$braceCloseIndex of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:getReplacementTokenClones\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:fixGetClassCall\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixer\\:\\:getReplacementTokenClones\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Offset 'use_yoda_style' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/IsNullFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:getArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\NoUnsetOnPropertyFixer\\:\\:isProperty\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\NoUnsetOnPropertyFixer\\:\\:isProperty\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\LanguageConstruct\\\\NoUnsetOnPropertyFixer\\:\\:getUnsetsInfo\\(\\) should return array\\<array\\<string, bool\\|int\\>\\> but returns array\\<int, array\\<string, bool\\|int\\|null\\>\\>\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, bool\\|int given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, bool\\|int given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, bool\\|int given on the right side\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, bool\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, bool\\|int given\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, bool\\|int given\\.$#"
+			count: 3
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, bool\\|int given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, bool\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\ListNotation\\\\ListSyntaxFixer\\:\\:\\$candidateTokenKind has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$configuration \\(array\\<string, string\\>\\|null\\) of method PhpCsFixer\\\\Fixer\\\\ListNotation\\\\ListSyntaxFixer\\:\\:configure\\(\\) should be contravariant with parameter \\$configuration \\(array\\|null\\) of method PhpCsFixer\\\\AbstractFixer\\:\\:configure\\(\\)$#"
+			count: 1
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$configuration \\(array\\<string, string\\>\\|null\\) of method PhpCsFixer\\\\Fixer\\\\ListNotation\\\\ListSyntaxFixer\\:\\:configure\\(\\) should be contravariant with parameter \\$configuration \\(array\\|null\\) of method PhpCsFixer\\\\Fixer\\\\ConfigurableFixerInterface\\:\\:configure\\(\\)$#"
+			count: 2
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Offset 'syntax' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ListNotation/ListSyntaxFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\NamespaceNotation\\\\BlankLineAfterNamespaceFixer\\:\\:getIndexToEnsureBlankLineAfter\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\NamespaceNotation\\\\NoLeadingNamespaceWhitespaceFixer\\:\\:endsWithWhitespace\\(\\) has parameter \\$str with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Naming\\\\NoHomoglyphNamesFixer\\:\\:\\$replacements type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Naming/NoHomoglyphNamesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$from of method PhpCsFixer\\\\Fixer\\\\Operator\\\\AlignDoubleArrowFixerHelper\\:\\:injectArrayAlignmentPlaceholders\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$start of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isPartialCodeMultiline\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/AlignEqualsFixerHelper.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:\\$allowedValues has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 12
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 11
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:isEqualPartOfDeclareStatement\\(\\) should return int\\|false but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Offset 'default' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Offset 'operators' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:resolveOperatorsFromConfig\\(\\) should return array\\<string, string\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:resolveOldConfig\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixer\\:\\:resolveOldConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$start of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isPartialCodeMultiline\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|false given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\:\\:\\$fixCallback has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Offset 'spacing' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Operator\\\\ConcatSpaceFixer\\)\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|true given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/ConcatSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Offset 'style' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Cannot clone non\\-object variable \\$token of type PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findEnd\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getTokenNotOfKindSibling\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\IncrementStyleFixer\\:\\:findStart\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/IncrementStyleFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\NewWithBracesFixer\\:\\:insertBracesAfter\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Dynamic call to static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\)\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NewWithBracesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NotOperatorWithSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/NotOperatorWithSpaceFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 8
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\StandardizeIncrementFixer\\:\\:findStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$indexEnd of method PhpCsFixer\\\\Fixer\\\\Operator\\\\StandardizeIncrementFixer\\:\\:clearRangeLeaveComments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Operator\\\\StandardizeIncrementFixer\\:\\:findStart\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/StandardizeIncrementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Operator\\\\TernaryToNullCoalescingFixer\\:\\:fixIsset\\(\\) expects int, int\\<1, max\\>\\|int\\<min, \\-1\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\Operator\\\\TernaryToNullCoalescingFixer\\:\\:isHigherPrecedenceAssociativityOperator\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\Operator\\\\TernaryToNullCoalescingFixer\\:\\:getMeaningfulSequence\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$end of method PhpCsFixer\\\\Fixer\\\\Operator\\\\TernaryToNullCoalescingFixer\\:\\:getMeaningfulSequence\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromArray\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Operator/UnaryOperatorSpacesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromCode\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/FullOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/FullOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php
+
+		-
+			message: "#^Binary operation \"\\-\" between int\\|string\\|null and 1 results in an error\\.$#"
+			count: 3
+			path: src/Fixer/PhpTag/NoClosingTagFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/NoClosingTagFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/NoClosingTagFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/NoClosingTagFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/NoShortEchoTagFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpTag/NoShortEchoTagFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixer\\:\\:\\$assertionFixers has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixer\\)\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Cannot call method isNativeConstant\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$indexStart of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearRange\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:\\$fixMap has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Offset 'target' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:fixAssertTrueFalse\\(\\) has parameter \\$assertCall with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 6
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$callNSIndex of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:removeFunctionCall\\(\\) expects int\\|false, int\\|false\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$callIndex of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:removeFunctionCall\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$openIndex of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:removeFunctionCall\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixer\\:\\:fixAssertSameEquals\\(\\) has parameter \\$assertCall with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertInternalTypeFixer\\:\\:\\$typeToDedicatedAssertMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitExpectationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Offset 'target' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitExpectationFixer\\:\\:fixExpectation\\(\\) has parameter \\$endIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitExpectationFixer\\:\\:fixExpectation\\(\\) has parameter \\$startIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeTrailingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:getArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$indexStart of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$indexEnd of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitExpectationFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$i of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:isAllowedByConfiguration\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:getDocBlockIndex\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:hasDocBlock\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Offset 'types' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:createDocBlock\\(\\) has parameter \\$docBlockIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:updateDocBlockIfNeeded\\(\\) has parameter \\$docBlockIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixer\\:\\:getDocBlockIndex\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function end expects array\\|object, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Offset 'case' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitMethodCasingFixer\\:\\:getDocBlockIndex\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of class PhpCsFixer\\\\DocBlock\\\\Line constructor expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitMockFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Offset 'target' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:countArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 9
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 5
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNamespacedFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Offset 'target' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, PhpCsFixer\\\\Tokenizer\\\\Token\\|PhpCsFixer\\\\Tokenizer\\\\Tokens\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Offset 'target' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixer\\:\\:detectIndent\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixer\\:\\:annotationsToParamList\\(\\) has parameter \\$annotations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Offset 'use_class_const' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+
+		-
+			message: "#^Possibly invalid array key type array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+
+		-
+			message: "#^Parameter \\#4 \\$replacement of function array_splice expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$i of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:isAbstractClass\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:getDocBlockIndex\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:hasDocBlock\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:createDocBlock\\(\\) has parameter \\$docBlockIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Offset 'group' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:updateDocBlockIfNeeded\\(\\) has parameter \\$docBlockIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixer\\:\\:getDocBlockIndex\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function end expects array\\|object, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\<PhpCsFixer\\\\DocBlock\\\\Line\\>\\|PhpCsFixer\\\\DocBlock\\\\Line\\|string\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitStrictFixer\\:\\:\\$assertionMap has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitStrictFixer.php
+
+		-
+			message: "#^Offset 'assertions' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitStrictFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:countArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitStrictFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitStrictFixer.php
+
+		-
+			message: "#^Offset 'style' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixer\\:\\:getDocBlockIndex\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function lcfirst expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Offset 'case' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function end expects array\\|object, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixer\\:\\:detectIndent\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixer\\:\\:findWhereDependsFunctionNameStarts\\(\\) has parameter \\$line with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestCaseStaticMethodCallsFixer\\:\\:\\$allowedValues has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestCaseStaticMethodCallsFixer\\:\\:\\$staticMethods has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestCaseStaticMethodCallsFixer\\:\\:\\$conversionMap has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Offset 'call_type' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Offset 'methods' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$referenceIndex of method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestCaseStaticMethodCallsFixer\\:\\:needsConversion\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestClassRequiresCoversFixer\\:\\:addRequiresCover\\(\\) has parameter \\$startIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 4
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string given\\.$#"
+			count: 2
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between string and array\\<string\\>\\|string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\AlignMultilineCommentFixer\\:\\:\\$tokenKinds has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\AlignMultilineCommentFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Offset 'comment_type' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|string and string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+
+		-
+			message: "#^Offset 'annotations' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 13
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 6
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:fixFunctionDocComment\\(\\) has parameter \\$shortNames with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:fixPropertyDocComment\\(\\) has parameter \\$shortNames with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:getPropertyTypeInfo\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:parseTypeHint\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:getReturnTypeInfo\\(\\) has parameter \\$closingParenthesisIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:getPropertyTypeInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:parseTypeHint\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:annotationIsSuperfluous\\(\\) has parameter \\$info with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Offset 'allow_mixed' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixer\\:\\:toComparableNames\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:getArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Offset 'only_untyped' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixer\\:\\:prepareArgumentInformation\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixer\\:\\:\\$alignableTags has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixer\\:\\:\\$tagsWithName has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixer\\:\\:\\$tagsWithMethodSignature has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Offset 'tags' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 8
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Offset 'align' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|null given\\.$#"
+			count: 4
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Offset 0 does not exist on string\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Cannot call method setContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAlignFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocAnnotationWithoutDotFixer\\:\\:\\$tags has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+
+		-
+			message: "#^Cannot call method setContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Utils\\:\\:calculateTrailingWhitespaceIndent\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method isArray\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function ltrim expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocIndentFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+
+		-
+			message: "#^Offset 'replacements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$types of method PhpCsFixer\\\\DocBlock\\\\DocBlock\\:\\:getAnnotationsOfType\\(\\) expects array\\<string\\>\\|string, array\\<int, int\\|string\\> given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocNoUselessInheritdocFixer\\:\\:isExtendingOrImplementing\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocNoUselessInheritdocFixer\\:\\:isUsingTrait\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$classOpenIndex of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocNoUselessInheritdocFixer\\:\\:fixClassyInside\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$tokenIndex of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocNoUselessInheritdocFixer\\:\\:fixToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 4
+			path: src/Fixer/Phpdoc/PhpdocOrderFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocOrderFixer.php
+
+		-
+			message: "#^Cannot call method setContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocOrderFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocReturnSelfReferenceFixer\\:\\:\\$toTypes has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Offset 'replacements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocScalarFixer\\:\\:\\$types type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocScalarFixer.php
+
+		-
+			message: "#^Offset 'types' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocScalarFixer.php
+
+		-
+			message: "#^Cannot call method remove\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+
+		-
+			message: "#^Cannot call method addBlank\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocSingleLineVarSpacingFixer\\:\\:fixTokenContent\\(\\) should return string but returns array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+
+		-
+			message: "#^Cannot call method setContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$to of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimConsecutiveBlankLineSeparationFixer\\:\\:removeExtraBlankLinesBetween\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$current of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimConsecutiveBlankLineSeparationFixer\\:\\:removeExtraBlankLine\\(\\) expects PhpCsFixer\\\\DocBlock\\\\Line, PhpCsFixer\\\\DocBlock\\\\Line\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$next of method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimConsecutiveBlankLineSeparationFixer\\:\\:removeExtraBlankLine\\(\\) expects PhpCsFixer\\\\DocBlock\\\\Line, PhpCsFixer\\\\DocBlock\\\\Line\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Foreach overwrites \\$index with its key variable\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimConsecutiveBlankLineSeparationFixer\\:\\:findFirstAnnotationOrEnd\\(\\) should return int but returns int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Cannot call method containsUsefulContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimFixer\\:\\:fixStart\\(\\) should return string but returns array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTrimFixer\\:\\:fixEnd\\(\\) should return string but returns array\\<string\\>\\|string\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTrimFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTypesFixer\\:\\:\\$typesToFix type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Phpdoc\\\\PhpdocTypesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesFixer.php
+
+		-
+			message: "#^Offset 'groups' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 3
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Cannot call method setContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Offset 'sort_algorithm' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str1 of function strcasecmp expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$str2 of function strcasecmp expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Offset 'null_adjustment' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 2
+			path: src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\NoUselessReturnFixer\\:\\:fixFunction\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearTokenAndMergeSurroundingWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 10
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$functionOpenIndex of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:fixFunction\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:isSuperGlobal\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$assignVarIndex of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:simplifyReturnStatement\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#5 \\$returnVarEndIndex of method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:simplifyReturnStatement\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\ReturnNotation\\\\ReturnAssignmentFixer\\:\\:clearIfSave\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+
+		-
+			message: "#^Offset 'strategy' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$curlyCloseIndex of method PhpCsFixer\\\\Fixer\\\\Semicolon\\\\NoEmptyStatementFixer\\:\\:fixSemicolonAfterCurlyBraceClose\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isAnonymousClass\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoEmptyStatementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Offset 'remove_in_empty_for…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Strict/DeclareStrictTypesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Strict\\\\StrictParamFixer\\:\\:fixFunction\\(\\) has parameter \\$functionIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Strict\\\\StrictParamFixer\\:\\:fixFunction\\(\\) has parameter \\$functionParams with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Strict/StrictParamFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+
+		-
+			message: "#^Offset 'single_quoted' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+
+		-
+			message: "#^Offset 'double_quoted' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+
+		-
+			message: "#^Offset 'heredoc_syntax' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\StringNotation\\\\ExplicitStringVariableFixer\\:\\:isStringPartToken\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 2
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/HeredocToNowdocFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$items of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideRange\\(\\) expects array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|PhpCsFixer\\\\Tokenizer\\\\Tokens, array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\> given\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+
+		-
+			message: "#^Offset 'strings_containing…' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/SingleQuoteFixer.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Fixer/StringNotation/SingleQuoteFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:findArrayTokenRanges\\(\\) has parameter \\$from with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:findArrayTokenRanges\\(\\) has parameter \\$to with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:computeArrayLineSignificantBraces\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:getLineSignificantBraces\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:getLineSignificantBraces\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:isClosingLineWithMeaningfulContent\\(\\) has parameter \\$newLineIndex with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:getLineIndentation\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:extractIndent\\(\\) has parameter \\$content with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:getPreviousNewlineTokenIndex\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:newlineIsInArrayScope\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:newlineIsInArrayScope\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:indexIsInArrayTokenRanges\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:indexIsInArrayTokenRanges\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:isNewLineToken\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixer\\:\\:computeNewLineContent\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\<string\\>\\|string and string results in an error\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/ArrayIndentationFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixer\\:\\:\\$tokenMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixer\\:\\:\\$fixTokenMap type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Offset 'statements' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/CompactNullableTypehintFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/CompactNullableTypehintFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\HeredocIndentationFixer\\:\\:fixIndentation\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 6
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Variable \\$index might not be defined\\.$#"
+			count: 5
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/HeredocIndentationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Whitespace/IndentationTypeFixer.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/IndentationTypeFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/IndentationTypeFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\IndentationTypeFixer\\:\\:getExpectedIndent\\(\\) expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/IndentationTypeFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/IndentationTypeFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Whitespace/LineEndingFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/LineEndingFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/LineEndingFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\<0, max\\>\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\MethodChainingIndentationFixer\\:\\:getIndentAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\MethodChainingIndentationFixer\\:\\:currentLineRequiresExtraIndentLevel\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\$end of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\MethodChainingIndentationFixer\\:\\:currentLineRequiresExtraIndentLevel\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\MethodChainingIndentationFixer\\:\\:getIndentContentAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Offset 'tokens' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:fixByToken\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:fixByToken\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Variable method call on \\$this\\(PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\)\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:removeBetweenUse\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:removeMultipleBlankLines\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:fixAfterToken\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isLambda\\(\\) expects int, float\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:isAnonymousClass\\(\\) expects int, float\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixer\\:\\:removeEmptyLinesAfterLineWithTokenAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Variable \\$end might not be defined\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraConsecutiveBlankLinesFixer\\:\\:\\$fixer has no typehint specified\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraConsecutiveBlankLinesFixer\\:\\:configure\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\Fixer\\\\Whitespace\\\\NoExtraConsecutiveBlankLinesFixer\\:\\:getConfigurationDefinition\\(\\) should be covariant with return type \\(PhpCsFixer\\\\FixerConfiguration\\\\FixerConfigurationResolverInterface\\) of method PhpCsFixer\\\\Fixer\\\\ConfigurationDefinitionFixerInterface\\:\\:getConfigurationDefinition\\(\\)$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php
+
+		-
+			message: "#^Offset 'positions' does not exist on array\\<string, mixed\\>\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the left side\\.$#"
+			count: 1
+			path: src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOption\\:\\:__construct\\(\\) has parameter \\$alias with no typehint specified\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AliasedFixerOption.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOption\\:\\:getAllowedValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AliasedFixerOption.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOptionBuilder\\:\\:__construct\\(\\) has parameter \\$alias with no typehint specified\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AliasedFixerOptionBuilder.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOptionBuilder\\:\\:setAllowedValues\\(\\) has parameter \\$allowedValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AliasedFixerOptionBuilder.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerConfiguration\\\\AllowedValueSubset\\:\\:\\$allowedValues has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AllowedValueSubset.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\AllowedValueSubset\\:\\:__construct\\(\\) has parameter \\$allowedValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/AllowedValueSubset.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\DeprecatedFixerOption\\:\\:getAllowedValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/DeprecatedFixerOption.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerConfigurationResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: src/FixerConfiguration/FixerConfigurationResolverRootless.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 2
+			path: src/FixerConfiguration/FixerConfigurationResolverRootless.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerConfigurationResolverRootless.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerConfiguration\\\\FixerOption\\:\\:\\$allowedValues type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOption.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\FixerOption\\:\\:__construct\\(\\) has parameter \\$allowedValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOption.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\FixerOption\\:\\:getAllowedValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOption.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerConfiguration\\\\FixerOptionBuilder\\:\\:\\$allowedValues type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOptionBuilder.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\FixerOptionBuilder\\:\\:setAllowedValues\\(\\) has parameter \\$allowedValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOptionBuilder.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerConfiguration\\\\FixerOptionInterface\\:\\:getAllowedValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerConfiguration/FixerOptionInterface.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\CodeSample\\:\\:\\$configuration type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/CodeSample.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\CodeSample\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/CodeSample.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\CodeSample\\:\\:getConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/CodeSample.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\CodeSampleInterface\\:\\:getConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/CodeSampleInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\FileSpecificCodeSample\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/FileSpecificCodeSample.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\FileSpecificCodeSample\\:\\:getConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/FileSpecificCodeSample.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$riskyDescription has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$configurationDescription has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$defaultConfiguration has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$codeSamples has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$summary has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:\\$description has no typehint specified\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:__construct\\(\\) has parameter \\$defaultConfiguration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\FixerDefinition\\:\\:getDefaultConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinition.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\FixerDefinitionInterface\\:\\:getDefaultConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/FixerDefinitionInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\VersionSpecificCodeSample\\:\\:__construct\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/VersionSpecificCodeSample.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\FixerDefinition\\\\VersionSpecificCodeSample\\:\\:getConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/FixerDefinition/VersionSpecificCodeSample.php
+
+		-
+			message: "#^Call to function is_int\\(\\) with int will always evaluate to true\\.$#"
+			count: 2
+			path: src/FixerDefinition/VersionSpecification.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with array will always evaluate to true\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$arr1 of function array_intersect expects array, array\\<string\\>\\|null given\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$fixerConflicts of method PhpCsFixer\\\\FixerFactory\\:\\:generateConflictMessage\\(\\) expects array\\<string, array\\<string\\>\\>, array\\<int\\|string, array\\<mixed, mixed\\>\\> given\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: src/FixerFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Indicator\\\\PhpUnitTestCaseIndicator\\:\\:isPhpUnitClass\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Indicator\\\\PhpUnitTestCaseIndicator\\:\\:findPhpUnitClasses\\(\\) return type has no value type specified in iterable type Generator\\.$#"
+			count: 1
+			path: src/Indicator/PhpUnitTestCaseIndicator.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function crc32 expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Linter/CachingLinter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Linter\\\\ProcessLinter\\:\\:createProcessForFile\\(\\) return type has no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Linter\\\\ProcessLinter\\:\\:createProcessForSource\\(\\) return type has no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Linter\\\\ProcessLinter\\:\\:\\$temporaryFile \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method PhpCsFixer\\\\FileRemoval\\:\\:observe\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of function file_put_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Parameter \\#4 \\$path of class Symfony\\\\Component\\\\Filesystem\\\\Exception\\\\IOException constructor expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method PhpCsFixer\\\\Linter\\\\ProcessLinter\\:\\:createProcessForFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Linter\\\\ProcessLinterProcessBuilder\\:\\:build\\(\\) return type has no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+			count: 1
+			path: src/Linter/ProcessLinterProcessBuilder.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Linter\\\\ProcessLintingResult\\:\\:\\$process type has no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+			count: 1
+			path: src/Linter/ProcessLintingResult.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Linter\\\\ProcessLintingResult\\:\\:__construct\\(\\) has parameter \\$process with no value type specified in iterable type Symfony\\\\Component\\\\Process\\\\Process\\.$#"
+			count: 1
+			path: src/Linter/ProcessLintingResult.php
+
+		-
+			message: "#^Parameter \\#2 \\$code of class PhpCsFixer\\\\Linter\\\\LintingException constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Linter/ProcessLintingResult.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Linter/ProcessLintingResult.php
+
+		-
+			message: "#^Parameter \\#1 \\$pattern of function preg_match expects string, array\\<string\\>\\|string given\\.$#"
+			count: 2
+			path: src/Preg.php
+
+		-
+			message: "#^Parameter \\#1 \\$pattern of function preg_match_all expects string, array\\<string\\>\\|string given\\.$#"
+			count: 2
+			path: src/Preg.php
+
+		-
+			message: "#^Parameter \\#1 \\$pattern of function preg_split expects string, array\\<string\\>\\|string given\\.$#"
+			count: 2
+			path: src/Preg.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Preg\\:\\:addUtf8Modifier\\(\\) should return array\\<string\\>\\|string but returns array\\<array\\<string\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/Preg.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Preg\\:\\:removeUtf8Modifier\\(\\) should return array\\<string\\>\\|string but returns array\\<array\\<string\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/Preg.php
+
+		-
+			message: "#^Parameter \\#2 \\$start of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Preg.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int, int\\|false given\\.$#"
+			count: 1
+			path: src/Preg.php
+
+		-
+			message: "#^Offset 'message' does not exist on array\\('type' \\=\\> int, 'message' \\=\\> string, 'file' \\=\\> string, 'line' \\=\\> int\\)\\|null\\.$#"
+			count: 1
+			path: src/Preg.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\CheckstyleReporter\\:\\:generate\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Report/CheckstyleReporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Report/CheckstyleReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\GitlabReporter\\:\\:generate\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Report/GitlabReporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Report/GitlabReporter.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Report/JsonReporter.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 2
+			path: src/Report/JsonReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\JsonReporter\\:\\:generate\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Report/JsonReporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Report/JsonReporter.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 2
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\JunitReporter\\:\\:generate\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\JunitReporter\\:\\:createFailedTestCase\\(\\) has parameter \\$fixResult with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method DOMElement\\:\\:setAttribute\\(\\) expects string, array\\|string given\\.$#"
+			count: 1
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Report/JunitReporter.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Report\\\\ReportSummary\\:\\:\\$changed type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/ReportSummary.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\ReportSummary\\:\\:__construct\\(\\) has parameter \\$changed with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/ReportSummary.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\ReportSummary\\:\\:getChanged\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/ReportSummary.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 1
+			path: src/Report/ReporterFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\TextReporter\\:\\:getAppliedFixers\\(\\) has parameter \\$fixResult with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/TextReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\TextReporter\\:\\:getDiff\\(\\) has parameter \\$fixResult with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/TextReporter.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Report/TextReporter.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Report/XmlReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\XmlReporter\\:\\:generate\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Report/XmlReporter.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of static method Symfony\\\\Component\\\\Console\\\\Formatter\\\\OutputFormatter\\:\\:escape\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Report/XmlReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\XmlReporter\\:\\:createAppliedFixersElement\\(\\) has parameter \\$fixResult with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/XmlReporter.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Report\\\\XmlReporter\\:\\:createDiffElement\\(\\) has parameter \\$fixResult with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Report/XmlReporter.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\RuleSet\\:\\:\\$setDefinitions has no typehint specified\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\RuleSet\\:\\:\\$set type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\RuleSet\\:\\:\\$rules type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:__construct\\(\\) has parameter \\$set with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:create\\(\\) has parameter \\$set with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:getRuleConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:getSetDefinitionNames\\(\\) should return array\\<string\\> but returns array\\<int, int\\|string\\>\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:getSetDefinition\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Cannot access offset 0 on \\(int\\|string\\)\\.$#"
+			count: 2
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSet\\:\\:resolveSubset\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSet.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSetInterface\\:\\:__construct\\(\\) has parameter \\$set with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSetInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSetInterface\\:\\:create\\(\\) has parameter \\$set with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSetInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSetInterface\\:\\:getRuleConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSetInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\RuleSetInterface\\:\\:getRules\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/RuleSetInterface.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\FileCachingLintingIterator\\:\\:__construct\\(\\) has parameter \\$iterator with no value type specified in iterable type Iterator\\.$#"
+			count: 1
+			path: src/Runner/FileCachingLintingIterator.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of method PhpCsFixer\\\\Linter\\\\LinterInterface\\:\\:lintFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Runner/FileCachingLintingIterator.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\FileFilterIterator\\:\\:__construct\\(\\) has parameter \\$iterator with no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Runner/FileFilterIterator.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\Runner\\\\FileFilterIterator\\:\\:accept\\(\\) should be covariant with return type \\(bool\\) of method FilterIterator\\:\\:accept\\(\\)$#"
+			count: 1
+			path: src/Runner/FileFilterIterator.php
+
+		-
+			message: "#^Array \\(array\\<string, bool\\>\\) does not accept key 0\\|string\\.$#"
+			count: 1
+			path: src/Runner/FileFilterIterator.php
+
+		-
+			message: "#^Parameter \\#1 \\$filePath of method PhpCsFixer\\\\FileReader\\:\\:read\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Runner/FileFilterIterator.php
+
+		-
+			message: "#^Instanceof between Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface and Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface will always evaluate to true\\.$#"
+			count: 1
+			path: src/Runner/FileFilterIterator.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\FileLintingIterator\\:\\:__construct\\(\\) has parameter \\$iterator with no value type specified in iterable type Iterator\\.$#"
+			count: 1
+			path: src/Runner/FileLintingIterator.php
+
+		-
+			message: "#^Cannot call method lintFile\\(\\) on PhpCsFixer\\\\Linter\\\\LinterInterface\\|null\\.$#"
+			count: 1
+			path: src/Runner/FileLintingIterator.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Runner\\\\Runner\\:\\:\\$finder type has no value type specified in iterable type Traversable\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\Runner\\:\\:__construct\\(\\) has parameter \\$finder with no typehint specified\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\Runner\\:\\:__construct\\(\\) has parameter \\$fixers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\Runner\\:\\:__construct\\(\\) has parameter \\$isDryRun with no typehint specified\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\Runner\\:\\:__construct\\(\\) has parameter \\$stopOnViolation with no typehint specified\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Runner\\\\Runner\\:\\:fix\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Parameter \\#1 \\$filePath of method PhpCsFixer\\\\FileReader\\:\\:read\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of function file_put_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Parameter \\#4 \\$path of class Symfony\\\\Component\\\\Filesystem\\\\Exception\\\\IOException constructor expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string, int\\|string\\>\\|null given\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string, array\\<int, string\\>\\|string\\>\\|null given\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^Instanceof between Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface and Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface will always evaluate to true\\.$#"
+			count: 1
+			path: src/Runner/Runner.php
+
+		-
+			message: "#^PhpCsFixer\\\\StdinFileInfo\\:\\:__construct\\(\\) does not call parent constructor from SplFileInfo\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getRealPath\\(\\) should be covariant with return type \\(string\\|false\\) of method SplFileInfo\\:\\:getRealPath\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getATime\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getATime\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:getBasename\\(\\) has parameter \\$suffix with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getBasename\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getBasename\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getCTime\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getCTime\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getExtension\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getExtension\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:getFileInfo\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getFileInfo\\(\\) should be covariant with return type \\(SplFileInfo\\) of method SplFileInfo\\:\\:getFileInfo\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getFilename\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getFilename\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getGroup\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getGroup\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getInode\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getInode\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getLinkTarget\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getLinkTarget\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getMTime\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getMTime\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getOwner\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getOwner\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getPath\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getPath\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:getPathInfo\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getPathInfo\\(\\) should be covariant with return type \\(SplFileInfo\\) of method SplFileInfo\\:\\:getPathInfo\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getPathname\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getPathname\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getPerms\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getPerms\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getSize\\(\\) should be covariant with return type \\(int\\) of method SplFileInfo\\:\\:getSize\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:getType\\(\\) should be covariant with return type \\(string\\) of method SplFileInfo\\:\\:getType\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isDir\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isDir\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isExecutable\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isExecutable\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isFile\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isFile\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isLink\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isLink\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isReadable\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isReadable\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:isWritable\\(\\) should be covariant with return type \\(bool\\) of method SplFileInfo\\:\\:isWritable\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:openFile\\(\\) has parameter \\$context with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:openFile\\(\\) has parameter \\$openMode with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:openFile\\(\\) has parameter \\$useIncludePath with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\StdinFileInfo\\:\\:openFile\\(\\) should be covariant with return type \\(SplFileObject\\) of method SplFileInfo\\:\\:openFile\\(\\)$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:setFileClass\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\StdinFileInfo\\:\\:setInfoClass\\(\\) has parameter \\$className with no typehint specified\\.$#"
+			count: 1
+			path: src/StdinFileInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AbstractFixerTestCase\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AbstractIntegrationTestCase\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:\\$object has no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:\\$reflection has no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__call\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__call\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__isset\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Variable property access on \\$this\\(PhpCsFixer\\\\Test\\\\AccessibleObject\\)\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__get\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__set\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:__set\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\AccessibleObject\\:\\:create\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/AccessibleObject.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$requirements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Test\\\\IntegrationCase\\:\\:getRequirement\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: src/Test/IntegrationCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Tokenizer/AbstractTransformer.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/Analysis/ArgumentAnalysis.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\:\\:\\$reservedTypes type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/Analysis/TypeAnalysis.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\ArgumentAnalysis constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$nameIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\ArgumentAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\BlocksAnalyzer\\:\\:getBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/BlocksAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 11
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevNonWhitespace\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isStructuralElement\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$docsToken of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isValidControl\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$docsToken of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isValidLanguageConstruct\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:getCommentBlockIndices\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/CommentsAnalyzer.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\FunctionsAnalyzer\\:\\:\\$functionsAnalysis type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 8
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 4
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$openParenthesis of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzer\\:\\:getArguments\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$startIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:offsetExists\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\NamespaceUsesAnalyzer\\:\\:getDeclarations\\(\\) has parameter \\$useIndexes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Parameter \\#3 \\$endIndex of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\NamespaceUsesAnalyzer\\:\\:parseDeclaration\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\NamespaceUseAnalysis\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Analyzer/NamespaceUsesAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$shortName of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\NamespaceAnalysis constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Parameter \\#4 \\$endIndex of class PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\NamespaceAnalysis constructor expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Analyzer/NamespacesAnalyzer.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 3
+			path: src/Tokenizer/Resolver/TypeShortNameResolver.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Tokenizer/Resolver/TypeShortNameResolver.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:__construct\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the left side\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Call to function is_object\\(\\) with \\*NEVER\\* will always evaluate to true\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equals\\(\\) has parameter \\$other with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equalsAny\\(\\) has parameter \\$others with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getPrototype\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:override\\(\\) has parameter \\$other with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:toJson\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getTokenKindsForNames\\(\\) should return array\\<int, int\\> but returns array\\<int\\|string, mixed\\>\\.$#"
+			count: 1
+			path: src/Tokenizer/Token.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:\\$cache type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in &&, string\\|false given on the left side\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in \\|\\|, bool\\|null given on the right side\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot assign offset \\(int\\|string\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getBlockEdgeDefinitions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Return type \\(mixed\\) of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:setSize\\(\\) should be covariant with return type \\(bool\\) of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:setSize\\(\\)$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:unregisterFoundToken\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Parameter \\#1 \\$index \\(int\\) of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:offsetSet\\(\\) should be contravariant with parameter \\$index \\(int\\|null\\) of method SplFixedArray\\<PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:offsetSet\\(\\)$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Parameter \\#1 \\$index \\(int\\) of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:offsetSet\\(\\) should be contravariant with parameter \\$offset \\(int\\|null\\) of method ArrayAccess\\<int,PhpCsFixer\\\\Tokenizer\\\\Token\\>\\:\\:offsetSet\\(\\)$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Variable \\$count might not be defined\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 9
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findGivenKind\\(\\) has parameter \\$possibleKind with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findGivenKind\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextTokenOfKind\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getTokenOfKindSibling\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int given\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getTokenNotOfKindSibling\\(\\) has parameter \\$tokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findSequence\\(\\) has parameter \\$sequence with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Parameter \\#2 \\$key of static method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:isKeyCaseSensitive\\(\\) expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and int will always evaluate to true\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Foreach overwrites \\$key with its key variable\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findSequence\\(\\) should return array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\>\\|null but returns array\\<int, PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\>\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:registerFoundToken\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:clearAt\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:overrideAt\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method override\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isAllTokenKindsFound\\(\\) has parameter \\$tokenKinds with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 3
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isAnyTokenKindsFound\\(\\) has parameter \\$tokenKinds with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 2
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|null given on the left side\\.$#"
+			count: 2
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeWhitespaceSafely\\(\\) has parameter \\$direction with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeWhitespaceSafely\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:removeWhitespaceSafely\\(\\) has parameter \\$whitespaces with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Only numeric types are allowed in \\-, int\\|null given on the left side\\.$#"
+			count: 3
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Variable \\$index might not be defined\\.$#"
+			count: 4
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:registerFoundToken\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:unregisterFoundToken\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:extractTokenKind\\(\\) has parameter \\$token with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Tokens.php
+
+		-
+			message: "#^Cannot call method isClassy\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$classIndex of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:findClassyElements\\(\\) expects int, float\\|int given\\.$#"
+			count: 4
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:findClassyElements\\(\\) expects int, float\\|int given\\.$#"
+			count: 4
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 3
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 36
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 18
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Only booleans are allowed in &&, array\\|null given on the left side\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:getMethodAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-decrement, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 7
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevTokenOfKind\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method isArray\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\TokensAnalyzer\\:\\:findClassyElements\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, float\\|int given\\.$#"
+			count: 1
+			path: src/Tokenizer/TokensAnalyzer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\ArrayTypehintTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\BraceClassInstantiationTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\ClassConstantTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ClassConstantTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ClassConstantTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:transformIntoDollarCloseBrace\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:transformIntoDynamicPropBraces\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Cannot assign offset \\(float\\|int\\) to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:transformIntoDynamicVarBraces\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:transformIntoCurlyIndexBraces\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformer\\:\\:transformIntoGroupUseBraces\\(\\) has parameter \\$index with no typehint specified\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/CurlyBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\ImportTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ImportTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ImportTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\NamespaceOperatorTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\NullableTypeTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/NullableTypeTransformer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/NullableTypeTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\ReturnRefTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ReturnRefTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/ReturnRefTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\SquareBraceTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 5
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Cannot call method equalsAny\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 3
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Cannot assign offset int\\|null to PhpCsFixer\\\\Tokenizer\\\\Tokens\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getNextMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/SquareBraceTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\TypeAlternationTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 4
+			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeAlternationTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\TypeColonTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeColonTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeColonTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockStart\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeColonTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Transformer/TypeColonTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:getPrevMeaningfulToken\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/TypeColonTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\UseTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$searchIndex of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:findBlockEnd\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Only numeric types are allowed in pre\\-increment, int\\|null given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/UseTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\Transformer\\\\WhitespacyCommentTransformer\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tokenizer\\\\TransformerInterface\\:\\:getCustomTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tokenizer/TransformerInterface.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformers.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 1
+			path: src/Tokenizer/Transformers.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\ToolInfo\\:\\:\\$composerInstallationDetails type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/ToolInfo.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/ToolInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\ToolInfo\\:\\:getPharDownloadUri\\(\\) has parameter \\$version with no typehint specified\\.$#"
+			count: 1
+			path: src/ToolInfo.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\ToolInfoInterface\\:\\:getPharDownloadUri\\(\\) has parameter \\$version with no typehint specified\\.$#"
+			count: 1
+			path: src/ToolInfoInterface.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtolower expects string, array\\<string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 2
+			path: src/Utils.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, array\\<int\\|string, mixed\\> given\\.$#"
+			count: 1
+			path: src/Utils.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\WhitespacesFixerConfig\\:\\:\\$indent has no typehint specified\\.$#"
+			count: 1
+			path: src/WhitespacesFixerConfig.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\WhitespacesFixerConfig\\:\\:\\$lineEnding has no typehint specified\\.$#"
+			count: 1
+			path: src/WhitespacesFixerConfig.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AbstractDoctrineAnnotationFixerTestCase\\:\\:testConfigureWithInvalidConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AbstractDoctrineAnnotationFixerTestCase.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/AbstractDoctrineAnnotationFixerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AbstractDoctrineAnnotationFixerTestCase\\:\\:provideInvalidConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AbstractDoctrineAnnotationFixerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AbstractDoctrineAnnotationFixerTestCase\\:\\:createTestCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AbstractDoctrineAnnotationFixerTestCase.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\AbstractFunctionReferenceFixerTest\\:\\:\\$fixer has no typehint specified\\.$#"
+			count: 1
+			path: tests/AbstractFunctionReferenceFixerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Component\\\\Console\\\\Command\\\\Command\\:\\:getDefaultName\\(\\)\\.$#"
+			count: 1
+			path: tests/AutoReview/CommandTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: tests/AutoReview/CommandTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: tests/AutoReview/CommandTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/AutoReview/ComposerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: tests/AutoReview/FixerFactoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$file of class Symfony\\\\Component\\\\Finder\\\\SplFileInfo constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerFactoryTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerFactoryTest.php
+
+		-
+			message: "#^Only numeric types are allowed in \\+, int\\|false given on the left side\\.$#"
+			count: 2
+			path: tests/AutoReview/FixerFactoryTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\AutoReview\\\\FixerTest\\:\\:\\$allowedRequiredOptions has no typehint specified\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\AutoReview\\\\FixerTest\\:\\:\\$allowedFixersWithoutDefaultCodeSample has no typehint specified\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\Fixer…' and PhpCsFixer\\\\AbstractFixer will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with arguments 'PhpCsFixer…', PhpCsFixer\\\\FixerDefinition\\\\CodeSampleInterface and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'string', string and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'array', array and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to function array_search\\(\\) requires parameter \\#3 to be true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerConfiguration\\\\FixerConfigurationResolverInterface will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerConfiguration\\\\FixerOptionInterface will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Argument of an invalid type \\(array\\|null\\) supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'int', int and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'bool', bool and string will always evaluate to true\\.$#"
+			count: 4
+			path: tests/AutoReview/FixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 9
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 8
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 6
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, int given\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 8
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of class PhpCsFixer\\\\DocBlock\\\\DocBlock constructor expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromCode\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Only booleans are allowed in &&, PhpCsFixer\\\\DocBlock\\\\DocBlock\\|null given on the left side\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Only booleans are allowed in &&, int given on the right side\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\ProjectCodeTest\\:\\:getUsedDataProviderMethodNames\\(\\) has parameter \\$testClassName with no typehint specified\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Binary operation \"\\.\" between array\\|string and '\\.php' results in an error\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 2
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\ProjectCodeTest\\:\\:getPublicMethodNames\\(\\) has parameter \\$rc with generic class ReflectionClass but does not specify its types\\: T$#"
+			count: 1
+			path: tests/AutoReview/ProjectCodeTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\Config' and PhpCsFixer\\\\Config will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/ProjectFixerConfigurationTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'string', string and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/TransformerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'int', int and string will always evaluate to true\\.$#"
+			count: 2
+			path: tests/AutoReview/TransformerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with arguments 'array', array and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/AutoReview/TransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\TravisTest\\:\\:assertUpcomingPhpVersionIsCoveredByCiJob\\(\\) has parameter \\$ciVersions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\TravisTest\\:\\:assertUpcomingPhpVersionIsCoveredByCiJob\\(\\) has parameter \\$lastSupportedVersion with no typehint specified\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\TravisTest\\:\\:assertSupportedPhpVersionsAreCoveredByCiJobs\\(\\) has parameter \\$ciVersions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\TravisTest\\:\\:assertSupportedPhpVersionsAreCoveredByCiJobs\\(\\) has parameter \\$supportedVersions with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 2
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\AutoReview\\\\TravisTest\\:\\:convertPhpVerIdToNiceVer\\(\\) has parameter \\$verId with no typehint specified\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:fromCode\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|false\\.$#"
+			count: 2
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$input of static method Symfony\\\\Component\\\\Yaml\\\\Yaml\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/AutoReview/TravisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Cache\\\\CacheTest\\:\\:testFromJsonThrowsInvalidArgumentExceptionIfJsonIsMissingKey\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Cache/CacheTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of static method PhpCsFixer\\\\Cache\\\\Cache\\:\\:fromJson\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Cache/CacheTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Cache\\\\CacheTest\\:\\:provideMissingDataCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Cache/CacheTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: tests/Cache/CacheTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: tests/Cache/FileCacheManagerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\Cache…' and PhpCsFixer\\\\Cache\\\\FileHandler will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Cache/FileHandlerTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$cwd of class PhpCsFixer\\\\Console\\\\ConfigurationResolver constructor expects string, string\\|false given\\.$#"
+			count: 3
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$it of function iterator_to_array expects Traversable, iterable given\\.$#"
+			count: 2
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\ConfigTest\\:\\:testRegisterCustomFixers\\(\\) has parameter \\$suite with no value type specified in iterable type iterable\\.$#"
+			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\Finder' and PhpCsFixer\\\\Finder will always evaluate to true\\.$#"
+			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\ConfigTest\\:\\:provideRegisterCustomFixersCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/ConfigTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentExce…' and PhpCsFixer\\\\ConfigurationException\\\\InvalidConfigurationException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/ConfigurationException/InvalidConfigurationExceptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\ConfigurationException\\\\InvalidFixerConfigurationException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\ConfigurationException\\\\InvalidForEnvFixerConfigurationException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/ConfigurationException/InvalidForEnvFixerConfigurationExceptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\ConfigurationException\\\\RequiredFixerConfigurationException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/ConfigurationException/RequiredFixerConfigurationExceptionTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 3
+			path: tests/Console/Command/DescribeCommandTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'InvalidArgumentExce…' and PhpCsFixer\\\\Console\\\\Command\\\\DescribeNameNotFoundException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Console/Command/DescribeNameNotFoundExceptionTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\FixCommandTest\\:\\:doTestExecute\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Command/FixCommandTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotRegExp\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Console/Command/ReadmeCommandTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Console/Command/ReadmeCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:testExecute\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:testExecuteWhenNotAbleToGetLatestVersions\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string given\\.$#"
+			count: 2
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:testExecuteWhenNotInstalledAsPhar\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:execute\\(\\) has parameter \\$decorated with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:execute\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:assertDisplay\\(\\) has parameter \\$expectedDisplay with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Command\\\\SelfUpdateCommandTest\\:\\:createToolInfo\\(\\) has parameter \\$isInstalledAsPhar with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Cannot call method url\\(\\) on org\\\\bovigo\\\\vfs\\\\vfsStreamDirectory\\|null\\.$#"
+			count: 2
+			path: tests/Console/Command/SelfUpdateCommandTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:testResolveIntersectionOfPaths\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:testResolveIntersectionOfPaths\\(\\) has parameter \\$path with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function sort expects array, array\\|Exception given\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:testConfigFinderIsOverridden\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:testDeprecatedFixerConfigured\\(\\) has parameter \\$ruleConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:normalizePath\\(\\) has parameter \\$path with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:assertSameRules\\(\\) has parameter \\$actual with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:assertSameRules\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:assertSameRules\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:createConfigurationResolver\\(\\) has parameter \\$cwdPath with no typehint specified\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\ConfigurationResolverTest\\:\\:createConfigurationResolver\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/ConfigurationResolverTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of function get_class expects object, Throwable\\|null given\\.$#"
+			count: 1
+			path: tests/Console/Output/ErrorOutputTest.php
+
+		-
+			message: "#^Cannot call method getMessage\\(\\) on Throwable\\|null\\.$#"
+			count: 1
+			path: tests/Console/Output/ErrorOutputTest.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on Throwable\\|null\\.$#"
+			count: 1
+			path: tests/Console/Output/ErrorOutputTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of class Symfony\\\\Component\\\\Console\\\\Output\\\\StreamOutput constructor expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: tests/Console/Output/ErrorOutputTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Console/Output/ErrorOutputTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Output\\\\ProcessOutputTest\\:\\:testProcessProgressOutput\\(\\) has parameter \\$statuses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Output/ProcessOutputTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 3
+			path: tests/Console/Output/ProcessOutputTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Output\\\\ProcessOutputTest\\:\\:testProcessProgressOutputWithNumbers\\(\\) has parameter \\$statuses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Output/ProcessOutputTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Console\\\\Output\\\\ProcessOutputTest\\:\\:foreachStatus\\(\\) has parameter \\$statuses with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Console/Output/ProcessOutputTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Annotation\\|null\\.$#"
+			count: 2
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Cannot call method getStart\\(\\) on PhpCsFixer\\\\DocBlock\\\\Annotation\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Cannot call method getEnd\\(\\) on PhpCsFixer\\\\DocBlock\\\\Annotation\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Cannot call method getTag\\(\\) on PhpCsFixer\\\\DocBlock\\\\Annotation\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Cannot call method remove\\(\\) on PhpCsFixer\\\\DocBlock\\\\Annotation\\|null\\.$#"
+			count: 2
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 2
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'array' and array\\<string\\> will always evaluate to true\\.$#"
+			count: 1
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'string' and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/DocBlock/AnnotationTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'array' and array\\<PhpCsFixer\\\\DocBlock\\\\Line\\> will always evaluate to true\\.$#"
+			count: 1
+			path: tests/DocBlock/DocBlockTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\DocBlock…' and PhpCsFixer\\\\DocBlock\\\\Line will always evaluate to true\\.$#"
+			count: 1
+			path: tests/DocBlock/DocBlockTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'array' and array\\<PhpCsFixer\\\\DocBlock\\\\Annotation\\> will always evaluate to true\\.$#"
+			count: 5
+			path: tests/DocBlock/DocBlockTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\DocBlock…' and PhpCsFixer\\\\DocBlock\\\\Annotation will always evaluate to true\\.$#"
+			count: 1
+			path: tests/DocBlock/DocBlockTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/LineTest.php
+
+		-
+			message: "#^Cannot call method isTheStart\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/LineTest.php
+
+		-
+			message: "#^Cannot call method isTheEnd\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/LineTest.php
+
+		-
+			message: "#^Cannot call method containsUsefulContent\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/LineTest.php
+
+		-
+			message: "#^Cannot call method containsATag\\(\\) on PhpCsFixer\\\\DocBlock\\\\Line\\|null\\.$#"
+			count: 1
+			path: tests/DocBlock/LineTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Doctrine\\\\Annotation\\\\TokenTest\\:\\:provideIsTypeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/Annotation/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Doctrine\\\\Annotation\\\\TokenTest\\:\\:provideIsNotTypeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Doctrine/Annotation/TokenTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotSame\\(\\) with 1 and 2 will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Error/ErrorTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'array' and array\\<PhpCsFixer\\\\Error\\\\Error\\> will always evaluate to true\\.$#"
+			count: 3
+			path: tests/Error/ErrorsManagerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Symfony\\\\\\\\Contracts…' and PhpCsFixer\\\\Event\\\\Event will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Event/EventTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FileReader will always evaluate to true\\.$#"
+			count: 1
+			path: tests/FileReaderTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$actualClassOrObject of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertAttributeSame\\(\\) expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 2
+			path: tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of static method PHPUnit\\\\Framework\\\\Assert\\:\\:getObjectAttribute\\(\\) expects object, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 2
+			path: tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Alias\\\\RandomApiMigrationFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Alias\\\\RandomApiMigrationFixerTest\\:\\:testFix73\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/ArrayNotation/ArraySyntaxFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ArrayNotation\\\\NoWhitespaceBeforeCommaInArrayFixerTest\\:\\:testFix73\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ArrayNotation\\\\TrailingCommaInMultilineArrayFixerTest\\:\\:testFix73\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:\\$configurationOopPositionSameLine has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:\\$configurationCtrlStructPositionNextLine has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:\\$configurationAnonymousPositionNextLine has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 17
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixControlContinuationBraces\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixMissingBracesAndIndent\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixClassyBraces\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixAnonFunctionInShortArraySyntax\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixCommentBeforeBrace\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixCommentBeforeBrace70\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixWhitespaceBeforeBrace\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixFunctions\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixMultiLineStructures\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFixSpaceAroundToken\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFinally\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFunctionImport\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testFix70\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testPreserveLineAfterControlBrace\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\BracesFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Basic/BracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\EncodingFixerTest\\:\\:prepareTestCase\\(\\) has parameter \\$expectedFilename with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/EncodingFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Basic\\\\EncodingFixerTest\\:\\:prepareTestCase\\(\\) has parameter \\$inputFilename with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/EncodingFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 2
+			path: tests/Fixer/Basic/EncodingFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, SplFileInfo\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/EncodingFixerTest.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: tests/Fixer/Basic/EncodingFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Basic/Psr0FixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 4
+			path: tests/Fixer/CastNotation/CastSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\CastNotation\\\\LowercaseCastFixerTest\\:\\:createCasesFor\\(\\) has parameter \\$type with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\CastNotation\\\\ShortScalarCastFixerTest\\:\\:createCasesFor\\(\\) has parameter \\$from with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\CastNotation\\\\ShortScalarCastFixerTest\\:\\:createCasesFor\\(\\) has parameter \\$to with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionMethod constructor expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassAttributesSeparationFixerTest\\:\\:testWithConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:testClassyDefinitionInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionMethod constructor expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 2
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:testClassyInheritanceInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:testClassyInheritanceInfo7\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:doTestClassyInheritanceInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:doTestClassyInheritanceInfo\\(\\) has parameter \\$label with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:doTestClassyInheritanceInfo\\(\\) has parameter \\$source with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:provideClassyCases\\(\\) has parameter \\$classy with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ClassDefinitionFixerTest\\:\\:provideClassyExtendingCases\\(\\) has parameter \\$classy with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\FinalInternalClassFixerTest\\:\\:testFixWithConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/MethodSeparationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixerTest\\:\\:testFix71\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 7
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixerTest\\:\\:testLegacyFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixerTest\\:\\:testFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixerTest\\:\\:testFixWithSortingAlgorithm\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\OrderedClassElementsFixerTest\\:\\:testFix74\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\ProtectedToPrivateFixerTest\\:\\:getAttributesAndMethods\\(\\) has parameter \\$original with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixerTest\\:\\:testLegacyFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\SingleClassElementPerStatementFixerTest\\:\\:testFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\VisibilityRequiredFixerTest\\:\\:provideFixMethods70Cases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassNotation\\\\VisibilityRequiredFixerTest\\:\\:provideFixMethodsCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ClassUsage\\\\DateTimeImmutableFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Comment\\\\HeaderCommentFixerTest\\:\\:testFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Comment\\\\HeaderCommentFixerTest\\:\\:testMisconfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$configuration of method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractFixerWithAliasedOptionsTestCase\\:\\:configureFixerWithAliasedOptions\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Comment\\\\HeaderCommentFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Comment/HeaderCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method isComment\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionMethod constructor expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Comment/SingleLineCommentStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 13
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideInvalidConfigurationElementCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFixWithDefaultConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFix70WithDefaultConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFix71WithDefaultConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFixWithConfiguredCustomIncludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFixWithConfiguredOnlyIncludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ConstantNotation\\\\NativeConstantInvocationFixerTest\\:\\:provideFixWithConfiguredExcludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtoupper expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\NoUnneededControlParenthesesFixerTest\\:\\:\\$defaultStatements has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in &&, string\\|null given on the left side\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\NoUselessElseFixerTest\\:\\:testBlockDetection\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$class of class ReflectionMethod constructor expects object\\|string, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionObject constructor expects object, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:testFix\\(\\) has parameter \\$extraConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 12
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:testFixInverse\\(\\) has parameter \\$extraConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:testInvalidConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:provideInvalidConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerDefinition\\\\FixerDefinitionInterface will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method getDefinition\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:testWithConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\ControlStructure\\\\YodaStyleFixerTest\\:\\:testPHP74CasesInverse\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationArrayAssignmentFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationArrayAssignmentFixerTest\\:\\:provideFixWithColonCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationBracesFixerTest\\:\\:provideFixWithBracesCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationBracesFixerTest\\:\\:provideFixWithoutBracesCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationIndentationFixerTest\\:\\:provideFixWithIndentedMixedLinesCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 26
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixerTest\\:\\:provideFixAllCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixerTest\\:\\:provideFixAroundParenthesesOnlyCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixerTest\\:\\:provideFixAroundCommasOnlyCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixerTest\\:\\:provideFixAroundArgumentAssignmentsOnlyCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\DoctrineAnnotation\\\\DoctrineAnnotationSpacesFixerTest\\:\\:provideFixAroundArrayAssignmentsOnlyCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\FopenFlagsFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/FunctionNotation/FopenFlagsFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixerTest\\:\\:\\$configurationClosureSpacingNone has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 4
+			path: tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixerTest\\:\\:testFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixerTest\\:\\:test70\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\FunctionDeclarationFixerTest\\:\\:test74\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixerTest\\:\\:testFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and string will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in an elseif condition, int\\|false given\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixerTest\\:\\:testFixWithDifferentLineEndings\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixerTest\\:\\:testFix73\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\MethodArgumentSpaceFixerTest\\:\\:testFix74\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 8
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixerTest\\:\\:provideInvalidConfigurationElementCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function preg_quote expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixerTest\\:\\:provideFixWithDefaultConfigurationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixerTest\\:\\:provideFixWithConfiguredExcludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixerTest\\:\\:testFixWithConfiguredInclude\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NativeFunctionInvocationFixerTest\\:\\:provideFixWithConfiguredIncludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixerTest\\:\\:provideFix56Cases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixerTest\\:\\:provideFix71Cases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\NoUnreachableDefaultArgumentValueFixerTest\\:\\:provideFix74Cases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\FunctionNotation\\\\PhpdocToReturnTypeFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$expected of method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractFixerTestCase\\:\\:doTest\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Import\\\\OrderedImportsFixerTest\\:\\:testFix70\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Import/OrderedImportsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Import/OrderedImportsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Import\\\\OrderedImportsFixerTest\\:\\:testInvalidSortAlgorithm\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Import/OrderedImportsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Import\\\\OrderedImportsFixerTest\\:\\:testFix72\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Import/OrderedImportsFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\LanguageConstruct\\\\DeclareEqualNormalizeFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\LanguageConstruct\\\\DeclareEqualNormalizeFixerTest\\:\\:testInvalidConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\LanguageConstruct\\\\ErrorSuppressionFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\LanguageConstruct\\\\FunctionToConstantFixerTest\\:\\:testInvalidConfigurationKeys\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of static method PHPUnit\\\\Framework\\\\Assert\\:\\:getObjectAttribute\\(\\) expects object, PhpCsFixer\\\\AbstractFixer\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\NamespaceNotation\\\\NoBlankLinesBeforeNamespaceFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\NamespaceNotation\\\\SingleBlankLineBeforeNamespaceFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixerTest\\:\\:testWithTabs\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 19
+			path: tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixerTest\\:\\:testConfigured\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixerTest\\:\\:testPHP71Cases\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Operator\\\\BinaryOperatorSpacesFixerTest\\:\\:testFixPhp74\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 4
+			path: tests/Fixer/Operator/ConcatSpaceFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Operator/IncrementStyleFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: tests/Fixer/Operator/IncrementStyleFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpTag/BlankLineAfterOpeningTagFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpTag/LinebreakAfterOpeningTagFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: tests/Fixer/PhpTag/NoClosingTagFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: tests/Fixer/PhpTag/NoShortEchoTagFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in &&, string\\|null given on the left side\\.$#"
+			count: 2
+			path: tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixerTest\\:\\:generateCases\\(\\) has parameter \\$expectedTemplate with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitConstructFixerTest\\:\\:generateCases\\(\\) has parameter \\$inputTemplate with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitDedicateAssertFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitExpectationFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitInternalClassFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitMethodCasingFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitMockFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitMockShortWillReturnFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitNamespacedFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitNoExpectationAnnotationFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitSetUpTearDownVisibilityFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitSizeClassFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitSizeClassFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 4
+			path: tests/Fixer/PhpUnit/PhpUnitStrictFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixerTest\\:\\:testFixLegacyCaseOption\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixerTest\\:\\:provideFixLegacyCaseOptionCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestAnnotationFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\PhpUnit\\\\PhpUnitTestCaseStaticMethodCallsFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/AlignMultilineCommentFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\GeneralPhpdocAnnotationRemoveFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\GeneralPhpdocAnnotationRemoveFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\NoSuperfluousPhpdocTagsFixerTest\\:\\:testFixPhp74\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 8
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixerTest\\:\\:provideConfigureRejectsInvalidConfigurationValueCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixerTest\\:\\:testFix\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 3
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixerTest\\:\\:testFix70\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixerTest\\:\\:testFix71\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAddMissingParamAnnotationFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 38
+			path: tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixerTest\\:\\:testVariadicParams\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocAlignFixerTest\\:\\:testInvalidPhpdocsAreUnchanged\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+
+		-
+			message: "#^Foreach overwrites \\$tag with its value variable\\.$#"
+			count: 2
+			path: tests/Fixer/Phpdoc/PhpdocInlineTagFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocInlineTagFixerTest\\:\\:testFixInheritDoc\\(\\) has parameter \\$expected with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocInlineTagFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocInlineTagFixerTest\\:\\:testFixInheritDoc\\(\\) has parameter \\$input with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocInlineTagFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 11
+			path: tests/Fixer/Phpdoc/PhpdocNoAliasTagFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 6
+			path: tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocReturnSelfReferenceFixerTest\\:\\:testLegacyFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocReturnSelfReferenceFixerTest\\:\\:testFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Phpdoc\\\\PhpdocReturnSelfReferenceFixerTest\\:\\:testInvalidConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocScalarFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Phpdoc/PhpdocSummaryFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Phpdoc/PhpdocTypesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/ReturnNotation/BlankLineBeforeReturnFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 5
+			path: tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixerTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Fixer/Semicolon/SpaceAfterSemicolonFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\StringNotation\\\\EscapeImplicitBackslashesFixerTest\\:\\:testFix\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/StringNotation/EscapeImplicitBackslashesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\StringNotation\\\\SimpleToComplexStringVariableFixerTest\\:\\:provideFixCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/StringNotation/SimpleToComplexStringVariableFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/StringNotation/StringLineEndingFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixerTest\\:\\:withLongArraySyntaxCases\\(\\) has parameter \\$cases with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\ArrayIndentationFixerTest\\:\\:toLongArraySyntax\\(\\) has parameter \\$php with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 24
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideInvalidControlStatementCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithBreakCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithCaseCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithContinueCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithDeclareCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithDefaultCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithDieCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithDoCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithExitCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithGotoCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithIfCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithIncludeCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithIncludeOnceCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithRequireCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithRequireOnceCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithReturnCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithReturnAndMessyWhitespacesCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithSwitchCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithThrowCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithTryCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\BlankLineBeforeStatementFixerTest\\:\\:provideFixWithWhileCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/HeredocIndentationFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 3
+			path: tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$expected of method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractFixerTestCase\\:\\:doTest\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/IndentationTypeFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/LineEndingFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/LineEndingFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:\\$template has no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 16
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:testLegacyWithConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:testWithConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:testBraces\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:testMessyWhitespaces\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:testInSwitchStatement\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:removeLinesFromString\\(\\) has parameter \\$input with no typehint specified\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoExtraBlankLinesFixerTest\\:\\:removeLinesFromString\\(\\) has parameter \\$lineNumbers with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoSpacesAroundOffsetFixerTest\\:\\:testLegacyFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+
+		-
+			message: "#^Cannot call method configure\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 4
+			path: tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoSpacesAroundOffsetFixerTest\\:\\:testFixWithConfiguration\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Fixer\\\\Whitespace\\\\NoSpacesAroundOffsetFixerTest\\:\\:testPHP71\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/NoWhitespaceInBlankLineFixerTest.php
+
+		-
+			message: "#^Cannot call method setWhitespacesConfig\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Fixer/Whitespace/SingleBlankLineAtEofFixerTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 2
+			path: tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerConfiguration\\\\AliasedFixerOption will always evaluate to true\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerConfiguration\\\\AliasedFixerOptionTest\\:\\:testGetAllowedTypes\\(\\) has parameter \\$allowedTypes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/AliasedFixerOptionTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerConfiguration\\\\AliasedFixerOptionTest\\:\\:testGetAllowedValues\\(\\) has parameter \\$allowedValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/AliasedFixerOptionTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 2
+			path: tests/FixerConfiguration/AliasedFixerOptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerConfiguration\\\\DeprecatedFixerOption will always evaluate to true\\.$#"
+			count: 2
+			path: tests/FixerConfiguration/DeprecatedFixerOptionTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/DeprecatedFixerOptionTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/FixerConfigurationResolverTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/FixerConfigurationResolverTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 3
+			path: tests/FixerConfiguration/FixerOptionBuilderTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 2
+			path: tests/FixerConfiguration/FixerOptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Symfony\\\\\\\\Component…' and PhpCsFixer\\\\FixerConfiguration\\\\InvalidOptionsForEnvException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/FixerConfiguration/InvalidOptionsForEnvExceptionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$code of class PhpCsFixer\\\\FixerDefinition\\\\FileSpecificCodeSample constructor expects string, string\\|false given\\.$#"
+			count: 3
+			path: tests/FixerDefinition/FileSpecificCodeSampleTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerDefinition\\\\FileSpecificCodeSample will always evaluate to true\\.$#"
+			count: 1
+			path: tests/FixerDefinition/FileSpecificCodeSampleTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerDefinition\\\\VersionSpecificCodeSampleTest\\:\\:provideIsSuitableForVersionUsesVersionSpecificationCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerDefinition\\\\VersionSpecificationTest\\:\\:provideInvalidVersionCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerDefinition/VersionSpecificationTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerDefinition\\\\VersionSpecificationTest\\:\\:provideIsSatisfiedByReturnsTrueCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerDefinition/VersionSpecificationTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerDefinition\\\\VersionSpecificationTest\\:\\:provideIsSatisfiedByReturnsFalseCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/FixerDefinition/VersionSpecificationTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerFactory will always evaluate to true\\.$#"
+			count: 1
+			path: tests/FixerFactoryTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerFactoryTest\\:\\:createFixerDouble\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: tests/FixerFactoryTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\FixerFactoryTest\\:\\:createFixerDouble\\(\\) has parameter \\$priority with no typehint specified\\.$#"
+			count: 1
+			path: tests/FixerFactoryTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Linter\\\\AbstractLinterTestCase\\:\\:provideLintFileCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Linter/AbstractLinterTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Linter\\\\AbstractLinterTestCase\\:\\:provideLintSourceCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Linter/AbstractLinterTestCase.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and PhpCsFixer\\\\Linter\\\\LintingException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Linter/LintingExceptionTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and PhpCsFixer\\\\Linter\\\\UnavailableLinterException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Linter/UnavailableLinterExceptionTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$string of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringStartsWith\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/PharCheckerTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'RuntimeException' and PhpCsFixer\\\\PregException will always evaluate to true\\.$#"
+			count: 1
+			path: tests/PregExceptionTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: tests/PregTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/PregTest.php
+
+		-
+			message: "#^Cannot call method getFormat\\(\\) on PhpCsFixer\\\\Report\\\\ReporterInterface\\|null\\.$#"
+			count: 1
+			path: tests/Report/AbstractReporterTestCase.php
+
+		-
+			message: "#^Cannot call method generate\\(\\) on PhpCsFixer\\\\Report\\\\ReporterInterface\\|null\\.$#"
+			count: 1
+			path: tests/Report/AbstractReporterTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Report\\\\AbstractReporterTestCase\\:\\:provideGenerateCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Report/AbstractReporterTestCase.php
+
+		-
+			message: "#^Static property PhpCsFixer\\\\Tests\\\\Report\\\\CheckstyleReporterTest\\:\\:\\$xsd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: tests/Report/CheckstyleReporterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$xsd of class PhpCsFixer\\\\PhpunitConstraintXmlMatchesXsd\\\\Constraint\\\\XmlMatchesXsdForV7 constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Report/CheckstyleReporterTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/Report/JsonReporterTest.php
+
+		-
+			message: "#^Static property PhpCsFixer\\\\Tests\\\\Report\\\\JunitReporterTest\\:\\:\\$xsd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: tests/Report/JunitReporterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$xsd of class PhpCsFixer\\\\PhpunitConstraintXmlMatchesXsd\\\\Constraint\\\\XmlMatchesXsdForV7 constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Report/JunitReporterTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Report\\\\ReporterFactoryTest\\:\\:createReporterDouble\\(\\) has parameter \\$format with no typehint specified\\.$#"
+			count: 1
+			path: tests/Report/ReporterFactoryTest.php
+
+		-
+			message: "#^Static property PhpCsFixer\\\\Tests\\\\Report\\\\XmlReporterTest\\:\\:\\$xsd \\(string\\|null\\) does not accept string\\|false\\.$#"
+			count: 1
+			path: tests/Report/XmlReporterTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$xsd of class PhpCsFixer\\\\PhpunitConstraintXmlMatchesXsd\\\\Constraint\\\\XmlMatchesXsdForV7 constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Report/XmlReporterTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:testIfAllRulesInSetsExists\\(\\) has parameter \\$ruleConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$configuration of method PhpCsFixer\\\\Fixer\\\\ConfigurableFixerInterface\\:\\:configure\\(\\) expects array\\|null, array\\|false given\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:testThatDefaultConfigIsNotPassed\\(\\) has parameter \\$ruleConfig with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:provideSetDefinitionNameCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"array\"\\.$#"
+			count: 2
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:testRiskyRulesInSet\\(\\) has parameter \\$set with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:testResolveRules\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:testResolveRules\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"bool\"\\.$#"
+			count: 2
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:findInSets\\(\\) has parameter \\$config with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:findInSets\\(\\) has parameter \\$ruleName with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:findInSets\\(\\) has parameter \\$sets with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:expendSet\\(\\) has parameter \\$resolvedSets with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:expendSet\\(\\) has parameter \\$setDefinitions with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:expendSet\\(\\) has parameter \\$setName with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:expendSet\\(\\) has parameter \\$setValue with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:assertSameRules\\(\\) has parameter \\$actual with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:assertSameRules\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:assertSameRules\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:sort\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:allInteger\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\RuleSetTest\\:\\:createRuleSetToTestWith\\(\\) has parameter \\$rules with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$str1 of function strcmp expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/RuleSetTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"void\"\\.$#"
+			count: 4
+			path: tests/Runner/FileFilterIteratorTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\FixerFileProcessedEvent will always evaluate to true\\.$#"
+			count: 2
+			path: tests/Runner/FileFilterIteratorTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer\\\\\\\\Error…' and PhpCsFixer\\\\Error\\\\Error will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Runner/RunnerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\AbstractSmokeTest\\:\\:markTestSkippedOrFail\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/AbstractSmokeTest.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: tests/Smoke/AbstractSmokeTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Smoke\\\\CiIntegrationTest\\:\\:\\$fixtureDir has no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/CiIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Smoke/CiIntegrationTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\CiIntegrationTest\\:\\:executeCommand\\(\\) has parameter \\$command with no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/CiIntegrationTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\CiIntegrationTest\\:\\:executeScript\\(\\) has parameter \\$scriptParts with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Smoke/CiIntegrationTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Smoke\\\\InstallViaComposerTest\\:\\:\\$stepsToVerifyInstallation has no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function unlink expects string, string\\|false given\\.$#"
+			count: 3
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$dirs of method Symfony\\\\Component\\\\Filesystem\\\\Filesystem\\:\\:mkdir\\(\\) expects iterable\\|string, string\\|false given\\.$#"
+			count: 3
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$files of method Symfony\\\\Component\\\\Filesystem\\\\Filesystem\\:\\:remove\\(\\) expects iterable\\|string, string\\|false given\\.$#"
+			count: 3
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\InstallViaComposerTest\\:\\:assertCommandsWork\\(\\) has parameter \\$commands with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\InstallViaComposerTest\\:\\:assertCommandsWork\\(\\) has parameter \\$cwd with no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/InstallViaComposerTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Smoke\\\\PharTest\\:\\:\\$pharCwd has no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/PharTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Smoke\\\\PharTest\\:\\:\\$pharName has no typehint specified\\.$#"
+			count: 1
+			path: tests/Smoke/PharTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Smoke/PharTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function basename expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Smoke/StdinTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Smoke\\\\StdinTest\\:\\:unifyFooter\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: tests/Smoke/StdinTest.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 2
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Cannot call method supports\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Cannot call method isCandidate\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Cannot call method fix\\(\\) on PhpCsFixer\\\\AbstractFixer\\|null\\.$#"
+			count: 2
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Parameter \\#2 \\$constraint of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertThat\\(\\) expects PHPUnit\\\\Framework\\\\Constraint\\\\Constraint, PHPUnit\\\\Framework\\\\Constraint\\\\IsIdentical\\|PHPUnit_Framework_Constraint_IsIdentical given\\.$#"
+			count: 2
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Cannot call method lintSource\\(\\) on PhpCsFixer\\\\Linter\\\\LinterInterface\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$other of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equals\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenKind of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isTokenKindFound\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of static method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getNameForId\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractFixerWithAliasedOptionsTestCase\\:\\:configureFixerWithAliasedOptions\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractFixerWithAliasedOptionsTestCase.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, int\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationCaseFactory\\:\\:determineConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationCaseFactory\\:\\:determineRequirements\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationCaseFactory\\:\\:determineSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationCaseFactory\\:\\:parseJson\\(\\) has parameter \\$template with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationCaseFactory\\:\\:parseJson\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|null given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationCaseFactory.php
+
+		-
+			message: "#^Cannot call method delete\\(\\) on PhpCsFixer\\\\FileRemoval\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 2
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_dir expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$dirs of method Symfony\\\\Component\\\\Finder\\\\Finder\\:\\:in\\(\\) expects array\\<string\\>\\|string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#6 \\$linter of class PhpCsFixer\\\\Runner\\\\Runner constructor expects PhpCsFixer\\\\Linter\\\\LinterInterface, PhpCsFixer\\\\Linter\\\\LinterInterface\\|null given\\.$#"
+			count: 2
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#2 \\$constraint of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertThat\\(\\) expects PHPUnit\\\\Framework\\\\Constraint\\\\Constraint, PHPUnit\\\\Framework\\\\Constraint\\\\IsIdentical\\|PHPUnit_Framework_Constraint_IsIdentical given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#2 \\$fixedInputCode of static method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationTestCase\\:\\:assertRevertedOrderFixing\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Parameter \\#3 \\$fixedInputCodeWithReversedFixers of static method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractIntegrationTestCase\\:\\:assertRevertedOrderFixing\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: tests/Test/AbstractIntegrationTestCase.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|false given\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractTransformerTestCase\\:\\:doTest\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractTransformerTestCase\\:\\:doTest\\(\\) has parameter \\$observedKindsOrPrototypes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractTransformerTestCase\\:\\:doTest\\(\\) has parameter \\$source with no typehint specified\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\AbstractTransformerTestCase\\:\\:countTokenPrototypes\\(\\) has parameter \\$prototypes with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/AbstractTransformerTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$other of method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:equals\\(\\) expects array\\|PhpCsFixer\\\\Tokenizer\\\\Token\\|string, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$tokenKind of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:isTokenKindFound\\(\\) expects int\\|string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of static method PhpCsFixer\\\\Tokenizer\\\\Token\\:\\:getNameForId\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensTest\\:\\:testFindSequence\\(\\) has parameter \\$caseSensitive with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensTest\\:\\:testFindSequence\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensTest\\:\\:testFindSequenceException\\(\\) has parameter \\$sequence with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Cannot call method isWhitespace\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, string\\|false given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInternalType\\(\\) with 'array' and array\\<PhpCsFixer\\\\Tokenizer\\\\Token\\> will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$found has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensTest\\:\\:testTokenOfKindSibling\\(\\) has parameter \\$findTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Cannot call method equals\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:insertAt\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$token of static method PhpCsFixer\\\\Tokenizer\\\\Tokens\\:\\:detectBlockType\\(\\) expects PhpCsFixer\\\\Tokenizer\\\\Token, PhpCsFixer\\\\Tokenizer\\\\Token\\|null given\\.$#"
+			count: 3
+			path: tests/Tokenizer/TokensTest.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:\\$config has no typehint specified\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:\\$requirements type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Property PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:\\$settings type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$requirements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\IntegrationCase\\:\\:__construct\\(\\) has parameter \\$settings with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/IntegrationCase.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Test\\\\InternalIntegrationCaseFactory\\:\\:determineSettings\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Test/InternalIntegrationCaseFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/TextDiffTest.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/ArgumentAnalysisTest.php
+
+		-
+			message: "#^Cannot call method getStartIndex\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/ArgumentAnalysisTest.php
+
+		-
+			message: "#^Cannot call method getEndIndex\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/ArgumentAnalysisTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\NamespaceAnalysis will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/NamespaceAnalysisTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\NamespaceUseAnalysis will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/NamespaceUseAnalysisTest.php
+
+		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'PhpCsFixer…' and PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\Analysis\\\\TypeAnalysis will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/Analysis/TypeAnalysisTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzerTest\\:\\:testArguments\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzerTest\\:\\:testArgumentInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\ArgumentsAnalyzerTest\\:\\:testArguments73\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzerTest\\:\\:testComments\\(\\) has parameter \\$borders with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$index of method PhpCsFixer\\\\Tokenizer\\\\Analyzer\\\\CommentsAnalyzer\\:\\:isBeforeStructuralElement\\(\\) expects int, int\\|null given\\.$#"
+			count: 3
+			path: tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\FunctionsAnalyzerTest\\:\\:testFunctionArgumentInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\FunctionsAnalyzerTest\\:\\:testFunctionReturnTypeInfo\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\FunctionsAnalyzerTest\\:\\:testFunctionArgumentInfoPhp74\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\FunctionsAnalyzerTest\\:\\:testFunctionReturnTypeInfoPhp74\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\NamespaceUsesAnalyzerTest\\:\\:testUsesFromTokens\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/NamespaceUsesAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Analyzer\\\\NamespacesAnalyzerTest\\:\\:testNamespaces\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Analyzer/NamespacesAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Generator\\\\NamespacedStringTokenGeneratorTest\\:\\:testGenerator\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Generator/NamespacedStringTokenGeneratorTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/Tokenizer/Generator/NamespacedStringTokenGeneratorTest.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokenTest\\:\\:testEquals\\(\\) has parameter \\$other with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokenTest\\:\\:testEqualsAny\\(\\) has parameter \\$other with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokenTest\\:\\:testIsKeyCaseSensitive\\(\\) has parameter \\$caseSensitive with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokenTest\\:\\:testToArray\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokenTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsAnonymousClass\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsLambda\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsLambda70\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsLambda74\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsLambda71\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsConstantInvocation\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsConstantInvocation70\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsConstantInvocation71\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsUnarySuccessorOperator\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsUnaryPredecessorOperator\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsBinaryOperator\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsBinaryOperator70\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsBinaryOperator71\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testIsBinaryOperator74\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testGetFunctionProperties\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testGetImportUseIndexes\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testGetImportUseIndexesPHP70\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TokensAnalyzerTest\\:\\:testGetImportUseIndexesPHP72\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TokensAnalyzerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ArrayTypehintTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ArrayTypehintTransformerTest\\:\\:testProcessPhp74\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ArrayTypehintTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\BraceClassInstantiationTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\BraceClassInstantiationTransformerTest\\:\\:testProcess\\(\\) has parameter \\$observedKinds with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ClassConstantTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ClassConstantTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\CurlyBraceTransformerTest\\:\\:testProcess70\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ImportTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ImportTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\NamespaceOperatorTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/NamespaceOperatorTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\NullableTypeTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\NullableTypeTransformerTest\\:\\:testProcess74\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\NullableTypeTransformerTest\\:\\:testProcessPhp74\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ReturnRefTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ReturnRefTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\ReturnRefTransformerTest\\:\\:testProcessPhp74\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/ReturnRefTransformerTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 2
+			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+
+		-
+			message: "#^Cannot call method toJson\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\SquareBraceTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/SquareBraceTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\TypeAlternationTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\TypeColonTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\TypeColonTransformerTest\\:\\:testProcessPhp74\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\Transformer\\\\WhitespacyCommentTransformerTest\\:\\:testProcess\\(\\) has parameter \\$expectedTokens with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/Transformer/WhitespacyCommentTransformerTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\Tokenizer\\\\TransformersTest\\:\\:testTransform\\(\\) has parameter \\$expectedTokenKinds with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Tokenizer/TransformersTest.php
+
+		-
+			message: "#^Cannot call method isGivenKind\\(\\) on PhpCsFixer\\\\Tokenizer\\\\Token\\|null\\.$#"
+			count: 1
+			path: tests/Tokenizer/TransformersTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:provideCamelCaseToUnderscoreCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:testCalculateTrailingWhitespaceIndent\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:testStableSort\\(\\) has parameter \\$elements with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:testStableSort\\(\\) has parameter \\$expected with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"string\"\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Anonymous function should have native return typehint \"int\"\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:testNaturalLanguageJoinWithBackticks\\(\\) has parameter \\$names with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:testCalculateBitmask\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:createFixerDouble\\(\\) has parameter \\$name with no typehint specified\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\UtilsTest\\:\\:createFixerDouble\\(\\) has parameter \\$priority with no typehint specified\\.$#"
+			count: 1
+			path: tests/UtilsTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\WordMatcherTest\\:\\:testMatch\\(\\) has parameter \\$candidates with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/WordMatcherTest.php
+
+		-
+			message: "#^Method PhpCsFixer\\\\Tests\\\\WordMatcherTest\\:\\:provideMatchCases\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/WordMatcherTest.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,9 +2,11 @@ includes:
     - dev-tools/vendor/jangregor/phpstan-prophecy/src/extension.neon
     - dev-tools/vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - dev-tools/vendor/phpstan/phpstan-phpunit/extension.neon
+    - dev-tools/vendor/phpstan/phpstan-strict-rules/rules.neon
+    - phpstan-baseline.neon
 
 parameters:
-    level: 5
+    level: 8
     paths:
         - src
         - tests
@@ -46,4 +48,5 @@ parameters:
         -
             message: '/^Parameter #1 \$finder of method PhpCsFixer\\Config::setFinder\(\) expects iterable<string>, int given\.$/'
             path: tests/ConfigTest.php
+        - '/has no return typehint specified\.$/'
     tipsOfTheDay: false


### PR DESCRIPTION
This PR sets PHPStan analyse level to the maximum and enables strict rules. This results in 7905 new errors on 2.15 branch and we clearly don't have the time to fix all right now so I created a baseline file.

Nothing should be added to this file ever, except when merging the PR up to higher branches, where more errors might be reported. In such case, [the baseline file should be regenerated](https://phpstan.org/user-guide/baseline#generating-the-baseline). Then we can fix the errors step by step when we can. In the meantime, new errors in future PRs will be reported.