### PR TITLE
DX: MagicMethodCasingFixerTest - fix test case description

### DIFF
--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -133,7 +133,7 @@ final class MagicMethodCasingFixerTest extends AbstractFixerTestCase
             '<?php interface Foo {public function __tostring();}',
         ];
 
-        yield 'method declaration in interface' => [
+        yield 'method declaration in trait' => [
             '<?php trait Foo {public function __toString(){}}',
             '<?php trait Foo {public function __tostring(){}}',
         ];


### PR DESCRIPTION
> 1) Warning
The data provider specified for PhpCsFixer\Tests\Fixer\Casing\MagicMethodCasingFixerTest::testFix is invalid.
PHPUnit\Framework\InvalidDataProviderException: The key "method declaration in interface" has already been defined in the data provider "provideFixCases".
