### PR TITLE
PsrAutoloadingFixer - do not remove directory structure from the Class name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
+            job-description: 'with calculating code coverage'
+            calculate-code-coverage: 'yes'
+            phpunit-flags: '--testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '7.4'
             job-description: 'with migration rules'
             execute-migration-rules: 'yes' # should be checked on highest supported PHP version
 
@@ -61,11 +67,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Get code coverage driver
+        uses: actions/github-script@v3.1
+        id: code-coverage-driver
+        with:
+          script: 'return "${{ matrix.calculate-code-coverage }}" == "yes" ? "pcov" : "none"'
+          result-encoding: string
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
+          coverage: ${{ steps.code-coverage-driver.outputs.result }}
           tools: flex
         env:
           fail-fast: false # disabled as old PHP version cannot run flex
@@ -110,7 +123,13 @@ jobs:
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
           PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER: ${{ matrix.PHP_CS_FIXER_TEST_USE_LEGACY_TOKENIZER }}
           SYMFONY_DEPRECATIONS_HELPER: ${{ matrix.SYMFONY_DEPRECATIONS_HELPER }}
-        run: vendor/bin/phpunit
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+
+      - name: Upload coverage results to Coveralls
+        if: matrix.calculate-code-coverage == 'yes'
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: php vendor/bin/php-coveralls --verbose
 
       - name: Run PHP CS Fixer
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,33 +23,6 @@ before_install:
 jobs:
     include:
         -
-            stage: Test
-            php: 7.4
-            name: 7.4 | Collect coverage
-            before_install:
-                # for building a tag release we don't need to collect code coverage
-                - if [ $TRAVIS_TAG ]; then travis_terminate 0; fi
-
-                ## regular `before_install`
-                # turn off XDebug
-                - phpenv config-rm xdebug.ini || return 0
-
-                # Require PHPUnit 8
-                - composer require --dev --no-update phpunit/phpunit:^8
-
-                # Install PCOV
-                - pecl install pcov
-            install:
-                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
-                - composer info -D | sort
-            before_script:
-                # Make code compatible with PHPUnit 8
-                - PHP_CS_FIXER_FUTURE_MODE=1 php php-cs-fixer fix --rules=void_return -q tests || return 0
-            script:
-                - vendor/bin/phpunit --testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml || travis_terminate 1
-                - php vendor/bin/php-coveralls -v
-
-        -
             stage: Deployment
             php: 7.4
             install: ./dev-tools/build.sh

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "justinrainbow/json-schema": "^5.0",
         "keradus/cli-executor": "^1.4",
         "mikey179/vfsstream": "^1.6",
-        "php-coveralls/php-coveralls": "^2.4.1",
+        "php-coveralls/php-coveralls": "^2.4.2",
         "php-cs-fixer/accessible-object": "^1.0",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",

--- a/doc/rules/phpdoc/phpdoc_order_by_value.rst
+++ b/doc/rules/phpdoc/phpdoc_order_by_value.rst
@@ -12,7 +12,7 @@ Configuration
 
 List of annotations to order, e.g. ``["covers"]``.
 
-Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'requires', 'uses']``
+Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'requires', 'throws', 'uses']``
 
 Default value: ``['covers']``
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     enforceTimeLimit="true"
+    failOnWarning="true"
     processIsolation="false"
     stopOnFailure="false"
     timeoutForSmallTests="2"

--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -100,6 +100,16 @@ $c = 3;
 
     /**
      * {@inheritdoc}
+     *
+     * Must run after NoUselessReturnFixer.
+     */
+    public function getPriority()
+    {
+        return -19;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens)
     {

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -218,7 +218,7 @@ yield  from  baz();
                 continue;
             }
 
-            if ($token->isGivenKind(T_EXTENDS) && $this->isMultilineExtendsWithMoreThanOneAncestor($tokens, $index)) {
+            if ($token->isGivenKind([T_EXTENDS, T_IMPLEMENTS]) && $this->isMultilineExtendsOrImplementsWithMoreThanOneAncestor($tokens, $index)) {
                 continue;
             }
 
@@ -298,7 +298,7 @@ yield  from  baz();
      *
      * @return bool
      */
-    private function isMultilineExtendsWithMoreThanOneAncestor(Tokens $tokens, $index)
+    private function isMultilineExtendsOrImplementsWithMoreThanOneAncestor(Tokens $tokens, $index)
     {
         $hasMoreThanOneAncestor = false;
 

--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -49,7 +49,7 @@ class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocOrderFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
      * Must run after CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -49,7 +49,7 @@ class Baz
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocOrderFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
      * Must run after CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()

--- a/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
@@ -168,6 +168,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             'group',
             'internal',
             'requires',
+            'throws',
             'uses',
         ];
 

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -61,7 +61,7 @@ final class PhpdocOrderFixer extends AbstractFixer
      * {@inheritdoc}
      *
      * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run after CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -55,7 +55,7 @@ function example($b) {
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeReturnFixer, BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer.
+     * Must run before BlankLineBeforeReturnFixer, BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer, SingleLineCommentStyleFixer.
      * Must run after NoEmptyStatementFixer, NoUnneededCurlyBracesFixer, NoUselessElseFixer, SimplifiedNullReturnFixer.
      */
     public function getPriority()

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -192,6 +192,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_return'], $fixers['blank_line_before_statement']],
             [$fixers['no_useless_return'], $fixers['no_extra_blank_lines']],
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']],
+            [$fixers['no_useless_return'], $fixers['single_line_comment_style']],
             [$fixers['no_useless_sprintf'], $fixers['method_argument_space']],
             [$fixers['no_useless_sprintf'], $fixers['native_function_casing']],
             [$fixers['no_useless_sprintf'], $fixers['no_empty_statement']],
@@ -221,7 +222,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['phpdoc_annotation_without_dot'], $fixers['phpdoc_types']],
             [$fixers['phpdoc_annotation_without_dot'], $fixers['phpdoc_types_order']],
             [$fixers['phpdoc_no_access'], $fixers['no_empty_phpdoc']],
-            [$fixers['phpdoc_no_access'], $fixers['phpdoc_order']],
             [$fixers['phpdoc_no_access'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_access'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_alias_tag'], $fixers['phpdoc_add_missing_param_annotation']],
@@ -231,7 +231,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['phpdoc_no_empty_return'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_package'], $fixers['no_empty_phpdoc']],
-            [$fixers['phpdoc_no_package'], $fixers['phpdoc_order']],
             [$fixers['phpdoc_no_package'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_package'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_useless_inheritdoc'], $fixers['no_empty_phpdoc']],
@@ -338,13 +337,6 @@ final class FixerFactoryTest extends TestCase
      */
     public function testFixersPriorityPairsHaveIntegrationTest(FixerInterface $first, FixerInterface $second)
     {
-        // This structure contains older cases that are not yet covered by tests.
-        // It may only shrink, never add anything to it.
-        $casesWithoutTests = [
-            'phpdoc_no_access,phpdoc_order.test',
-            'phpdoc_no_package,phpdoc_order.test',
-        ];
-
         $integrationTestName = $this->generateIntegrationTestName($first, $second);
         $file = $this->getIntegrationPriorityDirectory().$integrationTestName;
 
@@ -355,11 +347,6 @@ final class FixerFactoryTest extends TestCase
             $file = $this->getIntegrationPriorityDirectory().$this->generateIntegrationTestName($second, $first);
             $description = sprintf('Integration of fixers: %s,%s.', $second->getName(), $first->getName());
             $integrationTestExists = is_file($file);
-        }
-
-        if (\in_array($integrationTestName, $casesWithoutTests, true)) {
-            static::assertFalse($integrationTestExists, sprintf('Case "%s" already has an integration test, so it should be removed from "$casesWithoutTests".', $integrationTestName));
-            static::markTestIncomplete(sprintf('Case "%s" has no integration test yet, please help and add it.', $integrationTestName));
         }
 
         static::assertTrue($integrationTestExists, sprintf('There shall be an integration test "%s". How do you know that priority set up is good, if there is no integration test to check it?', $integrationTestName));

--- a/tests/Fixer/Basic/Psr0FixerTest.php
+++ b/tests/Fixer/Basic/Psr0FixerTest.php
@@ -29,7 +29,7 @@ final class Psr0FixerTest extends AbstractFixerTestCase
         $fileProphecy->willExtend(\SplFileInfo::class);
         $fileProphecy->getBasename('.php')->willReturn('Bar');
         $fileProphecy->getExtension()->willReturn('php');
-        $fileProphecy->getRealPath()->willReturn(__DIR__.'/Psr0/Foo/Bar.php');
+        $fileProphecy->getRealPath()->willReturn(__DIR__.\DIRECTORY_SEPARATOR.'Psr0'.\DIRECTORY_SEPARATOR.'Foo'.\DIRECTORY_SEPARATOR.'Bar.php');
         $file = $fileProphecy->reveal();
 
         $expected = <<<'EOF'

--- a/tests/Fixer/Basic/Psr4FixerTest.php
+++ b/tests/Fixer/Basic/Psr4FixerTest.php
@@ -29,7 +29,7 @@ final class Psr4FixerTest extends AbstractFixerTestCase
         $fileProphecy->willExtend(\SplFileInfo::class);
         $fileProphecy->getBasename('.php')->willReturn('Bar');
         $fileProphecy->getExtension()->willReturn('php');
-        $fileProphecy->getRealPath()->willReturn(__DIR__.'/Psr4/Foo/Bar.php');
+        $fileProphecy->getRealPath()->willReturn(__DIR__.\DIRECTORY_SEPARATOR.'Psr4'.\DIRECTORY_SEPARATOR.'Foo'.\DIRECTORY_SEPARATOR.'Bar.php');
         $file = $fileProphecy->reveal();
 
         $expected = <<<'EOF'
@@ -47,7 +47,7 @@ EOF;
 
         $expected = <<<'EOF'
 <?php
-class Bar {}
+class Psr4_Foo_Bar {}
 EOF;
         $input = <<<'EOF'
 <?php

--- a/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
@@ -123,7 +123,7 @@ final class RegularCallableCallFixerTest extends AbstractFixerTestCase
         ];
 
         if (\PHP_VERSION_ID < 80000) {
-            yield 'call by variable' => [
+            yield 'call by variable (PHP < 8.0)' => [
                 '<?php
                     $a{"b"}{"c"}(1, 2);
                 ',

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -1544,6 +1544,13 @@ foo; foo: echo "Bar";',
                 '<?php class Foo implements /* foo */\Countable {}',
                 '<?php class Foo implements  /* foo */\Countable {}',
             ],
+            [
+                '<?php class Foo implements
+                    \Countable,
+                    Bar,
+                    Baz
+                {}',
+            ],
         ];
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
@@ -1057,6 +1057,145 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
      * @param string      $expected
      * @param null|string $input
      *
+     * @dataProvider provideFixWithThrowsCases
+     */
+    public function testFixWithThrows($expected, $input = null)
+    {
+        $this->fixer->configure([
+            'annotations' => [
+                'throws',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithThrowsCases()
+    {
+        return [
+            'skip on 1 or 0 occurrences' => [
+                '<?php
+                    class Foo {
+                        /**
+                         * @throws Bar
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function bar() {}
+
+                        /**
+                         * @params bool $bool
+                         * @return void
+                         */
+                        public function baz() {}
+                    }
+                ',
+            ],
+            'base case' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Bar
+                         * @throws Baz
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Baz
+                         * @throws Bar
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'preserve positions if other docblock parts are present' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * Comment 1
+                         * @throws Bar
+                         * Comment 3
+                         * @throws Baz
+                         * Comment 2
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * Comment 1
+                         * @throws Baz
+                         * Comment 2
+                         * @throws Bar
+                         * Comment 3
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'case-insensitive' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws A
+                         * @throws b
+                         * @throws C
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws b
+                         * @throws C
+                         * @throws A
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+            'fully-qualified' => [
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws \Bar\Baz\Qux
+                         * @throws Bar
+                         * @throws Foo
+                         */
+                        public function bar() {}
+                    }
+                ',
+                '<?php
+                    class Foo
+                    {
+                        /**
+                         * @throws Bar
+                         * @throws \Bar\Baz\Qux
+                         * @throws Foo
+                         */
+                        public function bar() {}
+                    }
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
      * @dataProvider provideFixWithUsesCases
      */
     public function testFixWithUses($expected, $input = null)

--- a/tests/Fixtures/Integration/priority/no_useless_return,single_line_comment_style.test
+++ b/tests/Fixtures/Integration/priority/no_useless_return,single_line_comment_style.test
@@ -1,0 +1,17 @@
+--TEST--
+Integration of fixers: no_useless_return,single_line_comment_style.
+--RULESET--
+{ "no_useless_return": true, "single_line_comment_style": true }
+--EXPECT--
+<?php
+function foo()
+{
+    // foo
+}
+
+--INPUT--
+<?php
+function foo()
+{
+    return/* foo */;
+}


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5377

Pinging @jaydiablo for review (as a reporter of the bug) - the issue you have reported is the one in "class with wrong casing (2 levels namespace)" case.