### PR TITLE
OrderedClassElementsFixer - added support for abstract method sorting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1378,14 +1378,17 @@ Choose from the list of available rules:
     'constant_private', 'property', 'property_static', 'property_public',
     'property_protected', 'property_private', 'property_public_static',
     'property_protected_static', 'property_private_static', 'method',
-    'method_static', 'method_public', 'method_protected', 'method_private',
-    'method_public_static', 'method_protected_static',
-    'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']``):
-    list of strings defining order of elements; defaults to ``['use_trait',
-    'constant_public', 'constant_protected', 'constant_private',
-    'property_public', 'property_protected', 'property_private',
-    'construct', 'destruct', 'magic', 'phpunit', 'method_public',
-    'method_protected', 'method_private']``
+    'method_abstract', 'method_static', 'method_public',
+    'method_protected', 'method_private', 'method_public_abstract',
+    'method_protected_abstract', 'method_public_abstract_static',
+    'method_protected_abstract_static', 'method_public_static',
+    'method_protected_static', 'method_private_static', 'construct',
+    'destruct', 'magic', 'phpunit']``): list of strings defining order of
+    elements; defaults to ``['use_trait', 'constant_public',
+    'constant_protected', 'constant_private', 'property_public',
+    'property_protected', 'property_private', 'construct', 'destruct',
+    'magic', 'phpunit', 'method_public', 'method_protected',
+    'method_private']``
   - ``sort_algorithm`` (``'alpha'``, ``'none'``): how multiple occurrences of same type
     statements should be sorted; defaults to ``'none'``; DEPRECATED alias:
     ``sortAlgorithm``

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -56,10 +56,15 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
         'property_protected_static' => ['property_static', 'property_protected'],
         'property_private_static' => ['property_static', 'property_private'],
         'method' => null,
+        'method_abstract' => ['method'],
         'method_static' => ['method'],
         'method_public' => ['method', 'public'],
         'method_protected' => ['method', 'protected'],
         'method_private' => ['method', 'private'],
+        'method_public_abstract' => ['method_abstract', 'method_public'],
+        'method_protected_abstract' => ['method_abstract', 'method_protected'],
+        'method_public_abstract_static' => ['method_abstract', 'method_static', 'method_public'],
+        'method_protected_abstract_static' => ['method_abstract', 'method_static', 'method_protected'],
         'method_public_static' => ['method_static', 'method_public'],
         'method_protected_static' => ['method_static', 'method_protected'],
         'method_private_static' => ['method_static', 'method_private'],
@@ -301,6 +306,7 @@ class Example
             $element = [
                 'start' => $startIndex,
                 'visibility' => 'public',
+                'abstract' => false,
                 'static' => false,
             ];
 
@@ -310,6 +316,12 @@ class Example
                 // class end
                 if ($token->equals('}')) {
                     return $elements;
+                }
+
+                if ($token->isGivenKind(T_ABSTRACT)) {
+                    $element['abstract'] = true;
+
+                    continue;
                 }
 
                 if ($token->isGivenKind(T_STATIC)) {
@@ -453,6 +465,9 @@ class Example
 
             if (\in_array($type, ['constant', 'property', 'method'], true)) {
                 $type .= '_'.$element['visibility'];
+                if ($element['abstract']) {
+                    $type .= '_abstract';
+                }
                 if ($element['static']) {
                     $type .= '_static';
                 }

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -438,92 +438,27 @@ EOT
     }
 
     /**
+     * @param string $input
      * @param string $expected
      *
      * @group legacy
      * @dataProvider provideConfigurationCases
      * @expectedDeprecation Passing "order" at the root of the configuration for rule "ordered_class_elements" is deprecated and will not be supported in 3.0, use "order" => array(...) option instead.
      */
-    public function testLegacyFixWithConfiguration(array $configuration, $expected)
+    public function testLegacyFixWithConfiguration(array $configuration, $expected, $input)
     {
-        static $input = <<<'EOT'
-<?php
-
-class Foo
-{
-    private static function privStatFunc() {}
-    protected static $protStatProp;
-    public static $pubStatProp1;
-    public function pubFunc1() {}
-    use BarTrait;
-    public $pubProp1;
-    public function __toString() {}
-    protected function protFunc() {}
-    protected $protProp;
-    function pubFunc2() {}
-    public function __destruct() {}
-    var $pubProp2;
-    private static $privStatProp;
-    use BazTrait;
-    public static function pubStatFunc1() {}
-    public function pubFunc3() {}
-    private $privProp;
-    const C1 = 1;
-    static function pubStatFunc2() {}
-    private function privFunc() {}
-    public static $pubStatProp2;
-    protected function __construct() {}
-    const C2 = 2;
-    public static function pubStatFunc3() {}
-    public $pubProp3;
-    protected static function protStatFunc() {}
-}
-EOT;
-
         $this->fixer->configure($configuration);
         $this->doTest($expected, $input);
     }
 
     /**
+     * @param string $input
      * @param string $expected
      *
      * @dataProvider provideConfigurationCases
      */
-    public function testFixWithConfiguration(array $configuration, $expected)
+    public function testFixWithConfiguration(array $configuration, $expected, $input)
     {
-        static $input = <<<'EOT'
-<?php
-
-class Foo
-{
-    private static function privStatFunc() {}
-    protected static $protStatProp;
-    public static $pubStatProp1;
-    public function pubFunc1() {}
-    use BarTrait;
-    public $pubProp1;
-    public function __toString() {}
-    protected function protFunc() {}
-    protected $protProp;
-    function pubFunc2() {}
-    public function __destruct() {}
-    var $pubProp2;
-    private static $privStatProp;
-    use BazTrait;
-    public static function pubStatFunc1() {}
-    public function pubFunc3() {}
-    private $privProp;
-    const C1 = 1;
-    static function pubStatFunc2() {}
-    private function privFunc() {}
-    public static $pubStatProp2;
-    protected function __construct() {}
-    const C2 = 2;
-    public static function pubStatFunc3() {}
-    public $pubProp3;
-    protected static function protStatFunc() {}
-}
-EOT;
         $this->fixer->configure(['order' => $configuration]);
         $this->doTest($expected, $input);
     }
@@ -566,6 +501,41 @@ class Foo
     public function __destruct() {}
 }
 EOT
+                ,
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
             ],
             [
                 ['public', 'protected', 'private'],
@@ -602,6 +572,41 @@ class Foo
     use BazTrait;
 }
 EOT
+                ,
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
             ],
             [
                 [
@@ -656,6 +661,326 @@ class Foo
     private function privFunc() {}
 }
 EOT
+                ,
+                <<<'EOT'
+<?php
+
+class Foo
+{
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
+            ],
+            [
+                ['use_trait', 'constant', 'property', 'construct', 'method', 'destruct'],
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    use BarTrait;
+    use BazTrait;
+    const C1 = 1;
+    const C2 = 2;
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public $pubProp1;
+    protected $protProp;
+    var $pubProp2;
+    private static $privStatProp;
+    private $privProp;
+    public static $pubStatProp2;
+    public $pubProp3;
+    protected function __construct() {}
+    abstract public function absPubFunc();
+    private static function privStatFunc() {}
+    public function pubFunc1() {}
+    abstract protected function absProtFunc();
+    public function __toString() {}
+    protected function protFunc() {}
+    function pubFunc2() {}
+    abstract protected static function absProtStatFunc();
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    abstract public static function absPubStatFunc();
+    public static function pubStatFunc3() {}
+    protected static function protStatFunc() {}
+    public function __destruct() {}
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    abstract public function absPubFunc();
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    abstract protected function absProtFunc();
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    abstract protected static function absProtStatFunc();
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    abstract public static function absPubStatFunc();
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
+            ],
+            [
+                ['public', 'protected', 'private'],
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    abstract public function absPubFunc();
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    public $pubProp1;
+    public function __toString() {}
+    function pubFunc2() {}
+    public function __destruct() {}
+    var $pubProp2;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    public static $pubStatProp2;
+    abstract public static function absPubStatFunc();
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static $protStatProp;
+    abstract protected function absProtFunc();
+    protected function protFunc() {}
+    protected $protProp;
+    abstract protected static function absProtStatFunc();
+    protected function __construct() {}
+    protected static function protStatFunc() {}
+    private static function privStatFunc() {}
+    private static $privStatProp;
+    private $privProp;
+    private function privFunc() {}
+    use BarTrait;
+    use BazTrait;
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    abstract public function absPubFunc();
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    abstract protected function absProtFunc();
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    abstract protected static function absProtStatFunc();
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    abstract public static function absPubStatFunc();
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
+            ],
+            [
+                [
+                    'use_trait',
+                    'constant',
+                    'property_public_static',
+                    'property_protected_static',
+                    'property_private_static',
+                    'property_public',
+                    'property_protected',
+                    'property_private',
+                    'construct',
+                    'destruct',
+                    'magic',
+                    'method_public_static',
+                    'method_public_abstract_static',
+                    'method_protected_static',
+                    'method_protected_abstract_static',
+                    'method_private_static',
+                    'method_public',
+                    'method_public_abstract',
+                    'method_protected',
+                    'method_protected_abstract',
+                    'method_private',
+                ],
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    use BarTrait;
+    use BazTrait;
+    const C1 = 1;
+    const C2 = 2;
+    public static $pubStatProp1;
+    public static $pubStatProp2;
+    protected static $protStatProp;
+    private static $privStatProp;
+    public $pubProp1;
+    var $pubProp2;
+    public $pubProp3;
+    protected $protProp;
+    private $privProp;
+    protected function __construct() {}
+    public function __destruct() {}
+    public function __toString() {}
+    public static function pubStatFunc1() {}
+    static function pubStatFunc2() {}
+    public static function pubStatFunc3() {}
+    abstract public static function absPubStatFunc();
+    protected static function protStatFunc() {}
+    abstract protected static function absProtStatFunc();
+    private static function privStatFunc() {}
+    public function pubFunc1() {}
+    function pubFunc2() {}
+    public function pubFunc3() {}
+    abstract public function absPubFunc();
+    protected function protFunc() {}
+    abstract protected function absProtFunc();
+    private function privFunc() {}
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    abstract public function absPubFunc();
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    public static $pubStatProp1;
+    public function pubFunc1() {}
+    abstract protected function absProtFunc();
+    use BarTrait;
+    public $pubProp1;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    abstract protected static function absProtStatFunc();
+    public function __destruct() {}
+    var $pubProp2;
+    private static $privStatProp;
+    use BazTrait;
+    public static function pubStatFunc1() {}
+    public function pubFunc3() {}
+    private $privProp;
+    const C1 = 1;
+    static function pubStatFunc2() {}
+    private function privFunc() {}
+    public static $pubStatProp2;
+    abstract public static function absPubStatFunc();
+    protected function __construct() {}
+    const C2 = 2;
+    public static function pubStatFunc3() {}
+    public $pubProp3;
+    protected static function protStatFunc() {}
+}
+EOT
+                ,
+            ],
+            [
+                [
+                    'method_public',
+                    'method_abstract',
+                ],
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    public function test2(){}
+    public abstract function test1();
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+
+abstract class Foo
+{
+    public abstract function test1();
+    public function test2(){}
+}
+EOT
+                ,
             ],
         ];
     }
@@ -819,6 +1144,124 @@ class Foo
     private function privFunc() {}
     protected function __construct() {}
     protected static function protStatFunc() {}
+}
+EOT
+                ,
+            ],
+            [
+                [
+                    'order' => [
+                        'use_trait',
+                        'constant',
+                        'property_public_static',
+                        'property_protected_static',
+                        'property_private_static',
+                        'property_public',
+                        'property_protected',
+                        'property_private',
+                        'construct',
+                        'destruct',
+                        'magic',
+                        'method_public_static',
+                        'method_public_abstract_static',
+                        'method_protected_static',
+                        'method_protected_abstract_static',
+                        'method_private_static',
+                        'method_public',
+                        'method_public_abstract',
+                        'method_protected',
+                        'method_protected_abstract',
+                        'method_private',
+                    ],
+                    'sort_algorithm' => 'alpha',
+                ],
+                <<<'EOT'
+<?php
+abstract class Foo
+{
+    use BarTrait;
+    use BazTrait;
+    const C1 = 1;
+    const C2 = 2;
+    public static $pubStatProp1;
+    public static $pubStatProp2;
+    protected static $protStatProp;
+    private static $privStatProp;
+    public $pubProp1;
+    var $pubProp2;
+    public $pubProp3;
+    protected $protProp;
+    private $privProp;
+    protected function __construct() {}
+    public function __destruct() {}
+    public function __magicA() {}
+    public function __magicB() {}
+    public function __toString() {}
+    public static function pubStatFunc1() {}
+    static function pubStatFunc2() {}
+    public static function pubStatFunc3() {
+        return $this->privFunc();
+    }
+    abstract public static function absPubStatFunc1();
+    protected static function protStatFunc() {}
+    abstract protected static function absProtStatFunc();
+    private static function privStatFunc() {}
+    public function pubFunc1() {}
+    function pubFunc2() {}
+    public function pubFunc3(int $b, int $c) {
+        $a = $b*$c;
+
+        return $a % 4;
+    }
+    abstract public function absPubFunc();
+    protected function protFunc() {}
+    abstract protected function absProtFunc();
+    private function privFunc() {}
+}
+EOT
+                ,
+                <<<'EOT'
+<?php
+abstract class Foo
+{
+    private static function privStatFunc() {}
+    protected static $protStatProp;
+    use BazTrait;
+    abstract public function absPubFunc();
+    public static $pubStatProp2;
+    public $pubProp3;
+    use BarTrait;
+    public function __toString() {}
+    protected function protFunc() {}
+    protected $protProp;
+    function pubFunc2() {}
+    public $pubProp1;
+    abstract protected static function absProtStatFunc();
+    public function __destruct() {}
+    var $pubProp2;
+    public function __magicB() {}
+    const C2 = 2;
+    public static $pubStatProp1;
+    public function __magicA() {}
+    private static $privStatProp;
+    static function pubStatFunc2() {}
+    public function pubFunc3(int $b, int $c) {
+        $a = $b*$c;
+
+        return $a % 4;
+    }
+    private $privProp;
+    const C1 = 1;
+    abstract protected function absProtFunc();
+    public static function pubStatFunc3() {
+        return $this->privFunc();
+    }
+    public function pubFunc1() {}
+    public static function pubStatFunc1() {}
+    private function privFunc() {}
+    protected function __construct() {}
+    protected static function protStatFunc() {}
+    abstract public static function absPubStatFunc1();
 }
 EOT
                 ,


### PR DESCRIPTION
Sorting can be weird sometimes with abstract methods. This lets you add abstract methods to the `order` sort option.