### PR TITLE
Allow "const" option on PHP <7.1

### DIFF
--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -17,7 +17,6 @@ use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverRootless;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
-use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
@@ -26,7 +25,6 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
-use Symfony\Component\OptionsResolver\Options;
 
 /**
  * Fixer for rules defined in PSR2 ¶4.3, ¶4.5.
@@ -88,13 +86,6 @@ class Sample
             (new FixerOptionBuilder('elements', 'The structural elements to fix (PHP >= 7.1 required for `const`).'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([new AllowedValueSubset(['property', 'method', 'const'])])
-                ->setNormalizer(static function (Options $options, $value) {
-                    if (\PHP_VERSION_ID < 70100 && \in_array('const', $value, true)) {
-                        throw new InvalidOptionsForEnvException('"const" option can only be enabled with PHP 7.1+.');
-                    }
-
-                    return $value;
-                })
                 ->setDefault(['property', 'method'])
                 ->getOption(),
         ], $this->getName());
@@ -112,6 +103,10 @@ class Sample
 
         foreach (array_reverse($elements, true) as $index => $element) {
             if (!\in_array($element['type'], $this->configuration['elements'], true)) {
+                continue;
+            }
+
+            if (\PHP_VERSION_ID < 70100 && 'const' === $element['type']) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -526,6 +526,15 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @requires PHP <7.1
+     */
+    public function testIgnoreConstants()
+    {
+        $this->fixer->configure(['elements' => ['const']]);
+        $this->doTest('<?php class A { const B=1; }');
+    }
+
     public function testInvalidConfigurationType()
     {
         $this->expectException(\PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException::class);
@@ -540,17 +549,6 @@ EOF;
         $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration: The option "elements" .*\.$/');
 
         $this->fixer->configure(['elements' => ['_unknown_']]);
-    }
-
-    /**
-     * @requires PHP <7.1
-     */
-    public function testInvalidConfigurationValueForPHPVersion()
-    {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidForEnvFixerConfigurationException::class);
-        $this->expectExceptionMessageRegExp('/^\[visibility_required\] Invalid configuration for env: "const" option can only be enabled with PHP 7\.1\+\.$/');
-
-        $this->fixer->configure(['elements' => ['const']]);
     }
 
     /**


### PR DESCRIPTION
This allows passing `const` to option `elements` in rulesets without runtime check like in #4943. It's also consistent with the fact that most fixers don't throw exceptions when passed allowed values that don't make sense (e.g. passing an empty array to that option).