### PR TITLE
PhpUnitMethodCasingFixer - Do not modify class name

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -126,16 +126,22 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
      */
     private function updateMethodCasing($functionName)
     {
+        $parts = explode('::', $functionName);
+
+        $functionNamePart = array_pop($parts);
+
         if (self::CAMEL_CASE === $this->configuration['case']) {
-            $newFunctionName = $functionName;
-            $newFunctionName = ucwords($newFunctionName, '_');
-            $newFunctionName = str_replace('_', '', $newFunctionName);
-            $newFunctionName = lcfirst($newFunctionName);
+            $newFunctionNamePart = $functionNamePart;
+            $newFunctionNamePart = ucwords($newFunctionNamePart, '_');
+            $newFunctionNamePart = str_replace('_', '', $newFunctionNamePart);
+            $newFunctionNamePart = lcfirst($newFunctionNamePart);
         } else {
-            $newFunctionName = Utils::camelCaseToUnderscore($functionName);
+            $newFunctionNamePart = Utils::camelCaseToUnderscore($functionNamePart);
         }
 
-        return $newFunctionName;
+        $parts[] = $newFunctionNamePart;
+
+        return implode('::', $parts);
     }
 
     /**

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -99,6 +99,42 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                     public function test_my_app_too() {}
                 }',
             ],
+            '@depends annotation with class name in PascalCase' => [
+                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function testMyApp () {}
+
+                    /**
+                     * @depends FooBarTest::testMyApp
+                     */
+                    public function testMyAppToo() {}
+                }',
+                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function test_my_app () {}
+
+                    /**
+                     * @depends FooBarTest::test_my_app
+                     */
+                    public function test_my_app_too() {}
+                }',
+            ],
+            '@depends annotation with class name in Snake_Case' => [
+                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function testMyApp () {}
+
+                    /**
+                     * @depends Foo_Bar_Test::testMyApp
+                     */
+                    public function testMyAppToo() {}
+                }',
+                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function test_my_app () {}
+
+                    /**
+                     * @depends Foo_Bar_Test::test_my_app
+                     */
+                    public function test_my_app_too() {}
+                }',
+            ],
             '@depends and @test annotation' => [
                 '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     /**


### PR DESCRIPTION
This PR

* [x] asserts that the `PhpUnitMethodCasingFixer` does not modify class names when using `@depends` annotations with `FooTest::testFoo()` style
* [x] adjusts the `PhpUnitMethodCasingFixer` to fix only the function name part