### PR TITLE
Support composer v2 installed.json files

### DIFF
--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -46,7 +46,9 @@ final class ToolInfo implements ToolInfoInterface
         if (null === $this->composerInstallationDetails) {
             $composerInstalled = json_decode(file_get_contents($this->getComposerInstalledFile()), true);
 
-            foreach ($composerInstalled as $package) {
+            $packages = isset($composerInstalled['packages']) ? $composerInstalled['packages'] : $composerInstalled;
+
+            foreach ($packages as $package) {
                 if (\in_array($package['name'], [self::COMPOSER_PACKAGE_NAME, self::COMPOSER_LEGACY_PACKAGE_NAME], true)) {
                     $this->composerInstallationDetails = $package;
 


### PR DESCRIPTION
Composer snapshot builds are now for composer 2.x and not 1.x, so people are starting to use composer v2 now, for real. The changes to the installed.json file are listed in their upgrading guide: https://github.com/composer/composer/blob/28d26bd3a4a70a2bcf1f42b95a9b3cabda711c53/UPGRADE-2.0.md#for-integrators-and-plugin-authors.