### PR TITLE
NoSuperfluousPhpdocTagsFixer - fix for @return with @inheritDoc in description

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -135,14 +135,14 @@ class Foo {
 
             $token = $tokens[$documentedElementIndex];
 
+            if ($this->configuration['remove_inheritdoc']) {
+                $content = $this->removeSuperfluousInheritDoc($content);
+            }
+
             if ($token->isGivenKind(T_FUNCTION)) {
                 $content = $this->fixFunctionDocComment($content, $tokens, $index, $shortNames);
             } elseif ($token->isGivenKind(T_VARIABLE)) {
                 $content = $this->fixPropertyDocComment($content, $tokens, $index, $shortNames);
-            }
-
-            if ($this->configuration['remove_inheritdoc']) {
-                $content = $this->removeSuperfluousInheritDoc($content);
             }
 
             if ($content !== $initialContent) {

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -1080,8 +1080,9 @@ class Foo {
      * @dataProvider provideFixPhp70Cases
      * @requires PHP 7.0
      */
-    public function testFixPhp70($expected, $input = null)
+    public function testFixPhp70($expected, $input = null, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -1224,6 +1225,20 @@ class Foo {
                      */
                      function display($number) {}
                 ',
+            ],
+            'return with @inheritDoc in description' => [
+                '<?php
+                    /**
+                     */
+                    function foo(): bool {}
+                ',
+                '<?php
+                    /**
+                     * @return bool @inheritDoc
+                     */
+                    function foo(): bool {}
+                ',
+                ['remove_inheritdoc' => true],
             ],
         ];
     }


### PR DESCRIPTION
To `2.16` as `2.15` does not have the option `remove_inheritdoc`.