### PR TITLE
Corrected linting error messages

### DIFF
--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -96,7 +96,7 @@ final class ProcessLinter implements LinterInterface
      */
     public function lintFile($path)
     {
-        return new ProcessLintingResult($this->createProcessForFile($path));
+        return new ProcessLintingResult($this->createProcessForFile($path), $path);
     }
 
     /**
@@ -104,7 +104,7 @@ final class ProcessLinter implements LinterInterface
      */
     public function lintSource($source)
     {
-        return new ProcessLintingResult($this->createProcessForSource($source));
+        return new ProcessLintingResult($this->createProcessForSource($source), $this->temporaryFile);
     }
 
     /**

--- a/src/Linter/TokenizerLintingResult.php
+++ b/src/Linter/TokenizerLintingResult.php
@@ -45,6 +45,6 @@ final class TokenizerLintingResult implements LintingResultInterface
 
     private function getMessagePrefix()
     {
-        return \get_class($this->error);
+        return $this->error instanceof \ParseError ? 'Parse error' : 'Fatal error';
     }
 }

--- a/tests/Linter/AbstractLinterTestCase.php
+++ b/tests/Linter/AbstractLinterTestCase.php
@@ -39,15 +39,15 @@ abstract class AbstractLinterTestCase extends TestCase
 
     /**
      * @param string      $file
-     * @param null|string $errorRegExp
+     * @param null|string $errorMessage
      *
      * @dataProvider provideLintFileCases
      */
-    public function testLintFile($file, $errorRegExp = null)
+    public function testLintFile($file, $errorMessage = null)
     {
-        if (null !== $errorRegExp) {
+        if (null !== $errorMessage) {
             $this->expectException(\PhpCsFixer\Linter\LintingException::class);
-            $this->expectExceptionMessageRegExp($errorRegExp);
+            $this->expectExceptionMessage($errorMessage);
         }
 
         $linter = $this->createLinter();
@@ -66,26 +66,26 @@ abstract class AbstractLinterTestCase extends TestCase
             ],
             [
                 __DIR__.'/../Fixtures/Linter/invalid.php',
-                '/syntax error, unexpected.*("echo"|T_ECHO).*line 5/',
+                sprintf('Parse error: syntax error, unexpected %s on line 5.', PHP_MAJOR_VERSION >= 8 ? 'token "echo"' : '\'echo\' (T_ECHO)'),
             ],
             [
                 __DIR__.'/../Fixtures/Linter/multiple.php',
-                '/Multiple access type modifiers are not allowed.*line 4/',
+                'Fatal error: Multiple access type modifiers are not allowed on line 4.',
             ],
         ];
     }
 
     /**
      * @param string      $source
-     * @param null|string $errorRegExp
+     * @param null|string $errorMessage
      *
      * @dataProvider provideLintSourceCases
      */
-    public function testLintSource($source, $errorRegExp = null)
+    public function testLintSource($source, $errorMessage = null)
     {
-        if (null !== $errorRegExp) {
+        if (null !== $errorMessage) {
             $this->expectException(\PhpCsFixer\Linter\LintingException::class);
-            $this->expectExceptionMessageRegExp($errorRegExp);
+            $this->expectExceptionMessage($errorMessage);
         }
 
         $linter = $this->createLinter();
@@ -109,7 +109,7 @@ abstract class AbstractLinterTestCase extends TestCase
                     print "line 4";
                     echo echo;
                 ',
-                '/syntax error, unexpected.*("echo"|T_ECHO).*line 5/',
+                sprintf('Parse error: syntax error, unexpected %s on line 5.', PHP_MAJOR_VERSION >= 8 ? 'token "echo"' : '\'echo\' (T_ECHO)'),
             ],
         ];
     }

--- a/tests/Linter/ProcessLintingResultTest.php
+++ b/tests/Linter/ProcessLintingResultTest.php
@@ -63,7 +63,7 @@ final class ProcessLintingResultTest extends TestCase
 
         $process
             ->getErrorOutput()
-            ->willReturn('test')
+            ->willReturn('PHP Parse error:  syntax error, unexpected end of file, expecting \'{\' in test.php on line 4')
         ;
 
         $process
@@ -71,13 +71,13 @@ final class ProcessLintingResultTest extends TestCase
             ->willReturn(123)
         ;
 
-        $result = new ProcessLintingResult($process->reveal());
+        $result = new ProcessLintingResult($process->reveal(), 'test.php');
 
         $this->expectException(
             \PhpCsFixer\Linter\LintingException::class
         );
-        $this->expectExceptionMessageRegExp(
-            '#^test$#'
+        $this->expectExceptionMessage(
+            'Parse error: syntax error, unexpected end of file, expecting \'{\' on line 4.'
         );
         $this->expectExceptionCode(
             123

--- a/tests/Linter/TokenizerLintingResultTest.php
+++ b/tests/Linter/TokenizerLintingResultTest.php
@@ -33,9 +33,9 @@ final class TokenizerLintingResultTest extends TestCase
         $result->check();
     }
 
-    public function testTokenizerLintingResultFail()
+    public function testTokenizerLintingResultFailParseError()
     {
-        $error = new \ParseError('PHPUnit', 567);
+        $error = new \ParseError('syntax error, unexpected end of file, expecting \'{\'', 567);
         $line = __LINE__ - 1;
 
         $result = new TokenizerLintingResult($error);
@@ -44,12 +44,33 @@ final class TokenizerLintingResultTest extends TestCase
             \PhpCsFixer\Linter\LintingException::class
         );
 
-        $this->expectExceptionMessageRegExp(
-            sprintf('#^%s: PHPUnit on line %d\.#', preg_quote(\get_class($error), '#'), $line)
+        $this->expectExceptionMessage(
+            sprintf('Parse error: syntax error, unexpected end of file, expecting \'{\' on line %d.', $line)
         );
 
         $this->expectExceptionCode(
             567
+        );
+
+        $result->check();
+    }
+
+    /**
+     * @requires PHP 7.3
+     */
+    public function testTokenizerLintingResultFailCompileError()
+    {
+        $error = new \CompileError('Multiple access type modifiers are not allowed');
+        $line = __LINE__ - 1;
+
+        $result = new TokenizerLintingResult($error);
+
+        $this->expectException(
+            \PhpCsFixer\Linter\LintingException::class
+        );
+
+        $this->expectExceptionMessage(
+            sprintf('Fatal error: Multiple access type modifiers are not allowed on line %d.', $line)
         );
 
         $result->check();


### PR DESCRIPTION
The reason for the trimming of the error message and the prefix normalisation is because the PHP parser, when compiled on macos vs linux, has different error messages and also additional whitespace at the start:

```
 ✘ graham@Grahams-MacBook-Pro  ~  php -l test.php 

Parse error: syntax error, unexpected end of file, expecting '{' in test.php on line 4
Errors parsing test.php
 ✘ graham@Grahams-MacBook-Pro  ~  php -l test2.php

Fatal error: Multiple access type modifiers are not allowed in test2.php on line 5
 ✘ graham@Grahams-MacBook-Pro  ~  php74 -l test.php
PHP Parse error:  syntax error, unexpected end of file, expecting '{' in test.php on line 4
Errors parsing test.php
 ✘ graham@Grahams-MacBook-Pro  ~  php74 -l test2.php
PHP Fatal error:  Multiple access type modifiers are not allowed in test2.php on line 5
```

`php` is running macos php, and `php74` is running in docker (linux).