### PR TITLE
MethodArgumentSpaceFixer - support use/import of anonymous functions.

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -141,7 +141,7 @@ SAMPLE
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $expectedTokens = [T_LIST, T_FUNCTION];
+        $expectedTokens = [T_LIST, T_FUNCTION, CT::T_USE_LAMBDA];
         if (\PHP_VERSION_ID >= 70400) {
             $expectedTokens[] = T_FN;
         }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -699,8 +699,11 @@ $b,
     $c#
 #
 )#
-use ($x,
-$y,$z) {
+use (
+    $b,
+    $c,
+    $d
+) {
 };
 EXPECTED
                 ,
@@ -927,6 +930,14 @@ if (true) {
                 [
                     'on_multiline' => 'ensure_fully_multiline',
                 ],
+            ],
+            'test anonymous functions' => [
+                '<?php
+$example = function () use ($message1, $message2) {
+};',
+                '<?php
+$example = function () use ($message1,$message2) {
+};',
             ],
         ];
     }


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5127

I can't rebase your fix on 2.15 on you fork/PR, so I created this PR, leaving you author.