### PR TITLE
PHP8 - mixed type support

### DIFF
--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -30,17 +30,18 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
     /**
      * https://secure.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.
      *
-     * self     PHP 5.0.0
-     * array    PHP 5.1.0
-     * callable PHP 5.4.0
-     * bool     PHP 7.0.0
-     * float    PHP 7.0.0
-     * int      PHP 7.0.0
-     * string   PHP 7.0.0
-     * iterable PHP 7.1.0
-     * void     PHP 7.1.0
-     * object   PHP 7.2.0
-     * static   PHP 8.0.0 (return type only)
+     * self     PHP 5.0
+     * array    PHP 5.1
+     * callable PHP 5.4
+     * bool     PHP 7.0
+     * float    PHP 7.0
+     * int      PHP 7.0
+     * string   PHP 7.0
+     * iterable PHP 7.1
+     * void     PHP 7.1
+     * object   PHP 7.2
+     * static   PHP 8.0 (return type only)
+     * mixed    PHP 8.0
      *
      * @var array<string, true>
      */
@@ -89,6 +90,7 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
 
         if (\PHP_VERSION_ID >= 80000) {
             $this->hints = array_merge($this->hints, ['static' => true]);
+            $this->hints = array_merge($this->hints, ['mixed' => true]);
         }
 
         $this->functionsAnalyzer = new FunctionsAnalyzer();

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -193,6 +193,10 @@ final class Foo {
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        if (\PHP_VERSION_ID >= 80000) {
+            unset($this->skippedTypes['mixed']);
+        }
+
         for ($index = $tokens->count() - 1; 0 < $index; --$index) {
             if (
                 !$tokens[$index]->isGivenKind(T_FUNCTION)

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -216,15 +216,19 @@ function Foo(INTEGER $a) {}
 
     public function provideFix80Cases()
     {
-        return [
-            [
-                '<?php class T { public function Foo(object $A): static {}}',
-                '<?php class T { public function Foo(object $A): StatiC {}}',
-            ],
-            [
-                '<?php class T { public function Foo(object $A): ?static {}}',
-                '<?php class T { public function Foo(object $A): ?StatiC {}}',
-            ],
+        yield [
+            '<?php class T { public function Foo(object $A): static {}}',
+            '<?php class T { public function Foo(object $A): StatiC {}}',
+        ];
+
+        yield [
+            '<?php class T { public function Foo(object $A): ?static {}}',
+            '<?php class T { public function Foo(object $A): ?StatiC {}}',
+        ];
+
+        yield [
+            '<?php class T { public function Foo(mixed $A): mixed {}}',
+            '<?php class T { public function Foo(Mixed $A): MIXED {}}',
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -267,4 +267,24 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php function foo(mixed $a){}',
+            '<?php function foo(mixed$a){}',
+        ];
+    }
 }

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -195,9 +195,6 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
             'skip resource special type' => [
                 '<?php /** @return resource */ function my_foo() {}',
             ],
-            'skip mixed special type' => [
-                '<?php /** @return mixed */ function my_foo() {}',
-            ],
             'null alone cannot be a return type' => [
                 '<?php /** @return null */ function my_foo() {}',
             ],
@@ -278,6 +275,10 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                     }
                 ',
             ];
+
+            yield 'skip mixed special type' => [
+                '<?php /** @return mixed */ function my_foo() {}',
+            ];
         }
     }
 
@@ -318,35 +319,49 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 
     public function provideFixPhp80Cases()
     {
-        return [
-            'static' => [
-                '<?php
-                    final class Foo {
-                        /** @return static */
-                        public function something(): static {}
-                    }
-                ',
-                '<?php
-                    final class Foo {
-                        /** @return static */
-                        public function something() {}
-                    }
-                ',
-            ],
-            'nullable static' => [
-                '<?php
-                    final class Foo {
-                        /** @return null|static */
-                        public function something(): ?static {}
-                    }
-                ',
-                '<?php
-                    final class Foo {
-                        /** @return null|static */
-                        public function something() {}
-                    }
-                ',
-            ],
+        yield 'static' => [
+            '<?php
+                final class Foo {
+                    /** @return static */
+                    public function something(): static {}
+                }
+            ',
+            '<?php
+                final class Foo {
+                    /** @return static */
+                    public function something() {}
+                }
+            ',
+        ];
+
+        yield 'nullable static' => [
+            '<?php
+                final class Foo {
+                    /** @return null|static */
+                    public function something(): ?static {}
+                }
+            ',
+            '<?php
+                final class Foo {
+                    /** @return null|static */
+                    public function something() {}
+                }
+            ',
+        ];
+
+        yield 'mixed' => [
+            '<?php
+                final class Foo {
+                    /** @return mixed */
+                    public function something(): mixed {}
+                }
+            ',
+            '<?php
+                final class Foo {
+                    /** @return mixed */
+                    public function something() {}
+                }
+            ',
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -191,4 +191,29 @@ string {}',
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php function foo(): mixed{}',
+            '<?php function foo()   :   mixed{}',
+        ];
+
+        yield [
+            '<?php class A { public function foo(): static{}}',
+            '<?php class A { public function foo()   :static{}}',
+        ];
+    }
 }

--- a/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
@@ -128,4 +128,24 @@ $a = $b->test(  // do not remove space
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield [
+            '<?php function foo(mixed $a){}',
+            '<?php function foo( mixed $a ){}',
+        ];
+    }
 }


### PR DESCRIPTION
On master check `phpdoc_to_param_type`  as well.

`PhpdocToReturnTypeFixer` could support:
```
            'skip mixed types' => [
                '<?php /** @return Foo|Bar */ function my_foo(): mixed {}',
                '<?php /** @return Foo|Bar */ function my_foo() {}',
            ],
```
through configuration if we want to