### PR TITLE
Add documentation to "yoda_style" sniff to convert Yoda style to non-Yoda style

### DIFF
--- a/doc/rules/control_structure/yoda_style.rst
+++ b/doc/rules/control_structure/yoda_style.rst
@@ -2,8 +2,9 @@
 Rule ``yoda_style``
 ===================
 
-Write conditions in Yoda style (``true``), non-Yoda style (``false``) or ignore
-those conditions (``null``) based on configuration.
+Write conditions in Yoda style (``true``), non-Yoda style (``['equal' => false,
+'identical' => false, 'less_and_greater' => false]``) or ignore those conditions
+(``null``) based on configuration.
 
 Configuration
 -------------
@@ -94,6 +95,23 @@ With configuration: ``['always_move_variable' => true]``.
     <?php
    -return $foo === count($bar);
    +return count($bar) === $foo;
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['equal' => false, 'identical' => false, 'less_and_greater' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   @@ -1,5 +1,5 @@
+    <?php
+        // Enforce non-Yoda style.
+   -    if (null === $a) {
+   +    if ($a === null) {
+            echo "null";
+        }
 
 Rule sets
 ---------

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -190,7 +190,7 @@ Control Structure
 - `switch_case_space <./control_structure/switch_case_space.rst>`_
     Removes extra spaces between colon and case value.
 - `yoda_style <./control_structure/yoda_style.rst>`_
-    Write conditions in Yoda style (``true``), non-Yoda style (``false``) or ignore those conditions (``null``) based on configuration.
+    Write conditions in Yoda style (``true``), non-Yoda style (``['equal' => false, 'identical' => false, 'less_and_greater' => false]``) or ignore those conditions (``null``) based on configuration.
 
 Doctrine Annotation
 -------------------

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -61,7 +61,7 @@ final class YodaStyleFixer extends AbstractFixer implements ConfigurationDefinit
     public function getDefinition()
     {
         return new FixerDefinition(
-            'Write conditions in Yoda style (`true`), non-Yoda style (`false`) or ignore those conditions (`null`) based on configuration.',
+            'Write conditions in Yoda style (`true`), non-Yoda style (`[\'equal\' => false, \'identical\' => false, \'less_and_greater\' => false]`) or ignore those conditions (`null`) based on configuration.',
             [
                 new CodeSample(
                     '<?php
@@ -88,6 +88,19 @@ return $foo === count($bar);
 ',
                     [
                         'always_move_variable' => true,
+                    ]
+                ),
+                new CodeSample(
+                    '<?php
+    // Enforce non-Yoda style.
+    if (null === $a) {
+        echo "null";
+    }
+',
+                    [
+                        'equal' => false,
+                        'identical' => false,
+                        'less_and_greater' => false,
                     ]
                 ),
             ]


### PR DESCRIPTION
Add documentation to "yoda_style" sniff to convert Yoda style to non-Yoda style

Relevant issue: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5281
Old PR: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5286

PS: Base branch is `2.16`, not `master`