### PR TITLE
YodaStyleFixer - fix for conditions weird are

### DIFF
--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -665,11 +665,11 @@ return $foo === count($bar);
             $token = $tokens[$index];
 
             if ($token->isComment() || $token->isWhitespace()) {
-                if ($expectNothing) {
-                    return false;
-                }
-
                 continue;
+            }
+
+            if ($expectNothing) {
+                return false;
             }
 
             if ($expectNumberOnly && !$token->isGivenKind([T_LNUMBER, T_DNUMBER])) {

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -220,6 +220,8 @@ if ($a = $obj instanceof A === true) {
             ['<?php $a = $b[$key]["1"] === $c["2"];'],
             ['<?php return $foo->$a[1] === $bar[$baz]{1}->$a[1][2][3]->$d[$z]{1};'],
             ['<?php return $foo->$a === $foo->$b->$c;'],
+            ['<?php return $x === 2 - 1;'],
+            ['<?php return $x === 2-1;'],
             // https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/693
             ['<?php return array(2) == $o;'],
             ['<?php return $p == array(2);'],


### PR DESCRIPTION
While on the [other](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4929) fix working I was, it thinking me made what the reason is for these conditions:
```php
            if ($token->isComment() || $token->isWhitespace()) {
                if ($expectNothing) {
                    return false;
                }

                continue;
            }
```
Why do the check we want for `$expectNothing` only for comments and whitespaces, expect the opposite I would. So these 2 test case added I have and what weird is only 1 failed has: https://travis-ci.org/github/FriendsOfPHP/PHP-CS-Fixer/jobs/678270023

The fix to not nest them is, @bgotink, @keradus and @SpacePossum I ping (as they the authors are) to review.

May the force be with you.