### PR TITLE
PhpdocAnnotationWithoutDotFixer - handle unicode characters using mb_*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "suggest": {
         "ext-dom": "For handling output formats in XML",
-        "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
+        "ext-mbstring": "For handling non-UTF8 characters.",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
         "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -114,6 +114,10 @@ function foo ($bar) {}
                 $content = Preg::replaceCallback(
                     '/^(\s*\*\s*@\w+\s+'.$optionalTypeRegEx.')(\p{Lu}?(?=\p{Ll}|\p{Zs}))(.*)$/',
                     static function (array $matches) {
+                        if (\function_exists('mb_strtolower')) {
+                            return $matches[1].mb_strtolower($matches[2]).$matches[3];
+                        }
+
                         return $matches[1].strtolower($matches[2]).$matches[3];
                     },
                     $startLine->getContent(),

--- a/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixerTest.php
@@ -207,6 +207,20 @@ final class PhpdocAnnotationWithoutDotFixerTest extends AbstractFixerTestCase
      */
     function nothingToDo() {}',
             ],
+            [
+                '<?php
+/**
+ * @param string $bar τάχιστη
+ */
+function foo ($bar) {}
+',
+                '<?php
+/**
+ * @param string $bar Τάχιστη.
+ */
+function foo ($bar) {}
+',
+            ],
         ];
     }
 }


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4977