### PR TITLE
Add inline_tag fixer

### DIFF
--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -379,6 +379,8 @@ PHP Tag
     Replaces short-echo ``<?=`` with long format ``<?php echo``/``<?php print`` syntax, or vice-versa.
 - `full_opening_tag <./php_tag/full_opening_tag.rst>`_
     PHP code must use the long ``<?php`` tags or short-echo ``<?=`` tags and not other tag variations.
+- `inline_tag <./php_tag/inline_tag.rst>`_
+    Changes spaces and semicolons in inline PHP tags.
 - `linebreak_after_opening_tag <./php_tag/linebreak_after_opening_tag.rst>`_
     Ensure there is no code on the same line as the PHP open tag.
 - `no_closing_tag <./php_tag/no_closing_tag.rst>`_

--- a/doc/rules/php_tag/inline_tag.rst
+++ b/doc/rules/php_tag/inline_tag.rst
@@ -1,0 +1,171 @@
+===================
+Rule ``inline_tag``
+===================
+
+Changes spaces and semicolons in inline PHP tags.
+
+Configuration
+-------------
+
+``space_before``
+~~~~~~~~~~~~~~~~
+
+The desired number of spaces at the beginning of the tag.
+
+Allowed values: ``'keep'``, ``'minimum'``, ``'one'``
+
+Default value: ``'one'``
+
+``space_after``
+~~~~~~~~~~~~~~~
+
+The desired number of spaces at the end of the tag.
+
+Allowed values: ``'keep'``, ``'minimum'``, ``'one'``
+
+Default value: ``'one'``
+
+``semicolon``
+~~~~~~~~~~~~~
+
+Whether there should be a semi-colon at the end.
+
+Allowed types: ``bool``, ``null``
+
+Default value: ``false``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?= 1 ?> <?= 1 ?> <?= 1 ?>
+   +<?= 2 ?> <?= 2 ?> <?= 2 ?>
+   +<?= 3 ?> <?= 3 ?> <?= 3 ?> <?= 3 ?>
+   +<?php echo 4 ?>
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['space_before' => 'keep']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?=1 ?> <?= 1 ?> <?=  1 ?>
+   +<?=2 ?> <?= 2 ?> <?=  2 ?>
+   +<?=3 ?> <?= 3 ?> <?=3 ?> <?=  3 ?>
+   +<?php   echo 4 ?>
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['space_before' => 'minimum']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?=1 ?> <?=1 ?> <?=1 ?>
+   +<?=2 ?> <?=2 ?> <?=2 ?>
+   +<?=3 ?> <?=3 ?> <?=3 ?> <?=3 ?>
+   +<?php echo 4 ?>
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['space_after' => 'keep']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?= 1?> <?= 1 ?> <?= 1  ?>
+   +<?= 2?> <?= 2 ?> <?= 2  ?>
+   +<?= 3  ?> <?= 3  ?> <?= 3  ?> <?= 3    ?>
+   +<?php echo 4    ?>
+
+Example #5
+~~~~~~~~~~
+
+With configuration: ``['space_after' => 'minimum']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?= 1?> <?= 1?> <?= 1?>
+   +<?= 2?> <?= 2?> <?= 2?>
+   +<?= 3?> <?= 3?> <?= 3?> <?= 3?>
+   +<?php echo 4?>
+
+Example #6
+~~~~~~~~~~
+
+With configuration: ``['semicolon' => null]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?= 1 ?> <?= 1 ?> <?= 1 ?>
+   +<?= 2; ?> <?= 2; ?> <?= 2; ?>
+   +<?= 3; ?> <?= 3; ?> <?= 3; ?> <?= 3; ?>
+   +<?php echo 4; ?>
+
+Example #7
+~~~~~~~~~~
+
+With configuration: ``['semicolon' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,4 +1,4 @@
+   -<?=1?> <?= 1 ?> <?=  1  ?>
+   -<?=2;?> <?= 2; ?> <?=  2;  ?>
+   -<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+   -<?php   echo 4  ;  ?>
+   +<?= 1; ?> <?= 1; ?> <?= 1; ?>
+   +<?= 2; ?> <?= 2; ?> <?= 2; ?>
+   +<?= 3; ?> <?= 3; ?> <?= 3; ?> <?= 3; ?>
+   +<?php echo 4; ?>

--- a/src/Fixer/PhpTag/InlineTagFixer.php
+++ b/src/Fixer/PhpTag/InlineTagFixer.php
@@ -217,6 +217,8 @@ EOT
             }
             $start = $nextIndex;
         }
+
+        return null;
     }
 
     /**
@@ -313,7 +315,7 @@ EOT
         for (;;) {
             $token = array_pop($tokens);
             if (null === $token) {
-                return $result;
+                break;
             }
             if ($semicolons && ';' === $token->getContent() || $whitespaces && $token->isWhitespace()) {
                 array_unshift($result, $token);
@@ -322,8 +324,10 @@ EOT
             }
             $tokens[] = $token;
 
-            return $result;
+            break;
         }
+
+        return $result;
     }
 
     /**

--- a/src/Fixer/PhpTag/InlineTagFixer.php
+++ b/src/Fixer/PhpTag/InlineTagFixer.php
@@ -1,0 +1,347 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\PhpTag;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurationDefinitionFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+/**
+ * @author Michele Locati <michele@locati.it>
+ */
+final class InlineTagFixer extends AbstractFixer implements ConfigurationDefinitionFixerInterface
+{
+    /**
+     * @internal
+     */
+    const OPTION_SPACEBEFORE = 'space_before';
+
+    /**
+     * @internal
+     */
+    const OPTION_SPACEAFTER = 'space_after';
+
+    /**
+     * @internal
+     */
+    const OPTION_SEMICOLON = 'semicolon';
+
+    /**
+     * @internal
+     */
+    const SPACE_MINIMUM = 'minimum';
+
+    /**
+     * @internal
+     */
+    const SPACE_ONE = 'one';
+
+    /**
+     * @internal
+     */
+    const SPACE_KEEP = 'keep';
+
+    /**
+     * @internal
+     */
+    const SUPPORTED_SPACEBEFORE_OPTIONS = [
+        self::SPACE_MINIMUM,
+        self::SPACE_ONE,
+        self::SPACE_KEEP,
+    ];
+
+    /**
+     * @internal
+     */
+    const SUPPORTED_SPACEAFTER_OPTIONS = [
+        self::SPACE_MINIMUM,
+        self::SPACE_ONE,
+        self::SPACE_KEEP,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        $sample = <<<'EOT'
+<?=1?> <?= 1 ?> <?=  1  ?>
+<?=2;?> <?= 2; ?> <?=  2;  ?>
+<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>
+<?php   echo 4  ;  ?>
+
+EOT
+        ;
+
+        return new FixerDefinition(
+            'Changes spaces and semicolons in inline PHP tags.',
+            [
+                new CodeSample($sample),
+                new CodeSample($sample, [self::OPTION_SPACEBEFORE => self::SPACE_KEEP]),
+                new CodeSample($sample, [self::OPTION_SPACEBEFORE => self::SPACE_MINIMUM]),
+                new CodeSample($sample, [self::OPTION_SPACEAFTER => self::SPACE_KEEP]),
+                new CodeSample($sample, [self::OPTION_SPACEAFTER => self::SPACE_MINIMUM]),
+                new CodeSample($sample, [self::OPTION_SEMICOLON => null]),
+                new CodeSample($sample, [self::OPTION_SEMICOLON => true]),
+            ],
+            null
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens)
+    {
+        if (self::SPACE_KEEP === $this->configuration[self::OPTION_SPACEBEFORE] && self::SPACE_KEEP === $this->configuration[self::OPTION_SPACEAFTER] && null === $this->configuration[self::OPTION_SEMICOLON]) {
+            return false;
+        }
+
+        return null !== $this->findApplicableRange($tokens);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder(self::OPTION_SPACEBEFORE, 'The desired number of spaces at the beginning of the tag.'))
+                ->setAllowedValues(self::SUPPORTED_SPACEBEFORE_OPTIONS)
+                ->setDefault(self::SPACE_ONE)
+                ->getOption(),
+            (new FixerOptionBuilder(self::OPTION_SPACEAFTER, 'The desired number of spaces at the end of the tag.'))
+                ->setAllowedValues(self::SUPPORTED_SPACEAFTER_OPTIONS)
+                ->setDefault(self::SPACE_ONE)
+                ->getOption(),
+            (new FixerOptionBuilder(self::OPTION_SEMICOLON, 'Whether there should be a semi-colon at the end.'))
+                ->setAllowedTypes(['bool', 'null'])
+                ->setDefault(false)
+                ->getOption(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(SplFileInfo $file, Tokens $tokens)
+    {
+        $index = 0;
+        for (;;) {
+            $range = $this->findApplicableRange($tokens, $index);
+            if (null === $range) {
+                return;
+            }
+            $newRange = $this->fixRange($range);
+            $tokens->overrideRange($index, $index + \count($range) - 1, $newRange);
+            $index += \count($newRange);
+        }
+    }
+
+    /**
+     * Builds the list of tokens that replace a long echo sequence.
+     *
+     * @param int $openTagIndex
+     * @param int $echoTagIndex
+     *
+     * @return Token[]
+     */
+    private function buildLongToShortTokens(Tokens $tokens, $openTagIndex, $echoTagIndex)
+    {
+        $result = [new Token([T_OPEN_TAG_WITH_ECHO, '<?='])];
+
+        $start = $tokens->getNextNonWhitespace($openTagIndex);
+
+        if ($start === $echoTagIndex) {
+            // No non-whitespace tokens between $openTagIndex and $echoTagIndex
+            return $result;
+        }
+        // Find the last non-whitespace index before $echoTagIndex
+        $end = $echoTagIndex - 1;
+        while ($tokens[$end]->isWhitespace()) {
+            --$end;
+        }
+        // Copy the non-whitespace tokens between $openTagIndex and $echoTagIndex
+        for ($index = $start; $index <= $end; ++$index) {
+            $result[] = clone $tokens[$index];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param mixed $start
+     *
+     * @return null|Token[]
+     */
+    private function findApplicableRange(Tokens $tokens, &$start = 0)
+    {
+        $maxIndex = $tokens->count() - 1;
+        for (; $start < $maxIndex; ++$start) {
+            $token = $tokens[$start];
+            // @var Token $startToken
+            if (!$token->isGivenKind([T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO])) {
+                continue;
+            }
+            if (false !== strpos($token->getContent(), "\n")) {
+                continue;
+            }
+            $result = [$token];
+            for ($nextIndex = $start + 1; $nextIndex <= $maxIndex; ++$nextIndex) {
+                $token = $tokens[$nextIndex];
+                if ($token->isGivenKind(T_CLOSE_TAG)) {
+                    $result[] = $token;
+
+                    return $result;
+                }
+                if (false !== strpos($token->getContent(), "\n")) {
+                    break;
+                }
+                $result[] = $token;
+            }
+            $start = $nextIndex;
+        }
+    }
+
+    /**
+     * @param Token[] $tokens
+     *
+     * @return Token[]
+     */
+    private function fixRange(array $tokens)
+    {
+        $start = $this->fixStart($tokens);
+        $end = $this->fixEnd($tokens);
+
+        return array_merge($start, $tokens, $end);
+    }
+
+    /**
+     * @param Token[] $tokens
+     *
+     * @return Token[]
+     */
+    private function fixStart(array &$tokens)
+    {
+        $token = array_shift($tokens);
+        $spaceBefore = $this->configuration[self::OPTION_SPACEBEFORE];
+        if (self::SPACE_KEEP === $spaceBefore) {
+            return [$token];
+        }
+        // Let's remove the extra whitespaces
+        while ($tokens[0]->isWhitespace()) {
+            array_shift($tokens);
+        }
+        if (T_OPEN_TAG_WITH_ECHO !== $token->getId()) {
+            return [new Token([$token->getId(), rtrim($token->getContent()).' '])];
+        }
+        $result = [new Token([T_OPEN_TAG_WITH_ECHO, '<?='])];
+        if (self::SPACE_ONE === $spaceBefore) {
+            $result[] = new Token([T_WHITESPACE, ' ']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param Token[] $tokens
+     *
+     * @return Token[]
+     */
+    private function fixEnd(array &$tokens)
+    {
+        $spaceAfter = $this->configuration[self::OPTION_SPACEAFTER];
+        $semicolon = $this->configuration[self::OPTION_SEMICOLON];
+        if (self::SPACE_KEEP === $spaceAfter && null === $semicolon) {
+            return [];
+        }
+        $token = array_pop($tokens);
+        if (self::SPACE_KEEP === $spaceAfter) {
+            $closing = [$token];
+        } else {
+            $closing = [new Token([$token->getId(), ltrim($token->getContent())])];
+            if (self::SPACE_ONE === $spaceAfter) {
+                array_unshift($closing, new Token([T_WHITESPACE, ' ']));
+            }
+        }
+        $spacesAfterSemicolons = $this->popWhitespacesAndSemicolons($tokens, false, true);
+        $semicolons = $this->popWhitespacesAndSemicolons($tokens, true, false);
+        $spacesBeforeSemicolons = $this->popWhitespacesAndSemicolons($tokens, false, true);
+        if ([] === $tokens && self::SPACE_KEEP === $this->configuration[self::OPTION_SPACEBEFORE]) {
+            $tokens = $spacesBeforeSemicolons;
+            $spacesBeforeSemicolons = [];
+        }
+        if (self::SPACE_KEEP !== $spaceAfter) {
+            $spacesBeforeSemicolons = [];
+            $spacesAfterSemicolons = [];
+        }
+        if (false === $semicolon) {
+            $semicolons = [];
+        } elseif (true === $semicolon) {
+            $semicolons = $this->needsSemicolonAfter($tokens) ? [new Token(';')] : [];
+        }
+
+        return array_merge($spacesBeforeSemicolons, $semicolons, $spacesAfterSemicolons, $closing);
+    }
+
+    /**
+     * @param Token[] $tokens
+     * @param bool    $semicolons
+     * @param bool    $whitespaces
+     *
+     * @return Token[]
+     */
+    private function popWhitespacesAndSemicolons(array &$tokens, $semicolons, $whitespaces)
+    {
+        $result = [];
+        for (;;) {
+            $token = array_pop($tokens);
+            if (null === $token) {
+                return $result;
+            }
+            if ($semicolons && ';' === $token->getContent() || $whitespaces && $token->isWhitespace()) {
+                array_unshift($result, $token);
+
+                continue;
+            }
+            $tokens[] = $token;
+
+            return $result;
+        }
+    }
+
+    /**
+     * @param Token[] $tokens
+     *
+     * @return bool
+     */
+    private function needsSemicolonAfter(array $tokens)
+    {
+        $count = \count($tokens);
+        if (0 === $count) {
+            return false;
+        }
+        $token = $tokens[$count - 1];
+        if ('}' === $token->getContent()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Fixer/PhpTag/InlineTagFixerTest.php
+++ b/tests/Fixer/PhpTag/InlineTagFixerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\PhpTag;
+
+use PhpCsFixer\Fixer\PhpTag\InlineTagFixer;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author Michele Locati <michele@locati.it>
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\PhpTag\InlineTagFixer
+ */
+final class InlineTagFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideTestCases
+     */
+    public function testInlineFixer($expected, $input = null, array $configuration = [])
+    {
+        $this->fixer->configure($configuration);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestCases()
+    {
+        $keepAll = [InlineTagFixer::OPTION_SPACEBEFORE => InlineTagFixer::SPACE_KEEP, InlineTagFixer::OPTION_SPACEAFTER => InlineTagFixer::SPACE_KEEP, InlineTagFixer::OPTION_SEMICOLON => null];
+        $removeAll = [InlineTagFixer::OPTION_SPACEBEFORE => InlineTagFixer::SPACE_MINIMUM, InlineTagFixer::OPTION_SPACEAFTER => InlineTagFixer::SPACE_MINIMUM, InlineTagFixer::OPTION_SEMICOLON => false];
+        $oneSpace = [InlineTagFixer::OPTION_SPACEBEFORE => InlineTagFixer::SPACE_ONE, InlineTagFixer::OPTION_SPACEAFTER => InlineTagFixer::SPACE_ONE];
+
+        return [
+            ['<?= 2 ?> <?= 2 ?> <?= 2 ?>', '<?=2;?> <?= 2; ?> <?=  2;  ?>'],
+            ['<?= 3 ?> <?= 3 ?> <?= 3 ?> <?= 3 ?>', '<?=3  ;?> <?= 3  ;?> <?=3  ;?> <?=  3  ;  ?>'],
+            ['<?php ', null, $keepAll],
+            ['<?php ', null, $removeAll],
+            ['<?php    ?>', null, $keepAll],
+            ['<?php    ?>', null, [InlineTagFixer::OPTION_SEMICOLON => false] + $keepAll],
+            ['<?php    ?>', null, [InlineTagFixer::OPTION_SEMICOLON => true] + $keepAll],
+            ['<?php ?>', '<?php    ?>', $removeAll],
+            ['<?php   ;   ?>', null, $keepAll],
+            ['<?php ?>', '<?php   ;   ?>', $removeAll],
+            ['<?php   ;?>', '<?php   ;   ?>', [InlineTagFixer::OPTION_SPACEAFTER => InlineTagFixer::SPACE_MINIMUM] + $keepAll],
+            ['<?php ;   ?>', '<?php   ;   ?>', [InlineTagFixer::OPTION_SPACEBEFORE => InlineTagFixer::SPACE_MINIMUM] + $keepAll],
+            ['<?php echo 1?>', '<?php   echo 1   ;   ?>', $removeAll],
+            ['<?php echo 1 ?>', '<?php   echo 1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => false] + $oneSpace],
+            ['<?php echo 1; ?>', '<?php   echo 1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => true] + $oneSpace],
+            ['<?php echo 1; ?>', '<?php   echo 1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => null] + $oneSpace],
+            ['<?=1?>', '<?=    1   ;   ?>', $removeAll],
+            ['<?= 1 ?>', '<?=    1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => false] + $oneSpace],
+            ['<?= 1; ?>', '<?=    1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => true] + $oneSpace],
+            ['<?= 1; ?>', '<?=   1  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => null] + $oneSpace],
+            ['<?php {}?>', '<?php   {}   ;   ?>', $removeAll],
+            ['<?php {} ?>', '<?php   {}  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => false] + $oneSpace],
+            ['<?php {} ?>', '<?php   {}  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => true] + $oneSpace],
+            ['<?php {}; ?>', '<?php   {}  ;   ?>', [InlineTagFixer::OPTION_SEMICOLON => null] + $oneSpace],
+            ["\n<?= 2 ?>\n", "\n<?=2;?>\n"],
+            ["<?=\n 2 ?>"],
+            ["<?= 2 \n?>"],
+        ];
+    }
+}


### PR DESCRIPTION
What about adding a fixer to format these cases?
`<?php /* anything except a new line */ ?>`
`<?= /* anything except a new line  */ ?>`

Examples:

---

![immagine](https://user-images.githubusercontent.com/928116/99190308-1f49a680-2766-11eb-8379-8ae8b36d60d8.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190317-283a7800-2766-11eb-816b-96c7797a8e23.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190321-2ec8ef80-2766-11eb-856a-38c9eb319e7d.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190327-39838480-2766-11eb-973e-d2187c4f24ae.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190331-42745600-2766-11eb-807d-5a323ba6f647.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190335-4902cd80-2766-11eb-91e6-1120f6da485e.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190342-528c3580-2766-11eb-9d15-edcb37b00c65.png)

---

![immagine](https://user-images.githubusercontent.com/928116/99190347-5a4bda00-2766-11eb-8762-f19e42411135.png)
