### PR TITLE
Fix file missing for php8

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -13,7 +13,8 @@
     "finder": [
         {
             "name": [
-                "*.php"
+                "*.php",
+                "*.php8"
             ],
             "exclude": [
                 "Test",


### PR DESCRIPTION
Fixes #5324

Because the version compatible with php 5.3 (1.19.0) require a file with a `.php8` extension 
https://github.com/symfony/polyfill/blob/ac41071c7ef43e26e1231100fa9a316cebecdec7/src/Mbstring/bootstrap.php#L115