### PR TITLE
ClassAttributesSeparationFixer - Introduce `including_doc_blocks` option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,9 @@ Choose from the list of available rules:
   - ``elements`` (``array``): dictionary of ``const|method|property`` => ``none|one``
     values; defaults to ``['const' => 'one', 'method' => 'one', 'property' =>
     'one']``
+  - ``including_doc_blocks`` (``bool``): whether the spacing rules should also be
+    enforced for consts, methods and properties with doc blocks; defaults
+    to ``false``
 
 * **class_definition** [@PSR2, @Symfony, @PhpCsFixer]
 

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -280,6 +280,17 @@ class Sample
             $nextNotWhite = $tokens->getNextNonWhitespace($nextNotWhite);
         }
 
+        while (true) {
+            $token = $tokens[$nextNotWhite];
+            if ($tokens[$nextNotWhite]->isGivenKind([T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC])) {
+                $nextNotWhite = $tokens->getNextNonWhitespace($nextNotWhite);
+
+                continue;
+            }
+
+            break;
+        }
+
         if ($tokens[$nextNotWhite]->isGivenKind(T_FUNCTION)) {
             $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, 2);
 

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -65,7 +65,7 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
     /**
      * @var bool
      */
-    private $includingDocBlocks = false;
+    private $includingDocBlocks = true;
 
     /**
      * {@inheritdoc}
@@ -199,7 +199,7 @@ class Sample
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('including_doc_blocks', 'Whether the spacing rules should also be enforced for consts, methods and properties with doc blocks.'))
                 ->setAllowedTypes(['bool'])
-                ->setDefault(false)
+                ->setDefault(true)
                 ->getOption(),
             (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property` => `none|one` values.'))
                 ->setNormalizer(static function (Options $options, $values) {
@@ -301,7 +301,7 @@ class Sample
 
         $reqLineCount = $nextNotWhite === $classEndIndex || self::SPACING_NONE === $spacing ? 1 : 2;
 
-        if (true === $this->includingDocBlocks && true === $tokens[$nonWhiteAbove]->isGivenKind(T_DOC_COMMENT)) {
+        if (false === $this->includingDocBlocks && true === $tokens[$nonWhiteAbove]->isGivenKind(T_DOC_COMMENT)) {
             $reqLineCount = 2;
         }
 
@@ -386,7 +386,7 @@ class Sample
                     $nonWhiteAbove - 1
                 );
 
-                if (true === $this->includingDocBlocks && true === $tokens[$nonWhiteAboveAbove]->isGivenKind(T_DOC_COMMENT)) {
+                if (false === $this->includingDocBlocks && true === $tokens[$nonWhiteAboveAbove]->isGivenKind(T_DOC_COMMENT)) {
                     $reqLineCount = 2;
                 }
             }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1312,7 +1312,11 @@ private $d = 123;
     {
         $this->fixer->configure([
             'including_doc_blocks' => true,
-            'elements' => ['property' => ClassAttributesSeparationFixer::SPACING_NONE],
+            'elements' => [
+                'const' => ClassAttributesSeparationFixer::SPACING_NONE,
+                'property' => ClassAttributesSeparationFixer::SPACING_NONE,
+                'method' => ClassAttributesSeparationFixer::SPACING_ONE,
+            ],
         ]);
         $this->doTest($expected, $input);
     }
@@ -1335,6 +1339,10 @@ private $d = 123;
                 private string $three;
                 private string $four;
                 private string $five;
+
+                final public static function __construct() {
+
+                }
             }',
             '<?php
             class Foo {
@@ -1353,6 +1361,100 @@ private $d = 123;
                 private string $four;
 
                 private string $five;
+
+                final public static function __construct() {
+
+                }
+            }',
+        ];
+
+        yield [
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+                private string $four;
+                private string $five;
+
+                public function __construct() {
+
+                }
+            }',
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+
+                private string $four;
+
+                private string $five;
+
+                public function __construct() {
+
+                }
+            }',
+        ];
+
+        yield [
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+                private string $four;
+                private string $five;
+
+                function __construct() {
+
+                }
+            }',
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+
+                private string $four;
+
+                private string $five;
+
+                function __construct() {
+
+                }
             }',
         ];
     }

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1272,14 +1272,14 @@ private $d = 123;
 
                 public iterable $baz;
 
-                var ? Foo\Bar $qux;
+                var ?Foo\Bar $qux;
             }',
             '<?php
             class Foo {
                 private ?int $foo;
                 protected string $bar;
                 public iterable $baz;
-                var ? Foo\Bar $qux;
+                var ?Foo\Bar $qux;
             }',
         ];
 

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1258,9 +1258,6 @@ private $d = 123;
      */
     public function testFix74($expected, $input = null)
     {
-        $this->fixer->configure([
-            'including_doc_blocks' => true,
-        ]);
         $this->doTest($expected, $input);
     }
 
@@ -1311,7 +1308,7 @@ private $d = 123;
     public function testDisablingIncludingDocBlocks($expected, $input = null)
     {
         $this->fixer->configure([
-            'including_doc_blocks' => true,
+            'including_doc_blocks' => false,
             'elements' => [
                 'const' => ClassAttributesSeparationFixer::SPACING_NONE,
                 'property' => ClassAttributesSeparationFixer::SPACING_NONE,

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1258,6 +1258,9 @@ private $d = 123;
      */
     public function testFix74($expected, $input = null)
     {
+        $this->fixer->configure([
+            'including_doc_blocks' => true,
+        ]);
         $this->doTest($expected, $input);
     }
 
@@ -1294,6 +1297,62 @@ private $d = 123;
             class Foo {
                 private array $foo;
                 private array $bar;
+            }',
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideDocBlocksCases
+     * @requires PHP 7.4
+     */
+    public function testDisablingIncludingDocBlocks($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'including_doc_blocks' => true,
+            'elements' => ['property' => ClassAttributesSeparationFixer::SPACING_NONE],
+        ]);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideDocBlocksCases()
+    {
+        yield [
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+                private string $four;
+                private string $five;
+            }',
+            '<?php
+            class Foo {
+                /**
+                 * @ORM\Column(name="one", type="text")
+                 */
+                private string $one;
+
+                /**
+                 * @ORM\Column(name="two", type="text")
+                 */
+                private string $two;
+
+                private string $three;
+
+                private string $four;
+
+                private string $five;
             }',
         ];
     }


### PR DESCRIPTION
I found out that `none` spacing for class attributes (introduced in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4875) is not working as I want.

```php
'class_attributes_separation' => ['elements' => ['property' => 'none']],
```

This source code:
```php
class Entity
{
    /**
     * @ORM\Column(name="one", type="text")
     */
    private string $one;
    
    /**
     * @ORM\Column(name="two", type="text")
     */
    private string $two;
    
    private string $three;
    
    private string $four;
    
    private string $five;
}
```
gets converted to
```php
class Entity
{
    /**
     * @ORM\Column(name="one", type="text")
     */
    private string $one;
    /**
     * @ORM\Column(name="two", type="text")
     */
    private string $two;
    private string $three;
    private string $four;
    private string $five;
}
```

This is not what I want. I want to keep a newline when doc blocks are involved.

With the changes in this PR, it will be fixed like this:
```php
class Entity
{
    /**
     * @ORM\Column(name="one", type="text")
     */
    private string $one;

    /**
     * @ORM\Column(name="two", type="text")
     */
    private string $two;

    private string $three;
    private string $four;
    private string $five;
}
```