### PR TITLE
PhpUnitDedicateAssertInternalTypeFixer - deprecate "target" option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1464,7 +1464,7 @@ Choose from the list of available rules:
   Configuration options:
 
   - ``target`` (``'7.5'``, ``'newest'``): target version of PHPUnit; defaults to
-    ``'newest'``
+    ``'newest'``. DEPRECATED: option was not used
 
 * **php_unit_expectation** [@PHPUnit52Migration:risky, @PHPUnit54Migration:risky, @PHPUnit55Migration:risky, @PHPUnit56Migration:risky, @PHPUnit57Migration:risky, @PHPUnit60Migration:risky, @PHPUnit75Migration:risky, @PHPUnit84Migration:risky]
 

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
@@ -118,11 +118,13 @@ final class MyTest extends \PHPUnit\Framework\TestCase
      */
     protected function createConfigurationDefinition()
     {
+        // @todo 3.0 drop `ConfigurationDefinitionFixerInterface`
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('target', 'Target version of PHPUnit.'))
                 ->setAllowedTypes(['string'])
                 ->setAllowedValues([PhpUnitTargetVersion::VERSION_7_5, PhpUnitTargetVersion::VERSION_NEWEST])
                 ->setDefault(PhpUnitTargetVersion::VERSION_NEWEST)
+                ->setDeprecationMessage('Option was not used.')
                 ->getOption(),
         ]);
     }

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -440,7 +440,7 @@ final class RuleSet implements RuleSetInterface
         ],
         '@PHPUnit75Migration:risky' => [
             '@PHPUnit60Migration:risky' => true,
-            'php_unit_dedicate_assert_internal_type' => ['target' => PhpUnitTargetVersion::VERSION_7_5],
+            'php_unit_dedicate_assert_internal_type' => true,
         ],
         '@PHPUnit84Migration:risky' => [
             '@PHPUnit75Migration:risky' => true,

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -19,6 +19,7 @@ use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTargetVersion;
+use PhpCsFixer\FixerConfiguration\DeprecatedFixerOption;
 use PhpCsFixer\FixerConfiguration\DeprecatedFixerOptionInterface;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet;
@@ -884,6 +885,9 @@ Integration of %s.
 
         foreach ($fixer->getConfigurationDefinition()->getOptions() as $option) {
             if ('target' === $option->getName()) {
+                if ($option instanceof DeprecatedFixerOption) {
+                    static::markTestSkipped(sprintf('The fixer "%s" has option "target" deprecated.', $fixer->getName()));
+                }
                 $allowedVersionsForFixer = array_diff($option->getAllowedValues(), [PhpUnitTargetVersion::VERSION_NEWEST]);
 
                 break;


### PR DESCRIPTION
The option was not used and is not needed - all the assertions were added in PHPUnit 7.5: https://github.com/sebastianbergmann/phpunit/blob/7.5.20/ChangeLog-7.5.md

Pinging @Slamdunk as the author of fixer.