### PR TITLE
Prevent error in CTTest::testConstants (for PHP8)

### DIFF
--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -74,7 +74,7 @@ final class CTTest extends TestCase
     public function testConstants($name, $value)
     {
         static::assertGreaterThan(10000, $value);
-        static::assertNull(@\constant($name), 'The CT name must not use native T_* name.');
+        static::assertFalse(\defined($name), 'The CT name must not use native T_* name.');
     }
 
     public function provideConstantsCases()


### PR DESCRIPTION
Noticed in https://travis-ci.org/github/FriendsOfPHP/PHP-CS-Fixer/jobs/692842752#L800

Even before PHP 8, I find the test cleaner like this