### PR TITLE
ArrayIndentationFixer - must run after MethodArgumentSpaceFixer

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -128,6 +128,7 @@ SAMPLE
     /**
      * {@inheritdoc}
      *
+     * Must run before ArrayIndentationFixer.
      * Must run after BracesFixer, CombineNestedDirnameFixer, ImplodeCallFixer, MethodChainingIndentationFixer, PowToExponentiationFixer.
      */
     public function getPriority()

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -227,7 +227,7 @@ $foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
      */
     public function getPriority()
     {
-        return -31;
+        return -32;
     }
 
     /**

--- a/src/Fixer/Whitespace/ArrayIndentationFixer.php
+++ b/src/Fixer/Whitespace/ArrayIndentationFixer.php
@@ -48,11 +48,11 @@ final class ArrayIndentationFixer extends AbstractFixer implements WhitespacesAw
      * {@inheritdoc}
      *
      * Must run before AlignMultilineCommentFixer, BinaryOperatorSpacesFixer.
-     * Must run after BracesFixer, MethodChainingIndentationFixer.
+     * Must run after BracesFixer, MethodArgumentSpaceFixer, MethodChainingIndentationFixer.
      */
     public function getPriority()
     {
-        return -30;
+        return -31;
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -109,6 +109,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['line_ending'], $fixers['braces']],
             [$fixers['list_syntax'], $fixers['binary_operator_spaces']],
             [$fixers['list_syntax'], $fixers['ternary_operator_spaces']],
+            [$fixers['method_argument_space'], $fixers['array_indentation']],
             [$fixers['method_chaining_indentation'], $fixers['array_indentation']],
             [$fixers['method_chaining_indentation'], $fixers['method_argument_space']],
             [$fixers['method_separation'], $fixers['braces']],

--- a/tests/Fixtures/Integration/misc/array_indentation,method_argument_space,method_chaining_indentation.test
+++ b/tests/Fixtures/Integration/misc/array_indentation,method_argument_space,method_chaining_indentation.test
@@ -1,0 +1,43 @@
+--TEST--
+Integration of fixers: array_indentation,method_argument_space,method_chaining_indentation.
+--RULESET--
+{
+    "array_indentation": true,
+    "method_argument_space": {"on_multiline" : "ensure_fully_multiline"},
+    "method_chaining_indentation": true
+}
+--EXPECT--
+<?php
+function foo($foo)
+{
+    $foo->bar()
+        ->baz(
+            [
+                $a,
+                $b
+            ],
+            [
+                $c,
+                $d
+            ]
+        )
+    ;
+}
+
+--INPUT--
+<?php
+function foo($foo)
+{
+    $foo->bar()
+            ->baz(
+                [
+                    $a,
+                    $b
+                ],
+                [
+                    $c,
+                    $d
+                ]
+            )
+    ;
+}

--- a/tests/Fixtures/Integration/priority/method_argument_space,array_indentation.test
+++ b/tests/Fixtures/Integration/priority/method_argument_space,array_indentation.test
@@ -1,0 +1,31 @@
+--TEST--
+Integration of fixers: method_argument_space,array_indentation.
+--RULESET--
+{"array_indentation": true, "method_argument_space": {"on_multiline" : "ensure_fully_multiline"}}
+--EXPECT--
+<?php
+function foo($foo)
+{
+    $foo
+        ->bar()
+        ->baz(
+            [
+                $x
+            ]
+        )
+    ;
+}
+
+--INPUT--
+<?php
+function foo($foo)
+{
+    $foo
+        ->bar()
+        ->baz(
+                [
+                    $x
+                ]
+            )
+    ;
+}


### PR DESCRIPTION
Follow up to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4962