### PR TITLE
Fixed minimum symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
         "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
         "phpunitgoodpractices/traits": "^1.9.1",
-        "symfony/phpunit-bridge": "^5.1",
+        "symfony/phpunit-bridge": "^5.1.7",
         "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "composer/xdebug-handler": "^1.2",
         "doctrine/annotations": "^1.2",
         "php-cs-fixer/diff": "^1.3",
-        "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
+        "symfony/console": "^3.4.45 || ^4.4.14 || ^5.1.6",
         "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
         "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
         "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-        "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+        "symfony/options-resolver": "^3.4.45 || ^4.4.14 || ^5.1.6",
         "symfony/polyfill-php70": "^1.0",
         "symfony/polyfill-php72": "^1.4",
-        "symfony/process": "^3.0 || ^4.0 || ^5.0",
+        "symfony/process": "^3.4.41 || ^4.4.9 || ^5.0.9",
         "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5183 highlighted issues with the minimum versions. This PR is needed for that one to pass.