### PR TITLE
SingleLineAfterImportsFixer - fix for line after import (and before another import) already added using CRLF

### DIFF
--- a/src/Fixer/Import/SingleLineAfterImportsFixer.php
+++ b/src/Fixer/Import/SingleLineAfterImportsFixer.php
@@ -142,7 +142,7 @@ final class Example
                     }
                     $nextMeaningfulAfterUseIndex = $tokens->getNextMeaningfulToken($insertIndex);
                     if (null !== $nextMeaningfulAfterUseIndex && $tokens[$nextMeaningfulAfterUseIndex]->isGivenKind(T_USE)) {
-                        if (substr_count($nextToken->getContent(), "\n") < 2) {
+                        if (substr_count($nextToken->getContent(), "\n") < 1) {
                             $tokens[$insertIndex] = new Token([T_WHITESPACE, $newline.$indent.ltrim($nextToken->getContent())]);
                         }
                     } else {

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -353,6 +353,14 @@ namespace Bar {
 ',
                 '<?php use A\B;',
             ],
+            [
+                str_replace("\n", "\r\n", '<?php
+use Foo;
+use Bar;
+
+class Baz {}
+'),
+            ],
         ];
     }
 
@@ -435,13 +443,6 @@ use const some\c;
                 ' <?php
 use some\a\ClassA; use function some\a\fn_a; use const some\c;
 ',
-            ],
-            [
-                str_replace("\n", "\r\n", '<?php
-use Foo;
-
-class Bar {}
-'),
             ],
         ];
     }


### PR DESCRIPTION
The original test for CRLF was run in tests for PHP 7.0, so in this PR it's moved to test which runs on all PHP versions.

Follow up to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5029