### PR TITLE
Allow to run ./vendor/bin/php-cs-fixer with PHP 8.0

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -23,8 +23,8 @@ if (defined('HHVM_VERSION_ID')) {
     } else {
         exit(1);
     }
-} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500) {
-    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.\n");
+} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 80100) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 8.0.*.\n");
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
         fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");


### PR DESCRIPTION
Currently PHP 8.0 is allowed on in composer.json, but ./vendor/bin/php-cs-fixer can't be executed. 

Progress/fixes for #4702