### PR TITLE
Add rule to change PhpUnit ExpectedExceptionMessageRegExp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1389,6 +1389,18 @@ Choose from the list of available rules:
   - ``target`` (``'7.5'``, ``'newest'``): target version of PHPUnit; defaults to
     ``'newest'``
 
+* **php_unit_exception_matches**
+
+  Changes expectExceptionMessageRegExp to expectExceptionMessageMatches
+  from PhpUnit 8.4.
+
+  *Risky rule: risky when project has PHPUnit incompatibilities.*
+
+  Configuration options:
+
+  - ``target`` (``'8.4'``, ``'newest'``): target version of PHPUnit; defaults to
+    ``'newest'``
+
 * **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky]
 
   Usages of ``->setExpectedException*`` methods MUST be replaced by

--- a/src/Fixer/PhpUnit/PhpUnitExceptionMessageMatchesFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExceptionMessageMatchesFixer.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpUnit;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Indicator\PhpUnitTestCaseIndicator;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+final class PhpUnitExceptionMessageMatchesFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    private $expectedExceptionMessageMatchesExists = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null)
+    {
+        parent::configure($configuration);
+        $this->expectedExceptionMessageMatchesExists = PhpUnitTargetVersion::fulfills($this->configuration['target'], PhpUnitTargetVersion::VERSION_8_4);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Changes expectExceptionMessageRegExp to expectExceptionMessageMatches from PhpUnit 8.4.', // Trailing dot is important. We thrive to use English grammar properly.
+            [
+                new CodeSample(
+                    '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testException()
+    {
+        $this->expectExceptionMessageMatches("/Message RegExp/");
+        foo();
+    }
+
+}',
+                    ['target' => PhpUnitTargetVersion::VERSION_8_4]
+                ),
+            ],
+            null,
+            'Risky when project has PHPUnit incompatibilities.'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        return $tokens->isTokenKindFound(T_CLASS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('target', 'Target version of PHPUnit.'))
+                ->setAllowedTypes(['string'])
+                ->setAllowedValues([PhpUnitTargetVersion::VERSION_8_4, PhpUnitTargetVersion::VERSION_NEWEST])
+                ->setDefault(PhpUnitTargetVersion::VERSION_NEWEST)
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        if (false === $this->expectedExceptionMessageMatchesExists) {
+            return;
+        }
+
+        $phpUnitTestCaseIndicator = new PhpUnitTestCaseIndicator();
+        foreach ($phpUnitTestCaseIndicator->findPhpUnitClasses($tokens) as $indexes) {
+            $this->fixExpectation($tokens, $indexes[0], $indexes[1]);
+        }
+    }
+
+    private function fixExpectation(Tokens $tokens, $startIndex, $endIndex)
+    {
+        $oldMethodSequence = [
+            new Token([T_VARIABLE, '$this']),
+            new Token([T_OBJECT_OPERATOR, '->']),
+            new Token([T_STRING, 'expectExceptionMessageRegExp']),
+        ];
+
+        for ($index = $startIndex; $startIndex < $endIndex; ++$index) {
+            $match = $tokens->findSequence($oldMethodSequence, $index);
+
+            if (null === $match) {
+                return;
+            }
+
+            list(, , $index) = array_keys($match);
+
+            $tokens[$index] = new Token([T_STRING, 'expectExceptionMessageMatches']);
+        }
+    }
+}

--- a/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
+++ b/src/Fixer/PhpUnit/PhpUnitTargetVersion.php
@@ -34,6 +34,7 @@ final class PhpUnitTargetVersion
     const VERSION_5_7 = '5.7';
     const VERSION_6_0 = '6.0';
     const VERSION_7_5 = '7.5';
+    const VERSION_8_4 = '8.4';
     const VERSION_NEWEST = 'newest';
 
     private function __construct()

--- a/tests/Fixer/PhpUnit/PhpUnitExceptionMessageMatchesFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExceptionMessageMatchesFixerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpUnit;
+
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpUnit\PhpUnitExceptionMessageMatchesFixer
+ */
+final class PhpUnitExceptionMessageMatchesFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null, array $config = [])
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases()
+    {
+        return [
+            [
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testException()
+    {
+        $this->expectExceptionMessageMatches("/Message RegExp/");
+        foo();
+    }
+
+}',
+                '<?php
+final class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testException()
+    {
+        $this->expectExceptionMessageRegExp("/Message RegExp/");
+        foo();
+    }
+
+}',
+                ['target' => PhpUnitTargetVersion::VERSION_8_4],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
As of phpunit 8 expectExceptionMessageRegExp is deprecated

Related issues: https://github.com/sebastianbergmann/phpunit/issues/4133, https://github.com/symfony/symfony/pull/36408

Let me know if there's a way to test that old versions of phpunit won't be affected by this rule.