### PR TITLE
fix: allow to run the PHAR with PHP 8

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -23,8 +23,8 @@ if (defined('HHVM_VERSION_ID')) {
     } else {
         exit(1);
     }
-} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500) {
-    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.\n");
+} elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 80100) {
+    fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 8.0.*.\n");
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
         fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -140,7 +140,7 @@ final class CiIntegrationTest extends AbstractSmokeTest
             $steps[4],
         ]);
 
-        $optionalIncompatibilityWarning = 'PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.
+        $optionalIncompatibilityWarning = 'PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 8.0.*.
 Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.
 ';
 


### PR DESCRIPTION
Currently, this check prevents to run the PHAR when using PHP 8.