### PR TITLE
PhpdocToReturnTypeFixer - fix for breaking PHP syntax for type having reserved name

### DIFF
--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -78,7 +78,7 @@ final class PhpdocToReturnTypeFixer extends AbstractFixer implements Configurati
     /**
      * @var array<string, bool>
      */
-    private $reservedKeywordCache = [];
+    private $returnTypeCache = [];
 
     /**
      * {@inheritdoc}
@@ -256,7 +256,7 @@ function my_foo()
                 continue;
             }
 
-            if ($this->isReservedKeyword($returnType)) {
+            if (!$this->isValidType($returnType)) {
                 continue;
             }
 
@@ -348,25 +348,21 @@ function my_foo()
     }
 
     /**
-     * Test if a given return type is a reserved PHP keyword.
-     *
      * @param string $returnType
      *
      * @return bool
      */
-    private function isReservedKeyword($returnType)
+    private function isValidType($returnType)
     {
-        if (! array_key_exists($returnType, $this->reservedKeywordCache)) {
-            $isReserved = false;
+        if (!\array_key_exists($returnType, $this->returnTypeCache)) {
             try {
                 Tokens::fromCode(sprintf('<?php function f():%s {}', $returnType));
+                $this->returnTypeCache[$returnType] = true;
             } catch (\ParseError $e) {
-                $isReserved = true;
+                $this->returnTypeCache[$returnType] = false;
             }
-
-            $this->reservedKeywordCache[$returnType] = $isReserved;
         }
-        
-        return $this->reservedKeywordCache[$returnType];
+
+        return $this->returnTypeCache[$returnType];
     }
 }

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -251,6 +251,12 @@ function my_foo()
                 continue;
             }
 
+            try {
+                Tokens::fromCode(sprintf('<?php function f():%s {}', $returnType));
+            } catch (\ParseError $e) {
+                continue;
+            }
+
             $this->fixFunctionDefinition($tokens, $startIndex, $isNullable, $returnType);
         }
     }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -60,6 +60,12 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             'invalid class 2' => [
                 '<?php /** @return \\Foo\\\\Bar */ function my_foo() {}',
             ],
+            'invalid class 3' => [
+                '<?php /** @return Break */ function my_foo() {}',
+            ],
+            'invalid class 4' => [
+                '<?php /** @return __CLASS__ */ function my_foo() {}',
+            ],
             'blacklisted class methods' => [
                 '<?php
 

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -66,6 +66,9 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             'invalid class 4' => [
                 '<?php /** @return __CLASS__ */ function my_foo() {}',
             ],
+            'invalid class 5' => [
+                '<?php /** @return I\Want\To\Break\Free */ function queen() {}',
+            ],
             'blacklisted class methods' => [
                 '<?php
 


### PR DESCRIPTION
This test tries all tokens as return type which results with 73 failures.

Limiting test to PHP 7.4 is only because of laziness - finally, it should run for all PHP versions.

A question to @keradus, @SpacePossum and @julienfalque: do you think we
- can have "internal" repository like `php-cs-fixer/all-token` to provide us with all tokens to test like this
- should I make the currently used Packagist/release ready and we can use the stable version of it
- should we put this somewhere in PHP CS Fixer repository?