### PR TITLE
Do not require blank line before "try" by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,7 +343,7 @@ Choose from the list of available rules:
     'include', 'include_once', 'require', 'require_once', 'return',
     'switch', 'throw', 'try', 'while', 'yield']``): list of statements which
     must be preceded by an empty line; defaults to ``['break', 'continue',
-    'declare', 'return', 'throw', 'try']``
+    'declare', 'return', 'throw']``
 
 * **braces** [@PSR2, @Symfony, @PhpCsFixer]
 

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -311,7 +311,6 @@ if (true) {
                     'declare',
                     'return',
                     'throw',
-                    'try',
                 ])
                 ->getOption(),
         ]);


### PR DESCRIPTION
all other defaults are "single line control statements"

try is very commonly used with some preparation code that is prefered to be not put inside try block, like:
```
$writer = new Writer();
try {
    $writer->write();
} catch (\Exception $e) {
    throw new \Exception('Write failed', 0, $e);
}
```
or
```
$isReadOnlyBackup = $this->isReadOnly;
try {
    $this->isReadOnly = true;
    $this->writeLog();
} finally {
    $this->isReadOnly = $isReadOnlyBackup;
}
```

because I belive there are a lot of real-world uses that make more sense without a blank line before try, I propose to change the default of `blank_line_before_statement` to not include `try` in default configuration

as this change relaxes the fixer, there should be no impact on already fixed code

also, I belive `die`, `exit`, `goto` should be included by default to include all "jumping single line statements", please advise, if welcomed