### PR TITLE
DX: cleanup php-cs-fixer entry file

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -23,10 +23,7 @@ if (defined('HHVM_VERSION_ID')) {
     } else {
         exit(1);
     }
-} elseif (
-    (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500)
-    && (!isset($_SERVER['argv'][1]) || 'documentation' !== $_SERVER['argv'][1])
-) {
+} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500) {
     fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.\n");
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {


### PR DESCRIPTION
potential cleanup after #3475
If i get it right, it was needed to generate the new docs from `php-cs-fixer` file, but then the logic was moved to `dev-tools/doc` file