### PR TITLE
PhpUnitTestCaseStaticMethodCallsFixer - add option to remove method call and use import function

### DIFF
--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -424,7 +424,7 @@ PHPUnit
 - `php_unit_test_annotation <./php_unit/php_unit_test_annotation.rst>`_ *(risky)*
     Adds or removes @test annotations from tests, following configuration.
 - `php_unit_test_case_static_method_calls <./php_unit/php_unit_test_case_static_method_calls.rst>`_ *(risky)*
-    Calls to ``PHPUnit\Framework\TestCase`` static methods must all be of the same type, either ``$this->``, ``self::`` or ``static::``.
+    Calls to ``PHPUnit\Framework\TestCase`` static methods must all be of the same type, either ``$this->``, ``self::`` or ``static::`` or cut call type and import method with ``use function``.
 - `php_unit_test_class_requires_covers <./php_unit/php_unit_test_class_requires_covers.rst>`_
     Adds a default ``@coversNothing`` annotation to PHPUnit test classes that have no ``@covers*`` annotation.
 

--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -3,7 +3,8 @@ Rule ``php_unit_test_case_static_method_calls``
 ===============================================
 
 Calls to ``PHPUnit\Framework\TestCase`` static methods must all be of the same
-type, either ``$this->``, ``self::`` or ``static::``.
+type, either ``$this->``, ``self::`` or ``static::`` or cut call type and import
+method with ``use function``.
 
 .. warning:: Using this rule is risky.
 
@@ -18,7 +19,7 @@ Configuration
 
 The call type to use for referring to PHPUnit methods.
 
-Allowed values: ``'self'``, ``'static'``, ``'this'``
+Allowed values: ``'none'``, ``'self'``, ``'static'``, ``'this'``
 
 Default value: ``'static'``
 

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -466,6 +466,128 @@ class FooTest extends TestCase
 EOF
                 ,
             ],
+            [
+                <<<'EOF'
+<?php
+
+use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\assertSame;
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBaseCase()
+    {
+        assertSame(1, 2);
+        assertTrue(true);
+        assertSame(1, 2);
+        static::someFunction('foo');
+    }
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBaseCase()
+    {
+        static::assertSame(1, 2);
+        $this->assertTrue(true);
+        self::assertSame(1, 2);
+        static::someFunction('foo');
+    }
+}
+EOF
+                ,
+                [
+                    'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_NONE,
+                ],
+            ],
+            [
+                <<<'EOF'
+<?php
+
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertTrue;
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExistingImport()
+    {
+        assertSame(1, 2);
+        assertTrue(true);
+        assertSame(1, 2);
+        static::someFunction('foo');
+    }
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+
+use function PHPUnit\Framework\assertSame;
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testExistingImport()
+    {
+        static::assertSame(1, 2);
+        $this->assertTrue(true);
+        self::assertSame(1, 2);
+        static::someFunction('foo');
+    }
+}
+EOF
+                ,
+                [
+                    'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_NONE,
+                ],
+            ],
+            [
+                <<<'EOF'
+<?php
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\assertSame;
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLambda()
+    {
+        assertSame(1, 2);
+        assertTrue(true);
+        assertFalse(false);
+
+        $lambda = function () {
+            $this->assertSame(1, 2);
+            self::assertTrue(true);
+            static::assertFalse(false);
+        };
+    }
+}
+EOF
+                ,
+                <<<'EOF'
+<?php
+class MyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLambda()
+    {
+        $this->assertSame(1, 2);
+        self::assertTrue(true);
+        static::assertFalse(false);
+
+        $lambda = function () {
+            $this->assertSame(1, 2);
+            self::assertTrue(true);
+            static::assertFalse(false);
+        };
+    }
+}
+EOF
+                ,
+                [
+                    'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_NONE,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Add call type "none". This type removes call type before function and import function in use block.