### PR TITLE
PhpdocToParamTypeFixer - fix for breaking PHP syntax for type having reserved name

### DIFF
--- a/src/AbstractPhpdocToTypeDeclarationFixer.php
+++ b/src/AbstractPhpdocToTypeDeclarationFixer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer;
+
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ */
+abstract class AbstractPhpdocToTypeDeclarationFixer extends AbstractFixer
+{
+    /**
+     * @var array<string, bool>
+     */
+    private static $syntaxValidationCache = [];
+
+    final protected function isValidSyntax($code)
+    {
+        if (!isset(self::$syntaxValidationCache[$code])) {
+            try {
+                Tokens::fromCode($code);
+                self::$syntaxValidationCache[$code] = true;
+            } catch (\ParseError $e) {
+                self::$syntaxValidationCache[$code] = false;
+            }
+        }
+
+        return self::$syntaxValidationCache[$code];
+    }
+}

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
-use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
@@ -29,7 +29,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Jan Gantzert <jan@familie-gantzert.de>
  */
-final class PhpdocToParamTypeFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+final class PhpdocToParamTypeFixer extends AbstractPhpdocToTypeDeclarationFixer implements ConfigurationDefinitionFixerInterface
 {
     /** @internal */
     const CLASS_REGEX = '/^\\\\?[a-zA-Z_\\x7f-\\xff](?:\\\\?[a-zA-Z0-9_\\x7f-\\xff]+)*(?<array>\[\])*$/';
@@ -260,6 +260,10 @@ function my_foo($bar)
                 }
 
                 if (!('(' === $tokens[$variableIndex - 1]->getContent()) && $this->hasParamTypeHint($tokens, $variableIndex - 2)) {
+                    continue;
+                }
+
+                if (!$this->isValidSyntax(sprintf('<?php function f(%s $x) {}', $paramType))) {
                     continue;
                 }
 

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
-use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
@@ -29,7 +29,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  */
-final class PhpdocToReturnTypeFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer implements ConfigurationDefinitionFixerInterface
 {
     /**
      * @var array<int, array<int, int|string>>
@@ -74,11 +74,6 @@ final class PhpdocToReturnTypeFixer extends AbstractFixer implements Configurati
      * @var string
      */
     private $classRegex = '/^\\\\?[a-zA-Z_\\x7f-\\xff](?:\\\\?[a-zA-Z0-9_\\x7f-\\xff]+)*(?<array>\[\])*$/';
-
-    /**
-     * @var array<string, bool>
-     */
-    private $returnTypeCache = [];
 
     /**
      * {@inheritdoc}
@@ -256,7 +251,7 @@ function my_foo()
                 continue;
             }
 
-            if (!$this->isValidType($returnType)) {
+            if (!$this->isValidSyntax(sprintf('<?php function f():%s {}', $returnType))) {
                 continue;
             }
 
@@ -345,24 +340,5 @@ function my_foo()
         $doc = new DocBlock($tokens[$index]->getContent());
 
         return $doc->getAnnotationsOfType('return');
-    }
-
-    /**
-     * @param string $returnType
-     *
-     * @return bool
-     */
-    private function isValidType($returnType)
-    {
-        if (!\array_key_exists($returnType, $this->returnTypeCache)) {
-            try {
-                Tokens::fromCode(sprintf('<?php function f():%s {}', $returnType));
-                $this->returnTypeCache[$returnType] = true;
-            } catch (\ParseError $e) {
-                $this->returnTypeCache[$returnType] = false;
-            }
-        }
-
-        return $this->returnTypeCache[$returnType];
     }
 }

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -80,6 +80,13 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                     function my_foo2($bar) {}
                     ',
             ],
+            'invalid - phpdoc param with keyword' => [
+                '<?php
+                    /** @param Break $foo */ function foo_break($foo) {}
+                    /** @param __CLASS__ $foo */ function foo_class($foo) {}
+                    /** @param I\Want\To\Break\Free $foo */ function foo_queen($foo) {}
+                ',
+            ],
             'non-root class with single int param' => [
                 '<?php /** @param int $bar */ function my_foo(int $bar) {}',
                 '<?php /** @param int $bar */ function my_foo($bar) {}',


### PR DESCRIPTION
Twin PR to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4963

I wonder if it would be useful to have some class e.g. `SyntaxChecker` with (static?) method `isValid`, which will handle cache internally and all needed will be to call it like this:
```php
if (!SyntaxChecker::isValid(sprintf('<?php function f(%s $x) {}', $returnType))) {
    continue;
}
```

Currently, this will have 2 uses (here and `PhpdocToReturnTypeFixer`, maybe also `AbstractPsrAutoloadingFixer`, not mandatory), but I imagine quite soon we will have `PhpdocToPropertyTypeFixer`.