### PR TITLE
DX: cleanup Github Actions configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,7 @@ jobs:
             composer-
 
       - name: Configure Symfony Flex
-        run: |
-            composer config extra.symfony.require ${{ matrix.execute-flex-with-symfony-version }}
+        run: composer config extra.symfony.require ${{ matrix.execute-flex-with-symfony-version }}
         if: "matrix.execute-flex-with-symfony-version"
 
       - name: Install dependencies
@@ -98,11 +97,10 @@ jobs:
           retry_wait_seconds: 30
           command: |
             composer update --optimize-autoloader --no-interaction --no-progress ${{ matrix.composer-flags }}
-            composer info -D | sort
+            composer info -D
 
       - name: Execute migration rules
-        run: |
-          php php-cs-fixer fix --rules @PHP73Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q
+        run: php php-cs-fixer fix --rules @PHP73Migration,@PHP71Migration:risky,blank_line_after_opening_tag -q
         if: "matrix.execute-migration-rules == 'yes'"
 
       - name: Run tests
@@ -112,12 +110,10 @@ jobs:
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
           PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER: ${{ matrix.PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER }}
           SYMFONY_DEPRECATIONS_HELPER: ${{ matrix.SYMFONY_DEPRECATIONS_HELPER }}
-        run: |
-          vendor/bin/phpunit
+        run: vendor/bin/phpunit
 
       - name: Run PHP CS Fixer
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           PHP_CS_FIXER_FUTURE_MODE: 1
-        run: |
-          php php-cs-fixer --diff --dry-run -v fix
+        run: php php-cs-fixer --diff --dry-run -v fix

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -49,12 +49,10 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           retry_wait_seconds: 30
-          command: |
-            composer update --optimize-autoloader --no-interaction --no-progress ${{ matrix.composer-flags }}
+          command: composer update --optimize-autoloader --no-interaction --no-progress ${{ matrix.composer-flags }}
 
       - name: Report versions
-        run: |
-          composer info -D
+        run: composer info -D
 
       - name: Install dev-tools
         uses: nick-invision/retry@v2
@@ -62,8 +60,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           retry_wait_seconds: 30
-          command: |
-            ./dev-tools/install.sh
+          command: ./dev-tools/install.sh
 
       - name: Run checks
         run: |
@@ -92,8 +89,7 @@ jobs:
 
       - name: Validate changed files
         if: ${{ github.env.CHANGED_PHP_FILES }}
-        run: |
-          ./dev-tools/vendor/bin/phpmd `echo "$CHANGED_PHP_FILES" | xargs | sed 's/ /,/g'` text phpmd.xml
+        run: ./dev-tools/vendor/bin/phpmd `echo "$CHANGED_PHP_FILES" | xargs | sed 's/ /,/g'` text phpmd.xml
 
       - name: Check for unknown files (to be removed in 3.0)
         run: |

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -18,5 +18,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run yamllint
-        run: |
-          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint
+        run: find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint


### PR DESCRIPTION
This PR:
 - updates `.editorconfig` with the indent for YAML files (as we apparently use 2 spaces instead of 4)
 - removes `|` when there is actually one line command
 - removes `sort` from `composer info -D` as Composer already sort the dependencies