### PR TITLE
BacktickToShellExecFixer - add priority relation to NativeFunctionInvocationFixer and SingleQuoteFixer

### DIFF
--- a/src/Fixer/Alias/BacktickToShellExecFixer.php
+++ b/src/Fixer/Alias/BacktickToShellExecFixer.php
@@ -56,7 +56,7 @@ EOT
     /**
      * {@inheritdoc}
      *
-     * Must run before EscapeImplicitBackslashesFixer, ExplicitStringVariableFixer.
+     * Must run before EscapeImplicitBackslashesFixer, ExplicitStringVariableFixer, NativeFunctionInvocationFixer, SingleQuoteFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
+++ b/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php
@@ -179,11 +179,11 @@ $c = get_class($d);
     /**
      * {@inheritdoc}
      *
-     * Must run after StrictParamFixer.
+     * Must run after BacktickToShellExecFixer, StrictParamFixer.
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Strict/StrictParamFixer.php
+++ b/src/Fixer/Strict/StrictParamFixer.php
@@ -60,7 +60,7 @@ final class StrictParamFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 1;
+        return 2;
     }
 
     /**

--- a/src/Fixer/StringNotation/SingleQuoteFixer.php
+++ b/src/Fixer/StringNotation/SingleQuoteFixer.php
@@ -55,7 +55,7 @@ EOF;
     /**
      * {@inheritdoc}
      *
-     * Must run after EscapeImplicitBackslashesFixer.
+     * Must run after BacktickToShellExecFixer, EscapeImplicitBackslashesFixer.
      */
     public function getPriority()
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -68,6 +68,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['array_syntax'], $fixers['ternary_operator_spaces']],
             [$fixers['backtick_to_shell_exec'], $fixers['escape_implicit_backslashes']],
             [$fixers['backtick_to_shell_exec'], $fixers['explicit_string_variable']],
+            [$fixers['backtick_to_shell_exec'], $fixers['native_function_invocation']],
+            [$fixers['backtick_to_shell_exec'], $fixers['single_quote']],
             [$fixers['blank_line_after_opening_tag'], $fixers['no_blank_lines_before_namespace']],
             [$fixers['braces'], $fixers['array_indentation']],
             [$fixers['braces'], $fixers['method_argument_space']],

--- a/tests/Fixtures/Integration/priority/backtick_to_shell_exec,native_function_invocation.test
+++ b/tests/Fixtures/Integration/priority/backtick_to_shell_exec,native_function_invocation.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: backtick_to_shell_exec,native_function_invocation.
+--RULESET--
+{"backtick_to_shell_exec": true, "native_function_invocation": true}
+--EXPECT--
+<?php
+$var = \shell_exec("pwd");
+
+--INPUT--
+<?php
+$var = `pwd`;

--- a/tests/Fixtures/Integration/priority/backtick_to_shell_exec,single_quote.test
+++ b/tests/Fixtures/Integration/priority/backtick_to_shell_exec,single_quote.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: backtick_to_shell_exec,single_quote.
+--RULESET--
+{"backtick_to_shell_exec": true, "single_quote": true}
+--EXPECT--
+<?php
+$var = shell_exec('pwd');
+
+--INPUT--
+<?php
+$var = `pwd`;


### PR DESCRIPTION
This is actually a bug fix, because at `2.16` `NativeFunctionInvocationFixer` has priority [10](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.16.4/src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php#L171), which is greater that `BacktickToShellExecFixer` priority ([2](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.16.4/src/Fixer/Alias/BacktickToShellExecFixer.php#L63)).

So, for the person who will be merging this up to `2.16`: on the conflict in `NativeFunctionInvocationFixer` for priorities `10` and `1` - choose `1` or tests would fail.