### PR TITLE
Fixed php-cs-fixer crashes on input file syntax error

### DIFF
--- a/src/Linter/TokenizerLinter.php
+++ b/src/Linter/TokenizerLinter.php
@@ -27,7 +27,7 @@ final class TokenizerLinter implements LinterInterface
 {
     public function __construct()
     {
-        if (false === \defined('TOKEN_PARSE')) {
+        if (false === \defined('TOKEN_PARSE') || false === class_exists(\CompileError::class)) {
             throw new UnavailableLinterException('Cannot use tokenizer as linter.');
         }
     }
@@ -55,7 +55,7 @@ final class TokenizerLinter implements LinterInterface
     {
         try {
             // To lint, we will parse the source into Tokens.
-            // During that process, it might throw ParseError.
+            // During that process, it might throw a ParseError or CompileError.
             // If it won't, cache of tokenized version of source will be kept, which is great for Runner.
             // Yet, first we need to clear already existing cache to not hit it and lint the code indeed.
             $codeHash = CodeHasher::calculateCodeHash($source);
@@ -64,6 +64,8 @@ final class TokenizerLinter implements LinterInterface
 
             return new TokenizerLintingResult();
         } catch (\ParseError $e) {
+            return new TokenizerLintingResult($e);
+        } catch (\CompileError $e) {
             return new TokenizerLintingResult($e);
         }
     }

--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -20,11 +20,11 @@ namespace PhpCsFixer\Linter;
 final class TokenizerLintingResult implements LintingResultInterface
 {
     /**
-     * @var null|\ParseError
+     * @var null|\Error
      */
     private $error;
 
-    public function __construct(\ParseError $error = null)
+    public function __construct(\Error $error = null)
     {
         $this->error = $error;
     }
@@ -36,10 +36,15 @@ final class TokenizerLintingResult implements LintingResultInterface
     {
         if (null !== $this->error) {
             throw new LintingException(
-                sprintf('PHP Parse error: %s on line %d.', $this->error->getMessage(), $this->error->getLine()),
+                sprintf('%s: %s on line %d.', $this->getMessagePrefix(), $this->error->getMessage(), $this->error->getLine()),
                 $this->error->getCode(),
                 $this->error
             );
         }
+    }
+
+    private function getMessagePrefix()
+    {
+        return \get_class($this->error);
     }
 }

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -90,14 +90,6 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
                     "<?php \\{$alias}(\$a);",
                 ];
                 $cases[] = [
-                    "<?php \$ref = &{$master}(\$a);",
-                    "<?php \$ref = &{$alias}(\$a);",
-                ];
-                $cases[] = [
-                    "<?php \$ref = &\\{$master}(\$a);",
-                    "<?php \$ref = &\\{$alias}(\$a);",
-                ];
-                $cases[] = [
                     "<?php {$master}
                                 (\$a);",
                     "<?php {$alias}

--- a/tests/Fixer/Alias/SetTypeToCastFixerTest.php
+++ b/tests/Fixer/Alias/SetTypeToCastFixerTest.php
@@ -225,25 +225,6 @@ $foo#5
     }
 
     /**
-     * @param string      $expected
-     * @param null|string $input
-     *
-     * @requires PHP 7.0
-     * @dataProvider provideFix70Cases
-     */
-    public function testFix70($expected, $input = null)
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        yield 'complex' => [
-            '<?php settype($foo + 1, "null");',
-        ];
-    }
-
-    /**
      * @param string $expected
      * @param string $input
      *

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -41,6 +41,8 @@ final class EncodingFixerTest extends AbstractFixerTestCase
         yield $this->prepareTestCase('test-utf8.case2.php', 'test-utf8.case2-bom.php');
 
         yield ['<?php'];
+
+        yield ['<?php '];
     }
 
     private function prepareTestCase($expectedFilename, $inputFilename = null)

--- a/tests/Fixer/Casing/LowercaseConstantsFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseConstantsFixerTest.php
@@ -107,13 +107,8 @@ final class LowercaseConstantsFixerTest extends AbstractFixerTestCase
             ['<?php echo $null;'],
             ['<?php $x = False::foo();'],
             ['<?php namespace Foo\Null;'],
-            ['<?php use Foo\Null;'],
-            ['<?php use Foo\Null as Null;'],
-            ['<?php class True {} class False {} class Null {}'],
             ['<?php class Foo extends True {}'],
             ['<?php class Foo implements False {}'],
-            ['<?php Class Null { use True; }'],
-            ['<?php interface True {}'],
             ['<?php $foo instanceof True; $foo instanceof False; $foo instanceof Null;'],
             [
                 '<?php
@@ -128,6 +123,30 @@ final class LowercaseConstantsFixerTest extends AbstractFixerTestCase
             ['<?php Null/**/::test();'],
             ['<?php True//
                                 ::test();'],
+            ['<?php class Foo { public function Bar() { $this->False = 1; $this->True = 2; $this->Null = 3; } }'],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp56Cases
+     * @requires PHP < 7
+     */
+    public function testFixPhp56($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixPhp56Cases()
+    {
+        return [
+            ['<?php use Foo\Null;'],
+            ['<?php use Foo\Null as Null;'],
+            ['<?php class True {} class False {} class Null {}'],
+            ['<?php Class Null { use True; }'],
+            ['<?php interface True {}'],
             ['<?php trait False {}'],
             [
                 '<?php
@@ -139,7 +158,6 @@ final class LowercaseConstantsFixerTest extends AbstractFixerTestCase
         }
     }',
             ],
-            ['<?php class Foo { public function Bar() { $this->False = 1; $this->True = 2; $this->Null = 3; } }'],
         ];
     }
 }

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -175,9 +175,6 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
             [
                 '<?php class Foo extends Bar { public function baz() : Self\Qux {} }',
             ],
-            [
-                '<?php namespace Parent;',
-            ],
         ];
     }
 

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -88,15 +88,15 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
-     * @requires PHP 7.0
-     * @dataProvider provideFix70Cases
+     * @requires PHP 7.4
+     * @dataProvider provideFix74Cases
      */
-    public function testFix70($expected, $input = null)
+    public function testFix74($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
 
-    public function provideFix70Cases()
+    public function provideFix74Cases()
     {
         return [
             [

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -83,10 +83,10 @@ function Foo(/**/ARRAY/**/$bar) {
             ],
             [
                 '<?php
-function Foo(array $a, callable $b, self $c) {}
+class Bar { function Foo(array $a, callable $b, self $c) {} }
                 ',
                 '<?php
-function Foo(ARRAY $a, CALLABLE $b, Self $c) {}
+class Bar { function Foo(ARRAY $a, CALLABLE $b, Self $c) {} }
                 ',
             ],
             [

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1055,7 +1055,7 @@ private $d = 123;
             [
                 '<?php
                 class Foo {
-    public abstract function A(){}
+    public function A(){}
 
     /**  */
     public const BAR = 123;
@@ -1068,7 +1068,7 @@ private $d = 123;
 
 
 
-    public abstract function A(){}
+    public function A(){}
 
 
     /**  */

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -138,7 +138,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
                     use some\a\{ClassA, ClassB, ClassC as C};
                     use function some\a\{fn_a, fn_b, fn_c};
                     use const some\a\{ConstA, ConstB, ConstC};
-                    use some\x\{ClassB, function CC as C, function D, const E, function A\B};
+                    use some\x\{ClassD, function CC as C, function D, const E, function A\B};
                     class Foo
                     {
                         public function getBar(): array

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -699,8 +699,8 @@ $b,
     $c#
 #
 )#
-use ($b,
-$c,$d) {
+use ($x,
+$y,$z) {
 };
 EXPECTED
                 ,
@@ -716,8 +716,8 @@ $a#
 $b,$c#
 #
 )#
-use ($b,
-$c,$d) {
+use ($x,
+$y,$z) {
 };
 INPUT
                 ,

--- a/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
+++ b/tests/Fixer/FunctionNotation/StaticLambdaFixerTest.php
@@ -274,8 +274,8 @@ $b->abc();
                 ',
             ],
             [
-                '<?php static fn($a = ["foo" => $this]) => [];',
-                '<?php fn($a = ["foo" => $this]) => [];',
+                '<?php static fn($a = ["foo" => "bar"]) => [];',
+                '<?php fn($a = ["foo" => "bar"]) => [];',
             ],
         ];
     }

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -89,28 +89,28 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
                 '<?php trait Test { public function foo($param) {} }',
             ],
             [
-                '<?php usort([], function ($a, $b): void {});',
-                '<?php usort([], function ($a, $b) {});',
+                '<?php $arr = []; usort($arr, function ($a, $b): void {});',
+                '<?php $arr = []; usort($arr, function ($a, $b) {});',
             ],
             [
-                '<?php $param = 1; usort([], function ($a, $b) use ($param): void {});',
-                '<?php $param = 1; usort([], function ($a, $b) use ($param) {});',
+                '<?php $arr = []; $param = 1; usort($arr, function ($a, $b) use ($param): void {});',
+                '<?php $arr = []; $param = 1; usort($arr, function ($a, $b) use ($param) {});',
             ],
             [
                 '<?php function foo($param) { return function($a) use ($param): void {}; }',
                 '<?php function foo($param) { return function($a) use ($param) {}; }',
             ],
             [
-                '<?php function foo($param): void { usort([], function ($a, $b) use ($param): void {}); }',
-                '<?php function foo($param) { usort([], function ($a, $b) use ($param) {}); }',
+                '<?php function foo($param): void { $arr = []; usort($arr, function ($a, $b) use ($param): void {}); }',
+                '<?php function foo($param) { $arr = []; usort($arr, function ($a, $b) use ($param) {}); }',
             ],
             [
-                '<?php function foo() { return usort([], new class { public function __invoke($a, $b): void {} }); }',
-                '<?php function foo() { return usort([], new class { public function __invoke($a, $b) {} }); }',
+                '<?php function foo() { $arr = []; return usort($arr, new class { public function __invoke($a, $b): void {} }); }',
+                '<?php function foo() { $arr = []; return usort($arr, new class { public function __invoke($a, $b) {} }); }',
             ],
             [
-                '<?php function foo(): void { usort([], new class { public function __invoke($a, $b): void {} }); }',
-                '<?php function foo() { usort([], new class { public function __invoke($a, $b) {} }); }',
+                '<?php function foo(): void { $arr = []; usort($arr, new class { public function __invoke($a, $b): void {} }); }',
+                '<?php function foo() { $arr = []; usort($arr, new class { public function __invoke($a, $b) {} }); }',
             ],
             [
                 '<?php
@@ -202,7 +202,7 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
                     /**
                      * @return void
                      */
-                    abstract private function foo($param): void;
+                    abstract protected function foo($param): void;
                 }',
 
                 '<?php
@@ -210,7 +210,7 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
                     /**
                      * @return void
                      */
-                    abstract private function foo($param);
+                    abstract protected function foo($param);
                 }',
             ],
         ];

--- a/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
+++ b/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
@@ -213,7 +213,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
 use const some\a\{ConstA,ConstB,ConstC
 ,
 };
-use const some\Z\{ConstA,ConstB,ConstC,};
+use const some\Z\{ConstX,ConstY,ConstZ,};
 ',
                 '<?php
 namespace AAA;
@@ -222,7 +222,7 @@ use function \some\a\{fn_a, fn_b, fn_c,};
 use const \some\a\{ConstA,ConstB,ConstC
 ,
 };
-use const \some\Z\{ConstA,ConstB,ConstC,};
+use const \some\Z\{ConstX,ConstY,ConstZ,};
 ',
             ],
         ];

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -660,30 +660,30 @@ use some\b\{
 };
 use const some\a\{ConstA, ConstB, ConstC};
 use const some\b\{
-    ConstA,
-    ConstB,
-    ConstC
+    ConstX,
+    ConstY,
+    ConstZ
 };
 use function some\a\{fn_a, fn_b, fn_c};
 use function some\b\{
-    fn_a,
-    fn_b,
-    fn_c
+    fn_x,
+    fn_y,
+    fn_z
 };
 ',
                 '<?php
 use some\a\{ClassA, ClassB, ClassC as C};
 use function some\b\{
-    fn_b,
-    fn_c,
-    fn_a
+    fn_y,
+    fn_z,
+    fn_x
 };
 use function some\a\{fn_a, fn_b, fn_c};
 use A\B;
 use const some\b\{
-    ConstC,
-    ConstA,
-    ConstB
+    ConstZ,
+    ConstX,
+    ConstY
 };
 use const some\a\{ConstA, ConstB, ConstC};
 use some\b\{
@@ -733,29 +733,29 @@ use some\b\{
     ClassG
 };
 use const some\b\{
-    ConstA,
-    ConstB,
-    ConstC
+    ConstX,
+    ConstY,
+    ConstZ
 };
 use function some\b\{
-    fn_a,
-    fn_b,
-    fn_c
+    fn_x,
+    fn_y,
+    fn_z
 };
 ',
                 '<?php
 use some\a\{ClassA, ClassB, ClassC as C};
 use function some\b\{
-    fn_b,
-    fn_c,
-    fn_a
+    fn_y,
+    fn_z,
+    fn_x
 };
 use function some\a\{fn_a, fn_b, fn_c};
 use A\B;
 use const some\b\{
-    ConstC,
-    ConstA,
-    ConstB
+    ConstZ,
+    ConstX,
+    ConstY
 };
 use const some\a\{ConstA, ConstB, ConstC};
 use some\b\{
@@ -1753,7 +1753,7 @@ use some\b\{
 use function some\a\{fn_a, fn_b, fn_c};
 use some\b\{ClassA, ClassB, ClassC as C};
 use const some\a\{ConstA, ConstB, ConstC};
-use some\a\{ClassA as A /*z*/, ClassB, ClassC};
+use some\a\{ClassX as X /*z*/, ClassY, ClassZ};
 use Some\Biz\Barz\Boozz\Foz\Which\Is\Really\Long;
 use const some\b\{ConstG, ConstX, ConstY, ConstZ};
 use some\c\{ClassR, ClassT, ClassV as V, NiceClassName};
@@ -1771,7 +1771,7 @@ use some\b\{
 use const some\a\{ConstB, ConstA, ConstC};
 use const some\b\{ConstX, ConstY, ConstZ, ConstG};
 use some\b\{ClassA, ClassB, ClassC as C};
-use some\a\{  ClassB,ClassC, /*z*/ ClassA as A};
+use some\a\{  ClassY,ClassZ, /*z*/ ClassX as X};
 ',
             ],
             [
@@ -1820,7 +1820,7 @@ use some\b\{
 };
 use some\a\{ClassA, ClassB, ClassC as C};
 use some\b\{ClassK, ClassL, ClassM as M};
-use some\a\{ClassA as A /*z*/, ClassB, ClassC};
+use some\a\{ClassX as X /*z*/, ClassY, ClassZ};
 use const some\a\{ConstA, ConstB, ConstC};
 use const some\b\{ConstD, ConstE, ConstF};
 use function some\a\{fn_a, fn_b};
@@ -1832,7 +1832,7 @@ use const some\a\{ConstA, ConstB, ConstC};
 use some\a\{ClassA, ClassB, ClassC as C};
 use Foo\Zar\Baz;
 use some\b\{ClassK, ClassL, ClassM as M};
-use some\a\{ClassA as A /*z*/, ClassB, ClassC};
+use some\a\{ClassX as X /*z*/, ClassY, ClassZ};
 use A\B;
 use some\b\{
     ClassF,

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -491,7 +491,7 @@ class Bar {}
             'some\a\{ClassA, ClassB, ClassC as C,};',
             'function some\a\{fn_a, fn_b, fn_c,};',
             'const some\a\{ConstA,ConstB,ConstC,};',
-            'const some\Z\{ConstA,ConstB,ConstC,};',
+            'const some\Z\{ConstX,ConstY,ConstZ,};',
         ];
 
         $cases = [

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -272,33 +272,43 @@ final class ClassKeywordRemoveFixerTest extends AbstractFixerTestCase
                 echo ClassB::class;
                 echo C::class;
                 ',
-            ],
-            [
                 "<?php
-                var_dump('Foo');
+                namespace {
+                    var_dump('Foo');
+                }
                 namespace A {
                     use B\\C;
                     var_dump('B\\C');
                 }
-                var_dump('Bar\\Baz');
+                namespace {
+                    var_dump('Bar\\Baz');
+                }
                 namespace B {
                     use A\\C\\D;
                     var_dump('A\\C\\D');
                 }
-                var_dump('Qux\\Quux');
+                namespace {
+                    var_dump('Qux\\Quux');
+                }
                 ",
                 '<?php
-                var_dump(Foo::class);
+                namespace {
+                    var_dump(Foo::class);
+                }
                 namespace A {
                     use B\\C;
                     var_dump(C::class);
                 }
-                var_dump(Bar\\Baz::class);
+                namespace {
+                    var_dump(Bar\\Baz::class);
+                }
                 namespace B {
                     use A\\C\\D;
                     var_dump(D::class);
                 }
-                var_dump(Qux\\Quux::class);
+                namespace {
+                    var_dump(Qux\\Quux::class);
+                }
                 ',
             ],
         ];

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -254,6 +254,9 @@ get_called_class#1
                 null,
                 ['functions' => ['get_class_this']],
             ],
+            [
+                "<?php namespace Foo;\nfunction &PHPversion(){}",
+            ],
         ];
     }
 
@@ -283,26 +286,5 @@ get_called_class#1
         $this->expectExceptionMessageRegExp('#^\[function_to_constant\] Invalid configuration: The option "0" does not exist\. Defined options are: "functions"\.$#');
 
         $this->fixer->configure(['pi123']);
-    }
-
-    /**
-     * @param string      $expected
-     * @param null|string $input
-     *
-     * @requires PHP 7.0
-     * @dataProvider provideFix70Cases
-     */
-    public function testFix70($expected, $input = null)
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
-            [
-                '<?php function &PHPversion(){} ?>',
-            ],
-        ];
     }
 }

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -208,6 +208,42 @@ $a;#
     {
         return [
             [
+                '<?php [$a, $b,, [$c, $d]] = $a;',
+                '<?php list($a, $b,, list($c, $d)) = $a;',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @requires PHP 7.3
+     * @dataProvider providePhp73Cases
+     */
+    public function testFixToShortSyntaxPhp73($expected, $input)
+    {
+        $this->fixer->configure(['syntax' => 'short']);
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected
+     *
+     * @requires PHP 7.3
+     * @dataProvider providePhp73Cases
+     */
+    public function testFixToLongSyntaxPhp73($input, $expected)
+    {
+        $this->fixer->configure(['syntax' => 'long']);
+        $this->doTest($expected, $input);
+    }
+
+    public function providePhp73Cases()
+    {
+        return [
+            [
                 '<?php [&$a, $b] = $a;',
                 '<?php list(&$a, $b) = $a;',
             ],
@@ -218,10 +254,6 @@ $a;#
             [
                 '<?php [&$a, $b,, [&$c, $d]] = $a;',
                 '<?php list(&$a, $b,, list(&$c, $d)) = $a;',
-            ],
-            [
-                '<?php [$a, $b,, [$c, $d]] = $a;',
-                '<?php list($a, $b,, list($c, $d)) = $a;',
             ],
         ];
     }

--- a/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
+++ b/tests/Fixer/ReturnNotation/SimplifiedNullReturnFixerTest.php
@@ -89,7 +89,6 @@ final class SimplifiedNullReturnFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php function foo(): void { return; }',
-                '<?php function foo(): void { return null; }',
             ],
         ];
     }

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -35,7 +35,7 @@ class Test {
     public function testThrow($a)
     {
         if ($a) {
-            throw new InvalidArgumentException('test'); // test
+            throw new InvalidArgumentException('test.'); // test
 
         }
         $date = new DateTime();
@@ -854,8 +854,8 @@ class Foo
                 "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
             ],
             [
-                "<?php throw new \\Exception('do not import');\n",
-                "<?php throw new \\Exception('do not import');\n\n",
+                "<?php throw new \\Exception('do not import.');\n",
+                "<?php throw new \\Exception('do not import.');\n\n",
             ],
             [
                 "<?php\n\n\$a = \$b{0};\n\n",
@@ -1207,7 +1207,7 @@ use function some\a\{fn_a, fn_b, fn_c,};
 use const some\a\{ConstA,ConstB,ConstC
 ,
 };
-use const some\Z\{ConstA,ConstB,ConstC,};
+use const some\Z\{ConstX,ConstY,ConstZ,};
 ',
             '<?php
 use some\a\{ClassA, ClassB, ClassC as C,};
@@ -1219,7 +1219,7 @@ use const some\a\{ConstA,ConstB,ConstC
 ,
 };
   '.'
-use const some\Z\{ConstA,ConstB,ConstC,};
+use const some\Z\{ConstX,ConstY,ConstZ,};
 ',
         ];
     }

--- a/tests/Fixtures/Integration/misc/PHP7_0.test
+++ b/tests/Fixtures/Integration/misc/PHP7_0.test
@@ -24,14 +24,14 @@ use function some\a\fn_a;
 use function some\a\fn_b;
 use function some\a\fn_c;
 use function some\x\CC as C;
-use some\x\ClassB;
+use some\x\ClassX;
 use function some\x\D;
 use const some\x\E;
 
 function dummyUsage()
 {
     // class' class const
-    echo ClassA::class.ClassB::class.C::class.E;
+    echo ClassA::class.ClassB::class.ClassX::class.C::class.E;
 
     fn_a(fn_b(fn_c()));
     D();
@@ -136,12 +136,12 @@ declare (strict_types = 1);
 use some\a\{ClassA, ClassB, ClassC as C};
 use function some\a\{fn_a, fn_b, fn_c};
 use const some\a\{ConstA, ConstB, ConstC};
-use some\x\{ClassB, function CC as C, function D, const E, function A\B};
+use some\x\{ClassX, function CC as C, function D, const E, function A\B};
 
 function dummyUsage()
 {
     // class' class const
-    echo ClassA::class . ClassB::class . C::class.E;
+    echo ClassA::class . ClassB::class . ClassX::class . C::class.E;
 
     fn_a(fn_b(fn_c())); D();
 

--- a/tests/Fixtures/Linter/multiple.php
+++ b/tests/Fixtures/Linter/multiple.php
@@ -1,0 +1,5 @@
+<?php
+
+class Foo {
+    public protected $foo;
+}

--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -68,6 +68,10 @@ abstract class AbstractLinterTestCase extends TestCase
                 __DIR__.'/../Fixtures/Linter/invalid.php',
                 '/syntax error, unexpected.*("echo"|T_ECHO).*line 5/',
             ],
+            [
+                __DIR__.'/../Fixtures/Linter/multiple.php',
+                '/Multiple access type modifiers are not allowed.*line 4/',
+            ],
         ];
     }
 

--- a/tests/Linter/LinterTest.php
+++ b/tests/Linter/LinterTest.php
@@ -25,7 +25,7 @@ final class LinterTest extends AbstractLinterTestCase
 {
     public function testIsAsync()
     {
-        static::assertSame(!\defined('TOKEN_PARSE'), $this->createLinter()->isAsync());
+        static::assertSame(!class_exists(\CompileError::class), $this->createLinter()->isAsync());
     }
 
     /**

--- a/tests/Linter/TokenizerLinterTest.php
+++ b/tests/Linter/TokenizerLinterTest.php
@@ -19,7 +19,7 @@ use PhpCsFixer\Linter\TokenizerLinter;
  *
  * @internal
  *
- * @requires PHP 7.0
+ * @requires PHP 7.3
  * @covers \PhpCsFixer\Linter\TokenizerLinter
  * @covers \PhpCsFixer\Linter\TokenizerLintingResult
  */

--- a/tests/Linter/TokenizerLintingResultTest.php
+++ b/tests/Linter/TokenizerLintingResultTest.php
@@ -43,9 +43,11 @@ final class TokenizerLintingResultTest extends TestCase
         $this->expectException(
             \PhpCsFixer\Linter\LintingException::class
         );
+
         $this->expectExceptionMessageRegExp(
-            sprintf('#^PHP Parse error: PHPUnit on line %d.#', $line)
+            sprintf('#^%s: PHPUnit on line %d\.#', preg_quote(\get_class($error), '#'), $line)
         );
+
         $this->expectExceptionCode(
             567
         );


### PR DESCRIPTION
1. Some tokenizing lintier errors on PHP 7.0-7.2 cause the entire PHP process to fatal error. This was fixed in PHP 7.3, and so we should only use this linter on PHP 7.3 (catching the new type of error it can raise, instead of crashing).
2. The above change highlighted the fact that some of the code samples in the tests are only valid on PHP 5, or are not valid at all. Those that are not valid on PHP 7, but are valid on PHP 5, I've updated to only run on PHP 5. Those that are not valid syntax, but can be corrected, I have corrected. Those that are just totally incorrect, have been removed.

---

Closes #5067.