### PR TITLE
PHP 8: Fix references to missing SplFixedArray methods

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -476,7 +476,6 @@ class Tokens extends \SplFixedArray
      */
     public function findGivenKind($possibleKind, $start = 0, $end = null)
     {
-        $this->rewind();
         if (null === $end) {
             $end = $this->count();
         }
@@ -1058,7 +1057,6 @@ class Tokens extends \SplFixedArray
             $this->registerFoundToken($token);
         }
 
-        $this->rewind();
         $this->changeCodeHash(self::calculateCodeHash($code));
         $this->changed = true;
     }
@@ -1076,8 +1074,6 @@ class Tokens extends \SplFixedArray
         foreach ($this as $index => $token) {
             $output[$index] = $token->toArray();
         }
-
-        $this->rewind();
 
         return json_encode($output, $options);
     }

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -44,7 +44,6 @@ final class TokensAnalyzer
      */
     public function getClassyElements()
     {
-        $this->tokens->rewind();
         $elements = [];
 
         for ($index = 1, $count = \count($this->tokens) - 2; $index < $count; ++$index) {
@@ -69,8 +68,6 @@ final class TokensAnalyzer
     public function getImportUseIndexes($perNamespace = false)
     {
         $tokens = $this->tokens;
-
-        $tokens->rewind();
 
         $uses = [];
         $namespaceIndex = 0;


### PR DESCRIPTION
This commit addresses the following PHP8 backwards-incompatible change:

> SplFixedArray is now an IteratorAggregate and not an Iterator. SplFixedArray::rewind(), ::current(), ::key(), ::next(), and ::valid() have been removed. In their place, SplFixedArray::getIterator() has been added. Any code which uses explicit iteration over SplFixedArray must now obtain an Iterator through SplFixedArray::getIterator(). This means that SplFixedArray is now safe to use in nested loops.

I performed a scan for any references to the above-mentioned methods. `SplFixedArray::rewind()` was the only one that was used.  In all cases, the call was unnecessary, because there are no calls to other methods that could move the cursor. This project exclusively uses `foreach()` on instances of the Tokens class, which automatically rewinds the cursor. [Reference: See Example \#1](https://www.php.net/manual/en/class.iterator.php)

Addresses #4702