### PR TITLE
Enable MethodArgumentSpaceFixer to support use in anonymous functions.

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -141,7 +141,7 @@ SAMPLE
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $expectedTokens = [T_LIST, T_FUNCTION];
+        $expectedTokens = [T_LIST, T_FUNCTION, CT::T_USE_LAMBDA];
         if (\PHP_VERSION_ID >= 70400) {
             $expectedTokens[] = T_FN;
         }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -699,8 +699,11 @@ $b,
     $c#
 #
 )#
-use ($b,
-$c,$d) {
+use (
+    $b,
+    $c,
+    $d
+) {
 };
 EXPECTED
                 ,
@@ -927,6 +930,14 @@ if (true) {
                 [
                     'on_multiline' => 'ensure_fully_multiline',
                 ],
+            ],
+            'test anonymous functions' => [
+                '<?php
+$example = function () use ($message1, $message2) {
+};',
+                '<?php
+$example = function () use ($message1,$message2) {
+};',
             ],
         ];
     }


### PR DESCRIPTION
Currently, the `MethodArgumentSpaceFixer` is not useful for the following example:
```
<?php
$example = function () use ($message1,$message2,   $message3) {
};
```

This pr could fix it.
