### PR TITLE
Explicitly define visibility_required elements for PSR2

### DIFF
--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -54,7 +54,7 @@ final class RuleSet implements RuleSetInterface
             'single_line_after_imports' => true,
             'switch_case_semicolon_to_colon' => true,
             'switch_case_space' => true,
-            'visibility_required' => true,
+            'visibility_required' => ['elements' => ['method', 'property']],
         ],
         '@Symfony' => [
             '@PSR2' => true,

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -232,7 +232,7 @@ final class RuleSetTest extends TestCase
                 'strict_comparison' => true,
                 'switch_case_semicolon_to_colon' => true,
                 'switch_case_space' => true,
-                'visibility_required' => true,
+                'visibility_required' => ['elements' => ['method', 'property']],
             ],
             $ruleSet->getRules()
         );
@@ -271,7 +271,7 @@ final class RuleSetTest extends TestCase
                 'single_line_after_imports' => true,
                 'switch_case_semicolon_to_colon' => true,
                 'switch_case_space' => true,
-                'visibility_required' => true,
+                'visibility_required' => ['elements' => ['method', 'property']],
             ],
             $ruleSet->getRules()
         );


### PR DESCRIPTION
This is so that the PSR2 present doesn't accidentally fix too much if the default is later changed.