### PR TITLE
NoSpacesAfterFunctionNameFixer - introduce fix_special_constructs option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1196,6 +1196,11 @@ Choose from the list of available rules:
   When making a method or function call, there MUST NOT be a space between
   the method or function name and the opening parenthesis.
 
+  Configuration options:
+
+  - ``fix_special_constructs`` (``bool``): whether to fix ``echo``, ``print``,
+    ``include``, ``include_once``, ``require``, ``require_once``; defaults to ``true``
+
 * **no_spaces_around_offset** [@Symfony, @PhpCsFixer]
 
   There MUST NOT be spaces around offset braces.

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -75,14 +75,15 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             $prevNonWhitespace = $tokens->getPrevNonWhitespace($index);
 
             // check for special construct with ternary operator
-            $endParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
-            $nextMeaningful = $tokens->getNextMeaningfulToken($endParenthesisIndex);
-            if (
-                null !== $nextMeaningful
-                && $tokens[$nextMeaningful]->equals('?')
-                && $tokens[$prevNonWhitespace]->isGivenKind($specialConstructTokenKinds)
-            ) {
-                continue;
+            if ($tokens[$prevNonWhitespace]->isGivenKind($specialConstructTokenKinds)) {
+                $endParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+                $nextMeaningful = $tokens->getNextMeaningfulToken($endParenthesisIndex);
+                if (
+                    null !== $nextMeaningful
+                    && $tokens[$nextMeaningful]->equals('?')
+                ) {
+                    continue;
+                }
             }
 
             // check if it is a function call

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -53,7 +53,8 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionyTokenKinds(), [T_STRING]));
+        return $tokens->isTokenKindFound('(')
+            && $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionyTokenKinds(), [T_STRING]));
     }
 
     /**

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -145,21 +145,34 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     private function getFunctionyTokenKinds()
     {
+        static $tokenKinds;
+
+        if (null === $tokenKinds) {
+            $tokenKinds = array_merge(
+                $this->getLanguageConstructTokenKinds(),
+                $this->getSpecialConstructTokenKinds(),
+                [T_VARIABLE]
+            );
+        }
+
+        return $tokenKinds;
+    }
+
+    /**
+     * Gets the functiony token kinds which need parentheses around their argument(s).
+     *
+     * @return int[]
+     */
+    private function getLanguageConstructTokenKinds()
+    {
         static $tokenKinds = [
             T_ARRAY,
-            T_ECHO,
             T_EMPTY,
             T_EVAL,
             T_EXIT,
-            T_INCLUDE,
-            T_INCLUDE_ONCE,
             T_ISSET,
             T_LIST,
-            T_PRINT,
-            T_REQUIRE,
-            T_REQUIRE_ONCE,
             T_UNSET,
-            T_VARIABLE,
         ];
 
         return $tokenKinds;

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -116,6 +116,7 @@ final class RuleSet implements RuleSetInterface
             'no_multiline_whitespace_around_double_arrow' => true,
             'no_short_bool_cast' => true,
             'no_singleline_whitespace_before_semicolons' => true,
+            'no_spaces_after_function_name' => ['fix_special_constructs' => false],
             'no_spaces_around_offset' => true,
             'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'allow_unused_params' => true],
             'no_trailing_comma_in_list_call' => true,

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -29,8 +29,12 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
      *
      * @dataProvider provideFixCases
      */
-    public function testFix($expected, $input = null)
+    public function testFix($expected, $input = null, array $config = null)
     {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
         $this->doTest($expected, $input);
     }
 
@@ -80,6 +84,43 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
     foo ();
     $foo = &ref ();
     ',
+            ],
+            'test function-like constructs, excluding special' => [
+                '<?php
+    include ("something.php");
+    include_once ("something.php");
+    require ("something.php");
+    require_once ("something.php");
+    print ("hello");
+    unset($hello);
+    isset($hello);
+    empty($hello);
+    die($hello);
+    echo ("hello");
+    array("hello");
+    list($a, $b) = $c;
+    eval("a");
+    foo();
+    $foo = &ref();
+    ',
+                '<?php
+    include ("something.php");
+    include_once ("something.php");
+    require ("something.php");
+    require_once ("something.php");
+    print ("hello");
+    unset ($hello);
+    isset ($hello);
+    empty ($hello);
+    die ($hello);
+    echo ("hello");
+    array ("hello");
+    list ($a, $b) = $c;
+    eval ("a");
+    foo ();
+    $foo = &ref ();
+    ',
+                ['fix_special_constructs' => false],
             ],
             [
                 '<?php echo foo(1) ? "y" : "n";',


### PR DESCRIPTION
Closes #4817
Opt-in version of #4837
Alternative to (but not incompatible with) #4893

(The first commits are just refactoring and optimization, the actual change is the last commit)

This option is enabled by default (to keep BC) but disabled in the `@Symfony` ruleset (cf. https://github.com/symfony/symfony/pull/35588#discussion_r401497202)