### PR TITLE
DX: drop non-maintained Symfony <3.4 and <4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         "composer/xdebug-handler": "^1.2",
         "doctrine/annotations": "^1.2",
         "php-cs-fixer/diff": "^1.3",
-        "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
-        "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
-        "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
-        "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-        "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
+        "symfony/console": "^3.4.46 || ^4.4.16 || ^5.0",
+        "symfony/event-dispatcher": "^3.4.46 || ^4.4.16 || ^5.0",
+        "symfony/filesystem": "^3.4.46 || ^4.4.16 || ^5.0",
+        "symfony/finder": "^3.4.46 || ^4.4.16 || ^5.0",
+        "symfony/options-resolver": "^3.4.46 || ^4.4.16 || ^5.0",
         "symfony/polyfill-php70": "^1.0",
         "symfony/polyfill-php72": "^1.4",
-        "symfony/process": "^3.0 || ^4.0 || ^5.0",
-        "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+        "symfony/process": "^3.4.46 || ^4.4.16 || ^5.0",
+        "symfony/stopwatch": "^3.4.46 || ^4.4.16 || ^5.0"
     },
     "require-dev": {
         "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
@@ -43,7 +43,7 @@
         "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
         "phpunitgoodpractices/traits": "^1.9.1",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+        "symfony/yaml": "^3.4.46 || ^4.4.16 || ^5.0"
     },
     "suggest": {
         "ext-dom": "For handling output formats in XML",


### PR DESCRIPTION
I was struggling with some issue which looked related to --prefer-lowest (ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5242#issuecomment-723671891 ) and having 1000 possible combinations to check is pointless.

(not fully dropping v3, as it's still in serious usage in prod: https://packagist.org/packages/symfony/console/stats#major/all )