### PR TITLE
PhpdocOrderByValueFixer - Allow sorting of throws annotations by value

### DIFF
--- a/doc/rules/phpdoc/phpdoc_order_by_value.rst
+++ b/doc/rules/phpdoc/phpdoc_order_by_value.rst
@@ -12,7 +12,7 @@ Configuration
 
 List of annotations to order, e.g. ``["covers"]``.
 
-Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'requires', 'uses']``
+Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'requires', 'throws', 'uses']``
 
 Default value: ``['covers']``
 

--- a/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
@@ -168,6 +168,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             'group',
             'internal',
             'requires',
+            'throws',
             'uses',
         ];
 

--- a/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
@@ -1057,6 +1057,145 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
+     * @dataProvider provideFixWithThrowsCases
+     */
+    public function testFixWithThrows($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'annotations' => [
+                'throws',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithThrowsCases()
+    {
+        return [
+            'skip on 1 or 0 occurrences' => [
+                '<?php
+                    class Foo {
+                        /**
+                         * @throws Bar
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function bar() {}
+
+                        /**
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function baz() {}
+                    }
+                ',
+            ],
+            'base case' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Bar
+                         * @throws Baz
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Baz
+                         * @throws Bar
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'preserve positions if other docblock parts are present' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * Comment 1
+                         * @throws Bar
+                         * Comment 3
+                         * @throws Baz
+                         * Comment 2
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * Comment 1
+                         * @throws Baz
+                         * Comment 2
+                         * @throws Bar
+                         * Comment 3
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'case-insensitive' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws A
+                         * @throws b
+                         * @throws C
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws b
+                         * @throws C
+                         * @throws A
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'fully-qualified' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws \Bar\Baz\Qux
+                         * @throws Bar
+                         * @throws Foo
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Bar
+                         * @throws \Bar\Baz\Qux
+                         * @throws Foo
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
      * @dataProvider provideFixWithUsesCases
      */
     public function testFixWithUses($expected, $input = null)


### PR DESCRIPTION
This PR

* [x] ajusts the `PhpdocOrderByValueFixer` to allow sorting of `@throws` annotations by value