### PR TITLE
PHP8 - add NoUnreachableDefaultArgumentValueFixer to risky set

### DIFF
--- a/doc/ruleSets/PHP80MigrationRisky.rst
+++ b/doc/ruleSets/PHP80MigrationRisky.rst
@@ -12,4 +12,6 @@ Rules
 - `no_alias_functions <./../rules/alias/no_alias_functions.rst>`_
   config:
   ``['sets' => ['@all']]``
+- `no_php4_constructor <./../rules/class_notation/no_php4_constructor.rst>`_
 - `no_unneeded_final_method <./../rules/class_notation/no_unneeded_final_method.rst>`_
+- `no_unreachable_default_argument_value <./../rules/function_notation/no_unreachable_default_argument_value.rst>`_

--- a/doc/ruleSets/SymfonyRisky.rst
+++ b/doc/ruleSets/SymfonyRisky.rst
@@ -28,6 +28,7 @@ Rules
   ``['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true]``
 - `no_alias_functions <./../rules/alias/no_alias_functions.rst>`_
 - `no_homoglyph_names <./../rules/naming/no_homoglyph_names.rst>`_
+- `no_php4_constructor <./../rules/class_notation/no_php4_constructor.rst>`_
 - `no_unneeded_final_method <./../rules/class_notation/no_unneeded_final_method.rst>`_
 - `non_printable_character <./../rules/basic/non_printable_character.rst>`_
 - `php_unit_construct <./../rules/php_unit/php_unit_construct.rst>`_

--- a/doc/rules/class_notation/no_php4_constructor.rst
+++ b/doc/rules/class_notation/no_php4_constructor.rst
@@ -28,3 +28,17 @@ Example #1
         {
         }
     }
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+@PHP80Migration:risky
+  Using the `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_ rule set will enable the ``no_php4_constructor`` rule.
+
+@PhpCsFixer:risky
+  Using the `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_ rule set will enable the ``no_php4_constructor`` rule.
+
+@Symfony:risky
+  Using the `@Symfony:risky <./../../ruleSets/SymfonyRisky.rst>`_ rule set will enable the ``no_php4_constructor`` rule.

--- a/doc/rules/function_notation/no_unreachable_default_argument_value.rst
+++ b/doc/rules/function_notation/no_unreachable_default_argument_value.rst
@@ -29,7 +29,10 @@ Example #1
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
+
+@PHP80Migration:risky
+  Using the `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_ rule set will enable the ``no_unreachable_default_argument_value`` rule.
 
 @PhpCsFixer:risky
   Using the `@PhpCsFixer:risky <./../../ruleSets/PhpCsFixerRisky.rst>`_ rule set will enable the ``no_unreachable_default_argument_value`` rule.

--- a/src/RuleSet/Sets/PHP80MigrationRiskySet.php
+++ b/src/RuleSet/Sets/PHP80MigrationRiskySet.php
@@ -29,7 +29,9 @@ final class PHP80MigrationRiskySet extends AbstractRuleSetDescription
                     '@all',
                 ],
             ],
+            'no_php4_constructor' => true,
             'no_unneeded_final_method' => true,
+            'no_unreachable_default_argument_value' => true,
         ];
     }
 

--- a/src/RuleSet/Sets/SymfonyRiskySet.php
+++ b/src/RuleSet/Sets/SymfonyRiskySet.php
@@ -60,6 +60,7 @@ final class SymfonyRiskySet extends AbstractRuleSetDescription
             ],
             'no_alias_functions' => true,
             'no_homoglyph_names' => true,
+            'no_php4_constructor' => true,
             'no_unneeded_final_method' => true,
             'non_printable_character' => true,
             'php_unit_construct' => true,


### PR DESCRIPTION
The following no longer parses on PHP8

```php
<?php

function foo($a = 1, $b){
    
}
```

https://3v4l.org/RQha3


```php
<?php
class Point {
    public function Point(
        public float $x = 70.0) {}
}

$a = new Point();
echo $a->x;
```

https://3v4l.org/OG8r1