### PR TITLE
Symfony's finder already ignores vcs and dot files by default

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -27,8 +27,6 @@ class Finder extends BaseFinder
         $this
             ->files()
             ->name('*.php')
-            ->ignoreDotFiles(true)
-            ->ignoreVCS(true)
             ->exclude('vendor')
         ;
     }


### PR DESCRIPTION
This is the case for all versions we support.