### PR TITLE
Add yamllint workflow, validates .yaml files

### DIFF
--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -1,0 +1,21 @@
+# yamllint disable rule:line-length
+
+name: YAML Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run YAMLlint
+        run: |
+          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint -d relaxed
+


### PR DESCRIPTION
This has two effects:

- It will validate `.yaml` files for general correctness everywhere except `vendor` and `dev-tools/vendor`
- And as a side-effect, it might enable other workflows to happen. E.g. we will no longer need to consult with forks to see if  #5295 #5268 #5183 etc are working.