### PR TITLE
DX: automatically generate priorities basing on priority tests

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -3,6 +3,7 @@
         "Symfony\\Contracts\\EventDispatcher\\Event",
         "Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface",
         "Symfony\\Component\\EventDispatcher\\Event",
+        "PhpCsFixer\\Tests\\AutoReview\\FixerFactoryTest",
         "PhpCsFixer\\PhpunitConstraintIsIdenticalString\\Constraint\\IsIdenticalString",
         "PhpCsFixer\\Tests\\Test\\Constraint\\SameStringsConstraint",
         "PhpCsFixer\\Tests\\Test\\IsIdenticalConstraint",

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 /phpmd.xml export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
+/src/Priority/ export-ignore
 
 *       text=auto eol=lf
 *.json  text whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,13 +16,17 @@ $finder = PhpCsFixer\Finder::create()
     ->append([__DIR__.'/php-cs-fixer'])
 ;
 
+$priorityFixer = new \PhpCsFixer\Priority\PriorityFixer();
+
 $config = PhpCsFixer\Config::create()
+    ->registerCustomFixers([$priorityFixer])
     ->setRiskyAllowed(true)
     ->setRules([
         '@PHP56Migration' => true,
         '@PHPUnit60Migration:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
+        $priorityFixer->getName() => true,
         'header_comment' => ['header' => $header],
         'list_syntax' => ['syntax' => 'long'],
     ])

--- a/src/AbstractPsrAutoloadingFixer.php
+++ b/src/AbstractPsrAutoloadingFixer.php
@@ -44,14 +44,6 @@ abstract class AbstractPsrAutoloadingFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
-    {
-        return -10;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function supports(\SplFileInfo $file)
     {
         if ($file instanceof StdinFileInfo) {

--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -161,7 +161,7 @@ mbereg_search_getregs();
      */
     public function getPriority()
     {
-        return 0;
+        return 6;
     }
 
     /**

--- a/src/Fixer/Alias/NoMixedEchoPrintFixer.php
+++ b/src/Fixer/Alias/NoMixedEchoPrintFixer.php
@@ -80,7 +80,7 @@ final class NoMixedEchoPrintFixer extends AbstractFixer implements Configuration
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Alias/PowToExponentiationFixer.php
+++ b/src/Fixer/Alias/PowToExponentiationFixer.php
@@ -58,7 +58,7 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
      */
     public function getPriority()
     {
-        return 3;
+        return 5;
     }
 
     /**

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -129,7 +129,7 @@ class Foo
      */
     public function getPriority()
     {
-        return -25;
+        return 6;
     }
 
     /**

--- a/src/Fixer/Basic/EncodingFixer.php
+++ b/src/Fixer/Basic/EncodingFixer.php
@@ -58,7 +58,7 @@ echo "Hello!";
     public function getPriority()
     {
         // must run first (at least before Fixers that using Tokens) - for speed reason of whole fixing process
-        return 100;
+        return 19;
     }
 
     /**

--- a/src/Fixer/CastNotation/CastSpacesFixer.php
+++ b/src/Fixer/CastNotation/CastSpacesFixer.php
@@ -68,7 +68,7 @@ final class CastSpacesFixer extends AbstractFixer implements ConfigurationDefini
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/CastNotation/NoShortBoolCastFixer.php
+++ b/src/Fixer/CastNotation/NoShortBoolCastFixer.php
@@ -30,7 +30,7 @@ final class NoShortBoolCastFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -9;
+        return 1;
     }
 
     /**

--- a/src/Fixer/CastNotation/NoUnsetCastFixer.php
+++ b/src/Fixer/CastNotation/NoUnsetCastFixer.php
@@ -36,6 +36,16 @@ final class NoUnsetCastFixer extends AbstractFixer
 
     /**
      * {@inheritdoc}
+     *
+     * Must run before BinaryOperatorSpacesFixer.
+     */
+    public function getPriority()
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens)
     {

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -110,7 +110,7 @@ class Sample
      */
     public function getPriority()
     {
-        return 55;
+        return 13;
     }
 
     /**

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -77,7 +77,7 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
      */
     public function getPriority()
     {
-        return 67;
+        return 16;
     }
 
     /**

--- a/src/Fixer/ClassNotation/MethodSeparationFixer.php
+++ b/src/Fixer/ClassNotation/MethodSeparationFixer.php
@@ -58,7 +58,7 @@ final class Sample
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 13;
     }
 
     /**

--- a/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+++ b/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
@@ -53,7 +53,7 @@ class Foo
      */
     public function getPriority()
     {
-        return 75;
+        return 15;
     }
 
     /**

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -217,7 +217,7 @@ class Example
      */
     public function getPriority()
     {
-        return 65;
+        return 14;
     }
 
     /**

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -57,7 +57,7 @@ final class Sample
      */
     public function getPriority()
     {
-        return 66;
+        return 15;
     }
 
     /**

--- a/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php
@@ -50,7 +50,7 @@ final class SingleClassElementPerStatementFixer extends AbstractFixer implements
      */
     public function getPriority()
     {
-        return 56;
+        return 14;
     }
 
     /**

--- a/src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
+++ b/src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php
@@ -49,7 +49,7 @@ final class Example
      */
     public function getPriority()
     {
-        return 1;
+        return 7;
     }
 
     public function isCandidate(Tokens $tokens)

--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -51,7 +51,7 @@ final class CommentToPhpdocFixer extends AbstractFixer implements WhitespacesAwa
     public function getPriority()
     {
         // Should be run before all other PHPDoc fixers
-        return 26;
+        return 13;
     }
 
     /**

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -120,7 +120,7 @@ echo 1;
         // When this fixer is configured with ["separate" => "bottom", "comment_type" => "PHPDoc"]
         // and the target file has no namespace or declare() construct,
         // the fixed header comment gets trimmed by NoBlankLinesAfterPhpdocFixer if we run before it.
-        return -30;
+        return 0;
     }
 
     /**

--- a/src/Fixer/ControlStructure/ElseifFixer.php
+++ b/src/Fixer/ControlStructure/ElseifFixer.php
@@ -44,7 +44,7 @@ final class ElseifFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 7;
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+++ b/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
@@ -69,7 +69,7 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 26;
+        return 8;
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+++ b/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
@@ -49,7 +49,7 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 0;
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -111,7 +111,7 @@ yield(2);
      */
     public function getPriority()
     {
-        return 30;
+        return 1;
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php
@@ -65,7 +65,7 @@ namespace Foo {
      */
     public function getPriority()
     {
-        return 26;
+        return 8;
     }
 
     /**

--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -51,7 +51,7 @@ final class NoUselessElseFixer extends AbstractNoUselessElseFixer
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 7;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+++ b/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
@@ -67,7 +67,7 @@ final class CombineNestedDirnameFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 3;
+        return 5;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/ImplodeCallFixer.php
+++ b/src/Fixer/FunctionNotation/ImplodeCallFixer.php
@@ -65,7 +65,7 @@ final class ImplodeCallFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -1;
+        return 5;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -133,7 +133,7 @@ SAMPLE
      */
     public function getPriority()
     {
-        return -30;
+        return 4;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -45,7 +45,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 2;
+        return 3;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -151,7 +151,7 @@ function bar() {}
      */
     public function getPriority()
     {
-        return 13;
+        return 7;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -64,7 +64,7 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
      */
     public function getPriority()
     {
-        return -17;
+        return 0;
     }
 
     /**

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -54,7 +54,7 @@ final class VoidReturnFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 5;
+        return 4;
     }
 
     /**

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -80,7 +80,7 @@ class SomeClass
      */
     public function getPriority()
     {
-        return 7;
+        return 6;
     }
 
     /**

--- a/src/Fixer/Import/NoLeadingImportSlashFixer.php
+++ b/src/Fixer/Import/NoLeadingImportSlashFixer.php
@@ -44,7 +44,7 @@ final class NoLeadingImportSlashFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -20;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -47,7 +47,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -10;
+        return 2;
     }
 
     /**

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -163,7 +163,7 @@ use Bar;
      */
     public function getPriority()
     {
-        return -30;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -47,7 +47,7 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
      */
     public function getPriority()
     {
-        return 1;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Import/SingleLineAfterImportsFixer.php
+++ b/src/Fixer/Import/SingleLineAfterImportsFixer.php
@@ -80,7 +80,7 @@ final class Example
      */
     public function getPriority()
     {
-        return -11;
+        return 0;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -58,7 +58,7 @@ $className = Baz::class;
      */
     public function getPriority()
     {
-        return 0;
+        return 3;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php
@@ -41,7 +41,7 @@ final class CombineConsecutiveIssetsFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 3;
+        return 4;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -42,7 +42,7 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 24;
+        return 2;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/DirConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/DirConstantFixer.php
@@ -51,7 +51,7 @@ final class DirConstantFixer extends AbstractFunctionReferenceFixer
      */
     public function getPriority()
     {
-        return 4;
+        return 6;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/FunctionToConstantFixer.php
@@ -105,7 +105,7 @@ final class FunctionToConstantFixer extends AbstractFixer implements Configurati
      */
     public function getPriority()
     {
-        return 1;
+        return 2;
     }
 
     /**

--- a/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
+++ b/src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
@@ -63,7 +63,7 @@ final class NoUnsetOnPropertyFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 25;
+        return 3;
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)

--- a/src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php
@@ -48,7 +48,7 @@ final class BlankLineAfterNamespaceFixer extends AbstractFixer implements Whites
      */
     public function getPriority()
     {
-        return -20;
+        return 0;
     }
 
     /**

--- a/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
+++ b/src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php
@@ -51,7 +51,7 @@ final class SingleBlankLineBeforeNamespaceFixer extends AbstractLinesBeforeNames
      */
     public function getPriority()
     {
-        return -21;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -223,11 +223,11 @@ $foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
     /**
      * {@inheritdoc}
      *
-     * Must run after ArrayIndentationFixer, ArraySyntaxFixer, ListSyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer.
+     * Must run after ArrayIndentationFixer, ArraySyntaxFixer, ListSyntaxFixer, NoMultilineWhitespaceAroundDoubleArrowFixer, NoUnsetCastFixer, PowToExponentiationFixer, StandardizeNotEqualsFixer, StrictComparisonFixer.
      */
     public function getPriority()
     {
-        return -32;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSpaceFixer.php
@@ -48,7 +48,7 @@ if (!$bar) {
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
@@ -48,7 +48,7 @@ if (!$bar) {
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Operator/StandardizeNotEqualsFixer.php
+++ b/src/Fixer/Operator/StandardizeNotEqualsFixer.php
@@ -41,7 +41,7 @@ final class StandardizeNotEqualsFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Operator/UnaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/UnaryOperatorSpacesFixer.php
@@ -41,7 +41,7 @@ final class UnaryOperatorSpacesFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/PhpTag/FullOpeningTagFixer.php
+++ b/src/Fixer/PhpTag/FullOpeningTagFixer.php
@@ -50,7 +50,7 @@ echo "Hello!";
     public function getPriority()
     {
         // must run before all Token-based fixers
-        return 98;
+        return 18;
     }
 
     /**

--- a/src/Fixer/PhpTag/NoShortEchoTagFixer.php
+++ b/src/Fixer/PhpTag/NoShortEchoTagFixer.php
@@ -41,7 +41,7 @@ final class NoShortEchoTagFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -89,7 +89,7 @@ $this->assertNotSame(null, $d);
      */
     public function getPriority()
     {
-        return -10;
+        return 2;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php
@@ -172,7 +172,7 @@ $this->assertTrue(is_readable($a));
      */
     public function getPriority()
     {
-        return -15;
+        return 1;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
@@ -99,7 +99,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
      */
     public function getPriority()
     {
-        return -16;
+        return 0;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php
@@ -58,7 +58,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     public function getPriority()
     {
-        return -9;
+        return 3;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php
@@ -55,7 +55,7 @@ final class PhpUnitInternalClassFixer extends AbstractFixer implements Whitespac
      */
     public function getPriority()
     {
-        return 68;
+        return 17;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -109,7 +109,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     public function getPriority()
     {
-        return 10;
+        return 3;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php
@@ -54,7 +54,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php
@@ -73,7 +73,7 @@ public function testItDoesSomething() {}}'.$this->whitespacesConfig->getLineEndi
      */
     public function getPriority()
     {
-        return 10;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
+++ b/src/Fixer/Phpdoc/AlignMultilineCommentFixer.php
@@ -91,7 +91,7 @@ with a line not prefixed with asterisk
      */
     public function getPriority()
     {
-        return -40;
+        return 2;
     }
 
     /**

--- a/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
+++ b/src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php
@@ -70,7 +70,7 @@ function foo() {}
      */
     public function getPriority()
     {
-        return 10;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php
@@ -62,7 +62,7 @@ class Bar {}
      */
     public function getPriority()
     {
-        return -20;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
+++ b/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -42,7 +42,7 @@ final class NoEmptyPhpdocFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 3;
+        return 2;
     }
 
     /**

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -87,7 +87,7 @@ class Foo {
      */
     public function getPriority()
     {
-        return 6;
+        return 5;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -83,7 +83,7 @@ function f9(string $foo, $bar, $baz) {}
      */
     public function getPriority()
     {
-        return 10;
+        return 6;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -155,7 +155,7 @@ EOF;
          * annotations are of the correct type, and are grouped correctly
          * before running this fixer.
          */
-        return -42;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php
@@ -51,7 +51,7 @@ function foo ($bar) {}
      */
     public function getPriority()
     {
-        return 17;
+        return 10;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocIndentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocIndentFixer.php
@@ -53,7 +53,7 @@ class DocBlocks
      */
     public function getPriority()
     {
-        return 20;
+        return 11;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocInlineTagFixer.php
@@ -52,7 +52,7 @@ final class PhpdocInlineTagFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -54,7 +54,7 @@ class Foo
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php
@@ -89,7 +89,7 @@ final class Example
      */
     public function getPriority()
     {
-        return 11;
+        return 7;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php
@@ -69,7 +69,7 @@ function foo() {}
      */
     public function getPriority()
     {
-        return 4;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -54,7 +54,7 @@ class Baz
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php
@@ -49,7 +49,7 @@ final class PhpdocNoUselessInheritdocFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 6;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -65,7 +65,7 @@ final class PhpdocOrderFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -2;
+        return 2;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -109,7 +109,7 @@ class Sample
      */
     public function getPriority()
     {
-        return 10;
+        return 6;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -95,7 +95,7 @@ function sample($a, $b, $c)
          * the phpdoc_types_fixer because it can convert types to things that
          * we can fix.
          */
-        return 15;
+        return 8;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -60,7 +60,7 @@ function fnc($foo, $bar) {}
      */
     public function getPriority()
     {
-        return -3;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php
@@ -45,7 +45,7 @@ final class PhpdocSingleLineVarSpacingFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -10;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSummaryFixer.php
@@ -50,7 +50,7 @@ function foo () {}
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocToCommentFixer.php
@@ -46,7 +46,7 @@ final class PhpdocToCommentFixer extends AbstractFixer
          * don't touch doc comments which are meant to be converted to regular
          * comments.
          */
-        return 25;
+        return 12;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php
@@ -67,7 +67,7 @@ function fnc($foo) {}
      */
     public function getPriority()
     {
-        return -41;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocTrimFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTrimFixer.php
@@ -51,7 +51,7 @@ final class Foo {}
      */
     public function getPriority()
     {
-        return -5;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocTypesFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesFixer.php
@@ -128,7 +128,7 @@ final class PhpdocTypesFixer extends AbstractPhpdocTypesFixer implements Configu
          * the type and thereby un-aligning the params. We also must run before
          * the phpdoc_scalar_fixer so that it can make changes after us.
          */
-        return 16;
+        return 9;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -92,7 +92,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements Configuration
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixer.php
@@ -43,7 +43,7 @@ $foo = 2 + 2;
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     public function isCandidate(Tokens $tokens)

--- a/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php
@@ -59,7 +59,7 @@ final class Foo
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
+++ b/src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php
@@ -47,7 +47,7 @@ final class BlankLineBeforeReturnFixer extends AbstractProxyFixer implements Dep
      */
     public function getPriority()
     {
-        return parent::getPriority();
+        return 0;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -60,7 +60,7 @@ function example($b) {
      */
     public function getPriority()
     {
-        return -18;
+        return 2;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -43,7 +43,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return -15;
+        return 1;
     }
 
     /**

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -57,7 +57,7 @@ EOT
      */
     public function getPriority()
     {
-        return 16;
+        return 5;
     }
 
     /**

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -76,7 +76,7 @@ function foo () {
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Semicolon/NoEmptyStatementFixer.php
+++ b/src/Fixer/Semicolon/NoEmptyStatementFixer.php
@@ -42,7 +42,7 @@ final class NoEmptyStatementFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 26;
+        return 8;
     }
 
     /**

--- a/src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
+++ b/src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php
@@ -56,7 +56,7 @@ final class SpaceAfterSemicolonFixer extends AbstractFixer implements Configurat
      */
     public function getPriority()
     {
-        return -1;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Strict/StrictComparisonFixer.php
+++ b/src/Fixer/Strict/StrictComparisonFixer.php
@@ -40,7 +40,7 @@ final class StrictComparisonFixer extends AbstractFixer
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
+++ b/src/Fixer/StringNotation/ExplicitStringVariableFixer.php
@@ -57,7 +57,7 @@ EOT
      */
     public function getPriority()
     {
-        return 0;
+        return 1;
     }
 
     /**

--- a/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
+++ b/src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php
@@ -62,7 +62,7 @@ EOT
      */
     public function getPriority()
     {
-        return -10;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Whitespace/ArrayIndentationFixer.php
+++ b/src/Fixer/Whitespace/ArrayIndentationFixer.php
@@ -52,7 +52,7 @@ final class ArrayIndentationFixer extends AbstractFixer implements WhitespacesAw
      */
     public function getPriority()
     {
-        return -31;
+        return 3;
     }
 
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -257,7 +257,7 @@ if (true) {
      */
     public function getPriority()
     {
-        return -21;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -53,7 +53,7 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
      */
     public function getPriority()
     {
-        return 50;
+        return 12;
     }
 
     /**

--- a/src/Fixer/Whitespace/LineEndingFixer.php
+++ b/src/Fixer/Whitespace/LineEndingFixer.php
@@ -59,7 +59,7 @@ final class LineEndingFixer extends AbstractFixer implements WhitespacesAwareFix
      */
     public function getPriority()
     {
-        return 0;
+        return 7;
     }
 
     /**

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -45,7 +45,7 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
      */
     public function getPriority()
     {
-        return -29;
+        return 5;
     }
 
     /**

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -282,7 +282,7 @@ switch($a) {
      */
     public function getPriority()
     {
-        return -20;
+        return 1;
     }
 
     /**

--- a/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
+++ b/src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php
@@ -52,7 +52,7 @@ function foo( \$bar, \$baz )
      */
     public function getPriority()
     {
-        return 2;
+        return 3;
     }
 
     /**

--- a/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+++ b/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
@@ -43,7 +43,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
      */
     public function getPriority()
     {
-        return -19;
+        return 0;
     }
 
     /**

--- a/src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php
+++ b/src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php
@@ -48,7 +48,7 @@ final class SingleBlankLineAtEofFixer extends AbstractFixer implements Whitespac
     public function getPriority()
     {
         // must run last to be sure the file is properly formatted before it runs
-        return -50;
+        return -1;
     }
 
     /**

--- a/src/Priority/PrioritiesCalculator.php
+++ b/src/Priority/PrioritiesCalculator.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Priority;
+
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Tests\AutoReview\FixerFactoryTest;
+
+/**
+ * @internal
+ */
+final class PrioritiesCalculator
+{
+    public function calculate()
+    {
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+
+        $priorities = [];
+        foreach ($fixerFactory->getFixers() as $fixer) {
+            $priorities[$fixer->getName()] = new Priority();
+        }
+
+        $cases = array_merge(
+            FixerFactoryTest::provideFixersPriorityCases(),
+            FixerFactoryTest::provideFixersPrioritySpecialPhpdocCases()
+        );
+
+        foreach ($cases as $beforeAfter) {
+            list($before, $after) = $beforeAfter;
+
+            $beforeName = $before->getName();
+            $afterName = $after->getName();
+
+            $priorities[$beforeName]->addLowerPriority($priorities[$afterName]);
+        }
+
+        $priorities = array_map(
+            function (Priority $x) {
+                return $x->getPriority();
+            },
+            $priorities
+        );
+
+        // update edge cases
+        $priorities['final_class'] = $priorities['final_internal_class'];
+        $priorities['no_multiline_whitespace_before_semicolons'] = $priorities['multiline_whitespace_before_semicolons'];
+        $priorities['no_extra_consecutive_blank_lines'] = $priorities['no_extra_blank_lines'];
+        $priorities['full_opening_tag'] = max($priorities) + 1;
+        $priorities['encoding'] = max($priorities) + 1;
+        $priorities['single_blank_line_at_eof'] = min($priorities) - 1;
+        asort($priorities);
+
+        return $priorities;
+    }
+}

--- a/src/Priority/Priority.php
+++ b/src/Priority/Priority.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Priority;
+
+class Priority
+{
+    private $priority = 0;
+    private $higherPriorities = [];
+
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+
+    public function addLowerPriority(self $lowerPriority)
+    {
+        $lowerPriority->higherPriorities[] = $this;
+        $this->updatePriority($lowerPriority->getPriority());
+    }
+
+    public function updatePriority($priority)
+    {
+        $this->priority = max($this->priority, $priority + 1);
+        foreach ($this->higherPriorities as $priority) {
+            $priority->updatePriority($this->priority);
+        }
+    }
+}

--- a/src/Priority/PriorityFixer.php
+++ b/src/Priority/PriorityFixer.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Priority;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
+
+/**
+ * @internal
+ */
+final class PriorityFixer extends AbstractFixer
+{
+    public function getName()
+    {
+        return 'Internal/'.strtolower(str_replace('\\', '_', Utils::camelCaseToUnderscore(__CLASS__)));
+    }
+
+    public function getPriority()
+    {
+        return -100;
+    }
+
+    public function supports(\SplFileInfo $file)
+    {
+        return false !== strpos($file->getPath(), 'src'.\DIRECTORY_SEPARATOR.'Fixer'.\DIRECTORY_SEPARATOR);
+    }
+
+    public function isCandidate(Tokens $tokens)
+    {
+        return true;
+    }
+
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            'Priorities calculated by PrioritiesCalculator must be used.',
+            [
+                new CodeSample(
+                    '<?php class NonPrintableCharacterFixer extends AbstractFixer {
+                    public function getPriority() { return -100; }
+                    }'
+                ),
+            ]
+        );
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens)
+    {
+        $priority = $this->findPriority($tokens);
+        if (null === $priority) {
+            return;
+        }
+
+        $range = $this->findRangeToOverride($tokens);
+        if (null === $range) {
+            return;
+        }
+        list($priorityStartIndex, $priorityEndIndex) = $range;
+
+        $tokens->overrideRange($priorityStartIndex, $priorityEndIndex, [new Token([T_LNUMBER, (string) $priority])]);
+    }
+
+    /**
+     * @return null|int
+     */
+    private function findPriority(Tokens $tokens)
+    {
+        $indices = $tokens->findSequence([[T_EXTENDS]]);
+
+        if (null === $indices) {
+            return null;
+        }
+
+        /** @var int $sequencesStartIndex */
+        $sequencesStartIndex = key($indices);
+
+        /** @var int $classNameIndex */
+        $classNameIndex = $tokens->getPrevMeaningfulToken($sequencesStartIndex);
+
+        /** @var Token $classNameToken */
+        $classNameToken = $tokens[$classNameIndex];
+
+        $className = $classNameToken->getContent();
+
+        $nameParts = explode('\\', $className);
+        $name = substr(end($nameParts), 0, -\strlen('Fixer'));
+
+        $name = Utils::camelCaseToUnderscore($name);
+
+        static $priorities;
+
+        if (null === $priorities) {
+            $prioritiesCalculator = new PrioritiesCalculator();
+            $priorities = $prioritiesCalculator->calculate();
+        }
+
+        if (!isset($priorities[$name])) {
+            return null;
+        }
+
+        return $priorities[$name];
+    }
+
+    /**
+     * @return null|int[]
+     */
+    private function findRangeToOverride(Tokens $tokens)
+    {
+        $indices = $tokens->findSequence([[T_PUBLIC], [T_FUNCTION], [T_STRING, 'getPriority']]);
+
+        if (null === $indices) {
+            return null;
+        }
+
+        /** @var int $sequencesStartIndex */
+        $sequencesStartIndex = key($indices);
+
+        /** @var int $returnIndex */
+        $returnIndex = $tokens->getNextTokenOfKind($sequencesStartIndex, [[T_RETURN]]);
+
+        $priorityStartIndex = $returnIndex + 2;
+
+        /** @var Token $priorityStartToken */
+        $priorityStartToken = $tokens[$priorityStartIndex];
+
+        if ($priorityStartToken->isGivenKind(T_VARIABLE)) {
+            return null;
+        }
+
+        /** @var int $nextIndex */
+        $nextIndex = $tokens->getNextTokenOfKind($priorityStartIndex, [';']);
+
+        $priorityEndIndex = $nextIndex - 1;
+
+        return [$priorityStartIndex, $priorityEndIndex];
+    }
+}

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -49,7 +49,7 @@ final class FixerFactoryTest extends TestCase
         static::assertLessThan($first->getPriority(), $second->getPriority(), sprintf('"%s" should have less priority than "%s"', \get_class($second), \get_class($first)));
     }
 
-    public function provideFixersPriorityCases()
+    public static function provideFixersPriorityCases()
     {
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();
@@ -158,6 +158,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_else']],
             [$fixers['no_unneeded_curly_braces'], $fixers['no_useless_return']],
             [$fixers['no_unneeded_curly_braces'], $fixers['return_assignment']],
+            [$fixers['no_unset_cast'], $fixers['binary_operator_spaces']],
             [$fixers['no_unset_on_property'], $fixers['combine_consecutive_unsets']],
             [$fixers['no_unused_imports'], $fixers['blank_line_after_namespace']],
             [$fixers['no_unused_imports'], $fixers['no_extra_blank_lines']],
@@ -247,7 +248,7 @@ final class FixerFactoryTest extends TestCase
         ];
     }
 
-    public function provideFixersPrioritySpecialPhpdocCases()
+    public static function provideFixersPrioritySpecialPhpdocCases()
     {
         $factory = new FixerFactory();
         $factory->registerBuiltInFixers();
@@ -308,6 +309,7 @@ final class FixerFactoryTest extends TestCase
         // It may only shrink, never add anything to it.
         $casesWithoutTests = [
             'indentation_type,phpdoc_indent.test',
+            'no_unset_cast,binary_operator_spaces.test', // Will be gone in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5077
             'phpdoc_no_access,phpdoc_order.test',
             'phpdoc_no_package,phpdoc_order.test',
         ];
@@ -494,8 +496,8 @@ final class FixerFactoryTest extends TestCase
     public function testFixerPriorityComment()
     {
         $cases = array_merge(
-            $this->provideFixersPriorityCases(),
-            $this->provideFixersPrioritySpecialPhpdocCases()
+            self::provideFixersPriorityCases(),
+            self::provideFixersPrioritySpecialPhpdocCases()
         );
 
         $map = [];

--- a/tests/AutoReview/ProjectFixerConfigurationTest.php
+++ b/tests/AutoReview/ProjectFixerConfigurationTest.php
@@ -33,7 +33,7 @@ final class ProjectFixerConfigurationTest extends TestCase
         $config = $this->loadConfig();
 
         static::assertInstanceOf(\PhpCsFixer\Config::class, $config);
-        static::assertEmpty($config->getCustomFixers());
+        static::assertCount(1, $config->getCustomFixers());
         static::assertNotEmpty($config->getRules());
 
         // call so the fixers get configured to reveal issue (like deprecated configuration used etc.)

--- a/tests/Priority/PrioritiesCalculatorTest.php
+++ b/tests/Priority/PrioritiesCalculatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Priority;
+
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Priority\PrioritiesCalculator;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Priority\PrioritiesCalculator
+ */
+final class PrioritiesCalculatorTest extends TestCase
+{
+    public function testAllFixersGetPriority()
+    {
+        $calculator = new PrioritiesCalculator();
+        $priorities = $calculator->calculate();
+
+        $fixers = new FixerFactory();
+        $fixers->registerBuiltInFixers();
+
+        foreach ($fixers->getFixers() as $fixer) {
+            if (!isset($priorities[$fixer->getName()])) {
+                continue;
+            }
+            static::assertArrayHasKey($fixer->getName(), $priorities);
+            static::assertSame($fixer->getPriority(), $priorities[$fixer->getName()], sprintf('Fixer "%s" has incorrect priority', $fixer->getName()));
+        }
+    }
+}

--- a/tests/Priority/PriorityFixerTest.php
+++ b/tests/Priority/PriorityFixerTest.php
@@ -53,7 +53,7 @@ final class PriorityFixerTest extends AbstractFixerTestCase
      */
     public function testFix($expected, $input = null)
     {
-        $this->doTest($expected, $input, new \SplFileInfo(__DIR__.'/../../src/Fixer/Basic/EncodingFixer.php'));
+        $this->doTest($expected, $input, new \SplFileInfo(realpath(__DIR__.'/../../src/Fixer/Basic/EncodingFixer.php')));
     }
 
     public static function provideFixCases()

--- a/tests/Priority/PriorityFixerTest.php
+++ b/tests/Priority/PriorityFixerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Priority;
+
+use PhpCsFixer\FixerFactory;
+use PhpCsFixer\Priority\PrioritiesCalculator;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Priority\PriorityFixer
+ */
+final class PriorityFixerTest extends AbstractFixerTestCase
+{
+    public function testFixerIsRunLast()
+    {
+        $calculator = new PrioritiesCalculator();
+        $priorities = $calculator->calculate();
+
+        static::assertLessThan(min($priorities), $this->fixer->getPriority());
+    }
+
+    public function testAllFixersAreSupported()
+    {
+        $fixerFactory = new FixerFactory();
+        $fixerFactory->registerBuiltInFixers();
+
+        foreach ($fixerFactory->getFixers() as $fixer) {
+            $reflection = new \ReflectionObject($fixer);
+            $file = new \SplFileObject($reflection->getFileName());
+            static::assertTrue($this->fixer->supports($file));
+            static::assertTrue($this->fixer->isCandidate(Tokens::fromCode('<?php // dummy code to make sure always being candidate')));
+        }
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixCases
+     */
+    public function testFix($expected, $input = null)
+    {
+        $this->doTest($expected, $input, new \SplFileInfo(__DIR__.'/../../src/Fixer/Basic/EncodingFixer.php'));
+    }
+
+    public static function provideFixCases()
+    {
+        return [
+            [
+                '<?php class Foo {}',
+            ],
+            [
+                '<?php class Foo extends Bar {}',
+            ],
+            [
+                '<?php class NonPrintableCharacterFixer extends AbstractFixer {}',
+            ],
+            [
+                '<?php class NonPrintableCharacterFixer extends AbstractFixer {
+                    public function getPriority() { return $this->proxyFixer->getPriority(); }
+                }',
+            ],
+            [
+                '<?php class NonPrintableCharacterFixer extends AbstractFixer {
+                    public function getPriority() { return 0; }
+                }',
+                '<?php class NonPrintableCharacterFixer extends AbstractFixer {
+                    public function getPriority() { return -100; }
+                }',
+            ],
+        ];
+    }
+}

--- a/tests/Priority/PriorityTest.php
+++ b/tests/Priority/PriorityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Priority;
+
+use PhpCsFixer\Priority\Priority;
+use PhpCsFixer\Tests\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Priority\Priority
+ */
+final class PriorityTest extends TestCase
+{
+    /**
+     * The final relation should be:
+     * first - $a
+     *         $b
+     *         $c1, $c2
+     * last -  $d.
+     */
+    public function testAddingRelations()
+    {
+        $a = new Priority();
+        $b = new Priority();
+        $c1 = new Priority();
+        $c2 = new Priority();
+        $d = new Priority();
+
+        $a->addLowerPriority($d);
+        static::assertSame(1, $a->getPriority());
+        static::assertSame(0, $d->getPriority());
+
+        $b->addLowerPriority($d);
+        static::assertSame(1, $b->getPriority());
+        static::assertSame(0, $d->getPriority());
+
+        $a->addLowerPriority($b);
+        static::assertSame(2, $a->getPriority());
+        static::assertSame(1, $b->getPriority());
+        static::assertSame(0, $d->getPriority());
+
+        $c1->addLowerPriority($d);
+        static::assertSame(1, $c1->getPriority());
+        static::assertSame(0, $d->getPriority());
+
+        $c2->addLowerPriority($d);
+        static::assertSame(1, $c2->getPriority());
+        static::assertSame(0, $d->getPriority());
+
+        $b->addLowerPriority($c1);
+        static::assertSame(3, $a->getPriority());
+        static::assertSame(2, $b->getPriority());
+        static::assertSame(1, $c1->getPriority());
+        static::assertSame(1, $c2->getPriority());
+        static::assertSame(0, $d->getPriority());
+    }
+}


### PR DESCRIPTION
The algorithm for calculating priorities is quite simple:
 - set all priorities to `0`,
 - for each relation (based on integration priority tests) update the priority of fixer that must be run earlier and update all priorities of fixers that must run before it recursively (logic is in `Priority` class).

Main questions for this RFC are:
1. Is the `PriorityFixer` good approach or we only want `AutoReview` test, something similar to `FixerFactoryTest::testFixerPriorityComment`?
2. In the `PrioritiesCalculator` should I remove the lines:
    ```php
        $priorities['final_class'] = $priorities['final_internal_class'];
        $priorities['no_multiline_whitespace_before_semicolons'] = $priorities['multiline_whitespace_before_semicolons'];
        $priorities['no_extra_consecutive_blank_lines'] = $priorities['no_extra_blank_lines'];
    ```
or they could stay? They are because of using `AbstractProxyFixer`.
3. Any hint on how to make fabbot.io happy?