### PR TITLE
NativeConstantInvocation - Add "PHP_INT_SIZE" to SF rule set

### DIFF
--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -226,6 +226,7 @@ final class RuleSet implements RuleSetInterface
                 'fix_built_in' => false,
                 'include' => [
                     'DIRECTORY_SEPARATOR',
+                    'PHP_INT_SIZE',
                     'PHP_SAPI',
                     'PHP_VERSION_ID',
                 ],


### PR DESCRIPTION
As [requested](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943#issuecomment-625799682) by @nicolas-grekas.

Added as a feature because it is [change](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3127#issuecomment-343485622) request.