### PR TITLE
Add PHP 8.0 install/runtime support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.6 || ^7.0 || ^8.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "composer/semver": "^1.4",
+        "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/xdebug-handler": "^1.2",
         "doctrine/annotations": "^1.2",
         "php-cs-fixer/diff": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer/semver": "^1.4",


### PR DESCRIPTION
`"php-cs-fixer/diff": "^1.3"` does not allow PHP 8.0, PR like this opened, see https://github.com/PHP-CS-Fixer/diff/pull/18

how to test?
1. add the following to the composer.json file and check if it installs with this PR:
```
    "config": {
        "platform": {
            "php": "8.0.0"
        }
    },
```
2. run all tests with php8