### PR TITLE
Add option to sort within import groups

### DIFF
--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -83,7 +83,7 @@ use Bar;
                     ['sort_algorithm' => self::SORT_LENGTH]
                 ),
                 new CodeSample(
-                    "<?php\nuse Acme\{Foo, Bar, Baz};\n",
+                    "<?php\nuse Acme\\{Foo, Bar, Baz};\n",
                     ['group_sort' => true]
                 ),
                 new VersionSpecificCodeSample(
@@ -297,10 +297,10 @@ use Bar;
      */
     private function sortAlphabetically(array $first, array $second)
     {
-        if ($first['group'] === true && $this->configuration['group_sort']) {
+        if (true === $first['group'] && $this->configuration['group_sort']) {
             $first['namespace'] = $this->sortNamespaceGroup($first['namespace']);
         }
-        if ($second['group'] === true && $this->configuration['group_sort']) {
+        if (true === $second['group'] && $this->configuration['group_sort']) {
             $second['namespace'] = $this->sortNamespaceGroup($second['namespace']);
         }
 
@@ -323,10 +323,10 @@ use Bar;
      */
     private function sortByLength(array $first, array $second)
     {
-        if ($first['group'] === true && $this->configuration['group_sort']) {
+        if (true === $first['group'] && $this->configuration['group_sort']) {
             $first['namespace'] = $this->sortNamespaceGroup($first['namespace']);
         }
-        if ($second['group'] === true && $this->configuration['group_sort']) {
+        if (true === $second['group'] && $this->configuration['group_sort']) {
             $second['namespace'] = $this->sortNamespaceGroup($second['namespace']);
         }
 
@@ -362,10 +362,11 @@ use Bar;
      */
     private function sortNamespaceGroup($namespace)
     {
-        return Preg::replaceCallback('/\{(.*)\}/s', function($matches) {
+        return Preg::replaceCallback('/\{(.*)\}/s', function ($matches) {
             $parts = array_map('trim', explode(',', $matches[1]));
             natsort($parts);
-            return '{' . implode(', ', $parts) . '}';
+
+            return '{'.implode(', ', $parts).'}';
         }, $namespace);
     }
 

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -82,8 +82,9 @@ use Bar;
 ',
                     ['sort_algorithm' => self::SORT_LENGTH]
                 ),
-                new CodeSample(
+                new VersionSpecificCodeSample(
                     "<?php\nuse Acme\\{Foo, Bar, Baz};\n",
+                    new VersionSpecification(70000),
                     ['group_sort' => true]
                 ),
                 new VersionSpecificCodeSample(

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -973,10 +973,10 @@ use A\A1;
             'grouped import sorting' => [
                 '<?php
 use Acme\{Bar, Baz, Foo};
-use Zoo\Baz;
+use Zoo\Zab;
                 ',
                 '<?php
-use Zoo\Baz;
+use Zoo\Zab;
 use Acme\{Foo, Bar, Baz};
                  ',
                 [

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -978,7 +978,7 @@ use Zoo\Zab;
                 '<?php
 use Zoo\Zab;
 use Acme\{Foo, Bar, Baz};
-                 ',
+                ',
                 [
                     'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
                     'group_sort' => true,

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -970,6 +970,20 @@ use A\A1;
                     'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
                 ],
             ],
+            'grouped import sorting' => [
+                '<?php
+use Acme\{Bar, Baz, Foo};
+use Zoo\Baz;
+                ',
+                '<?php
+use Zoo\Baz;
+use Acme\{Foo, Bar, Baz};
+                 ',
+                [
+                    'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
+                    'group_sort' => true,
+                ],
+            ],
         ];
     }
 
@@ -2143,49 +2157,5 @@ class AnnotatedClass
 EOF;
 
         $this->doTest($expected);
-    }
-
-    public function testFixWithGroupedImports()
-    {
-        $this->fixer->configure([
-            'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
-            'group_sort' => true,
-        ]);
-
-        $expected = <<<'EOF'
-The normal
-use of this fixer
-should not change this sentence nor those statements below
-use Zoo\Baz;
-use abc\Bar;
-
-<?php
-
-use Acme\{Bar, Baz, Foo};
-use Zoo\Baz;
-
-class Test
-{
-}
-EOF;
-
-        $input = <<<'EOF'
-The normal
-use of this fixer
-should not change this sentence nor those statements below
-use Zoo\Baz;
-use abc\Bar;
-
-<?php
-
-use Zoo\Baz;
-use Acme\{Foo, Bar, Baz};
-
-class Test
-{
-}
-EOF;
-
-        $this->doTest($expected, $input);
     }
 }

--- a/tests/Fixer/Import/OrderedImportsFixerTest.php
+++ b/tests/Fixer/Import/OrderedImportsFixerTest.php
@@ -2144,4 +2144,48 @@ EOF;
 
         $this->doTest($expected);
     }
+
+    public function testFixWithGroupedImports()
+    {
+        $this->fixer->configure([
+            'sort_algorithm' => OrderedImportsFixer::SORT_ALPHA,
+            'group_sort' => true,
+        ]);
+
+        $expected = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Baz;
+use abc\Bar;
+
+<?php
+
+use Acme\{Bar, Baz, Foo};
+use Zoo\Baz;
+
+class Test
+{
+}
+EOF;
+
+        $input = <<<'EOF'
+The normal
+use of this fixer
+should not change this sentence nor those statements below
+use Zoo\Baz;
+use abc\Bar;
+
+<?php
+
+use Zoo\Baz;
+use Acme\{Foo, Bar, Baz};
+
+class Test
+{
+}
+EOF;
+
+        $this->doTest($expected, $input);
+    }
 }


### PR DESCRIPTION
Within the Ordered Imports fixer, import groups such as this are left unsorted:

```php
use Foo\{Baz, Bar};
```

This PR adds an option to alphabetically sort elements inside groups.
