### PR TITLE
[WIP] Adding separate job for PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,33 @@ jobs:
                 - php vendor/bin/php-coveralls -v
 
         -
+            stage: Test
+            php: 8.0
+            name: 8.0 | Collect coverage
+            before_install:
+                # for building a tag release we don't need to collect code coverage
+                - if [ $TRAVIS_TAG ]; then travis_terminate 0; fi
+
+                ## regular `before_install`
+                # turn off XDebug
+                - phpenv config-rm xdebug.ini || return 0
+
+                # Require PHPUnit 8
+                - composer require --dev --no-update phpunit/phpunit:^8
+
+                # Install PCOV
+                - pecl install pcov
+            install:
+                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
+                - composer info -D | sort
+            before_script:
+                # Make code compatible with PHPUnit 8
+                - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer fix --rules=void_return -q tests || return 0
+            script:
+                - vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
+                - php vendor/bin/php-coveralls -v
+
+        -
             stage: Deployment
             php: 7.4
             install: ./dev-tools/build.sh


### PR DESCRIPTION
An additional job was added to ensure syntax-compatibility with PHP 7.x as well as PHP 8.0. 

The deployment is unaffected by PHP versions and can therefore stay at PHP 7.4.

See #4702
