### PR TITLE
BlankLineBeforeStatementFixer - handle comment case

### DIFF
--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -212,7 +212,7 @@ switch ($a) {
                     '<?php
 if (null === $a) {
     $foo->bar();
-    throw new \UnexpectedValueException("A cannot be null");
+    throw new \UnexpectedValueException("A cannot be null.");
 }
 ',
                     [
@@ -271,40 +271,23 @@ if (true) {
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $lineEnding = $this->whitespacesConfig->getLineEnding();
         $tokenKinds = array_values($this->fixTokenMap);
         $analyzer = new TokensAnalyzer($tokens);
 
-        for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
             $token = $tokens[$index];
 
             if (!$token->isGivenKind($tokenKinds) || ($token->isGivenKind(T_WHILE) && $analyzer->isWhilePartOfDoWhile($index))) {
                 continue;
             }
 
-            $prevNonWhitespaceToken = $tokens[$tokens->getPrevNonWhitespace($index)];
+            $prevNonWhitespace = $tokens->getPrevNonWhitespace($index);
 
-            if (!$prevNonWhitespaceToken->equalsAny([';', '}'])) {
-                continue;
+            if ($this->shouldAddBlankLine($tokens, $prevNonWhitespace)) {
+                $this->insertBlankLine($tokens, $index);
             }
 
-            $prevIndex = $index - 1;
-            $prevToken = $tokens[$prevIndex];
-
-            if ($prevToken->isWhitespace()) {
-                $countParts = substr_count($prevToken->getContent(), "\n");
-
-                if (0 === $countParts) {
-                    $tokens[$prevIndex] = new Token([T_WHITESPACE, rtrim($prevToken->getContent(), " \t").$lineEnding.$lineEnding]);
-                } elseif (1 === $countParts) {
-                    $tokens[$prevIndex] = new Token([T_WHITESPACE, $lineEnding.$prevToken->getContent()]);
-                }
-            } else {
-                $tokens->insertAt($index, new Token([T_WHITESPACE, $lineEnding.$lineEnding]));
-
-                ++$index;
-                ++$limit;
-            }
+            $index = $prevNonWhitespace;
         }
     }
 
@@ -327,5 +310,53 @@ if (true) {
                 ])
                 ->getOption(),
         ]);
+    }
+
+    /**
+     * @param int $prevNonWhitespace
+     *
+     * @return bool
+     */
+    private function shouldAddBlankLine(Tokens $tokens, $prevNonWhitespace)
+    {
+        $prevNonWhitespaceToken = $tokens[$prevNonWhitespace];
+
+        if ($prevNonWhitespaceToken->isComment()) {
+            for ($j = $prevNonWhitespace - 1; $j >= 0; --$j) {
+                if (false !== strpos($tokens[$j]->getContent(), "\n")) {
+                    return false;
+                }
+
+                if ($tokens[$j]->isWhitespace() || $tokens[$j]->isComment()) {
+                    continue;
+                }
+
+                return !$tokens[$j]->equals('{');
+            }
+        }
+
+        return $prevNonWhitespaceToken->equalsAny([';', '}']);
+    }
+
+    /**
+     * @param int $index
+     */
+    private function insertBlankLine(Tokens $tokens, $index)
+    {
+        $prevIndex = $index - 1;
+        $prevToken = $tokens[$prevIndex];
+        $lineEnding = $this->whitespacesConfig->getLineEnding();
+
+        if ($prevToken->isWhitespace()) {
+            $newlinesCount = substr_count($prevToken->getContent(), "\n");
+
+            if (0 === $newlinesCount) {
+                $tokens[$prevIndex] = new Token([T_WHITESPACE, rtrim($prevToken->getContent(), " \t").$lineEnding.$lineEnding]);
+            } elseif (1 === $newlinesCount) {
+                $tokens[$prevIndex] = new Token([T_WHITESPACE, $lineEnding.$prevToken->getContent()]);
+            }
+        } else {
+            $tokens->insertAt($index, new Token([T_WHITESPACE, $lineEnding.$lineEnding]));
+        }
     }
 }

--- a/tests/AutoReview/ComposerTest.php
+++ b/tests/AutoReview/ComposerTest.php
@@ -32,6 +32,7 @@ final class ComposerTest extends TestCase
 
         if (!isset($composerJson['extra']['branch-alias'])) {
             $this->addToAssertionCount(1); // composer.json doesn't contain branch alias, all good!
+
             return;
         }
 

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -162,6 +162,15 @@ while (true) {
     }
 }',
             ],
+            [
+                '<?php
+while (true) {
+    if ($foo === $bar) {
+        /** X */
+        break 1;
+    }
+}',
+            ],
         ];
     }
 
@@ -659,6 +668,44 @@ if ($foo === $bar) {
     }
 
     /**
+     * @return array
+     */
+    public function provideFixWithIfCases()
+    {
+        return [
+            [
+                '<?php if (true) {
+    echo $bar;
+}',
+            ],
+            [
+                '<?php
+if (true) {
+    echo $bar;
+}',
+            ],
+            [
+                '<?php
+$foo = $bar;
+
+if (true) {
+    echo $bar;
+}',
+                '<?php
+$foo = $bar;
+if (true) {
+    echo $bar;
+}',
+            ],
+            [
+                '<?php
+// foo
+if ($foo) { }',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideFixWithForEachCases
      *
      * @param string      $expected
@@ -686,39 +733,6 @@ if ($foo === $bar) {
                     echo 1;
                     foreach($a as $b){break;}
                 ',
-            ],
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    public function provideFixWithIfCases()
-    {
-        return [
-            [
-                '<?php
-if (true) {
-    echo $bar;
-}',
-            ],
-            [
-                '<?php
-$foo = $bar;
-
-if (true) {
-    echo $bar;
-}',
-                '<?php
-$foo = $bar;
-if (true) {
-    echo $bar;
-}',
-            ],
-            [
-                '<?php
-// foo
-if ($foo) { }',
             ],
         ];
     }
@@ -893,6 +907,20 @@ require_once "foo.php";',
     {
         return [
             [
+                '<?php
+if ($a) { /* 1 */ /* 2 */ /* 3 */ // something about $a
+    return $b;
+}
+',
+            ],
+            [
+                '<?php
+if ($a) { // something about $a
+    return $b;
+}
+',
+            ],
+            [
                 '
 $a = $a;
 return $a;',
@@ -974,7 +1002,7 @@ elseif (false)
             ],
             [
                 '<?php
-throw new Exception("return true;");',
+throw new Exception("return true; //.");',
             ],
             [
                 '<?php
@@ -1100,7 +1128,7 @@ switch ($foo) {
             [
                 '<?php
 if (false) {
-    throw new \Exception("Something unexpected happened");
+    throw new \Exception("Something unexpected happened.");
 }',
             ],
             [
@@ -1108,12 +1136,12 @@ if (false) {
 if (false) {
     $log->error("No");
 
-    throw new \Exception("Something unexpected happened");
+    throw new \Exception("Something unexpected happened.");
 }',
                 '<?php
 if (false) {
     $log->error("No");
-    throw new \Exception("Something unexpected happened");
+    throw new \Exception("Something unexpected happened.");
 }',
             ],
         ];
@@ -1251,6 +1279,54 @@ do {
     public function provideFixWithYieldCases()
     {
         return [
+            [
+                '<?php
+function foo() {
+yield $a; /* a *//* b */     /* c */       /* d *//* e *//* etc */
+   '.'
+yield $b;
+}',
+                '<?php
+function foo() {
+yield $a; /* a *//* b */     /* c */       /* d *//* e *//* etc */   '.'
+yield $b;
+}',
+            ],
+            [
+                '<?php
+function foo() {
+    yield $a; // test
+
+    yield $b; // test /* A */
+
+    yield $c;
+
+    yield $d;
+
+yield $e;#
+
+yield $f;
+    /* @var int $g */
+    yield $g;
+/* @var int $h */
+yield $i;
+
+yield $j;
+}',
+                '<?php
+function foo() {
+    yield $a; // test
+    yield $b; // test /* A */
+    yield $c;
+    yield $d;yield $e;#
+yield $f;
+    /* @var int $g */
+    yield $g;
+/* @var int $h */
+yield $i;
+yield $j;
+}',
+            ],
             [
                 '<?php
 function foo() {


### PR DESCRIPTION
because of the comment this was not fixed:

```php
yield $a; // comment
yield $b;
```

with this PR it will now be fixed, this is still supported as well:

```php
yield $a;
/** @var int $b */
yield $b;
```
