### PR TITLE
Fix PHPDoc line span fixer when property has array typehint

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -144,6 +144,7 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
             T_STATIC,
             T_STRING,
             T_NS_SEPARATOR,
+            CT::T_ARRAY_TYPEHINT,
             CT::T_NULLABLE_TYPE,
         ]));
 

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -511,6 +511,27 @@ class Foo
                     'property' => 'single',
                 ],
             ],
+            'It can handle properties with array type declaration' => [
+                '<?php
+
+class Foo
+{
+    /** @var string[] */
+    private array $foo;
+}',
+                '<?php
+
+class Foo
+{
+    /**
+     * @var string[]
+     */
+    private array $foo;
+}',
+                [
+                    'property' => 'single',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
`PhpdocLineSpanFixer` does not fix if property has array typehint, this PR fix it