### PR TITLE
Tests: do not skip documentation test

### DIFF
--- a/tests/AutoReview/DocumentationTest.php
+++ b/tests/AutoReview/DocumentationTest.php
@@ -14,7 +14,6 @@ namespace PhpCsFixer\Tests\AutoReview;
 
 use PhpCsFixer\Documentation\DocumentationGenerator;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSampleInterface;
 use PhpCsFixer\FixerFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -35,12 +34,6 @@ final class DocumentationTest extends TestCase
     public function testFixerDocumentationFileIsUpToDate(DefinedFixerInterface $fixer)
     {
         $samples = $fixer->getDefinition()->getCodeSamples();
-
-        foreach ($samples as $sample) {
-            if ($sample instanceof VersionSpecificCodeSampleInterface && !$sample->isSuitableFor(\PHP_VERSION_ID)) {
-                static::markTestIncomplete(sprintf('Define whether this test for "%d" brings value and drop it or fix it - https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5209 .', $fixer->getName()));
-            }
-        }
 
         $generator = new DocumentationGenerator();
 


### PR DESCRIPTION
closes: #5209 

looks like we can re-enable the docs tests after the fixes in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5236

related:
- #5256 => green Travis on 2.16 with test enabled
- #5257 => green Travis on master with test enabled
- #5258 => green Travis on 3.0 with test enabled