### PR TITLE
Improve handling of unavailable code samples

### DIFF
--- a/dev-tools/doc.php
+++ b/dev-tools/doc.php
@@ -11,6 +11,8 @@
  * with this source code in the file LICENSE.
  */
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 require __DIR__.'/../vendor/autoload.php';
 
 use PhpCsFixer\Console\Command\DocumentationCommand;

--- a/src/Documentation/DocumentationGenerator.php
+++ b/src/Documentation/DocumentationGenerator.php
@@ -304,7 +304,7 @@ RST;
                     }
                 }
 
-                $doc .= "\n".$this->generateSampleDiff($fixer, $sample, $index, $name);
+                $doc .= "\n".$this->generateSampleDiff($fixer, $sample, $index + 1, $name);
             }
         }
 
@@ -450,18 +450,28 @@ RST;
     }
 
     /**
-     * @param int    $sampleIndex
+     * @param int    $sampleNumber
      * @param string $ruleName
      *
      * @return string
      */
-    private function generateSampleDiff(FixerInterface $fixer, CodeSampleInterface $sample, $sampleIndex, $ruleName)
+    private function generateSampleDiff(FixerInterface $fixer, CodeSampleInterface $sample, $sampleNumber, $ruleName)
     {
         if ($sample instanceof VersionSpecificCodeSampleInterface && !$sample->isSuitableFor(\PHP_VERSION_ID)) {
+            $existingFile = @file_get_contents($this->getFixerDocumentationFilePath($fixer));
+
+            if (false !== $existingFile) {
+                Preg::match("/\\RExample #{$sampleNumber}\\R.+?(?<diff>\\R\\.\\. code-block:: diff\\R\\R.*?)\\R(?:\\R\\S|$)/s", $existingFile, $matches);
+
+                if (isset($matches['diff'])) {
+                    return $matches['diff'];
+                }
+            }
+
             $error = <<<RST
 
 .. error::
-   Cannot generate diff for code sample #{$sampleIndex} of rule {$ruleName}:
+   Cannot generate diff for code sample #{$sampleNumber} of rule {$ruleName}:
    the sample is not suitable for current version of PHP (%s).
 RST;
 

--- a/src/Documentation/DocumentationGenerator.php
+++ b/src/Documentation/DocumentationGenerator.php
@@ -129,11 +129,7 @@ RST;
                 $attributes = '';
             }
 
-            $path = Preg::replace(
-                '#^'.preg_quote($this->getFixersDocumentationDirectoryPath(), '#').'/#',
-                './',
-                $this->getFixerDocumentationFilePath($fixer)
-            );
+            $path = './'.$this->getFixerDocumentationFileRelativePath($fixer);
 
             $documentation .= <<<RST
 
@@ -157,6 +153,18 @@ RST;
             },
             \get_class($fixer)
         ).'.rst';
+    }
+
+    /**
+     * @return string
+     */
+    public function getFixerDocumentationFileRelativePath(FixerInterface $fixer)
+    {
+        return Preg::replace(
+            '#^'.preg_quote($this->getFixersDocumentationDirectoryPath(), '#').'/#',
+            '',
+            $this->getFixerDocumentationFilePath($fixer)
+        );
     }
 
     /**


### PR DESCRIPTION
Ref: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5209#issuecomment-720163602

When a code sample cannot be generated because the command runs on the wrong PHP version, the command will try to find it in the existing documentation file in case it was already generated in a previous run on the expected PHP version.

This might have weird results in case this happens when code samples are added or removed, but I think it's a better DX than to manually revert all _"Cannot generate diff..."_ that get added on every run.