### PR TITLE
OrderedClassElementsFixer - PHPUnit Bridge support

### DIFF
--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -382,9 +382,13 @@ class Example
         if (
             $nameToken->equalsAny([
                 [T_STRING, 'setUpBeforeClass'],
+                [T_STRING, 'doSetUpBeforeClass'],
                 [T_STRING, 'tearDownAfterClass'],
+                [T_STRING, 'doTearDownAfterClass'],
                 [T_STRING, 'setUp'],
+                [T_STRING, 'doSetUp'],
                 [T_STRING, 'tearDown'],
+                [T_STRING, 'doTearDown'],
             ], false)
         ) {
             return ['phpunit', strtolower($nameToken->getContent())];
@@ -426,9 +430,13 @@ class Example
     {
         static $phpunitPositions = [
             'setupbeforeclass' => 1,
-            'teardownafterclass' => 2,
-            'setup' => 3,
-            'teardown' => 4,
+            'dosetupbeforeclass' => 2,
+            'teardownafterclass' => 3,
+            'doteardownafterclass' => 4,
+            'setup' => 5,
+            'dosetup' => 6,
+            'teardown' => 7,
+            'doteardown' => 8,
         ];
 
         foreach ($elements as &$element) {

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -147,7 +147,11 @@ abstract class Foo extends FooParent implements FooInterface1, FooInterface2
 
     protected function setUp() {}
 
+    protected function doSetUp() {}
+
     protected function tearDown() {}
+
+    protected function doTearDown() {}
 
     abstract public function foo1($a, $b = 1);
 
@@ -195,6 +199,10 @@ abstract class Foo extends FooParent implements FooInterface1, FooInterface2
     abstract public function foo1($a, $b = 1);
 
     protected function tearDown() {}
+
+    protected function doSetUp() {}
+
+    protected function doTearDown() {}
 
     public function __clone() {}
 


### PR DESCRIPTION
Add support for PHPUnit Bridge stand-in methods:

- doSetUp()
- doTearDown()
- doSetUpBeforeClass()
- doTearDownAfterClass()

(in trait Symfony\Bridge\PhpUnit\SetUpTearDownTrait)

Issue: #5310