### PR TITLE
SwitchContinueToBreakFixer - do not support alternative syntax

### DIFF
--- a/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+++ b/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
@@ -58,7 +58,7 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, ElseifFixer, NoSuperfluousElseifFixer, NoUselessElseFixer.
+     * Must run before BracesFixer, ElseifFixer, NoSuperfluousElseifFixer, NoUselessElseFixer, SwitchContinueToBreakFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
+++ b/src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php
@@ -63,10 +63,20 @@ switch ($foo) {
 
     /**
      * {@inheritdoc}
+     *
+     * Must run after NoAlternativeSyntaxFixer.
+     */
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAllTokenKindsFound([T_SWITCH, T_CONTINUE, T_LNUMBER]);
+        return $tokens->isAllTokenKindsFound([T_SWITCH, T_CONTINUE, T_LNUMBER]) && !$tokens->hasAlternativeSyntax();
     }
 
     /**

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -135,6 +135,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_alternative_syntax'], $fixers['elseif']],
             [$fixers['no_alternative_syntax'], $fixers['no_superfluous_elseif']],
             [$fixers['no_alternative_syntax'], $fixers['no_useless_else']],
+            [$fixers['no_alternative_syntax'], $fixers['switch_continue_to_break']],
             [$fixers['no_blank_lines_after_phpdoc'], $fixers['header_comment']],
             [$fixers['no_blank_lines_after_phpdoc'], $fixers['single_blank_line_before_namespace']],
             [$fixers['no_empty_comment'], $fixers['no_extra_blank_lines']],

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -35,6 +35,27 @@ final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
     public function provideTestFixCases()
     {
         return [
+            'alternative syntax |' => [
+                '<?php
+                    switch($foo):
+                        case 3:
+                            continue;
+                    endswitch?>
+                ',
+            ],
+            'alternative syntax ||' => [
+                '<?php
+
+foreach ([] as $v) {
+    continue;
+}
+
+if ($foo != 0) {
+}
+
+switch ($foo):
+endswitch;',
+            ],
             'simple case' => [
                 '<?php
 switch($a) {

--- a/tests/Fixtures/Integration/priority/no_alternative_syntax,switch_continue_to_break.test
+++ b/tests/Fixtures/Integration/priority/no_alternative_syntax,switch_continue_to_break.test
@@ -1,0 +1,17 @@
+--TEST--
+Integration of fixers: no_alternative_syntax,switch_continue_to_break.
+--RULESET--
+{"no_alternative_syntax": true, "switch_continue_to_break": true}
+--EXPECT--
+<?php
+    switch ($foo) {
+        case 1:
+            break;
+    }
+
+--INPUT--
+<?php
+    switch ($foo) :
+        case 1:
+            continue;
+    endswitch;


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5076