### PR TITLE
DX: add missing priority test between NoUnsetCastFixer and BinaryOperatorSpacesFixer

### DIFF
--- a/src/Fixer/CastNotation/NoUnsetCastFixer.php
+++ b/src/Fixer/CastNotation/NoUnsetCastFixer.php
@@ -44,6 +44,16 @@ final class NoUnsetCastFixer extends AbstractFixer
 
     /**
      * {@inheritdoc}
+     *
+     * Must run before BinaryOperatorSpacesFixer.
+     */
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -223,7 +223,7 @@ $foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
     /**
      * {@inheritdoc}
      *
-     * Must run after ArrayIndentationFixer, ArraySyntaxFixer, ListSyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer.
+     * Must run after ArrayIndentationFixer, ArraySyntaxFixer, ListSyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, NoUnsetCastFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer.
      */
     public function getPriority()
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -158,6 +158,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_else']],
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_return']],
             [$fixers['no_unneeded_curly_braces'], $fixers['return_assignment']],
+            [$fixers['no_unset_cast'], $fixers['binary_operator_spaces']],
             [$fixers['no_unset_on_property'], $fixers['combine_consecutive_unsets']],
             [$fixers['no_unused_imports'], $fixers['blank_line_after_namespace']],
             [$fixers['no_unused_imports'], $fixers['no_extra_blank_lines']],

--- a/tests/Fixtures/Integration/priority/no_unset_cast,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/no_unset_cast,binary_operator_spaces.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: no_unset_cast,binary_operator_spaces.
+--RULESET--
+{"no_unset_cast": true, "binary_operator_spaces": true}
+--EXPECT--
+<?php
+
+$foo = null;
+
+--INPUT--
+<?php
+
+$foo = (unset) $bar;


### PR DESCRIPTION
The priorities are currently fine, but let's make sure they stays fine.