### PR TITLE
[TASK] Added disable-commit-unfixed-files option

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -102,6 +102,7 @@ final class FixCommand extends Command
                     new InputOption('allow-risky', '', InputOption::VALUE_REQUIRED, 'Are risky fixers allowed (can be yes or no).'),
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The path to a .php_cs file.'),
                     new InputOption('dry-run', '', InputOption::VALUE_NONE, 'Only shows which files would have been modified.'),
+                    new InputOption('disable-commit-unfixed-code', '', InputOption::VALUE_NONE, 'If code contains unfixed files, it will thow exception.'),
                     new InputOption('rules', '', InputOption::VALUE_REQUIRED, 'The rules.'),
                     new InputOption('using-cache', '', InputOption::VALUE_REQUIRED, 'Does cache should be used (can be yes or no).'),
                     new InputOption('cache-file', '', InputOption::VALUE_REQUIRED, 'The path to the cache file.'),
@@ -134,6 +135,7 @@ final class FixCommand extends Command
                 'dry-run' => $input->getOption('dry-run'),
                 'rules' => $passedRules,
                 'path' => $input->getArgument('path'),
+                'disable-commit-unfixed-code' => $input->getOption('disable-commit-unfixed-code'),
                 'path-mode' => $input->getOption('path-mode'),
                 'using-cache' => $input->getOption('using-cache'),
                 'cache-file' => $input->getOption('cache-file'),
@@ -220,6 +222,10 @@ final class FixCommand extends Command
         $this->stopwatch->stop('fixFiles');
 
         $progressOutput->printLegend();
+
+        if (!empty($changed) && $resolver->isDisableCommitUnfixedCode()) {
+            throw new \InvalidArgumentException('Check all fixed files before commit');
+        }
 
         $fixEvent = $this->stopwatch->getEvent('fixFiles');
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -98,6 +98,11 @@ final class ConfigurationResolver
     private $isDryRun;
 
     /**
+     * @var null|bool
+     */
+    private $isDisableCommitUnfixedCode;
+
+    /**
      * @var null|FixerInterface[]
      */
     private $fixers;
@@ -122,6 +127,7 @@ final class ConfigurationResolver
         'diff' => null,
         'diff-format' => null,
         'dry-run' => null,
+        'disable-commit-unfixed-code' => null,
         'format' => null,
         'path' => [],
         'path-mode' => self::PATH_MODE_OVERRIDE,
@@ -544,6 +550,20 @@ final class ConfigurationResolver
         }
 
         return $this->isDryRun;
+    }
+
+    /**
+     * Returns disable-commit-unfixed-code flag.
+     *
+     * @return bool
+     */
+    public function isDisableCommitUnfixedCode()
+    {
+        if (null === $this->isDisableCommitUnfixedCode) {
+            $this->isDisableCommitUnfixedCode = $this->options['disable-commit-unfixed-code'];
+        }
+
+        return $this->isDisableCommitUnfixedCode;
     }
 
     public function shouldStopOnViolation()


### PR DESCRIPTION
I added a new option for git commit pre-hooks. If php-cs-fixer find some unfixed files, it will not be able to commit, because command throw new InvalidExp.