### PR TITLE
DX: fix UPGRADE.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ jobs:
                 token:
                     secure: K9NKi7X1OPz898fxtVc1RfWrSI+4hTFFYOik932wTz1jC4dQJ64Khh1LV9frA1+JiDS3+R6TvmQtpzbkX3y4L75UrSnP1ADH5wfMYIVmydG3ZjTMo8SWQWHmRMh3ORAKTMMpjl4Q7EkRkLp6RncKe+FAFPP5mgv55mtIMaE4qUk=
                 file: php-cs-fixer.phar
-                cleanup : false
+                cleanup: false
                 on:
                     repo: FriendsOfPHP/PHP-CS-Fixer
                     tags: true

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,7 +12,7 @@ Default ruleset was changed from Symfony standard to more generic PSR2. You can 
 The term of risky fixers was introduced. Risky fixer is a fixer that may change the meaning of code (like `StrictComparisonFixer` fixer, which will change `==` into `===`). No rules that are followed by risky fixers are run by default. You need to explicitly permit risky fixers to run them.
 
 Default configuration changes
-----------------------------
+-----------------------------
 By default, PSR2 rules are used instead of Symfony rules.
 Files that will be fixed are php/phpt/twig instead of php/twig/xml/yml.
 Finally, the caching mechanism is enabled by default.


### PR DESCRIPTION
This is test issue from https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5099 to see if after passing Travis build the https://cs.symfony.com/download/php-cs-fixer-v2.phar will be 2.16 version.