### PR TITLE
Do not fix "alias" group in "phpdoc_types" rule by default in "Symfony" ruleset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1714,7 +1714,7 @@ Choose from the list of available rules:
   Configuration options:
 
   - ``groups`` (a subset of ``['simple', 'alias', 'meta']``): type groups to fix;
-    defaults to ``['simple', 'alias', 'meta']``
+    defaults to ``['simple', 'meta']``
 
 * **phpdoc_types_order** [@Symfony, @PhpCsFixer]
 

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -140,7 +140,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
      */
     protected function createConfigurationDefinition()
     {
-        $possibleGroups = array_keys(array_diff_key(self::$possibleTypes, ['alias' => true]));
+        $possibleGroups = array_keys(array_diff_key(self::$possibleTypes, array_flip(['alias'])));
 
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('groups', 'Type groups to fix.'))

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -140,7 +140,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
      */
     protected function createConfigurationDefinition()
     {
-        $possibleGroups = array_keys(self::$possibleTypes);
+        $possibleGroups = array_keys(array_diff_key(self::$possibleTypes, ['alias' => true]));
 
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('groups', 'Type groups to fix.'))

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -143,7 +143,7 @@ final class RuleSet implements RuleSetInterface
             'phpdoc_trim' => true,
             'phpdoc_trim_consecutive_blank_line_separation' => true,
             'phpdoc_types' => [
-                'groups' => ['simple', 'meta']
+                'groups' => ['simple', 'meta'],
             ],
             'phpdoc_types_order' => [
                 'null_adjustment' => 'always_last',

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -142,7 +142,9 @@ final class RuleSet implements RuleSetInterface
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_trim_consecutive_blank_line_separation' => true,
-            'phpdoc_types' => true,
+            'phpdoc_types' => [
+                'groups' => ['simple', 'meta']
+            ],
             'phpdoc_types_order' => [
                 'null_adjustment' => 'always_last',
                 'sort_algorithm' => 'none',

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -142,9 +142,7 @@ final class RuleSet implements RuleSetInterface
             'phpdoc_to_comment' => true,
             'phpdoc_trim' => true,
             'phpdoc_trim_consecutive_blank_line_separation' => true,
-            'phpdoc_types' => [
-                'groups' => ['simple', 'meta'],
-            ],
+            'phpdoc_types' => true,
             'phpdoc_types_order' => [
                 'null_adjustment' => 'always_last',
                 'sort_algorithm' => 'none',


### PR DESCRIPTION
Aliased keywords come from old ages of phpdoc.

These keywords should be not fixed by default. Keyword like `Callback` is perfectly valid name for a class name it should be not fixed by any default ruleset.