### PR TITLE
DX: test "isRisky" method in fixer tests, not as auto review

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1596,7 +1596,7 @@ Choose from the list of available rules:
   EXPERIMENTAL: Takes ``@return`` annotation of non-mixed types and adjusts
   accordingly the function signature. Requires PHP >= 7.0.
 
-  *Risky rule: [1] This rule is EXPERIMENTAL and is not covered with backward compatibility promise. [2] ``@return`` annotation is mandatory for the fixer to make changes, signatures of methods without it (no docblock, inheritdocs) will not be fixed. [3] Manual actions are required if inherited signatures are not properly documented. [4] ``@inheritdocs`` support is under construction.*
+  *Risky rule: this rule is EXPERIMENTAL and [1] is not covered with backward compatibility promise. [2] ``@return`` annotation is mandatory for the fixer to make changes, signatures of methods without it (no docblock, inheritdocs) will not be fixed. [3] Manual actions are required if inherited signatures are not properly documented. [4] ``@inheritdocs`` support is under construction.*
 
   Configuration options:
 

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -112,7 +112,7 @@ function my_foo()
                 ),
             ],
             null,
-            '[1] This rule is EXPERIMENTAL and is not covered with backward compatibility promise. [2] `@return` annotation is mandatory for the fixer to make changes, signatures of methods without it (no docblock, inheritdocs) will not be fixed. [3] Manual actions are required if inherited signatures are not properly documented. [4] `@inheritdocs` support is under construction.'
+            'This rule is EXPERIMENTAL and [1] is not covered with backward compatibility promise. [2] `@return` annotation is mandatory for the fixer to make changes, signatures of methods without it (no docblock, inheritdocs) will not be fixed. [3] Manual actions are required if inherited signatures are not properly documented. [4] `@inheritdocs` support is under construction.'
         );
     }
 

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -97,14 +97,6 @@ function f9(string $foo, $bar, $baz) {}
     /**
      * {@inheritdoc}
      */
-    public function isRisky()
-    {
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         $argumentsAnalyzer = new ArgumentsAnalyzer();

--- a/tests/AutoReview/FixerTest.php
+++ b/tests/AutoReview/FixerTest.php
@@ -170,12 +170,6 @@ final class FixerTest extends TestCase
                 static::assertRegExp('/^[a-z_]+[a-z]$/', $option->getName(), sprintf('[%s] Option %s is not snake_case.', $fixerName, $option->getName()));
             }
         }
-
-        if ($fixer->isRisky()) {
-            self::assertValidDescription($fixerName, 'risky description', $definition->getRiskyDescription());
-        } else {
-            static::assertNull($definition->getRiskyDescription(), sprintf('[%s] Fixer is not risky so no description of it expected.', $fixerName));
-        }
     }
 
     /**
@@ -294,7 +288,6 @@ final class FixerTest extends TestCase
         $emptyTokens = new Tokens();
 
         static::assertInternalType('int', $fixer->getPriority(), sprintf('Return type for ::getPriority of "%s" is invalid.', $fixer->getName()));
-        static::assertInternalType('bool', $fixer->isRisky(), sprintf('Return type for ::isRisky of "%s" is invalid.', $fixer->getName()));
         static::assertInternalType('bool', $fixer->supports(new \SplFileInfo(__FILE__)), sprintf('Return type for ::supports of "%s" is invalid.', $fixer->getName()));
 
         static::assertInternalType('bool', $fixer->isCandidate($emptyTokens), sprintf('Return type for ::isCandidate with empty tokens of "%s" is invalid.', $fixer->getName()));

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -110,13 +110,6 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
         $this->doTest($after, $before);
     }
 
-    public function testIsRisky()
-    {
-        $fixer = $this->createFixer();
-
-        static::assertTrue($fixer->isRisky());
-    }
-
     /**
      * @dataProvider provideFixWithDefaultConfigurationCases
      *

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -167,13 +167,6 @@ PHP;
         $this->doTest($after, $before);
     }
 
-    public function testIsRisky()
-    {
-        $fixer = $this->createFixer();
-
-        static::assertTrue($fixer->isRisky());
-    }
-
     /**
      * @dataProvider provideFixWithDefaultConfigurationCases
      *


### PR DESCRIPTION
This PR:
 - moves all tests of fixer's `isRisky` method from `AutoReview/FixerTest` to `AbstractFixerTestCase`
 - makes check better because the risky description [wasn't always](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.15.7/tests/AutoReview/FixerTest.php#L151) tested (thus the change in description)
 - adds a test that if `isRisky` returns `false` it must be the definition from `AbstractFixer`