### PR TITLE
SingleLineCommentStyleFixer- run before NoUselessReturnFixer

### DIFF
--- a/src/Fixer/Comment/SingleLineCommentStyleFixer.php
+++ b/src/Fixer/Comment/SingleLineCommentStyleFixer.php
@@ -100,6 +100,16 @@ $c = 3;
 
     /**
      * {@inheritdoc}
+     *
+     * Must run after NoUselessReturnFixer.
+     */
+    public function getPriority()
+    {
+        return -19;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens)
     {

--- a/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
+++ b/src/Fixer/ReturnNotation/NoUselessReturnFixer.php
@@ -55,7 +55,7 @@ function example($b) {
     /**
      * {@inheritdoc}
      *
-     * Must run before BlankLineBeforeReturnFixer, BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer.
+     * Must run before BlankLineBeforeReturnFixer, BlankLineBeforeStatementFixer, NoExtraBlankLinesFixer, NoWhitespaceInBlankLineFixer, SingleLineCommentStyleFixer.
      * Must run after NoEmptyStatementFixer, NoUnneededCurlyBracesFixer, NoUselessElseFixer, SimplifiedNullReturnFixer.
      */
     public function getPriority()

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -192,6 +192,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['no_useless_return'], $fixers['blank_line_before_statement']],
             [$fixers['no_useless_return'], $fixers['no_extra_blank_lines']],
             [$fixers['no_useless_return'], $fixers['no_whitespace_in_blank_line']],
+            [$fixers['no_useless_return'], $fixers['single_line_comment_style']],
             [$fixers['no_useless_sprintf'], $fixers['method_argument_space']],
             [$fixers['no_useless_sprintf'], $fixers['native_function_casing']],
             [$fixers['no_useless_sprintf'], $fixers['no_empty_statement']],

--- a/tests/Fixtures/Integration/priority/no_useless_return,single_line_comment_style.test
+++ b/tests/Fixtures/Integration/priority/no_useless_return,single_line_comment_style.test
@@ -1,0 +1,17 @@
+--TEST--
+Integration of fixers: no_useless_return,single_line_comment_style.
+--RULESET--
+{ "no_useless_return": true, "single_line_comment_style": true }
+--EXPECT--
+<?php
+function foo()
+{
+    // foo
+}
+
+--INPUT--
+<?php
+function foo()
+{
+    return/* foo */;
+}


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5382

Ping @mvorisek for review (as a reporter of bug).