### PR TITLE
Show runtime PHP version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,8 +12,8 @@ labels: kind/bug
   Please describe the problem and provide technical details such as:
    * PHP version: php -v
    * PHP CS Fixer version: php-cs-fixer -V
-   * the command used to run PHP CS Fixer
-   * the configuration file you used
+   * the command used to run PHP CS Fixer (run with `-vvv`)
+   * the configuration (file) you used
 -->
 
 ### Code snippet that reproduces the problem

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -169,6 +169,9 @@ final class FixCommand extends Command
 
             $configFile = $resolver->getConfigFile();
             $stdErr->writeln(sprintf('Loaded config <comment>%s</comment>%s.', $resolver->getConfig()->getName(), null === $configFile ? '' : ' from "'.$configFile.'"'));
+            if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+                $stdErr->writeln(sprintf('Runtime: <info>PHP %s</info>', \PHP_VERSION));
+            }
 
             if ($resolver->getUsingCache()) {
                 $cacheFile = $resolver->getCacheFile();

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -148,10 +148,11 @@ If you need help while solving warnings, ask at https://gitter.im/PHP-CS-Fixer, 
 ';
 
         $pattern = sprintf(
-            '/^(?:%s)?(?:%s)?%s\n([\.S]{%d})\n%s$/',
+            '/^(?:%s)?(?:%s)?%s\n(?:%s)([\.S]{%d})\n%s$/',
             preg_quote($optionalIncompatibilityWarning, '/'),
             preg_quote($optionalXdebugWarning, '/'),
             preg_quote('Loaded config default from ".php_cs.dist".', '/'),
+            preg_quote(sprintf("Runtime: PHP %s\n", \PHP_VERSION), '/'),
             \strlen($expectedResult3Files),
             preg_quote('Legend: ?-unknown, I-invalid file syntax (file ignored), S-skipped (cached or empty file), .-no changes, F-fixed, E-error', '/')
         );


### PR DESCRIPTION
@keradus @SpacePossum @julienfalque @localheinz does this make sense?

Can be useful in cases like [this](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5121).