### PR TITLE
Do not replace mt_rand to random_int - seed is ignored

### DIFF
--- a/doc/ruleSets/PHP70MigrationRisky.rst
+++ b/doc/ruleSets/PHP70MigrationRisky.rst
@@ -14,5 +14,3 @@ Rules
   config:
   ``['use_escape_sequences_in_strings' => true]``
 - `random_api_migration <./../rules/alias/random_api_migration.rst>`_
-  config:
-  ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``

--- a/doc/rules/alias/random_api_migration.rst
+++ b/doc/rules/alias/random_api_migration.rst
@@ -64,16 +64,10 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PHP70Migration:risky
-  Using the `@PHP70Migration:risky <./../../ruleSets/PHP70MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the config below:
-
-  ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
+  Using the `@PHP70Migration:risky <./../../ruleSets/PHP70MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the default config.
 
 @PHP71Migration:risky
-  Using the `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the config below:
-
-  ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
+  Using the `@PHP71Migration:risky <./../../ruleSets/PHP71MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the default config.
 
 @PHP80Migration:risky
-  Using the `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the config below:
-
-  ``['replacements' => ['mt_rand' => 'random_int', 'rand' => 'random_int']]``
+  Using the `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_ rule set will enable the ``random_api_migration`` rule with the default config.

--- a/src/RuleSet/Sets/PHP70MigrationRiskySet.php
+++ b/src/RuleSet/Sets/PHP70MigrationRiskySet.php
@@ -28,12 +28,7 @@ final class PHP70MigrationRiskySet extends AbstractRuleSetDescription
             'non_printable_character' => [
                 'use_escape_sequences_in_strings' => true,
             ],
-            'random_api_migration' => [
-                'replacements' => [
-                    'mt_rand' => 'random_int',
-                    'rand' => 'random_int',
-                ],
-            ],
+            'random_api_migration' => true,
         ];
     }
 

--- a/tests/Fixtures/Integration/misc/PHP7_3.test
+++ b/tests/Fixtures/Integration/misc/PHP7_3.test
@@ -81,7 +81,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     }
 }
 $a ** 1; // `pow_to_exponentiation` rule
-random_int($a, $b, ); // `random_api_migration` rule
+mt_rand($a, $b, ); // `random_api_migration` rule
 $foo = (int) $foo; // `set_type_to_cast` rule
 in_array($b, $c, true, ); // `strict_param` rule
 @trigger_error('Warning.', E_USER_DEPRECATED, ); // `error_suppression` rule


### PR DESCRIPTION
`mt_rand` function is semantically different than `random_int`

- `mt_rand` is seedable random number generator
- `random_int` is cryptographically secure random number generator and can not seeded [1]

because of this, I belive this is a bug and replacing `mt_rand` to `random_int` should never be done by default

[1]  - https://stackoverflow.com/questions/39352599/php-random-int-seeding#61375549