### PR TITLE
Fixed invalid PHP 5.6 syntax

### DIFF
--- a/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of PHP CS Fixer.
  *

--- a/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
+++ b/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of PHP CS Fixer.
  *

--- a/tests/Tokenizer/Analyzer/SwitchAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/SwitchAnalyzerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of PHP CS Fixer.
  *


### PR DESCRIPTION
PHP 5.6 was outputting:

```
Warning: Unsupported declare 'strict_types' in /home/travis/build/FriendsOfPHP/PHP-CS-Fixer/tests/Tokenizer/Analyzer/SwitchAnalyzerTest.php on line 3
Warning: Unsupported declare 'strict_types' in /home/travis/build/FriendsOfPHP/PHP-CS-Fixer/tests/Tokenizer/Analyzer/Analysis/CaseAnalysisTest.php on line 3
Warning: Unsupported declare 'strict_types' in /home/travis/build/FriendsOfPHP/PHP-CS-Fixer/tests/Tokenizer/Analyzer/Analysis/SwitchAnalysisTest.php on line 3
```