### PR TITLE
TernaryOperatorSpacesFixer - fix for discovering ":" correctly

### DIFF
--- a/src/Fixer/Operator/TernaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/TernaryOperatorSpacesFixer.php
@@ -15,6 +15,8 @@ namespace PhpCsFixer\Fixer\Operator;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\SwitchAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -57,20 +59,36 @@ final class TernaryOperatorSpacesFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $ternaryLevel = 0;
+        $ternaryOperatorIndices = [];
+        $excludedIndices = [];
 
         foreach ($tokens as $index => $token) {
+            if ($token->isGivenKind(T_SWITCH)) {
+                $excludedIndices = array_merge($excludedIndices, $this->getColonIndicesForSwitch($tokens, $index));
+
+                continue;
+            }
+
+            if (!$token->equalsAny(['?', ':'])) {
+                continue;
+            }
+
+            if (\in_array($index, $excludedIndices, true)) {
+                continue;
+            }
+
+            $ternaryOperatorIndices[] = $index;
+        }
+
+        foreach (array_reverse($ternaryOperatorIndices) as $index) {
+            $token = $tokens[$index];
+
             if ($token->equals('?')) {
-                ++$ternaryLevel;
-
                 $nextNonWhitespaceIndex = $tokens->getNextNonWhitespace($index);
-                $nextNonWhitespaceToken = $tokens[$nextNonWhitespaceIndex];
 
-                if ($nextNonWhitespaceToken->equals(':')) {
+                if ($tokens[$nextNonWhitespaceIndex]->equals(':')) {
                     // for `$a ?: $b` remove spaces between `?` and `:`
-                    if ($tokens[$index + 1]->isWhitespace()) {
-                        $tokens->clearAt($index + 1);
-                    }
+                    $tokens->ensureWhitespaceAtIndex($index + 1, 0, '');
                 } else {
                     // for `$a ? $b : $c` ensure space after `?`
                     $this->ensureWhitespaceExistence($tokens, $index + 1, true);
@@ -82,7 +100,7 @@ final class TernaryOperatorSpacesFixer extends AbstractFixer
                 continue;
             }
 
-            if ($ternaryLevel && $token->equals(':')) {
+            if ($token->equals(':')) {
                 // for `$a ? $b : $c` ensure space after `:`
                 $this->ensureWhitespaceExistence($tokens, $index + 1, true);
 
@@ -92,10 +110,23 @@ final class TernaryOperatorSpacesFixer extends AbstractFixer
                     // for `$a ? $b : $c` ensure space before `:`
                     $this->ensureWhitespaceExistence($tokens, $index - 1, false);
                 }
-
-                --$ternaryLevel;
             }
         }
+    }
+
+    /**
+     * @param int $switchIndex
+     *
+     * @return int[]
+     */
+    private function getColonIndicesForSwitch(Tokens $tokens, $switchIndex)
+    {
+        return array_map(
+            static function (CaseAnalysis $caseAnalysis) {
+                return $caseAnalysis->getColonIndex();
+            },
+            (new SwitchAnalyzer())->getSwitchAnalysis($tokens, $switchIndex)->getCases()
+        );
     }
 
     /**

--- a/src/Tokenizer/Analyzer/Analysis/CaseAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/CaseAnalysis.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class CaseAnalysis
+{
+    /**
+     * @var int
+     */
+    private $colonIndex;
+
+    /**
+     * @param int $colonIndex
+     */
+    public function __construct($colonIndex)
+    {
+        $this->colonIndex = $colonIndex;
+    }
+
+    /**
+     * @return int
+     */
+    public function getColonIndex()
+    {
+        return $this->colonIndex;
+    }
+}

--- a/src/Tokenizer/Analyzer/Analysis/SwitchAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/SwitchAnalysis.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class SwitchAnalysis
+{
+    /**
+     * @var int
+     */
+    private $casesStart;
+
+    /**
+     * @var int
+     */
+    private $casesEnd;
+
+    /**
+     * @var CaseAnalysis[]
+     */
+    private $cases = [];
+
+    /**
+     * @param int            $casesStart
+     * @param int            $casesEnd
+     * @param CaseAnalysis[] $cases
+     */
+    public function __construct($casesStart, $casesEnd, array $cases)
+    {
+        $this->casesStart = $casesStart;
+        $this->casesEnd = $casesEnd;
+        $this->cases = $cases;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCasesStart()
+    {
+        return $this->casesStart;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCasesEnd()
+    {
+        return $this->casesEnd;
+    }
+
+    /**
+     * @return CaseAnalysis[]
+     */
+    public function getCases()
+    {
+        return $this->cases;
+    }
+}

--- a/src/Tokenizer/Analyzer/SwitchAnalyzer.php
+++ b/src/Tokenizer/Analyzer/SwitchAnalyzer.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\SwitchAnalysis;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @internal
+ */
+final class SwitchAnalyzer
+{
+    /**
+     * @param int $switchIndex
+     *
+     * @return SwitchAnalysis
+     */
+    public function getSwitchAnalysis(Tokens $tokens, $switchIndex)
+    {
+        if (!$tokens[$switchIndex]->isGivenKind(T_SWITCH)) {
+            throw new \InvalidArgumentException(sprintf('Index %d is not "switch".', $switchIndex));
+        }
+
+        $casesStartIndex = $this->getCasesStart($tokens, $switchIndex);
+        $casesEndIndex = $this->getCasesEnd($tokens, $casesStartIndex);
+
+        $cases = [];
+        $ternaryOperatorDepth = 0;
+        $index = $casesStartIndex;
+        while ($index < $casesEndIndex) {
+            ++$index;
+            if ($tokens[$index]->isGivenKind(T_SWITCH)) {
+                $index = (new self())->getSwitchAnalysis($tokens, $index)->getCasesEnd();
+
+                continue;
+            }
+            if ($tokens[$index]->equals('?')) {
+                ++$ternaryOperatorDepth;
+
+                continue;
+            }
+            if (!$tokens[$index]->equals(':')) {
+                continue;
+            }
+            if ($ternaryOperatorDepth > 0) {
+                --$ternaryOperatorDepth;
+
+                continue;
+            }
+            $cases[] = new CaseAnalysis($index);
+        }
+
+        return new SwitchAnalysis($casesStartIndex, $casesEndIndex, $cases);
+    }
+
+    /**
+     * @param int $switchIndex
+     *
+     * @return int
+     */
+    private function getCasesStart(Tokens $tokens, $switchIndex)
+    {
+        /** @var int $parenthesisStartIndex */
+        $parenthesisStartIndex = $tokens->getNextMeaningfulToken($switchIndex);
+        $parenthesisEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $parenthesisStartIndex);
+
+        $casesStartIndex = $tokens->getNextMeaningfulToken($parenthesisEndIndex);
+        \assert(\is_int($casesStartIndex));
+
+        return $casesStartIndex;
+    }
+
+    /**
+     * @param int $casesStartIndex
+     *
+     * @return int
+     */
+    private function getCasesEnd(Tokens $tokens, $casesStartIndex)
+    {
+        if ($tokens[$casesStartIndex]->equals('{')) {
+            return $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $casesStartIndex);
+        }
+
+        $depth = 1;
+        $index = $casesStartIndex;
+        while ($depth > 0) {
+            /** @var int $index */
+            $index = $tokens->getNextMeaningfulToken($index);
+
+            if ($tokens[$index]->isGivenKind(T_ENDSWITCH)) {
+                --$depth;
+
+                continue;
+            }
+
+            if (!$tokens[$index]->isGivenKind(T_SWITCH)) {
+                continue;
+            }
+            $index = $this->getCasesStart($tokens, $index);
+            if ($tokens[$index]->equals(':')) {
+                ++$depth;
+            }
+        }
+
+        /** @var int $afterEndswitchIndex */
+        $afterEndswitchIndex = $tokens->getNextMeaningfulToken($index);
+
+        return $tokens[$afterEndswitchIndex]->equals(';') ? $afterEndswitchIndex : $index;
+    }
+}

--- a/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
@@ -122,6 +122,30 @@ $a = ($b
     : ($d1?$d2:$d3)
 );',
             ],
+            [
+                '<?php
+                $foo = $isBar ? 1 : 2;
+                switch ($foo) {
+                    case 1: return 3;
+                    case 2: return 4;
+                }
+                ',
+                '<?php
+                $foo = $isBar? 1 : 2;
+                switch ($foo) {
+                    case 1: return 3;
+                    case 2: return 4;
+                }
+                ',
+            ],
+            [
+                '<?php
+                return $isBar ? array_sum(array_map(function ($x) { switch ($x) { case 1: return $y ? 2 : 3; case 4: return 5; } }, [1, 2, 3])) : 128;
+                ',
+                '<?php
+                return $isBar?array_sum(array_map(function ($x) { switch ($x) { case 1: return $y? 2 : 3; case 4: return 5; } }, [1, 2, 3])):128;
+                ',
+            ],
         ];
     }
 }

--- a/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer\Analysis;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis;
+
+/**
+ * @covers \PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis
+ *
+ * @internal
+ */
+final class CaseAnalysisTest extends TestCase
+{
+    public function testColonIndex()
+    {
+        $analysis = new CaseAnalysis(20);
+        static::assertSame(20, $analysis->getColonIndex());
+    }
+}

--- a/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer\Analysis;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\SwitchAnalysis;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @covers  \PhpCsFixer\Tokenizer\Analyzer\Analysis\SwitchAnalysis
+ *
+ * @internal
+ */
+final class SwitchAnalysisTest extends TestCase
+{
+    public function testCasesStart()
+    {
+        $analysis = new SwitchAnalysis(10, 20, []);
+        static::assertSame(10, $analysis->getCasesStart());
+    }
+
+    public function testCasesEnd()
+    {
+        $analysis = new SwitchAnalysis(10, 20, []);
+        static::assertSame(20, $analysis->getCasesEnd());
+    }
+
+    public function testCases()
+    {
+        $cases = [new CaseAnalysis(12), new CaseAnalysis(16)];
+
+        $analysis = new SwitchAnalysis(10, 20, $cases);
+        static::assertSame($cases, $analysis->getCases());
+    }
+}

--- a/tests/Tokenizer/Analyzer/SwitchAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/SwitchAnalyzerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\CaseAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\SwitchAnalysis;
+use PhpCsFixer\Tokenizer\Analyzer\SwitchAnalyzer;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author Kuba Werłos <werlos@gmail.com>
+ *
+ * @covers  \PhpCsFixer\Tokenizer\Analyzer\SwitchAnalyzer
+ *
+ * @internal
+ */
+final class SwitchAnalyzerTest extends TestCase
+{
+    public function testForNotSwitch()
+    {
+        $analyzer = new SwitchAnalyzer();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Index 3 is not "switch".');
+
+        $analyzer->getSwitchAnalysis(Tokens::fromCode('<?php $a;$b;$c;'), 3);
+    }
+
+    /**
+     * @dataProvider provideGettingSwitchAnalysisCases
+     *
+     * @param mixed $code
+     * @param mixed $index
+     */
+    public function testGettingSwitchAnalysis(SwitchAnalysis $expected, $code, $index)
+    {
+        $tokens = Tokens::fromCode($code);
+        $analyzer = new SwitchAnalyzer();
+
+        static::assertSame(serialize($expected), serialize(($analyzer->getSwitchAnalysis($tokens, $index))));
+    }
+
+    public static function provideGettingSwitchAnalysisCases()
+    {
+        yield 'two cases' => [
+            new SwitchAnalysis(7, 29, [new CaseAnalysis(12), new CaseAnalysis(22)]),
+            '<?php switch ($foo) { case 10: return true; case 100: return false; }',
+            1,
+        ];
+
+        yield 'two case and default' => [
+            new SwitchAnalysis(7, 37, [new CaseAnalysis(12), new CaseAnalysis(22), new CaseAnalysis(30)]),
+            '<?php switch ($foo) { case 10: return true; case 100: return false; default: return -1;}',
+            1,
+        ];
+
+        yield 'ternary operator in case' => [
+            new SwitchAnalysis(7, 39, [new CaseAnalysis(22), new CaseAnalysis(32)]),
+            '<?php switch ($foo) { case ($bar ? 10 : 20): return true; case 100: return false; }',
+            1,
+        ];
+
+        yield 'nested switch' => [
+            new SwitchAnalysis(7, 67, [new CaseAnalysis(12), new CaseAnalysis(60)]),
+            '<?php switch ($foo) { case 10:
+                switch ($bar) { case "a": return "b"; case "c": return "d"; case "e": return "f"; }
+                return;
+                case 100: return false; }',
+            1,
+        ];
+
+        yield 'switch in case' => [
+            new SwitchAnalysis(7, 98, [new CaseAnalysis(81), new CaseAnalysis(91)]),
+            '<?php switch ($foo) { case (
+                array_sum(array_map(function ($x) { switch ($bar) { case "a": return "b"; case "c": return "d"; case "e": return "f"; } }, [1, 2, 3]))
+            ): return true; case 100: return false; }',
+            1,
+        ];
+
+        yield 'alternative syntax' => [
+            new SwitchAnalysis(7, 30, [new CaseAnalysis(12), new CaseAnalysis(22)]),
+            '<?php switch ($foo) : case 10: return true; case 100: return false; endswitch;',
+            1,
+        ];
+
+        yield 'alternative syntax with closing tag' => [
+            new SwitchAnalysis(7, 29, [new CaseAnalysis(12), new CaseAnalysis(22)]),
+            '<?php switch ($foo) : case 10: return true; case 100: return false; endswitch ?>',
+            1,
+        ];
+
+        yield 'alternative syntax nested' => [
+            new SwitchAnalysis(7, 69, [new CaseAnalysis(12), new CaseAnalysis(61)]),
+            '<?php switch ($foo) : case 10:
+                switch ($bar) : case "a": return "b"; case "c": return "d"; case "e": return "f"; endswitch;
+                return;
+                case 100: return false; endswitch;',
+            1,
+        ];
+
+        if (PHP_VERSION >= 70000) {
+            yield 'function with return type' => [
+                new SwitchAnalysis(7, 43, [new CaseAnalysis(12), new CaseAnalysis(36)]),
+                '<?php switch ($foo) { case 10: function foo($x): int {}; return true; case 100: return false; }',
+                1,
+            ];
+        }
+
+        if (PHP_VERSION >= 70100) {
+            yield 'function with nullable parameter' => [
+                new SwitchAnalysis(7, 43, [new CaseAnalysis(12), new CaseAnalysis(36)]),
+                '<?php switch ($foo) { case 10: function foo(?int $x) {}; return true; case 100: return false; }',
+                1,
+            ];
+        }
+    }
+}


### PR DESCRIPTION
In the original code for each occurrence of `?` it was assumed that the next `:` is the other part of the operator - which is not always true - see the latter test added to `TernaryOperatorSpacesFixerTest.php`.

Also, when there was no whitespace before `?` the operator was counted twice, because:
 - the loop was iterating by increasing index
 - so at one moment `?` was found at index `n`
 - as it had no whitespace before it, the whitespace was added - at index `n`, so the `?` was moved to position `n + 1`
 - next loop iteration with `n + 1` discovered the very same `?` once again and increased `$ternaryLevel` for the second time.

This scenario is covered by the first test added to `TernaryOperatorSpacesFixerTest.php` - the second `:` (the one from `switch`) was recognized as part of the ternary operator.

THE FIX:
As it might look as overkill it is actually copied from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4021 - so it will be reused there and I believe is quite clean and - especially - bulletproof solution.