### PR TITLE
Bump allowed PHP version to run php-cs-fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
             php-version: '8.0'
             composer-flags: '--ignore-platform-req=php' # as this is a version not yet officially supported by PHP CS Fixer
 
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.1'
+            composer-flags: '--ignore-platform-req=php' # as this is a version not yet officially supported by PHP CS Fixer
+            PHP_CS_FIXER_IGNORE_ENV: 1
+
           - operating-system: 'windows-latest'
             php-version: '7.4'
             job-description: 'on Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
           - operating-system: 'ubuntu-20.04'
             php-version: '8.0'
             composer-flags: '--ignore-platform-req=php' # as this is a version not yet officially supported by PHP CS Fixer
-            PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'windows-latest'
             php-version: '7.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
     include:
         -
             stage: Test
-            php: 7.4
-            name: 7.4 | Collect coverage
+            php: 8.0
+            name: 8.0 | Collect coverage
             before_install:
                 # for building a tag release we don't need to collect code coverage
                 - if [ $TRAVIS_TAG ]; then travis_terminate 0; fi
@@ -51,7 +51,7 @@ jobs:
 
         -
             stage: Deployment
-            php: 7.4
+            php: 8.0
             install: ./dev-tools/build.sh
             script:
                 - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 vendor/bin/phpunit tests/Smoke/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     include:
         -
             stage: Test
-            php: 8.0
+            php: '8.0'
             name: 8.0 | Collect coverage
             before_install:
                 # for building a tag release we don't need to collect code coverage
@@ -51,7 +51,7 @@ jobs:
 
         -
             stage: Deployment
-            php: 8.0
+            php: '8.0'
             install: ./dev-tools/build.sh
             script:
                 - PHP_CS_FIXER_TEST_ALLOW_SKIPPING_SMOKE_TESTS=0 vendor/bin/phpunit tests/Smoke/

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -23,8 +23,8 @@ if (defined('HHVM_VERSION_ID')) {
     } else {
         exit(1);
     }
-} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500) {
-    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.\n");
+} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 80100) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 8.0.*.\n");
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
         fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -40,6 +40,11 @@ final class CiConfigurationTest extends TestCase
             $supportedVersions[] = '5.6';
         }
 
+        if ($supportedMinPhp < 8) {
+            $supportedMinPhp = 8;
+            $supportedVersions = array_merge($supportedVersions, ['7.0', '7.1', '7.2', '7.3', '7.4']);
+        }
+
         for ($version = $supportedMinPhp; $version <= $supportedMaxPhp; $version += 0.1) {
             $supportedVersions[] = sprintf('%.1f', $version);
         }


### PR DESCRIPTION
It's currently allowed to install `php-cs-fixer` under PHP 8 but it's impossible to run it without setting `PHP_CS_FIXER_IGNORE_ENV`.

This change makes it possible to run `php-cs-fixer` under PHP 8 with the default settings.

**Note that this changes the "default" version in CI to 8.0, which may not be what we want just yet?**