### PR TITLE
PHP8 - throw expression support

### DIFF
--- a/src/AbstractNoUselessElseFixer.php
+++ b/src/AbstractNoUselessElseFixer.php
@@ -36,6 +36,7 @@ abstract class AbstractNoUselessElseFixer extends AbstractFixer
     protected function isSuperfluousElse(Tokens $tokens, $index)
     {
         $previousBlockStart = $index;
+
         do {
             // Check if all 'if', 'else if ' and 'elseif' blocks above this 'else' always end,
             // if so this 'else' is overcomplete.
@@ -69,10 +70,19 @@ abstract class AbstractNoUselessElseFixer extends AbstractFixer
                 ]
             );
 
-            if (
-                null === $candidateIndex
-                || $tokens[$candidateIndex]->equalsAny([';', [T_CLOSE_TAG], [T_IF]])
-                || $this->isInConditional($tokens, $candidateIndex, $previousBlockStart)
+            if (null === $candidateIndex || $tokens[$candidateIndex]->equalsAny([';', [T_CLOSE_TAG], [T_IF]])) {
+                return false;
+            }
+
+            if ($tokens[$candidateIndex]->equals([T_THROW])) {
+                $previousIndex = $tokens->getPrevMeaningfulToken($candidateIndex);
+
+                if (!$tokens[$previousIndex]->equalsAny([';', '{'])) {
+                    return false;
+                }
+            }
+
+            if ($this->isInConditional($tokens, $candidateIndex, $previousBlockStart)
                 || $this->isInConditionWithoutBraces($tokens, $candidateIndex, $previousBlockStart)
             ) {
                 return false;
@@ -165,6 +175,7 @@ abstract class AbstractNoUselessElseFixer extends AbstractFixer
             if ($token->equals(';')) {
                 return false;
             }
+
             if ($token->equals('{')) {
                 $index = $tokens->getPrevMeaningfulToken($index);
 

--- a/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
+++ b/src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php
@@ -71,11 +71,10 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
      */
     private function isElseif(Tokens $tokens, $index)
     {
-        if ($tokens[$index]->isGivenKind(T_ELSEIF)) {
-            return true;
-        }
-
-        return $tokens[$index]->isGivenKind(T_ELSE) && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_IF);
+        return
+            $tokens[$index]->isGivenKind(T_ELSEIF)
+            || ($tokens[$index]->isGivenKind(T_ELSE) && $tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_IF))
+        ;
     }
 
     /**
@@ -90,6 +89,7 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
         }
 
         $whitespace = '';
+
         for ($previous = $index - 1; $previous > 0; --$previous) {
             $token = $tokens[$previous];
             if ($token->isWhitespace() && Preg::match('/(\R\N*)$/', $token->getContent(), $matches)) {
@@ -104,6 +104,7 @@ final class NoSuperfluousElseifFixer extends AbstractNoUselessElseFixer
         }
 
         $previousToken = $tokens[$index - 1];
+
         if (!$previousToken->isWhitespace()) {
             $tokens->insertAt($index, new Token([T_WHITESPACE, $whitespace]));
         } elseif (!Preg::match('/\R/', $previousToken->getContent())) {

--- a/src/Fixer/ControlStructure/NoUselessElseFixer.php
+++ b/src/Fixer/ControlStructure/NoUselessElseFixer.php
@@ -90,6 +90,7 @@ final class NoUselessElseFixer extends AbstractNoUselessElseFixer
     private function fixEmptyElse(Tokens $tokens, $index)
     {
         $next = $tokens->getNextMeaningfulToken($index);
+
         if ($tokens[$next]->equals('{')) {
             $close = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $next);
             if (1 === $close - $next) { // '{}'
@@ -117,6 +118,7 @@ final class NoUselessElseFixer extends AbstractNoUselessElseFixer
 
         // clear T_ELSE and the '{' '}' if there are any
         $next = $tokens->getNextMeaningfulToken($index);
+
         if (!$tokens[$next]->equals('{')) {
             return;
         }

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -734,19 +734,25 @@ switch ($foo) {
             [
                 '<?php
 switch ($foo) {
-    case 1:
+    case 1: {
         throw new \Exception();
+    }
     case 2:
+        ?>
+        <?php
         throw new \Exception();
     default:
         throw new \Exception();
 }',
                 '<?php
 switch ($foo) {
-    case 1:
+    case 1: {
         // no break
         throw new \Exception();
+    }
     case 2:
+        ?>
+        <?php
         // no break
         throw new \Exception();
     default:
@@ -1112,5 +1118,55 @@ switch ($foo) {
         $this->expectExceptionMessageRegExp('/^\[no_break_comment\] Invalid configuration: The option "foo" does not exist\. Defined options are: "comment_text"\.$/');
 
         $this->fixer->configure(['foo' => true]);
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php
+                switch ($foo) {
+                    case 1:
+                        foo() ?? throw new \Exception();
+                        // no break
+                    case 2:
+                        $a = $condition and throw new Exception();
+                        // no break
+                    case 3:
+                        $callable = fn() => throw new Exception();
+                        // no break
+                    case 4:
+                        $value = $falsableValue ?: throw new InvalidArgumentException();
+                        // no break
+                    default:
+                        echo "PHP8";
+                }
+            ',
+            '<?php
+                switch ($foo) {
+                    case 1:
+                        foo() ?? throw new \Exception();
+                    case 2:
+                        $a = $condition and throw new Exception();
+                    case 3:
+                        $callable = fn() => throw new Exception();
+                    case 4:
+                        $value = $falsableValue ?: throw new InvalidArgumentException();
+                    default:
+                        echo "PHP8";
+                }
+            ',
+        ];
     }
 }

--- a/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
@@ -279,4 +279,28 @@ if ($some) { return 1; } elseif ($a == 6){ $test = false; } //',
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php
+            if ($foo) {
+                $a = $bar ?? throw new \Exception();
+            } elseif ($bar) {
+                echo 1;
+            }
+            ',
+        ];
+    }
 }

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -55,17 +55,9 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
         }
     }
 
-    /**
-     * @return array
-     */
     public function provideFixCases()
     {
-        return [
-            [
-                '<?php $a = ($b + $c) || 1 === true ? 1 : 2;',
-                null,
-                ['always_move_variable' => true],
-            ],
+        $tests = [
             [
                 '<?php $a = 1 + ($b + $c) === true ? 1 : 2;',
                 null,
@@ -621,10 +613,6 @@ $a#4
                 '<?php $a = reset($foo) === -/* bar */1;',
             ],
             [
-                '<?php $a **= 4 === $b ? 2 : 3;',
-                '<?php $a **= $b === 4 ? 2 : 3;',
-            ],
-            [
                 '<?php $a %= 4 === $b ? 2 : 3;',
                 '<?php $a %= $b === 4 ? 2 : 3;',
             ],
@@ -648,7 +636,37 @@ $a#4
                     // 1
                 ];',
             ],
+            [
+                '<?php $a = $b = null === $c;',
+                '<?php $a = $b = $c === null;',
+            ],
         ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        $template = '<?php $a = ($b + $c) %s 1 === true ? 1 : 2;';
+        $operators = ['||', '&&'];
+
+        foreach ($operators as $operator) {
+            yield [
+                sprintf($template, $operator),
+                null,
+                ['always_move_variable' => true],
+            ];
+        }
+
+        $templateExpected = '<?php $a %s 4 === $b ? 2 : 3;';
+        $templateInput = '<?php $a %s $b === 4 ? 2 : 3;';
+        $operators = ['**=', '*=', '|=', '+=', '-=', '^=', 'xor', 'or', 'and', '<<=', '>>=', '&=', '.=', '/=', '-=', '||', '&&'];
+
+        foreach ($operators as $operator) {
+            yield [
+                sprintf($templateExpected, $operator),
+                sprintf($templateInput, $operator),
+            ];
+        }
     }
 
     /**
@@ -677,9 +695,6 @@ $a#4
         $this->doTest($input, $expected);
     }
 
-    /**
-     * @return array<string[]>
-     */
     public function provideLessGreaterCases()
     {
         return [
@@ -782,9 +797,6 @@ $a#4
         }
     }
 
-    /**
-     * @return array<string[]>
-     */
     public function providePHP70Cases()
     {
         return [
@@ -845,9 +857,6 @@ function a() {
         }
     }
 
-    /**
-     * @return array<string[]>
-     */
     public function providePHP71Cases()
     {
         return [

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -1234,6 +1234,37 @@ use const some\Z\{ConstX,ConstY,ConstZ,};
         ];
     }
 
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected)
+    {
+        $this->fixer->configure(['tokens' => ['throw']]);
+
+        $this->doTest($expected);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php
+                $a = $bar ?? throw new \Exception();
+                $a = $bar ?? throw new \Exception();
+                $a = $bar ?? throw new \Exception();
+            ',
+            '<?php
+                $a = $bar ?? throw new \Exception();
+
+                $a = $bar ?? throw new \Exception();
+
+                $a = $bar ?? throw new \Exception();
+            ',
+        ];
+    }
+
     private function removeLinesFromString($input, array $lineNumbers)
     {
         sort($lineNumbers);


### PR DESCRIPTION
I think these are all effected fixers for
https://wiki.php.net/rfc/throw_expression

However maybe the Yoda fixer is effected somehow but I couldn't come up with a case for it. This seems dead code: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.15.9/src/Fixer/ControlStructure/YodaStyleFixer.php#L471
