### PR TITLE
Enable testing with PHPUnit 9.x

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,5 +1,6 @@
 {
     "symbol-whitelist" : [
+        "LegacyPHPUnit\\TestCase",
         "PhpCsFixer\\PhpunitConstraintIsIdenticalString\\Constraint\\IsIdenticalString",
         "PhpCsFixer\\Tests\\Test\\Constraint\\SameStringsConstraint",
         "PhpCsFixer\\Tests\\Test\\IsIdenticalConstraint",

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,10 @@
         "php-cs-fixer/accessible-object": "^1.0",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
+        "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.4.4 <9.5",
         "phpunitgoodpractices/polyfill": "^1.5",
         "phpunitgoodpractices/traits": "^1.9.1",
+        "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
         "symfony/phpunit-bridge": "^5.1",
         "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,8 @@ parameters:
         - '/^Return typehint of method PhpCsFixer\\Tests\\Test\\.+::createIsIdenticalStringConstraint\(\) has invalid type PHPUnit_Framework_Constraint_IsIdentical\.$/'
         - '/^Class (Symfony\\Contracts\\EventDispatcher\\Event|Symfony\\Component\\EventDispatcher\\Event) not found.$/'
         - '/^Constant T_NAME_(RELATIVE|FULLY_QUALIFIED|QUALIFIED) not found\.$/'
+        - '/Instantiated class .*TraversableContains is abstract/'
+        - '/assertInstanceOf\(\) expects class-string.*, string given/'
         -
             message: '/^Unsafe usage of new static\(\)\.$/'
             path: src/Config.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
     enforceTimeLimit="true"
     processIsolation="false"
     stopOnFailure="false"
+    timeoutForSmallTests="2"
     verbose="true"
 >
     <testsuites>

--- a/tests/AbstractFunctionReferenceFixerTest.php
+++ b/tests/AbstractFunctionReferenceFixerTest.php
@@ -24,18 +24,18 @@ final class AbstractFunctionReferenceFixerTest extends TestCase
 {
     private $fixer;
 
-    protected function setUp()
+    protected function doSetUp()
     {
         $this->fixer = new FunctionReferenceTestFixer();
 
-        parent::setUp();
+        parent::doSetUp();
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
         $this->fixer = null;
 
-        parent::tearDown();
+        parent::doTearDown();
     }
 
     /**

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -262,7 +262,7 @@ final class ProjectCodeTest extends TestCase
 
         foreach ($publicMethods as $method) {
             static::assertMatchesRegularExpression(
-                '/^(test|expect|provide|setUpBeforeClass$|tearDownAfterClass$)/',
+                '/^(test|expect|provide|doSetUpBeforeClass$|doTearDownAfterClass$)/',
                 $method->getName(),
                 sprintf('Public method "%s::%s" is not properly named.', $reflectionClass->getName(), $method->getName())
             );

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -27,9 +27,9 @@ use PhpCsFixer\Tests\TestCase;
  */
 final class FileHandlerTest extends TestCase
 {
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $file = $this->getFile();
 

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -36,9 +36,9 @@ final class SelfUpdateCommandTest extends TestCase
      */
     private $root;
 
-    protected function setUp()
+    protected function doSetUp()
     {
-        parent::setUp();
+        parent::doSetUp();
 
         $this->root = vfsStream::setup();
 
@@ -48,9 +48,9 @@ final class SelfUpdateCommandTest extends TestCase
         file_put_contents("{$this->root->url()}/{$this->getNewMajorVersion()}.phar", 'New major version of PHP CS Fixer.');
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->root = null;
 

--- a/tests/FileReaderTest.php
+++ b/tests/FileReaderTest.php
@@ -25,9 +25,9 @@ use PhpCsFixer\Tests\Fixtures\Test\FileReaderTest\StdinFakeStream;
  */
 final class FileReaderTest extends TestCase
 {
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
-        parent::tearDownAfterClass();
+        parent::doTearDownAfterClass();
 
         // testReadStdinCaches registers a stream wrapper for php so we can mock
         // php://stdin. Restore the original stream wrapper after this class so

--- a/tests/FileRemovalTest.php
+++ b/tests/FileRemovalTest.php
@@ -35,7 +35,7 @@ final class FileRemovalTest extends TestCase
      */
     private static $removeFilesOnTearDown = true;
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
         if (self::$removeFilesOnTearDown) {
             @unlink(sys_get_temp_dir().'/cs_fixer_foo.php');

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -40,8 +40,11 @@ final class NoAliasFunctionsFixerTest extends AbstractFixerTestCase
         $cases = [];
 
         foreach (['internalSet', 'imapSet'] as $setStaticAttributeName) {
+            $reflectionProperty = new \ReflectionProperty(\PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer::class, $setStaticAttributeName);
+            $reflectionProperty->setAccessible(true);
+
             /** @var string[] $aliases */
-            $aliases = static::getStaticAttribute(\PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer::class, $setStaticAttributeName);
+            $aliases = $reflectionProperty->getValue();
 
             foreach ($aliases as $alias => $master) {
                 // valid cases

--- a/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
+++ b/tests/Fixer/Alias/NoMixedEchoPrintFixerTest.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\Tests\Fixer\Alias;
 
+use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -281,14 +282,14 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure(null);
 
-        static::assertAttributeSame(T_PRINT, 'candidateTokenType', $this->fixer);
+        static::assertCandidateTokenType(T_PRINT, $this->fixer);
     }
 
     public function testDefaultConfig()
     {
         $this->fixer->configure([]);
 
-        static::assertAttributeSame(T_PRINT, 'candidateTokenType', $this->fixer);
+        static::assertCandidateTokenType(T_PRINT, $this->fixer);
     }
 
     /**
@@ -325,5 +326,13 @@ final class NoMixedEchoPrintFixerTest extends AbstractFixerTestCase
                 '#^\[no_mixed_echo_print\] Invalid configuration: The option "use" with value "_invalid_" is invalid\. Accepted values are: "print", "echo"\.$#',
             ],
         ];
+    }
+
+    private static function assertCandidateTokenType($expected, AbstractFixer $fixer)
+    {
+        $reflectionProperty = new \ReflectionProperty($fixer, 'candidateTokenType');
+        $reflectionProperty->setAccessible(true);
+
+        static::assertSame($expected, $reflectionProperty->getValue($fixer));
     }
 }

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -48,11 +48,14 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure(['rand' => 'random_int']);
 
+        $reflectionProperty = new \ReflectionProperty($this->fixer, 'configuration');
+        $reflectionProperty->setAccessible(true);
+
         static::assertSame(
             ['replacements' => [
                 'rand' => ['alternativeName' => 'random_int', 'argumentCount' => [0, 2]], ],
             ],
-            static::getObjectAttribute($this->fixer, 'configuration')
+            $reflectionProperty->getValue($this->fixer)
         );
     }
 
@@ -60,11 +63,14 @@ final class RandomApiMigrationFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure(['replacements' => ['rand' => 'random_int']]);
 
+        $reflectionProperty = new \ReflectionProperty($this->fixer, 'configuration');
+        $reflectionProperty->setAccessible(true);
+
         static::assertSame(
             ['replacements' => [
                 'rand' => ['alternativeName' => 'random_int', 'argumentCount' => [0, 2]], ],
             ],
-            static::getObjectAttribute($this->fixer, 'configuration')
+            $reflectionProperty->getValue($this->fixer)
         );
     }
 

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -40,10 +40,10 @@ final class ClassDefinitionFixerTest extends AbstractFixerWithAliasedOptionsTest
 
         $fixer = new ClassDefinitionFixer();
         $fixer->configure($defaultConfig);
-        static::assertAttributeSame($defaultConfig, 'configuration', $fixer);
+        static::assertConfigurationSame($defaultConfig, $fixer);
 
         $fixer->configure(null);
-        static::assertAttributeSame($defaultConfig, 'configuration', $fixer);
+        static::assertConfigurationSame($defaultConfig, $fixer);
     }
 
     public function testConfigureDefaultToNull()
@@ -56,10 +56,10 @@ final class ClassDefinitionFixerTest extends AbstractFixerWithAliasedOptionsTest
 
         $fixer = new ClassDefinitionFixer();
         $fixer->configure($defaultConfig);
-        static::assertAttributeSame($defaultConfig, 'configuration', $fixer);
+        static::assertConfigurationSame($defaultConfig, $fixer);
 
         $fixer->configure([]);
-        static::assertAttributeSame($defaultConfig, 'configuration', $fixer);
+        static::assertConfigurationSame($defaultConfig, $fixer);
     }
 
     /**
@@ -696,6 +696,14 @@ $a = new class implements
                 "<?php\r\nclass Aaa implements\r\n\tBbb, Ccc,\r\n\tDdd\r\n\t{\r\n\t}",
             ],
         ];
+    }
+
+    private static function assertConfigurationSame(array $expected, ClassDefinitionFixer $fixer)
+    {
+        $reflectionProperty = new \ReflectionProperty($fixer, 'configuration');
+        $reflectionProperty->setAccessible(true);
+
+        static::assertSame($expected, $reflectionProperty->getValue($fixer));
     }
 
     private function doTestClassyInheritanceInfo($source, $label, array $expected)

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -27,9 +27,9 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 {
     private static $defaultStatements;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         $fixer = new NoUnneededControlParenthesesFixer();
         foreach ($fixer->getConfigurationDefinition()->getOptions() as $option) {

--- a/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/IsNullFixerTest.php
@@ -52,7 +52,11 @@ final class IsNullFixerTest extends AbstractFixerTestCase
     {
         $this->fixer->configure(['use_yoda_style' => false]);
 
-        $configuration = static::getObjectAttribute($this->fixer, 'configuration');
+        $reflectionProperty = new \ReflectionProperty($this->fixer, 'configuration');
+        $reflectionProperty->setAccessible(true);
+
+        $configuration = $reflectionProperty->getValue($this->fixer);
+
         static::assertFalse($configuration['use_yoda_style']);
     }
 

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -29,18 +29,18 @@ final class PhpUnitTestCaseIndicatorTest extends TestCase
      */
     private $indicator;
 
-    protected function setUp()
+    protected function doSetUp()
     {
         $this->indicator = new PhpUnitTestCaseIndicator();
 
-        parent::setUp();
+        parent::doSetUp();
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
         $this->indicator = null;
 
-        parent::tearDown();
+        parent::doTearDown();
     }
 
     /**

--- a/tests/Report/AbstractReporterTestCase.php
+++ b/tests/Report/AbstractReporterTestCase.php
@@ -28,16 +28,16 @@ abstract class AbstractReporterTestCase extends TestCase
      */
     protected $reporter;
 
-    protected function setUp()
+    protected function doSetUp()
     {
-        parent::setUp();
+        parent::doSetUp();
 
         $this->reporter = $this->createReporter();
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->reporter = null;
     }

--- a/tests/Report/CheckstyleReporterTest.php
+++ b/tests/Report/CheckstyleReporterTest.php
@@ -32,12 +32,12 @@ final class CheckstyleReporterTest extends AbstractReporterTestCase
      */
     private static $xsd;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
         self::$xsd = file_get_contents(__DIR__.'/../../doc/report-schema/checkstyle.xsd');
     }
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
         self::$xsd = null;
     }

--- a/tests/Report/JunitReporterTest.php
+++ b/tests/Report/JunitReporterTest.php
@@ -35,16 +35,16 @@ final class JunitReporterTest extends AbstractReporterTestCase
      */
     private static $xsd;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         self::$xsd = file_get_contents(__DIR__.'/../../doc/report-schema/junit-10.xsd');
     }
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
-        parent::tearDownAfterClass();
+        parent::doTearDownAfterClass();
 
         self::$xsd = null;
     }

--- a/tests/Report/XmlReporterTest.php
+++ b/tests/Report/XmlReporterTest.php
@@ -31,16 +31,16 @@ final class XmlReporterTest extends AbstractReporterTestCase
      */
     private static $xsd;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         self::$xsd = file_get_contents(__DIR__.'/../../doc/report-schema/xml.xsd');
     }
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
-        parent::tearDownAfterClass();
+        parent::doTearDownAfterClass();
 
         self::$xsd = null;
     }

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -29,9 +29,9 @@ final class CiIntegrationTest extends AbstractSmokeTest
 {
     public static $fixtureDir;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         self::$fixtureDir = __DIR__.'/../Fixtures/ci-integration';
 
@@ -61,16 +61,16 @@ final class CiIntegrationTest extends AbstractSmokeTest
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
-        parent::tearDownAfterClass();
+        parent::doTearDownAfterClass();
 
         self::executeCommand('rm -rf .git');
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         self::executeScript([
             'git reset . -q',

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -40,9 +40,9 @@ final class InstallViaComposerTest extends AbstractSmokeTest
         'vendor/bin/php-cs-fixer fix --help',
     ];
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
             static::markTestIncomplete('This test is broken on Windows');

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -32,9 +32,9 @@ final class PharTest extends AbstractSmokeTest
     private static $pharCwd;
     private static $pharName;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         self::$pharCwd = __DIR__.'/../..';
         self::$pharName = 'php-cs-fixer.phar';

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -65,9 +65,9 @@ abstract class AbstractFixerTestCase extends TestCase
         'general_phpdoc_annotation_remove' => true,
     ];
 
-    protected function setUp()
+    protected function doSetUp()
     {
-        parent::setUp();
+        parent::doSetUp();
 
         $this->linter = $this->getLinter();
         $this->fixer = $this->createFixer();
@@ -78,9 +78,9 @@ abstract class AbstractFixerTestCase extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->linter = null;
         $this->fixer = null;

--- a/tests/Test/AbstractFixerWithAliasedOptionsTestCase.php
+++ b/tests/Test/AbstractFixerWithAliasedOptionsTestCase.php
@@ -30,9 +30,9 @@ abstract class AbstractFixerWithAliasedOptionsTestCase extends AbstractFixerTest
      */
     private $fixerWithAliasedConfig;
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->fixerWithAliasedConfig = null;
     }
@@ -62,7 +62,7 @@ abstract class AbstractFixerWithAliasedOptionsTestCase extends AbstractFixerTest
     protected function configureFixerWithAliasedOptions(array $configuration)
     {
         if (!$this->fixer instanceof ConfigurationDefinitionFixerInterface) {
-            throw new \LogicException('Fixer is not configurable');
+            throw new \LogicException('Fixer is not configurable.');
         }
 
         $this->fixer->configure($configuration);
@@ -85,7 +85,7 @@ abstract class AbstractFixerWithAliasedOptionsTestCase extends AbstractFixerTest
         }
 
         if (!$hasAliasedOptions) {
-            throw new \LogicException('Fixer has no aliased options');
+            throw new \LogicException('Fixer has no aliased options.');
         }
 
         $this->fixerWithAliasedConfig = clone $this->fixer;

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -75,9 +75,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
      */
     private static $fileRemoval;
 
-    public static function setUpBeforeClass()
+    public static function doSetUpBeforeClass()
     {
-        parent::setUpBeforeClass();
+        parent::doSetUpBeforeClass();
 
         $tmpFile = static::getTempFile();
         self::$fileRemoval = new FileRemoval();
@@ -93,9 +93,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function doTearDownAfterClass()
     {
-        parent::tearDownAfterClass();
+        parent::doTearDownAfterClass();
 
         $tmpFile = static::getTempFile();
 
@@ -103,9 +103,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
         self::$fileRemoval = null;
     }
 
-    protected function setUp()
+    protected function doSetUp()
     {
-        parent::setUp();
+        parent::doSetUp();
 
         $this->linter = $this->getLinter();
 
@@ -115,9 +115,9 @@ abstract class AbstractIntegrationTestCase extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->linter = null;
 

--- a/tests/Test/AbstractTransformerTestCase.php
+++ b/tests/Test/AbstractTransformerTestCase.php
@@ -29,9 +29,9 @@ abstract class AbstractTransformerTestCase extends TestCase
      */
     protected $transformer;
 
-    protected function setUp()
+    protected function doSetUp()
     {
-        parent::setUp();
+        parent::doSetUp();
 
         $this->transformer = $this->createTransformer();
 
@@ -41,9 +41,9 @@ abstract class AbstractTransformerTestCase extends TestCase
         }
     }
 
-    protected function tearDown()
+    protected function doTearDown()
     {
-        parent::tearDown();
+        parent::doTearDown();
 
         $this->transformer = null;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@
 
 namespace PhpCsFixer\Tests;
 
-use PHPUnit\Framework\TestCase as BaseTestCase;
+use LegacyPHPUnit\TestCase as BaseTestCase;
 use PHPUnitGoodPractices\Polyfill\PolyfillTrait;
 use PHPUnitGoodPractices\Traits\ExpectationViaCodeOverAnnotationTrait;
 use PHPUnitGoodPractices\Traits\ExpectOverSetExceptionTrait;


### PR DESCRIPTION
Replaces #5262 

Uses PHPUnit 9.4 on PHP 8: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5314/checks?check_run_id=1491483701#step:9:9