### PR TITLE
TernaryToNullCoalescingFixer - concat precedence fix

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -46,4 +46,8 @@ parameters:
         -
             message: '/^Parameter #1 \$finder of method PhpCsFixer\\Config::setFinder\(\) expects iterable<string>, int given\.$/'
             path: tests/ConfigTest.php
+
+        -
+            message: '/^Property .*::\$indicator .* does not accept null\.$/'
+            path: tests/Indicator/PhpUnitTestCaseIndicatorTest.php
     tipsOfTheDay: false

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -182,6 +182,7 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
             '^',
             '|',
             '~',
+            '.',
         ];
 
         return isset($operatorsPerId[$token->getId()]) || $token->equalsAny($operatorsPerContent);

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -222,6 +222,9 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
                 '<?php echo $a[1]** $b[2+5];',
                 '<?php echo pow($a[1], $b[2+5]);',
             ],
+            [
+                '<?php pow($b, ...$a);',
+            ],
         ];
 
         foreach ($tests as $index => $test) {

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -53,6 +53,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
             ['<?php $x = ! isset($a) ? $a : null;'],
             ['<?php $x = false === isset($a) ? $a : 2;'],
             ['<?php $x = 4 * isset($a) ? $a : 2;'],
+            ['<?php $x = "4" . isset($a) ? $a : 2;'],
             ['<?php $x = 3 ** isset($a) ? $a : 2;'],
             ['<?php $x = 1 | isset($a) ? $a : 2;'],
             ['<?php $x = (array) isset($a) ? $a : 2;'],

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -32,6 +32,15 @@ final class PhpUnitTestCaseIndicatorTest extends TestCase
     protected function setUp()
     {
         $this->indicator = new PhpUnitTestCaseIndicator();
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        $this->indicator = null;
+
+        parent::tearDown();
     }
 
     /**


### PR DESCRIPTION
While looking into PHP8 https://wiki.php.net/rfc/concatenation_precedence change I found this one.
Example: https://3v4l.org/Nvubm

(I didn't find other issues related to the PHP8 change)