### PR TITLE
DX: Check trailing spaces in project files only

### DIFF
--- a/check_trailing_spaces.sh
+++ b/check_trailing_spaces.sh
@@ -2,14 +2,8 @@
 set -eu
 
 files_with_trailing_spaces=$(
-    find . \
-        -type f \
-        -not -path "./.git/*" \
-        -not -path "./dev-tools/bin/*" \
-        -not -path "./dev-tools/vendor/*" \
-        -not -path "./vendor/*" \
-        -not -path "./tests/Fixtures/*" \
-        -exec grep -EIHn "\\s$" {} \; \
+    git grep -EIn "\\s$" \
+        ':!tests/Fixtures/*' \
     | sort -fh
 )
 
@@ -17,7 +11,7 @@ if [ "$files_with_trailing_spaces" ]
 then
     printf '\033[97;41mTrailing whitespaces detected:\033[0m\n'
     e=$(printf '\033')
-    echo "${files_with_trailing_spaces}" | sed -E "s/^\\.\\/([^:]+):([0-9]+):(.*[^\\t ])?([\\t ]+)$/${e}[0;31m - in ${e}[0;33m\\1${e}[0;31m at line ${e}[0;33m\\2\\n   ${e}[0;31m>${e}[0m \\3${e}[41;1m\\4${e}[0m/"
+    echo "${files_with_trailing_spaces}" | sed -E "s/^([^:]+):([0-9]+):(.*[^\\t ])?([\\t ]+)$/${e}[0;31m - in ${e}[0;33m\\1${e}[0;31m at line ${e}[0;33m\\2\\n   ${e}[0;31m>${e}[0m \\3${e}[41;1m\\4${e}[0m/"
 
     exit 3
 fi


### PR DESCRIPTION
(minor change despite longer description)

Previously the `check_trailing_spaces.sh` script was checking files that do not belong to the project, for example:

 - diverse `composer.lock` files
 - local development files like `.idea` or temporary files created

In its' previous design, the list of files to check for trailing spaces is generated by `find` which is not aware about different files (not) in the project. To exclude non-project files, it worked with a larger
blacklist of checking if a file is not in diverse paths, for example and most prominently:

  - -not -path "./.git/*"

which is kind of contradictory as the project *is* managed by git, but that folder can have a totally different name.

This blacklist is pretty verbose and also needs extra knowledge and care due to the nature of `find` as it operates on file-system level, not project level.

Files in the project are managed by `git` and `git` knows which files belong into the project and which not. Git on ...

 - ... repository level contains the information which project files are ignored. for example the `composer.lock` files.
 - ... developer or system level also knows about which files are ignored. for example the `.idea` folder (see "global .gitignore")

Change here is to replace `find` as file-system only utility with `git` itself, namely the `git-ls-files` command, for the operation to obtain the list of files to check. the `find` package (*findutils*) is not replaced as the `xargs` utility from it is in use.

This allows to drop the manually crafted blacklist and to specifically mark paths/files not to be checked which are (only) the test fixtures in:

 - tests/Fixtures/

The knowledge of git about the project itself and how the developer works next to the reduced list of files to check has the additional benefit of a cache and overall results in a much better performance.