### PR TITLE
PhpUnitExpectationFixer - update for Phpunit 8.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1418,7 +1418,7 @@ Choose from the list of available rules:
     defaults to ``['assertEquals', 'assertSame', 'assertNotEquals',
     'assertNotSame']``
 
-* **php_unit_dedicate_assert** [@PHPUnit30Migration:risky, @PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
+* **php_unit_dedicate_assert** [@PHPUnit30Migration:risky, @PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   PHPUnit assertions like ``assertInternalType``, ``assertFileExists``, should
   be used over ``assertTrue``.
@@ -1436,7 +1436,7 @@ Choose from the list of available rules:
   - ``target`` (``'3.0'``, ``'3.5'``, ``'5.0'``, ``'5.6'``, ``'newest'``): target version of
     PHPUnit; defaults to ``'5.0'``
 
-* **php_unit_dedicate_assert_internal_type** [@PHPUnit75Migration:risky]
+* **php_unit_dedicate_assert_internal_type** [@PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   PHPUnit assertions like ``assertIsArray`` should be used over
   ``assertInternalType``.
@@ -1448,7 +1448,7 @@ Choose from the list of available rules:
   - ``target`` (``'7.5'``, ``'newest'``): target version of PHPUnit; defaults to
     ``'newest'``
 
-* **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
+* **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   Usages of ``->setExpectedException*`` methods MUST be replaced by
   ``->expectException*`` methods.
@@ -1457,8 +1457,8 @@ Choose from the list of available rules:
 
   Configuration options:
 
-  - ``target`` (``'5.2'``, ``'5.6'``, ``'newest'``): target version of PHPUnit; defaults to
-    ``'newest'``
+  - ``target`` (``'5.2'``, ``'5.6'``, ``'8.4'``, ``'newest'``): target version of PHPUnit;
+    defaults to ``'newest'``
 
 * **php_unit_fqcn_annotation** [@Symfony, @PhpCsFixer]
 
@@ -1483,7 +1483,7 @@ Choose from the list of available rules:
   - ``case`` (``'camel_case'``, ``'snake_case'``): apply camel or snake case to test
     methods; defaults to ``'camel_case'``
 
-* **php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
+* **php_unit_mock** [@PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   Usages of ``->getMock`` and
   ``->getMockWithoutInvokingTheOriginalConstructor`` methods MUST be
@@ -1503,7 +1503,7 @@ Choose from the list of available rules:
 
   *Risky rule: risky when PHPUnit classes are overridden or not accessible, or when project has PHPUnit incompatibilities.*
 
-* **php_unit_namespaced** [@PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
+* **php_unit_namespaced** [@PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   PHPUnit classes MUST be used in namespaced version, e.g.
   ``\PHPUnit\Framework\TestCase`` instead of ``\PHPUnit_Framework_TestCase``.
@@ -1515,7 +1515,7 @@ Choose from the list of available rules:
   - ``target`` (``'4.8'``, ``'5.7'``, ``'6.0'``, ``'newest'``): target version of PHPUnit;
     defaults to ``'newest'``
 
-* **php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
+* **php_unit_no_expectation_annotation** [@PHPUnit32Migration:risky, @PHPUnit35Migration:risky, @PHPUnit43Migration:risky, @PHPUnit48Migration:risky, @PHPUnit50Migration:risky, @PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 
   Usages of ``@expectedException*`` annotations MUST be replaced by
   ``->setExpectedException*`` methods.

--- a/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
@@ -48,6 +48,11 @@ final class PhpUnitExpectationFixer extends AbstractFixer implements Configurati
         if (PhpUnitTargetVersion::fulfills($this->configuration['target'], PhpUnitTargetVersion::VERSION_5_6)) {
             $this->methodMap['setExpectedExceptionRegExp'] = 'expectExceptionMessageRegExp';
         }
+
+        if (PhpUnitTargetVersion::fulfills($this->configuration['target'], PhpUnitTargetVersion::VERSION_8_4)) {
+            $this->methodMap['setExpectedExceptionRegExp'] = 'expectExceptionMessageMatches';
+            $this->methodMap['expectExceptionMessageRegExp'] = 'expectExceptionMessageMatches';
+        }
     }
 
     /**
@@ -75,6 +80,25 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     }
 }
 '
+                ),
+                new CodeSample(
+                    '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        $this->setExpectedException("RuntimeException", null, 123);
+        foo();
+    }
+
+    public function testBar()
+    {
+        $this->setExpectedExceptionRegExp("RuntimeException", "/Msg.*/", 123);
+        bar();
+    }
+}
+',
+                    ['target' => PhpUnitTargetVersion::VERSION_8_4]
                 ),
                 new CodeSample(
                     '<?php
@@ -165,7 +189,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('target', 'Target version of PHPUnit.'))
                 ->setAllowedTypes(['string'])
-                ->setAllowedValues([PhpUnitTargetVersion::VERSION_5_2, PhpUnitTargetVersion::VERSION_5_6, PhpUnitTargetVersion::VERSION_NEWEST])
+                ->setAllowedValues([PhpUnitTargetVersion::VERSION_5_2, PhpUnitTargetVersion::VERSION_5_6, PhpUnitTargetVersion::VERSION_8_4, PhpUnitTargetVersion::VERSION_NEWEST])
                 ->setDefault(PhpUnitTargetVersion::VERSION_NEWEST)
                 ->getOption(),
         ]);
@@ -260,7 +284,11 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 $tokens->overrideRange($argBefore, $argBefore, $tokensOverrideArgBefore);
             }
 
-            $tokens[$index] = new Token([T_STRING, 'expectException']);
+            $methodName = 'expectException';
+            if ('expectExceptionMessageRegExp' === $tokens[$index]->getContent()) {
+                $methodName = $this->methodMap[$tokens[$index]->getContent()];
+            }
+            $tokens[$index] = new Token([T_STRING, $methodName]);
         }
     }
 

--- a/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
+++ b/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
@@ -34,6 +34,7 @@ final class PhpUnitTargetVersion
     const VERSION_5_7 = '5.7';
     const VERSION_6_0 = '6.0';
     const VERSION_7_5 = '7.5';
+    const VERSION_8_4 = '8.4';
     const VERSION_NEWEST = 'newest';
 
     private function __construct()

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -441,6 +441,10 @@ final class RuleSet implements RuleSetInterface
             '@PHPUnit60Migration:risky' => true,
             'php_unit_dedicate_assert_internal_type' => ['target' => PhpUnitTargetVersion::VERSION_7_5],
         ],
+        '@PHPUnit84Migration:risky' => [
+            '@PHPUnit75Migration:risky' => true,
+            'php_unit_expectation' => ['target' => PhpUnitTargetVersion::VERSION_8_4],
+        ],
     ];
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -240,7 +240,89 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     public function testBar()
     {
         $this->expectException("RuntimeException");
+        $this->expectExceptionMessageMatches("/Msg.*/");
+        $this->expectExceptionCode(123);
+        bar();
+    }
+}',
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        $this->setExpectedException("RuntimeException", "Msg", 123);
+        foo();
+    }
+
+    public function testBar()
+    {
+        $this->setExpectedExceptionRegExp("RuntimeException", "/Msg.*/", 123);
+        bar();
+    }
+}',
+                ['target' => PhpUnitTargetVersion::VERSION_8_4],
+            ],
+            [
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        $this->expectExceptionMessageMatches("/Msg.*/");
+        foo();
+    }
+}',
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
         $this->expectExceptionMessageRegExp("/Msg.*/");
+        foo();
+    }
+}',
+                ['target' => PhpUnitTargetVersion::VERSION_8_4],
+            ],
+            [
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        // turns wrong into wrong: has a single argument only, but ...
+        $this->expectExceptionMessageMatches("/Msg.*/");
+        $this->expectExceptionMessageMatches("fail-case");
+        foo();
+    }
+}',
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        // turns wrong into wrong: has a single argument only, but ...
+        $this->expectExceptionMessageRegExp("/Msg.*/", "fail-case");
+        foo();
+    }
+}',
+                ['target' => PhpUnitTargetVersion::VERSION_8_4],
+            ],
+            [
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFoo()
+    {
+        $this->expectException("RuntimeException");
+        $this->expectExceptionMessage("Msg");
+        $this->expectExceptionCode(123);
+        foo();
+    }
+
+    public function testBar()
+    {
+        $this->expectException("RuntimeException");
+        $this->expectExceptionMessageMatches("/Msg.*/");
         $this->expectExceptionCode(123);
         bar();
     }

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -658,6 +658,7 @@ final class RuleSetTest extends TestCase
             '@PHPUnit48Migration',
             '@PHPUnit55Migration:risky',
             '@PHPUnit75Migration:risky',
+            '@PHPUnit84Migration:risky',
             '@PSR1',
         ];
 
@@ -666,7 +667,7 @@ final class RuleSetTest extends TestCase
         }
 
         $setDefinitionFileNamePrefix = str_replace(':', '-', $setDefinitionName);
-        $dir = __DIR__.'/../tests/Fixtures/Integration/set';
+        $dir = __DIR__.'/Fixtures/Integration/set';
         $file = sprintf('%s/%s.test', $dir, $setDefinitionFileNamePrefix);
 
         static::assertFileExists($file);


### PR DESCRIPTION
With Phpunit 8.4 the method expectExceptionMessageRegExp has been
deprecated and it's replacement is the new expectExceptionMessageMatches.

When running the migration to target a more current Phpunit version, the
php_unit_expectation fixer previously did choose the deprecated (old)
method.

Improvement here is to map to the non-deprecated method for Phpunit 8.4+.

NOTE: The old method is removed in Phpunit 9 (not 10!)

Additionally the PhpUnitExpectationFixer fixer is extended replacing the deprecated method expectExceptionMessageRegExp with expectExceptionMessageMatches.

Ref: https://github.com/sebastianbergmann/phpunit/commit/d1199cb2e43a934b51521656be9748f63febe18e