### PR TITLE
Always lint test cases with the stricter process linter

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,7 @@ clone_folder: C:\projects\php-cs-fixer
 environment:
     matrix:
         - php_ver: 7.3.1
+          FAST_LINT_TEST_CASES: 1
         - php_ver: 5.6.40
           SKIP_LINT_TEST_CASES: 1
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -53,6 +53,7 @@
     <php>
         <ini name="zend.enable_gc" value="0"/>
         <ini name="memory_limit" value="1G"/>
+        <env name="FAST_LINT_TEST_CASES" value="0"/>
         <env name="SKIP_LINT_TEST_CASES" value="0"/>
         <env name="PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS" value="1"/>
         <env name="PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER" value="0"/>

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -37,7 +37,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php 1**2;',
                 '<?php pow(1,2);',
@@ -135,10 +135,6 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
                 '<?php echo pow(${$bar}, ${$foo});',
             ],
             [
-                '<?php echo $a{1}** $b{2+5};',
-                '<?php echo pow($a{1}, $b{2+5});',
-            ],
-            [
                 '<?php echo $a[2^3+1]->test(1,2)** $b[2+$c];',
                 '<?php echo pow($a[2^3+1]->test(1,2), $b[2+$c]);',
             ],
@@ -222,7 +218,22 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
                     public function &pow($a, $b);
                 }',
             ],
+            [
+                '<?php echo $a[1]** $b[2+5];',
+                '<?php echo pow($a[1], $b[2+5]);',
+            ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php echo $a{1}** $b{2+5};',
+                '<?php echo pow($a{1}, $b{2+5});',
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer
+ * @requires PHP <8.0
  */
 final class NormalizeIndexBraceFixerTest extends AbstractFixerTestCase
 {

--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -40,8 +40,6 @@ final class EncodingFixerTest extends AbstractFixerTestCase
 
         yield $this->prepareTestCase('test-utf8.case2.php', 'test-utf8.case2-bom.php');
 
-        yield ['<?php'];
-
         yield ['<?php '];
     }
 

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -93,6 +93,10 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
      */
     public function testFix74($expected, $input = null)
     {
+        if (\PHP_VERSION_ID >= 80000) {
+            static::markTestSkipped('PHP < 8.0 is required.');
+        }
+
         $this->doTest($expected, $input);
     }
 

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -57,8 +57,8 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
 
         // static version of '__set_state'
         yield 'method declaration for "__set_state".' => [
-            '<?php class Foo {public static function __set_state($a, $b){}}',
-            '<?php class Foo {public static function __set_STATE($a, $b){}}',
+            '<?php class Foo {public static function __set_state($a){}}',
+            '<?php class Foo {public static function __set_STATE($a){}}',
         ];
 
         yield 'static call to "__set_state".' => [
@@ -72,7 +72,7 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
             '<?php class Foo {public function __CLONE(){}}',
         ];
 
-        unset($allMethodNames['__clone']);
+        unset($allMethodNames['__clone'], $allMethodNames['__set_state']);
 
         // two arguments
         $methodNames = ['__call', '__set'];
@@ -94,7 +94,7 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
         }
 
         // single argument
-        $methodNames = ['__get', '__isset', '__unset'];
+        $methodNames = ['__get', '__isset', '__unset', '__unserialize'];
 
         foreach ($methodNames as $i => $name) {
             unset($allMethodNames[$name]);
@@ -148,7 +148,7 @@ class Foo extends Bar
     }
 
     public function __unserialize($payload) {
-        $this->__unserialize($this_>$a);
+        $this->__unserialize($this->$a);
     }
 }
 ',
@@ -161,7 +161,7 @@ class Foo extends Bar
     }
 
     public function __unSERIALIZE($payload) {
-        $this->__unSERIALIZE($this_>$a);
+        $this->__unSERIALIZE($this->$a);
     }
 }
 ',

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -72,7 +72,13 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        foreach (['boolean', 'bool', 'integer', 'int', 'double', 'float', 'float', 'string', 'array', 'object', 'unset', 'binary'] as $from) {
+        $types = ['boolean', 'bool', 'integer', 'int', 'double', 'float', 'float', 'string', 'array', 'object', 'binary'];
+
+        if (\PHP_VERSION_ID < 80000) {
+            $types[] = 'unset';
+        }
+
+        foreach ($types as $from) {
             foreach ($this->createCasesFor($from) as $case) {
                 yield $case;
             }

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -179,7 +179,7 @@ OVERRIDDEN;
 
     public function provideFix70Cases()
     {
-        return [
+        $tests = [
             [
                 '<?php $foo = ((string) $x)[0];',
                 '<?php $foo = strval($x)[0];',
@@ -188,11 +188,18 @@ OVERRIDDEN;
                 '<?php $foo = ((string) ($x + $y))[0];',
                 '<?php $foo = strval($x + $y)[0];',
             ],
-            [
+        ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
                 '<?php $foo = ((string) ($x + $y)){0};',
                 '<?php $foo = strval($x + $y){0};',
-            ],
-        ];
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\CastNotation\NoUnsetCastFixer
+ * @requires PHP <8.0
  */
 final class NoUnsetCastFixerTest extends AbstractFixerTestCase
 {

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -97,7 +97,13 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
     public function provideNoFixCases()
     {
         $cases = [];
-        foreach (['string', 'array', 'object', 'unset'] as $cast) {
+        $types = ['string', 'array', 'object'];
+
+        if (\PHP_VERSION_ID < 80000) {
+            $types[] = 'unset';
+        }
+
+        foreach ($types as $cast) {
             $cases[] = [sprintf('<?php $b=(%s) $d;', $cast)];
             $cases[] = [sprintf('<?php $b=( %s ) $d;', $cast)];
             $cases[] = [sprintf('<?php $b=(%s ) $d;', ucfirst($cast))];

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -36,7 +36,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             'simple sample, last token candidate' => [
                 '<?php  echo 1;',
                 '<?php { echo 1;}',
@@ -65,9 +65,6 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
             ],
             'no fixes' => [
                 '<?php
-                    echo ${$a};
-                    echo $a{1};
-
                     foreach($a as $b){}
                     while($a){}
                     do {} while($a);
@@ -116,6 +113,19 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield 'no fixes, offset access syntax with curly braces' => [
+                '<?php
+                    echo ${$a};
+                    echo $a{1};
+                ',
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -36,7 +36,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php
                 switch (1) {
@@ -133,20 +133,6 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php
-                switch ($a) {
-                    case $b ? "c" : "this" ? "is" : "ugly":
-                        break;
-                }
-                ',
-                '<?php
-                switch ($a) {
-                    case $b ? "c" : "this" ? "is" : "ugly";
-                        break;
-                }
-                ',
-            ],
-            [
-                '<?php
                 switch($a) {
                     case (int) $a < 1: {
                         echo "leave ; alone";
@@ -210,6 +196,27 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php
+                switch ($a) {
+                    case $b ? "c" : "this" ? "is" : "ugly":
+                        break;
+                }
+                ',
+                '<?php
+                switch ($a) {
+                    case $b ? "c" : "this" ? "is" : "ugly";
+                        break;
+                }
+                ',
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -36,7 +36,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php
     switch (1) {
@@ -197,20 +197,6 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
             [
                 '<?php
                 switch ($a) {
-                    case $b ? "c" : "this" ? "is" : "ugly":
-                        break;
-                }
-                ',
-                '<?php
-                switch ($a) {
-                    case $b ? "c" : "this" ? "is" : "ugly" :
-                        break;
-                }
-                ',
-            ],
-            [
-                '<?php
-                switch ($a) {
                     case $b ?: $c:
                         break;
                 }
@@ -345,5 +331,26 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
                 }',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php
+                switch ($a) {
+                    case $b ? "c" : "this" ? "is" : "ugly":
+                        break;
+                }
+                ',
+                '<?php
+                switch ($a) {
+                    case $b ? "c" : "this" ? "is" : "ugly" :
+                        break;
+                }
+                ',
+            ];
+        }
     }
 }

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -113,10 +113,6 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
                 '<?php echo (object) $a === 1 ? 8 : 7;',
             ],
             [
-                '<?php echo 1 === (unset) $a ? 8 : 7;',
-                '<?php echo (unset) $a === 1 ? 8 : 7;',
-            ],
-            [
                 '<?php echo 1 === (int) $a ? 8 : 7;',
                 '<?php echo (int) $a === 1 ? 8 : 7;',
             ],
@@ -213,12 +209,8 @@ if ($a = $obj instanceof A === true) {
             ['<?php $l = $c > 2;'],
             ['<?php return $this->myObject1->{$index}+$b === "";'],
             ['<?php return $m[2]+1 == 2;'],
-            ['<?php return $m{2}+1 == 2;'],
-            ['<?php return $m->a{2}+1 == 2;'],
             ['<?php return $foo === $bar[$baz][1];'],
-            ['<?php return $foo === $bar[$baz]{1};'],
             ['<?php $a = $b[$key]["1"] === $c["2"];'],
-            ['<?php return $foo->$a[1] === $bar[$baz]{1}->$a[1][2][3]->$d[$z]{1};'],
             ['<?php return $foo->$a === $foo->$b->$c;'],
             ['<?php return $x === 2 - 1;'],
             ['<?php return $x === 2-1;'],
@@ -976,6 +968,19 @@ while (2 !== $b = array_pop($c));
         yield [
             '<?php return A\/**//**//**/B/*a*//*a*//*a*//*a*/::MY_CONST === B\C::$myVariable;',
             '<?php return B\C::$myVariable === A\/**//**//**/B/*a*//*a*//*a*//*a*/::MY_CONST;',
+        ];
+
+        yield ['<?php return $foo === $bar[$baz]{1};'];
+
+        yield ['<?php return $foo->$a[1] === $bar[$baz]{1}->$a[1][2][3]->$d[$z]{1};'];
+
+        yield ['<?php return $m->a{2}+1 == 2;'];
+
+        yield ['<?php return $m{2}+1 == 2;'];
+
+        yield [
+            '<?php echo 1 === (unset) $a ? 8 : 7;',
+            '<?php echo (unset) $a === 1 ? 8 : 7;',
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -36,7 +36,7 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             'test function call' => [
                 '<?php abc($a);',
                 '<?php abc ($a);',
@@ -123,8 +123,8 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
                 }',
             ],
             'test dynamic by array' => [
-                '<?php $a["e"](1); $a{2}(1);',
-                '<?php $a["e"] (1); $a{2} (1);',
+                '<?php $a["e"](1); $a[2](1);',
+                '<?php $a["e"] (1); $a[2] (1);',
             ],
             'test variable variable' => [
                 '<?php
@@ -145,6 +145,22 @@ $$e(2);
  ($a);',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield 'test dynamic by array, curly mix' => [
+                '<?php $a["e"](1); $a{2}(1);',
+                '<?php $a["e"] (1); $a{2} (1);',
+            ];
+
+            yield 'test dynamic by array, curly only' => [
+                '<?php $a{"e"}(1); $a{2}(1);',
+                '<?php $a{"e"} (1); $a{2} (1);',
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
+++ b/tests/Fixer/Import/NoLeadingImportSlashFixerTest.php
@@ -90,9 +90,6 @@ final class NoLeadingImportSlashFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php
-                use C;
-                use C\X;
-
                 namespace Foo {
                     use A;
                     use A\X;
@@ -108,9 +105,6 @@ final class NoLeadingImportSlashFixerTest extends AbstractFixerTestCase
                 }
                 ',
                 '<?php
-                use \C;
-                use \C\X;
-
                 namespace Foo {
                     use \A;
                     use \A\X;
@@ -256,6 +250,45 @@ use const \some\Z\{ConstX,ConstY,ConstZ,};
             '<?php
                 use\Events\Payment\Base as PaymentEvent;
                 use const\d\e;
+            ',
+        ];
+
+        yield [
+            '<?php
+            use C;
+            use C\X;
+
+            namespace Foo {
+                use A;
+                use A\X;
+
+                new X();
+            }
+
+            namespace Bar {
+                use B;
+                use B\X;
+
+                new X();
+            }
+            ',
+            '<?php
+            use \C;
+            use \C\X;
+
+            namespace Foo {
+                use \A;
+                use \A\X;
+
+                new X();
+            }
+
+            namespace Bar {
+                use \B;
+                use \B\X;
+
+                new X();
+            }
             ',
         ];
     }

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -36,7 +36,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php //1
                     unset($foo/*;*/, /*;*/$bar, $c , $foobar  ,  $foobar2);
@@ -102,9 +102,6 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
                 ',
             ],
             [
-                '<?php (unset)$f;',
-            ],
-            [
                 '<?php unset($x, $b  , $d);  /**/   ?> b',
                 '<?php unset($x);  /**/ unset ($b  , $d) ?> b',
             ],
@@ -134,5 +131,15 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php (unset)$f;',
+            ];
+        }
     }
 }

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -36,7 +36,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar);',
@@ -79,9 +79,6 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php $foo->bar = null; unset($foo); unset($bar); unset($baz); $this->ab = null;',
                 '<?php unset($foo->bar, $foo, $bar, $baz, $this->ab);',
             ],
-            'It does not replace unsets on arrays with special notation' => [
-                '<?php unset($bar->foo{0});',
-            ],
             'It works when around messy whitespace' => [
                 '<?php
      unset($a); $this->b = null;
@@ -111,6 +108,16 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php unset($this->property[array_search(\Types::TYPE_RANDOM, $this->property)]);',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield 'It does not replace unsets on arrays with special notation' => [
+                '<?php unset($bar->foo{0});',
+            ];
+        }
     }
 
     /**
@@ -127,17 +134,20 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFix70Cases()
     {
-        return [
-            'It does not break complex expressions' => [
-                '<?php
-                    unset(a()[b()["a"]]);
-                    unset(a()[b()]);
-                    unset(a()["a"]);
-                    unset(a(){"a"});
-                    unset(c($a)->a);
-                ',
-            ],
+        yield 'It does not break complex expressions' => [
+            '<?php
+                unset(a()[b()["a"]]);
+                unset(a()[b()]);
+                unset(a()["a"]);
+                unset(c($a)->a);
+            ',
         ];
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield 'It does not break curly access expressions' => [
+                '<?php unset(a(){"a"});',
+            ];
+        }
     }
 
     /**
@@ -154,7 +164,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFix73Cases()
     {
-        return [
+        $tests = [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar,);',
@@ -192,9 +202,6 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
             'It works with consecutive unsets' => [
                 '<?php $foo->bar = null; unset($foo); unset($bar); unset($baz); $this->ab = null;',
                 '<?php unset($foo->bar, $foo, $bar, $baz, $this->ab,);',
-            ],
-            'It does not replace unsets on arrays with special notation' => [
-                '<?php unset($bar->foo{0},);',
             ],
             'It works when around messy whitespace' => [
                 '<?php
@@ -237,5 +244,15 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php unset($foo->bar , );',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield 'It does not replace unsets on arrays with special notation' => [
+                '<?php unset($bar->foo{0},);',
+            ];
+        }
     }
 }

--- a/tests/Fixer/Operator/IncrementStyleFixerTest.php
+++ b/tests/Fixer/Operator/IncrementStyleFixerTest.php
@@ -116,16 +116,8 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
                 '<?php $a[0]++;',
             ],
             [
-                '<?php ++$a{0};',
-                '<?php $a{0}++;',
-            ],
-            [
                 '<?php ++$a[$b];',
                 '<?php $a[$b]++;',
-            ],
-            [
-                '<?php ++${$a}->{$b."foo"}->bar[$c]->$baz;',
-                '<?php ${$a}->{$b."foo"}->bar[$c]->$baz++;',
             ],
 
             ['<?php $a = $b++;'],
@@ -180,10 +172,20 @@ final class IncrementStyleFixerTest extends AbstractFixerTestCase
             ],
         ];
 
-        if (\PHP_VERSION_ID >= 70000) {
+        if (\PHP_VERSION_ID >= 70000 && \PHP_VERSION_ID < 80000) {
             $cases[] = [
                 '<?php ++$a->$b::$c->${$d}->${$e}::f(1 + 2 * 3)->$g::$h;',
                 '<?php $a->$b::$c->${$d}->${$e}::f(1 + 2 * 3)->$g::$h++;',
+            ];
+
+            $cases[] = [
+                '<?php ++$a{0};',
+                '<?php $a{0}++;',
+            ];
+
+            $cases[] = [
+                '<?php ++${$a}->{$b."foo"}->bar[$c]->$baz;',
+                '<?php ${$a}->{$b."foo"}->bar[$c]->$baz++;',
             ];
         }
 

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -48,7 +48,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php class A { public function B(){ $static = new static(new \SplFileInfo(__FILE__)); }}',
             ],
@@ -115,18 +115,6 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
             [
                 '<?php $a = new $b[$c][0]();',
                 '<?php $a = new $b[$c][0];',
-            ],
-            [
-                '<?php $a = new $b{$c}();',
-                '<?php $a = new $b{$c};',
-            ],
-            [
-                '<?php $a = new $b{$c}{0}{1}() ?>',
-                '<?php $a = new $b{$c}{0}{1} ?>',
-            ],
-            [
-                '<?php $a = new $b{$c}[1]{0}[2]();',
-                '<?php $a = new $b{$c}[1]{0}[2];',
             ],
             [
                 '<?php $a = new $b[$c[$d ? foo() : bar("bar[...]") - 1]]();',
@@ -270,6 +258,27 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php $a = new $b{$c}();',
+                '<?php $a = new $b{$c};',
+            ];
+
+            yield [
+                '<?php $a = new $b{$c}{0}{1}() ?>',
+                '<?php $a = new $b{$c}{0}{1} ?>',
+            ];
+
+            yield [
+                '<?php $a = new $b{$c}[1]{0}[2]();',
+                '<?php $a = new $b{$c}[1]{0}[2];',
+            ];
+        }
     }
 
     public function provideFix70Cases()

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -37,7 +37,7 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             [
                 '<?php ++$i;',
                 '<?php $i += 1;',
@@ -87,14 +87,6 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
                 '<?php echo $foo[$i += 1];',
             ],
             [
-                '<?php echo ++$foo->{$bar};',
-                '<?php echo $foo->{$bar} += 1;',
-            ],
-            [
-                '<?php echo ++$foo->{$bar->{$baz}};',
-                '<?php echo $foo->{$bar->{$baz}} += 1;',
-            ],
-            [
                 '<?php echo ++$foo[$bar[$baz]];',
                 '<?php echo $foo[$bar[$baz]] += 1;',
             ],
@@ -115,8 +107,8 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
                 '<?php $$${$foo} += 1;',
             ],
             [
-                '<?php ++$a{$b};',
-                '<?php $a{$b} += 1;',
+                '<?php ++$a[$b];',
+                '<?php $a[$b] += 1;',
             ],
             [
                 '<?php ++$a[++$b];',
@@ -255,8 +247,8 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
                 '<?php $$${$foo} -= 1;',
             ],
             [
-                '<?php --$a{$b};',
-                '<?php $a{$b} -= 1;',
+                '<?php --$a[$b];',
+                '<?php $a[$b] -= 1;',
             ],
             [
                 '<?php --$a[--$b];',
@@ -562,6 +554,32 @@ $i#3
                 }',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php echo ++$foo->{$bar};',
+                '<?php echo $foo->{$bar} += 1;',
+            ];
+
+            yield [
+                '<?php echo ++$foo->{$bar->{$baz}};',
+                '<?php echo $foo->{$bar->{$baz}} += 1;',
+            ];
+
+            yield [
+                '<?php ++$a{$b};',
+                '<?php $a{$b} += 1;',
+            ];
+
+            yield [
+                '<?php --$a{$b};',
+                '<?php $a{$b} -= 1;',
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -37,7 +37,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
+        $tests = [
             // Do not fix cases.
             ['<?php $x = isset($a) ? $a[1] : null;'],
             ['<?php $x = isset($a) and $a ? $a : "";'],
@@ -45,7 +45,6 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             ['<?php $x = isset($a) ? $$a : null;'],
             ['<?php $x = isset($a) ? "$a" : null;'],
             ['<?php $x = isset($a) ?: false;'],
-            ['<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'],
             ['<?php $x = $y ?? isset($a) ? $a : null;'],
             ['<?php $x = isset($a) ?: $b;'],
             ['<?php $x = isset($a, $b) ? $a : null;'],
@@ -99,10 +98,6 @@ $x=isset($a)?$a:null?>',
                 '<?php $x = (isset($a) ? $a : isset($b)) ? $b : "";',
             ],
             [
-                '<?php $x = $a ?? isset($b) ? $b : isset($c) ? $c : "";',
-                '<?php $x = isset($a) ? $a : isset($b) ? $b : isset($c) ? $c : "";',
-            ],
-            [
                 '<?php $x = $obj->a ?? null;',
                 '<?php $x = isset($obj->a) ? $obj->a : null;',
             ],
@@ -151,10 +146,6 @@ $x=isset($a)?$a:null?>',
                 '<?php $x = isset($a[Foo::B]) ? $a[Foo::B] : null;',
             ],
             [
-                '<?php $x = /*a1*//*a2*/ /*b*/ $a /*c*/ ?? /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
-                '<?php $x = isset($a) /*a1*//*a2*/ ? /*b*/ $a /*c*/ : /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
-            ],
-            [
                 '<?php $x = (
 // c1
 // c2
@@ -185,5 +176,28 @@ null
 ;',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield ['<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'];
+
+            yield [
+                '<?php $x = $a ?? isset($b) ? $b : isset($c) ? $c : "";',
+                '<?php $x = isset($a) ? $a : isset($b) ? $b : isset($c) ? $c : "";',
+            ];
+
+            yield [
+                '<?php $x = /*a1*//*a2*/ /*b*/ $a /*c*/ ?? /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+                '<?php $x = isset($a) /*a1*//*a2*/ ? /*b*/ $a /*c*/ : /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+            ];
+
+            yield [
+                '<?php $x = /*a1*//*a2*/ /*b*/ $a /*c*/ ?? /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+                '<?php $x = isset($a) /*a1*//*a2*/ ? /*b*/ $a /*c*/ : /*d*/ isset($b) /*e*/ ? /*f*/ $b /*g*/ : /*h*/ isset($c) /*i*/ ? /*j*/ $c /*k*/ : /*l*/ "";',
+            ];
+        }
     }
 }

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -36,11 +36,7 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        return [
-            [
-                '<?php $a = [1,2,3]; echo $a{1}; ?>',
-                '<?php $a = [1,2,3]; echo $a{1} ?>',
-            ],
+        $tests = [
             'comment' => [
                 '<?php $a++;//a ?>',
                 '<?php $a++//a ?>',
@@ -87,6 +83,17 @@ A is equal to 5
 <?php } ?>',
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                '<?php $a = [1,2,3]; echo $a{1}; ?>',
+                '<?php $a = [1,2,3]; echo $a{1} ?>',
+            ];
+        }
     }
 
     public function testOpenWithEcho()

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -849,7 +849,7 @@ class Foo
 
     public function provideOneAndInLineCases()
     {
-        return [
+        $tests = [
             [
                 "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
             ],
@@ -858,12 +858,22 @@ class Foo
                 "<?php throw new \\Exception('do not import.');\n\n",
             ],
             [
-                "<?php\n\n\$a = \$b{0};\n\n",
+                "<?php\n\n\$a = \$b[0];\n\n",
             ],
             [
                 "<?php\n\n\$a->{'Test'};\nfunction test(){}\n",
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
+                "<?php\n\n\$a = \$b{0};\n\n",
+            ];
+        }
     }
 
     /**

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -123,7 +123,7 @@ EOF;
 
     public function provideOutsideCases()
     {
-        return [
+        $tests = [
             [
                 '<?php
 $a = $b[0]    ;',
@@ -184,19 +184,36 @@ $baz [0]
      [1]
      [2] = 3;',
             ],
-            [
+        ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\PHP_VERSION_ID < 80000) {
+            yield [
                 '<?php
 $foo{0}{1}{2} = 3;',
                 '<?php
 $foo {0} {1}   {2} = 3;',
-            ],
-            [
+            ];
+
+            yield [
                 '<?php
 $foobar = $foo{0}[1]{2};',
                 '<?php
 $foobar = $foo {0} [1]   {2};',
-            ],
-        ];
+            ];
+
+            yield [
+                '<?php
+$var = $arr[0]{0
+         };',
+                '<?php
+$var = $arr[0]{     0
+         };',
+            ];
+        }
     }
 
     public function provideInsideCases()
@@ -282,14 +299,6 @@ $var = $arr[0][0
 $var = $arr[0][     0
          ];',
             ],
-            [
-                '<?php
-$var = $arr[0]{0
-         };',
-                '<?php
-$var = $arr[0]{     0
-         };',
-            ],
         ];
     }
 
@@ -321,7 +330,7 @@ $var = $arr[0]{     0
 
     public function provideConfigurationCases()
     {
-        return [
+        $tests = [
             [
                 ['inside', 'outside'],
                 <<<'EOT'
@@ -362,6 +371,17 @@ EOT
                 ,
             ],
         ];
+
+        foreach ($tests as $index => $test) {
+            if (\PHP_VERSION_ID >= 80000) {
+                $test[1] = str_replace('{', '[', $test[1]);
+                $test[1] = str_replace('}', ']', $test[1]);
+                $test[2] = str_replace('{', '[', $test[2]);
+                $test[2] = str_replace('}', ']', $test[2]);
+            }
+
+            yield $index => $test;
+        }
     }
 
     public function testWrongConfig()

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -24,7 +24,7 @@ PHP 7.3 test.
     "trailing_comma_in_multiline_array": {"after_heredoc": true}
 }
 --REQUIREMENTS--
-{"php": 70300}
+{"php": 70300, "php<": 80000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/no_unset_cast,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/no_unset_cast,binary_operator_spaces.test
@@ -2,6 +2,8 @@
 Integration of fixers: no_unset_cast,binary_operator_spaces.
 --RULESET--
 {"no_unset_cast": true, "binary_operator_spaces": true}
+--REQUIREMENTS--
+{"php<": 80000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/set/@PHP8Migration-risky.test-in.php
+++ b/tests/Fixtures/Integration/set/@PHP8Migration-risky.test-in.php
@@ -3,3 +3,6 @@ declare(strict_types=1);
 
 $pieces = [1, 2];
 $f = implode($pieces, '');
+
+echo mktime();
+$exif = read_exif_data('tests/test1.jpg', 'IFD0');

--- a/tests/Fixtures/Integration/set/@PHP8Migration-risky.test-out.php
+++ b/tests/Fixtures/Integration/set/@PHP8Migration-risky.test-out.php
@@ -3,3 +3,6 @@ declare(strict_types=1);
 
 $pieces = [1, 2];
 $f = implode('', $pieces);
+
+echo time();
+$exif = exif_read_data('tests/test1.jpg', 'IFD0');

--- a/tests/Fixtures/Integration/set/@PHP8Migration.test
+++ b/tests/Fixtures/Integration/set/@PHP8Migration.test
@@ -1,6 +1,0 @@
---TEST--
-Integration of @PHP8Migration.
---RULESET--
-{"@PHP8Migration": true}
---REQUIREMENTS--
-{"php": 80000}

--- a/tests/Fixtures/Integration/set/@PHP8Migration.test-in.php
+++ b/tests/Fixtures/Integration/set/@PHP8Migration.test-in.php
@@ -1,6 +1,0 @@
-<?php
-declare(strict_types=1);
-
-$foo = 3;
-$bar = (unset) $foo;
-$foo = $bar{1};

--- a/tests/Fixtures/Integration/set/@PHP8Migration.test-out.php
+++ b/tests/Fixtures/Integration/set/@PHP8Migration.test-out.php
@@ -1,6 +1,0 @@
-<?php
-declare(strict_types=1);
-
-$foo = 3;
-$bar =  null;
-$foo = $bar[1];

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -88,4 +88,27 @@ final class IntegrationTest extends AbstractIntegrationTestCase
             );
         }
     }
+
+    protected function doTest(IntegrationCase $case)
+    {
+        $requirements = $case->getRequirements();
+
+        if (isset($requirements['php<'])) {
+            $phpUpperLimit = $requirements['php<'];
+
+            if (!\is_int($phpUpperLimit)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Expected int value like 50509 for "php<", got "%s". IN "%s".',
+                    \is_object($phpUpperLimit) ? \get_class($phpUpperLimit) : \gettype($phpUpperLimit).'#'.$phpUpperLimit,
+                    $case->getFileName()
+                ));
+            }
+
+            if (\PHP_VERSION_ID >= $phpUpperLimit) {
+                static::markTestSkipped(sprintf('PHP lower than %d is required for "%s", current "%d".', $phpUpperLimit, $case->getFileName(), \PHP_VERSION_ID));
+            }
+        }
+
+        parent::doTest($case);
+    }
 }

--- a/tests/RuleSetTest.php
+++ b/tests/RuleSetTest.php
@@ -658,6 +658,7 @@ final class RuleSetTest extends TestCase
             '@PHP71Migration',
             '@PHP71Migration:risky',
             '@PHP73Migration',
+            '@PHP8Migration',
             '@PhpCsFixer',
             '@PhpCsFixer:risky',
             '@PHPUnit48Migration',

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -27,6 +27,7 @@ use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
 use PhpCsFixer\Linter\CachingLinter;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\Linter\ProcessLinter;
 use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tests\Test\Assert\AssertTokensTrait;
 use PhpCsFixer\Tests\TestCase;
@@ -464,7 +465,9 @@ abstract class AbstractFixerTestCase extends TestCase
 
                 $linter = $linterProphecy->reveal();
             } else {
-                $linter = new CachingLinter(new Linter());
+                $linter = new CachingLinter(
+                    getenv('FAST_LINT_TEST_CASES') ? new Linter() : new ProcessLinter()
+                );
             }
         }
 

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -240,13 +240,11 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
         }
 
         if (null !== $template) {
-            $decoded = array_merge(
-                $template,
-                array_intersect_key(
-                    $decoded,
-                    array_flip(array_keys($template))
-                )
-            );
+            foreach ($template as $index => $value) {
+                if (!\array_key_exists($index, $decoded)) {
+                    $decoded[$index] = $value;
+                }
+            }
         }
 
         return $decoded;

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -22,6 +22,7 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\Linter\CachingLinter;
 use PhpCsFixer\Linter\Linter;
 use PhpCsFixer\Linter\LinterInterface;
+use PhpCsFixer\Linter\ProcessLinter;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -393,7 +394,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
 
                 $linter = $linterProphecy->reveal();
             } else {
-                $linter = new CachingLinter(new Linter());
+                $linter = new CachingLinter(
+                    getenv('FAST_LINT_TEST_CASES') ? new Linter() : new ProcessLinter()
+                );
             }
         }
 


### PR DESCRIPTION
This will prevent invalid test cases like the ones removed by https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5178.