### PR TITLE
FinalInternalClassFixer- Rename option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -713,12 +713,12 @@ Choose from the list of available rules:
 
   Configuration options:
 
-  - ``annotation_black_list`` (``array``): class level annotations tags that must be
+  - ``annotation_exclude`` (``array``): class level annotations tags that must be
     omitted to fix the class, even if all of the white list ones are used
     as well. (case insensitive); defaults to ``['@final', '@Entity',
     '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity']``;
     DEPRECATED alias: ``annotation-black-list``
-  - ``annotation_white_list`` (``array``): class level annotations tags that must be
+  - ``annotation_include`` (``array``): class level annotations tags that must be
     set in order to fix the class. (case insensitive); defaults to
     ``['@internal']``; DEPRECATED alias: ``annotation-white-list``
   - ``consider_absent_docblock_as_internal_class`` (``bool``): should classes

--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -51,7 +51,7 @@ class MyApp {}
     {
         $fixer = new FinalInternalClassFixer();
         $fixer->configure([
-            'annotation_white_list' => [],
+            'annotation_include' => [],
             'consider_absent_docblock_as_internal_class' => true,
         ]);
 

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -40,8 +40,8 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
         parent::configure($configuration);
 
         $intersect = array_intersect_assoc(
-            $this->configuration['annotation_white_list'],
-            $this->configuration['annotation_black_list']
+            $this->configuration['annotation_include'],
+            $this->configuration['annotation_exclude']
         );
 
         if (\count($intersect)) {
@@ -59,9 +59,10 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
             [
                 new CodeSample("<?php\n/**\n * @internal\n */\nclass Sample\n{\n}\n"),
                 new CodeSample(
-                    "<?php\n/** @CUSTOM */class A{}\n",
+                    "<?php\n/**\n * @CUSTOM\n */\nclass A{}\n\n/**\n * @CUSTOM\n * @not-fix\n */\nclass B{}\n",
                     [
-                        'annotation_white_list' => ['@Custom'],
+                        'annotation_include' => ['@Custom'],
+                        'annotation_exclude' => ['@not-fix'],
                     ]
                 ),
             ],
@@ -148,7 +149,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
 
         return new FixerConfigurationResolver([
             (new AliasedFixerOptionBuilder(
-                new FixerOptionBuilder('annotation_white_list', 'Class level annotations tags that must be set in order to fix the class. (case insensitive)'),
+                new FixerOptionBuilder('annotation_include', 'Class level annotations tags that must be set in order to fix the class. (case insensitive)'),
                 'annotation-white-list'
             ))
                 ->setAllowedTypes(['array'])
@@ -157,7 +158,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
                 ->setNormalizer($annotationsNormalizer)
                 ->getOption(),
             (new AliasedFixerOptionBuilder(
-                new FixerOptionBuilder('annotation_black_list', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)'),
+                new FixerOptionBuilder('annotation_exclude', 'Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)'),
                 'annotation-black-list'
             ))
                 ->setAllowedTypes(['array'])
@@ -204,7 +205,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
         foreach ($doc->getAnnotations() as $annotation) {
             Preg::match('/@\S+(?=\s|$)/', $annotation->getContent(), $matches);
             $tag = strtolower(substr(array_shift($matches), 1));
-            foreach ($this->configuration['annotation_black_list'] as $tagStart => $true) {
+            foreach ($this->configuration['annotation_exclude'] as $tagStart => $true) {
                 if (0 === strpos($tag, $tagStart)) {
                     return false; // ignore class: class-level PHPDoc contains tag that has been excluded through configuration
                 }
@@ -213,7 +214,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
             $tags[$tag] = true;
         }
 
-        foreach ($this->configuration['annotation_white_list'] as $tag => $true) {
+        foreach ($this->configuration['annotation_include'] as $tag => $true) {
             if (!isset($tags[$tag])) {
                 return false; // ignore class: class-level PHPDoc does not contain all tags that has been included through configuration
             }

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -40,7 +40,7 @@ final class PhpdocToParamTypeFixer extends AbstractFixer implements Configuratio
     /**
      * @var array{int, string}[]
      */
-    private $blacklistFuncNames = [
+    private $excludeFuncNames = [
         [T_STRING, '__clone'],
         [T_STRING, '__destruct'],
     ];
@@ -138,7 +138,7 @@ function my_foo($bar)
             }
 
             $funcName = $tokens->getNextMeaningfulToken($index);
-            if ($tokens[$funcName]->equalsAny($this->blacklistFuncNames, false)) {
+            if ($tokens[$funcName]->equalsAny($this->excludeFuncNames, false)) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -152,7 +152,7 @@ abstract class class4 {}
                 "<?php\n/** @CUSTOM */final class A{}",
                 "<?php\n/** @CUSTOM */class A{}",
                 [
-                    'annotation_white_list' => ['@Custom'],
+                    'annotation_include' => ['@Custom'],
                 ],
             ],
             [
@@ -181,7 +181,7 @@ class A{}
 class B{}
 ',
                 [
-                    'annotation_white_list' => ['@Custom', '@abc'],
+                    'annotation_include' => ['@Custom', '@abc'],
                 ],
             ],
             [
@@ -228,8 +228,8 @@ class B{}
  class C{}
 ',
                 [
-                    'annotation_white_list' => ['@Custom', '@internal'],
-                    'annotation_black_list' => ['@not-fix'],
+                    'annotation_include' => ['@Custom', '@internal'],
+                    'annotation_exclude' => ['@not-fix'],
                 ],
             ],
             [
@@ -256,7 +256,7 @@ class A{}
 class B{}
 ',
                 [
-                    'annotation_black_list' => ['abc'],
+                    'annotation_exclude' => ['abc'],
                 ],
             ],
         ];
@@ -293,8 +293,8 @@ $a = new class (){};',
         );
 
         $this->fixer->configure([
-            'annotation_white_list' => ['@internal123', 'a'],
-            'annotation_black_list' => ['@internal123', 'b'],
+            'annotation_include' => ['@internal123', 'a'],
+            'annotation_exclude' => ['@internal123', 'b'],
         ]);
     }
 }


### PR DESCRIPTION
follow up on 2.16 of #5008

This is not a BC break as the previous rename has not been released yet.