### PR TITLE
Allow composer/semver ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": "^5.6 || ^7.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
-        "composer/semver": "^1.4",
+        "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/xdebug-handler": "^1.2",
         "doctrine/annotations": "^1.2",
         "php-cs-fixer/diff": "^1.3",


### PR DESCRIPTION
Allow composer/semver ^2.0 and ^3.0.

This will allow usage of composer 2.0.

This PR replace PR #4935 since there is no activity on that PR.