### PR TITLE
[RFC] Add option "show-slowest-fixers"

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -130,6 +130,7 @@ final class ConfigurationResolver
         'stop-on-violation' => null,
         'using-cache' => null,
         'verbosity' => null,
+        'show-slowest-fixers' => null,
     ];
 
     private $cacheFile;
@@ -561,6 +562,14 @@ final class ConfigurationResolver
         }
 
         return $this->configFinderIsOverridden;
+    }
+
+    /**
+     * @return int
+     */
+    public function showSlowestFixers()
+    {
+        return $this->options['show-slowest-fixers'];
     }
 
     /**

--- a/src/Report/ReportSummary.php
+++ b/src/Report/ReportSummary.php
@@ -50,11 +50,17 @@ final class ReportSummary
     private $time;
 
     /**
-     * @param int  $time              duration in milliseconds
-     * @param int  $memory            memory usage in bytes
-     * @param bool $addAppliedFixers
-     * @param bool $isDryRun
-     * @param bool $isDecoratedOutput
+     * @var array<string, int>
+     */
+    private $slowestFixers;
+
+    /**
+     * @param int                $time              duration in milliseconds
+     * @param int                $memory            memory usage in bytes
+     * @param bool               $addAppliedFixers
+     * @param bool               $isDryRun
+     * @param bool               $isDecoratedOutput
+     * @param array<string, int> $slowestFixers
      */
     public function __construct(
         array $changed,
@@ -62,7 +68,8 @@ final class ReportSummary
         $memory,
         $addAppliedFixers,
         $isDryRun,
-        $isDecoratedOutput
+        $isDecoratedOutput,
+        array $slowestFixers = []
     ) {
         $this->changed = $changed;
         $this->time = $time;
@@ -70,6 +77,7 @@ final class ReportSummary
         $this->addAppliedFixers = $addAppliedFixers;
         $this->isDryRun = $isDryRun;
         $this->isDecoratedOutput = $isDecoratedOutput;
+        $this->slowestFixers = $slowestFixers;
     }
 
     /**
@@ -118,5 +126,13 @@ final class ReportSummary
     public function shouldAddAppliedFixers()
     {
         return $this->addAppliedFixers;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getSlowestFixers()
+    {
+        return $this->slowestFixers;
     }
 }

--- a/src/Report/TextReporter.php
+++ b/src/Report/TextReporter.php
@@ -49,6 +49,13 @@ final class TextReporter implements ReporterInterface
             $output .= PHP_EOL;
         }
 
+        if ($reportSummary->shouldAddAppliedFixers() && [] !== $reportSummary->getSlowestFixers()) {
+            $output .= PHP_EOL.sprintf('Top %d slowest fixers:', \count($reportSummary->getSlowestFixers())).PHP_EOL;
+            foreach ($reportSummary->getSlowestFixers() as $fixer => $duration) {
+                $output .= sprintf('Fixer %s duration: %d ms', $fixer, $duration).PHP_EOL;
+            }
+        }
+
         return $output.$this->getFooter($reportSummary->getTime(), $reportSummary->getMemory(), $reportSummary->isDryRun());
     }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1053,7 +1053,7 @@ final class ConfigurationResolverTest extends TestCase
 
         $options = $definition->getOptions();
         static::assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'diff-format', 'format', 'stop-on-violation', 'show-progress'],
+            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'diff-format', 'format', 'stop-on-violation', 'show-progress', 'show-slowest-fixers'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );
@@ -1069,6 +1069,7 @@ final class ConfigurationResolverTest extends TestCase
             'diff-format' => 'udiff',
             'format' => 'json',
             'stop-on-violation' => true,
+            'show-slowest-fixers' => 10,
         ]);
 
         static::assertTrue($resolver->shouldStopOnViolation());


### PR DESCRIPTION
This will add report like this:
```bash
$ php php-cs-fixer fix -v --show-slowest-fixers=10
Loaded config default from ".php_cs.dist".
......................................................................................................................................... 137 / 759 ( 18%)
......................................................................................................................................... 274 / 759 ( 36%)
......................................................................................................................................... 411 / 759 ( 54%)
......................................................................................................................................... 548 / 759 ( 72%)
......................................................................................................................................... 685 / 759 ( 90%)
..........................................................................                                                                759 / 759 (100%)
Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error

Top 10 slowest fixers:
Fixer braces duration: 3046 ms
Fixer native_function_invocation duration: 2024 ms
Fixer error_suppression duration: 1962 ms
Fixer no_extra_blank_lines duration: 1761 ms
Fixer array_indentation duration: 1758 ms
Fixer ereg_to_preg duration: 1176 ms
Fixer unary_operator_spaces duration: 1010 ms
Fixer modernize_types_casting duration: 1000 ms
Fixer strict_param duration: 904 ms
Fixer no_unused_imports duration: 812 ms

Fixed all files in 49.910 seconds, 46.000 MB memory used
```

Would that be useful?