### PR TITLE
DX: Travis CI config - fix warnings and infos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: xenial
+os: linux
+
 language: php
 
 git:
@@ -145,10 +148,10 @@ jobs:
                 - test $(php dev-tools/info-extractor.php | jq .version.vnumber) == "\"$TRAVIS_TAG\""
             deploy:
                 provider: releases
-                api_key:
+                token:
                     secure: K9NKi7X1OPz898fxtVc1RfWrSI+4hTFFYOik932wTz1jC4dQJ64Khh1LV9frA1+JiDS3+R6TvmQtpzbkX3y4L75UrSnP1ADH5wfMYIVmydG3ZjTMo8SWQWHmRMh3ORAKTMMpjl4Q7EkRkLp6RncKe+FAFPP5mgv55mtIMaE4qUk=
                 file: php-cs-fixer.phar
-                skip_cleanup: true
+                cleanup : false
                 on:
                     repo: FriendsOfPHP/PHP-CS-Fixer
                     tags: true


### PR DESCRIPTION
E.g https://travis-ci.org/github/FriendsOfPHP/PHP-CS-Fixer/jobs/676593896/config:

> Build config validation — 2 warnings, 4 infos 

After clicking there are details:

> Build config validation 
> `jobs.include.deploy`: deprecated key `skip_cleanup` (not supported in dpl v2, use cleanup)
> `jobs.include.deploy`: deprecated key `skip_cleanup` (not supported in dpl v2, use cleanup)
> `root`: missing `dist`, using the default `xenial`
> `root`: missing `os`, using the default `linux`
> `jobs.include.deploy`: key `api_key` is an alias for `token`, using `token`
> `jobs.include.deploy`: key `api_key` is an alias for `token`, using `token`
