### PR TITLE
PHP8 - Allow trailing comma in parameter list support

### DIFF
--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -1134,4 +1134,45 @@ EOF;
 
         $this->doTest($expected, $input);
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp80Cases
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixPhp80Cases()
+    {
+        yield [
+            <<<'EOF'
+<?php
+
+class Foo
+{
+    public function __construct($bar,)
+    {
+        var_dump(1);
+    }
+}
+EOF
+            ,
+            <<<'EOF'
+<?php
+
+class Foo
+{
+    public function Foo($bar,)
+    {
+        var_dump(1);
+    }
+}
+EOF
+        ];
+    }
 }

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -205,4 +205,24 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp80Cases
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixPhp80Cases()
+    {
+        yield [
+            '<?php interface Foo { public function bar(self $foo, self $bar,): self; }',
+            '<?php interface Foo { public function bar(Foo $foo, Foo $bar,): Foo; }',
+        ];
+    }
 }

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -442,6 +442,11 @@ foo#
                 self::$configurationClosureSpacingNone,
             ],
             [
+                '<?php fn&($a,$b) => null;',
+                '<?php fn &(  $a,$b  ) => null;',
+                self::$configurationClosureSpacingNone,
+            ],
+            [
                 '<?php $b = static fn ($a) => $a;',
                 '<?php $b = static     fn( $a )   => $a;',
             ],
@@ -450,6 +455,47 @@ foo#
                 '<?php $b = static     fn ( $a )   => $a;',
                 self::$configurationClosureSpacingNone,
             ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFixPhp80Cases
+     * @requires PHP 8.0
+     */
+    public function testFixPhp80($expected, $input = null, array $configuration = [])
+    {
+        $this->fixer->configure($configuration);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixPhp80Cases()
+    {
+        yield [
+            '<?php function ($i,) {};',
+            '<?php function(   $i,   ) {};',
+        ];
+
+        yield [
+            '<?php
+                    $b = static function ($a,$b,) {
+                        echo $a;
+                    };
+                ',
+            '<?php
+                    $b = static     function(  $a,$b,   )   {
+                        echo $a;
+                    };
+                ',
+        ];
+
+        yield [
+            '<?php fn&($a,$b,) => null;',
+            '<?php fn &(  $a,$b,   ) => null;',
+            self::$configurationClosureSpacingNone,
         ];
     }
 }

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -713,4 +713,47 @@ A();
             24,
         ];
     }
+
+    /**
+     * @param string $code
+     * @param int    $methodIndex
+     * @param array  $expected
+     *
+     * @dataProvider provideFunctionsWithArgumentsPhp80Cases
+     * @requires PHP 8.0
+     */
+    public function testFunctionArgumentInfoPhp80($code, $methodIndex, $expected)
+    {
+        $tokens = Tokens::fromCode($code);
+        $analyzer = new FunctionsAnalyzer();
+
+        static::assertSame(serialize($expected), serialize($analyzer->getFunctionArguments($tokens, $methodIndex)));
+    }
+
+    public function provideFunctionsWithArgumentsPhp80Cases()
+    {
+        yield ['<?php function($aa,){};', 1, [
+            '$aa' => new ArgumentAnalysis(
+                '$aa',
+                3,
+                null,
+                null
+            ),
+        ]];
+
+        yield ['<?php fn($a,    $bc  ,) => null;', 1, [
+            '$a' => new ArgumentAnalysis(
+                '$a',
+                3,
+                null,
+                null
+            ),
+            '$bc' => new ArgumentAnalysis(
+                '$bc',
+                6,
+                null,
+                null
+            ),
+        ]];
+    }
 }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -664,6 +664,22 @@ preg_replace_callback(
                     };',
                 [6 => true],
             ],
+            [
+                '<?php
+$c = 4; //
+$a = function(
+    $a,
+    $b,
+) use (
+    $c,
+) {
+    echo $a + $b + $c;
+};
+
+
+$a(1,2);',
+                [14 => true],
+            ],
         ];
     }
 


### PR DESCRIPTION
https://wiki.php.net/rfc/trailing_comma_in_parameter_list