### PR TITLE
DX: relax composer requirements to not block installation under PHP v8, support for PHP v8 is not yet ready

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.6 || ^7.0 || ^8.0",
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",


### PR DESCRIPTION
Current state:
- composer.json is having requirements for installation
- php-cs-fixer bin file is having requirements for runtime

Actually, not every user is using the composer.json file, thus we need a requirements check on runtime, and that can actually be good as only checker.
For that, we decided to relax the requirements in composer.json file.

Dropping `<8` from composer.json file DOES NOT MEAN we support PHP v8, it is still ongoing effort.

Until PHP v8 is not fully supported and support is claimed in bootstrap file, PHP tokenizer for new PHP syntax can introduce new custom tokens, to ease handling of new syntax by the tool and rules we have.