### PR TITLE
[DO NOT MERGE] Check if Composer snapshot is fixed

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,8 +29,7 @@ install:
     - echo extension=php_curl.dll >> php.ini
     - echo extension=php_openssl.dll >> php.ini
     - echo extension=php_mbstring.dll >> php.ini
-    - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/composer-stable.phar)
-    - copy composer-stable.phar composer.phar
+    - IF NOT EXIST C:\tools\composer.phar (cd C:\tools && appveyor DownloadFile https://getcomposer.org/composer.phar)
     - cd C:\projects\php-cs-fixer
     - php C:\tools\composer.phar global show hirak/prestissimo -q || php C:\tools\composer.phar global require hirak/prestissimo
 


### PR DESCRIPTION
This is check for Composer 2.0 snapshot after the fails fixed by https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4906 to verify the issue reported in https://github.com/composer/composer/issues/8757 was fixed.

It's done via PR as it was only happening here, on AppVeyor.