### PR TITLE
Allow T_NULLSAFE_OBJECT_OPERATOR to be tokenized with PHP 8.0.0

### DIFF
--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1050,7 +1050,12 @@ class Tokens extends \SplFixedArray
         // clear memory
         $this->setSize(0);
 
-        $tokens = \defined('TOKEN_PARSE')
+        /**
+         * T_NULLSAFE_OBJECT_OPERATOR will not appear if TOKEN_PARSE is used on PHP 8.0.0.
+         *
+         * @see https://bugs.php.net/bug.php?id=80462
+         */
+        $tokens = \defined('TOKEN_PARSE') && \PHP_VERSION_ID !== 80000
             ? token_get_all($code, TOKEN_PARSE)
             : token_get_all($code);
 


### PR DESCRIPTION
Due to https://bugs.php.net/bug.php?id=80462 `T_NULLSAFE_OBJECT_OPERATOR` never appears in tokens if `TOKEN_PARSE` is used.

This should only impacts PHP 8.0.0, cf. https://github.com/php/php-src/commit/7a61984