### PR TITLE
PhpUnitDedicateAssertInternalTypeFixer - recover target option

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
@@ -13,6 +13,9 @@
 namespace PhpCsFixer\Fixer\PhpUnit;
 
 use PhpCsFixer\Fixer\AbstractPhpUnitFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
@@ -22,7 +25,7 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
  */
-final class PhpUnitDedicateAssertInternalTypeFixer extends AbstractPhpUnitFixer
+final class PhpUnitDedicateAssertInternalTypeFixer extends AbstractPhpUnitFixer implements ConfigurableFixerInterface
 {
     /**
      * @var array
@@ -88,6 +91,21 @@ final class MyTest extends \PHPUnit\Framework\TestCase
     public function getPriority()
     {
         return -16;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition()
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('target', 'Target version of PHPUnit.'))
+                ->setAllowedTypes(['string'])
+                ->setAllowedValues([PhpUnitTargetVersion::VERSION_7_5, PhpUnitTargetVersion::VERSION_NEWEST])
+                ->setDefault(PhpUnitTargetVersion::VERSION_NEWEST)
+                ->setDeprecationMessage('Option was not used.')
+                ->getOption(),
+        ]);
     }
 
     /**

--- a/src/RuleSet/Sets/PHPUnit75MigrationRiskySet.php
+++ b/src/RuleSet/Sets/PHPUnit75MigrationRiskySet.php
@@ -23,7 +23,9 @@ final class PHPUnit75MigrationRiskySet extends AbstractRuleSetDescription
     {
         return [
             '@PHPUnit60Migration:risky' => true,
-            'php_unit_dedicate_assert_internal_type' => true,
+            'php_unit_dedicate_assert_internal_type' => [
+                'target' => '7.5',
+            ],
         ];
     }
 

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -274,10 +274,6 @@ Integration of %s.
         $targetVersion = null;
         $fixer = self::getFixerByName($ruleName);
 
-        if (!$fixer instanceof ConfigurableFixerInterface) {
-            static::markTestSkipped(sprintf('The fixer "%s" is not configurable.', $fixer->getName()));
-        }
-
         foreach ($fixer->getConfigurationDefinition()->getOptions() as $option) {
             if ($option instanceof DeprecatedFixerOption) {
                 continue;


### PR DESCRIPTION
partially reverts #5351

ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5351/files?diff=split&w=1#r544162908

Depends on:
- [x] #5366