### PR TITLE
Add support for custom differ

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -270,26 +270,36 @@ final class ConfigurationResolver
                 'udiff' => static function () { return new UnifiedDiffer(); },
             ];
 
-            if ($this->options['diff-format']) {
-                $option = $this->options['diff-format'];
-                if (!isset($mapper[$option])) {
-                    throw new InvalidConfigurationException(sprintf(
-                        '"diff-format" must be any of "%s", got "%s".',
-                        implode('", "', array_keys($mapper)),
-                        $option
-                    ));
-                }
+            if (!$this->options['diff']) {
+                $defaultOption = 'null';
+            } elseif (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+                $defaultOption = 'udiff';
             } else {
-                $default = 'sbd'; // @TODO: 3.0 change to udiff as default
-
-                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                    $default = 'udiff';
-                }
-
-                $option = $this->options['diff'] ? $default : 'null';
+                $defaultOption = 'sbd'; // @TODO: 3.0 change to udiff as default
             }
 
-            $this->differ = $mapper[$option]();
+            $option = isset($this->options['diff-format'])
+                ? $this->options['diff-format']
+                : $defaultOption;
+
+            if (!\is_string($option)) {
+                throw new InvalidConfigurationException(sprintf(
+                    '"diff-format" must be a string, "%s" given.',
+                    \gettype($option)
+                ));
+            }
+
+            if (is_subclass_of($option, DifferInterface::class)) {
+                $this->differ = new $option();
+            } elseif (!isset($mapper[$option])) {
+                throw new InvalidConfigurationException(sprintf(
+                    '"diff-format" must be any of "%s", got "%s".',
+                    implode('", "', array_keys($mapper)),
+                    $option
+                ));
+            } else {
+                $this->differ = $mapper[$option]();
+            }
         }
 
         return $this->differ;

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\Finder;
 use PhpCsFixer\Linter\LinterInterface;
 use PhpCsFixer\Tests\Fixtures\DeprecatedFixer;
+use PhpCsFixer\Tests\Fixtures\FakeDiffer;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\ToolInfo;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -1096,6 +1097,26 @@ final class ConfigurationResolverTest extends TestCase
         ]);
 
         static::assertInstanceOf($expected, $resolver->getDiffer());
+    }
+
+    public function testCustomDiffer()
+    {
+        $resolver = $this->createConfigurationResolver([
+            'diff-format' => FakeDiffer::class,
+        ]);
+
+        static::assertInstanceOf(FakeDiffer::class, $resolver->getDiffer());
+    }
+
+    public function testCustomDifferMustBeAString()
+    {
+        $resolver = $this->createConfigurationResolver([
+            'diff-format' => new FakeDiffer(),
+        ]);
+
+        $this->expectExceptionMessage('"diff-format" must be a string, "object" given');
+
+        $resolver->getDiffer();
     }
 
     public function provideDifferCases()

--- a/tests/Fixtures/FakeDiffer.php
+++ b/tests/Fixtures/FakeDiffer.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixtures;
+
+use PhpCsFixer\Differ\DifferInterface;
+
+class FakeDiffer implements DifferInterface
+{
+    public function diff($old, $new)
+    {
+        return 'my-custom-diff';
+    }
+}

--- a/tests/Fixtures/FakeDiffer.php
+++ b/tests/Fixtures/FakeDiffer.php
@@ -14,7 +14,10 @@ namespace PhpCsFixer\Tests\Fixtures;
 
 use PhpCsFixer\Differ\DifferInterface;
 
-class FakeDiffer implements DifferInterface
+/**
+ * @internal
+ */
+final class FakeDiffer implements DifferInterface
 {
     public function diff($old, $new)
     {


### PR DESCRIPTION
# Add support for custom differ

I have the need for my CI workflow to output custom diffs. I was quite surpised to see that this was not possible even though a DifferInterface exists.

## Usage

The idea is that anyone willing to use a custom differ can create one in his project and then specify it in the diff-format argument.

```bash
vendor/bin/php-cs-fixer fix --diff-format="\MyNamespace\MyLib\MyCustomDiffer"
```

## What's next ?

Tell me if any change is needed to get this (hopefully) merged :)