### PR TITLE
[FinalStaticAccessFixer] Handle new static() in final class

### DIFF
--- a/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
+++ b/src/Fixer/ClassNotation/FinalStaticAccessFixer.php
@@ -118,9 +118,10 @@ final class Sample
                 continue;
             }
 
+            $newIndex = $tokens->getPrevMeaningfulToken($index);
             $doubleColonIndex = $tokens->getNextMeaningfulToken($index);
 
-            if (!$tokens[$doubleColonIndex]->isGivenKind(T_DOUBLE_COLON)) {
+            if (!$tokens[$newIndex]->isGivenKind(T_NEW) && !$tokens[$doubleColonIndex]->isGivenKind(T_DOUBLE_COLON)) {
                 continue;
             }
 

--- a/tests/Fixer/ClassNotation/FinalStaticAccessFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalStaticAccessFixerTest.php
@@ -57,6 +57,18 @@ final class FinalStaticAccessFixerTest extends AbstractFixerTestCase
                 '<?php final class A { public function b() { echo self::C; } }',
                 '<?php final class A { public function b() { echo static::C; } }',
             ],
+            'in method as new' => [
+                '<?php final class A { public static function b() { return new self(); } }',
+                '<?php final class A { public static function b() { return new static(); } }',
+            ],
+            'in method as new with comments' => [
+                '<?php final class A { public static function b() { return new /* hmm */ self(); } }',
+                '<?php final class A { public static function b() { return new /* hmm */ static(); } }',
+            ],
+            'in method as new without parentheses' => [
+                '<?php final class A { public static function b() { return new self; } }',
+                '<?php final class A { public static function b() { return new static; } }',
+            ],
             'does not change non-final classes' => [
                 '<?php class A { public function b() { echo static::c(); } }',
             ],


### PR DESCRIPTION
This PR

* [x] handles `new static()` in `final` classes

💁‍♂️ Not sure, should I target the `2.15` branch instead?