### PR TITLE
SingleSpaceAfterConstructFixer: Do not adjust whitespace before multiple multi-line extends

### DIFF
--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -218,6 +218,10 @@ yield  from  baz();
                 continue;
             }
 
+            if ($token->isGivenKind(T_EXTENDS) && $this->isMultilineExtendsWithMoreThanOneAncestor($tokens, $index)) {
+                continue;
+            }
+
             if ($token->isGivenKind(T_RETURN) && $this->isMultiLineReturn($tokens, $index)) {
                 continue;
             }
@@ -283,6 +287,30 @@ yield  from  baz();
                 --$nestedCount;
             } elseif (0 === $nestedCount && $tokens[$index]->equalsAny([';', [T_CLOSE_TAG]])) {
                 break;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return bool
+     */
+    private function isMultilineExtendsWithMoreThanOneAncestor(Tokens $tokens, $index)
+    {
+        $hasMoreThanOneAncestor = false;
+
+        for ($i = $index + 1; $i < $tokens->getNextTokenOfKind($index, ['{']); ++$i) {
+            $token = $tokens[$i];
+
+            if (false !== strpos($token->getContent(), "\n") && $hasMoreThanOneAncestor) {
+                return true;
+            }
+
+            if (',' === $token->getContent()) {
+                $hasMoreThanOneAncestor = true;
             }
         }
 

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -302,15 +302,21 @@ yield  from  baz();
     {
         $hasMoreThanOneAncestor = false;
 
-        for ($i = $index + 1; $i < $tokens->getNextTokenOfKind($index, ['{']); ++$i) {
-            $token = $tokens[$i];
+        while (++$index) {
+            $token = $tokens[$index];
 
-            if (false !== strpos($token->getContent(), "\n") && $hasMoreThanOneAncestor) {
-                return true;
+            if ($token->equals(',')) {
+                $hasMoreThanOneAncestor = true;
+
+                continue;
             }
 
-            if (',' === $token->getContent()) {
-                $hasMoreThanOneAncestor = true;
+            if ($token->equals('{')) {
+                return false;
+            }
+
+            if ($hasMoreThanOneAncestor && false !== strpos($token->getContent(), "\n")) {
+                return true;
             }
         }
 

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -921,44 +921,44 @@ $foo;',
                 '<?php class Foo extends  /* foo */\InvalidArgumentException {}',
             ],
             [
-                '<?php interface Foo extends Bar {}',
-                '<?php interface Foo extends  Bar {}',
+                '<?php interface Foo extends Bar1 {}',
+                '<?php interface Foo extends  Bar1 {}',
             ],
             [
-                '<?php interface Foo extends Bar {}',
+                '<?php interface Foo extends Bar2 {}',
                 '<?php interface Foo extends
 
-Bar {}',
+Bar2 {}',
             ],
             [
-                '<?php interface Foo extends /* foo */Bar {}',
-                '<?php interface Foo extends/* foo */Bar {}',
+                '<?php interface Foo extends /* foo */Bar3 {}',
+                '<?php interface Foo extends/* foo */Bar3 {}',
             ],
             [
-                '<?php interface Foo extends /* foo */Bar {}',
-                '<?php interface Foo extends  /* foo */Bar {}',
+                '<?php interface Foo extends /* foo */Bar4 {}',
+                '<?php interface Foo extends  /* foo */Bar4 {}',
             ],
             [
-                '<?php interface Foo extends Bar, Baz, Qux {}',
-                '<?php interface Foo extends  Bar, Baz, Qux {}',
+                '<?php interface Foo extends Bar5, Baz, Qux {}',
+                '<?php interface Foo extends  Bar5, Baz, Qux {}',
             ],
             [
-                '<?php interface Foo extends Bar, Baz, Qux {}',
+                '<?php interface Foo extends Bar6, Baz, Qux {}',
                 '<?php interface Foo extends
 
-Bar, Baz, Qux {}',
+Bar6, Baz, Qux {}',
             ],
             [
-                '<?php interface Foo extends /* foo */Bar, Baz, Qux {}',
-                '<?php interface Foo extends/* foo */Bar, Baz, Qux {}',
+                '<?php interface Foo extends /* foo */Bar7, Baz, Qux {}',
+                '<?php interface Foo extends/* foo */Bar7, Baz, Qux {}',
             ],
             [
-                '<?php interface Foo extends /* foo */Bar, Baz, Qux {}',
-                '<?php interface Foo extends  /* foo */Bar, Baz, Qux {}',
+                '<?php interface Foo extends /* foo */Bar8, Baz, Qux {}',
+                '<?php interface Foo extends  /* foo */Bar8, Baz, Qux {}',
             ],
             [
                 '<?php interface Foo extends
-    Bar,
+    Bar9,
     Baz,
     Qux
 {}',

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -920,6 +920,49 @@ $foo;',
                 '<?php class Foo extends /* foo */\InvalidArgumentException {}',
                 '<?php class Foo extends  /* foo */\InvalidArgumentException {}',
             ],
+            [
+                '<?php interface Foo extends Bar {}',
+                '<?php interface Foo extends  Bar {}',
+            ],
+            [
+                '<?php interface Foo extends Bar {}',
+                '<?php interface Foo extends
+
+Bar {}',
+            ],
+            [
+                '<?php interface Foo extends /* foo */Bar {}',
+                '<?php interface Foo extends/* foo */Bar {}',
+            ],
+            [
+                '<?php interface Foo extends /* foo */Bar {}',
+                '<?php interface Foo extends  /* foo */Bar {}',
+            ],
+            [
+                '<?php interface Foo extends Bar, Baz, Qux {}',
+                '<?php interface Foo extends  Bar, Baz, Qux {}',
+            ],
+            [
+                '<?php interface Foo extends Bar, Baz, Qux {}',
+                '<?php interface Foo extends
+
+Bar, Baz, Qux {}',
+            ],
+            [
+                '<?php interface Foo extends /* foo */Bar, Baz, Qux {}',
+                '<?php interface Foo extends/* foo */Bar, Baz, Qux {}',
+            ],
+            [
+                '<?php interface Foo extends /* foo */Bar, Baz, Qux {}',
+                '<?php interface Foo extends  /* foo */Bar, Baz, Qux {}',
+            ],
+            [
+                '<?php interface Foo extends
+    Bar,
+    Baz,
+    Qux
+{}',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] ignores whitespace before multiple multi-line extends

Fixes #5337.