### PR TITLE
NativeFunctionInvocationFixer - BacktickToShellExecFixer - fix integration test

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,9 +15,6 @@ parameters:
         - '/^Class (Symfony\\Contracts\\EventDispatcher\\Event|Symfony\\Component\\EventDispatcher\\Event) not found.$/'
         - '/^(Access|Call) to an undefined (property|method) PhpCsFixer\\AccessibleObject\\AccessibleObject::.+$/'
         -
-            message: '/^Unsafe usage of new static\(\)\.$/'
-            path: src/Config.php
-        -
             message: '/^Else branch is unreachable because previous condition is always true\.$/'
             path: src/Event/Event.php
         -

--- a/tests/Fixtures/Integration/priority/backtick_to_shell_exec,native_function_invocation.test
+++ b/tests/Fixtures/Integration/priority/backtick_to_shell_exec,native_function_invocation.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: backtick_to_shell_exec,native_function_invocation.
 --RULESET--
-{"backtick_to_shell_exec": true, "native_function_invocation": true}
+{"backtick_to_shell_exec": true, "native_function_invocation": {"include": ["@internal"]}}
 --EXPECT--
 <?php
 $var = \shell_exec("pwd");

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -16,8 +16,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\AbstractProxyFixer;
 use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
-use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
-use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;


### PR DESCRIPTION
The default configuration for the `NativeFunctionInvocationFixer` was changed on 3.0 making this priority test fail on it.