### PR TITLE
OrderedImportsFixer - fix for trailing comma in group

### DIFF
--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -390,6 +390,7 @@ use Bar;
                         $firstIndent = '';
                         $separator = ', ';
                         $lastIndent = '';
+                        $hasGroupTrailingComma = false;
 
                         for ($k1 = $k + 1; $k1 < $namespaceTokensCount; ++$k1) {
                             $comment = '';
@@ -420,6 +421,12 @@ use Bar;
                             }
 
                             $namespacePart = trim($namespacePart);
+                            if ('' === $namespacePart) {
+                                $hasGroupTrailingComma = true;
+
+                                continue;
+                            }
+
                             $comment = trim($comment);
                             if ('' !== $comment) {
                                 $namespacePart .= ' '.$comment;
@@ -437,7 +444,7 @@ use Bar;
                         if ($sortedParts === $parts) {
                             $namespace = Tokens::fromArray($namespaceTokens)->generateCode();
                         } else {
-                            $namespace .= $firstIndent.implode($separator, $parts).$lastIndent.'}';
+                            $namespace .= $firstIndent.implode($separator, $parts).($hasGroupTrailingComma ? ',' : '').$lastIndent.'}';
                         }
                     } else {
                         $namespace = Tokens::fromArray($namespaceTokens)->generateCode();

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -2074,6 +2074,30 @@ use function some\a\{fn_a, fn_b, fn_c,};
                     'imports_order' => [OrderedImportsFixer::IMPORT_TYPE_CLASS, OrderedImportsFixer::IMPORT_TYPE_CONST, OrderedImportsFixer::IMPORT_TYPE_FUNCTION],
                 ],
             ],
+            [
+                '<?php
+use Foo\{
+    Aaa,
+    Bbb,
+};',
+                '<?php
+use Foo\{
+    Bbb,
+    Aaa,
+};',
+            ],
+            [
+                '<?php
+use Foo\{
+    Aaa /* 3 *//* 4 *//* 5 */,
+    Bbb /* 1 *//* 2 */,
+};',
+                '<?php
+use Foo\{
+    /* 1 */Bbb/* 2 */,/* 3 */
+    /* 4 */Aaa/* 5 */,/* 6 */
+};',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4955

Originally added test fails, as the result code is:
```php
<?php use Foo\{
    ,
    Aaa,
    Bbb
};
```