### PR TITLE
Test code samples with Windows line endings

### DIFF
--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -173,6 +173,28 @@ abstract class AbstractFixerTestCase extends TestCase
                 $duplicatedCodeSample,
                 sprintf('[%s] Sample #%d duplicates #%d.', $fixerName, $sampleCounter, $duplicatedCodeSample)
             );
+
+            $fixerNamesThatRemoveWindowsLineEndings = [
+                'line_ending',
+                'string_line_ending',
+            ];
+
+            if (!\in_array($fixerName, $fixerNamesThatRemoveWindowsLineEndings, true)) {
+                $fixedCodeWithWindowsLineEnding = str_replace("\n", "\r\n", $tokens->generateCode());
+
+                Tokens::clearCache();
+                $fixedTokensWithWindowsLineEnding = Tokens::fromCode($fixedCodeWithWindowsLineEnding);
+
+                $this->fixer->fix(
+                    $sample instanceof FileSpecificCodeSampleInterface ? $sample->getSplFileInfo() : $dummyFileInfo,
+                    $fixedTokensWithWindowsLineEnding
+                );
+
+                Tokens::clearCache();
+                $this->assertTokens(Tokens::fromCode($fixedCodeWithWindowsLineEnding), $fixedTokensWithWindowsLineEnding);
+
+                static::assertFalse($fixedTokensWithWindowsLineEnding->isChanged(), sprintf('[%s] Sample #%d fixed code must not change when with Windows line endings.', $fixerName, $sampleCounter));
+            }
         }
 
         if ($fixerIsConfigurable) {


### PR DESCRIPTION
The idea is to take each (except the fixers that suppose to change line endings) code sample after fixing, convert line endings to Windows ones and run fixing once again - the code should not change.