### PR TITLE
Improve InstallViaComposerTest

### DIFF
--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -135,7 +135,7 @@ final class InstallViaComposerTest extends AbstractSmokeTest
         $stepsToInitializeArtifact = [
             // Clone current version of project to new location, as we gonna modify it.
             // Warning! Only already committed changes will be cloned!
-            "git clone . {$tmpArtifactPath}",
+            "git clone --depth=1 . {$tmpArtifactPath}",
         ];
         $stepsToPrepareArtifact = [
             // Configure git user for new repo to not use global git user.
@@ -143,7 +143,7 @@ final class InstallViaComposerTest extends AbstractSmokeTest
             'git config user.name test && git config user.email test',
             // Adjust cloned project to expose version in `composer.json`.
             // Without that, it would not be possible to use it as Composer Artifact.
-            "composer config version {$fakeVersion} && git add . && git commit -m 'provide version'",
+            "composer config version {$fakeVersion} && git add . && git commit --no-gpg-sign -m 'provide version'",
             // Create repo archive that will serve as Composer Artifact.
             'git archive HEAD --format=zip -o archive.zip',
             // Drop the repo, keep the archive


### PR DESCRIPTION
This PR:

- [x] Changes the test to clone only one level deep. This is faster.
- [x] Changes commit op to work without GPG signing. If it was configured on the system level, the commit will fail.

Extracted from #5262