### PR TITLE
DX: remove incorrect priority relations

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoAccessFixer.php
@@ -49,7 +49,7 @@ class Foo
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocOrderFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
      * Must run after CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()

--- a/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocNoPackageFixer.php
@@ -49,7 +49,7 @@ class Baz
     /**
      * {@inheritdoc}
      *
-     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocOrderFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run before NoEmptyPhpdocFixer, PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
      * Must run after CommentToPhpdocFixer, PhpdocIndentFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -61,7 +61,7 @@ final class PhpdocOrderFixer extends AbstractFixer
      * {@inheritdoc}
      *
      * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * Must run after CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
      */
     public function getPriority()
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -221,7 +221,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['phpdoc_annotation_without_dot'], $fixers['phpdoc_types']],
             [$fixers['phpdoc_annotation_without_dot'], $fixers['phpdoc_types_order']],
             [$fixers['phpdoc_no_access'], $fixers['no_empty_phpdoc']],
-            [$fixers['phpdoc_no_access'], $fixers['phpdoc_order']],
             [$fixers['phpdoc_no_access'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_access'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_alias_tag'], $fixers['phpdoc_add_missing_param_annotation']],
@@ -231,7 +230,6 @@ final class FixerFactoryTest extends TestCase
             [$fixers['phpdoc_no_empty_return'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_empty_return'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_package'], $fixers['no_empty_phpdoc']],
-            [$fixers['phpdoc_no_package'], $fixers['phpdoc_order']],
             [$fixers['phpdoc_no_package'], $fixers['phpdoc_separation']],
             [$fixers['phpdoc_no_package'], $fixers['phpdoc_trim']],
             [$fixers['phpdoc_no_useless_inheritdoc'], $fixers['no_empty_phpdoc']],
@@ -338,13 +336,6 @@ final class FixerFactoryTest extends TestCase
      */
     public function testFixersPriorityPairsHaveIntegrationTest(FixerInterface $first, FixerInterface $second)
     {
-        // This structure contains older cases that are not yet covered by tests.
-        // It may only shrink, never add anything to it.
-        $casesWithoutTests = [
-            'phpdoc_no_access,phpdoc_order.test',
-            'phpdoc_no_package,phpdoc_order.test',
-        ];
-
         $integrationTestName = $this->generateIntegrationTestName($first, $second);
         $file = $this->getIntegrationPriorityDirectory().$integrationTestName;
 
@@ -355,11 +346,6 @@ final class FixerFactoryTest extends TestCase
             $file = $this->getIntegrationPriorityDirectory().$this->generateIntegrationTestName($second, $first);
             $description = sprintf('Integration of fixers: %s,%s.', $second->getName(), $first->getName());
             $integrationTestExists = is_file($file);
-        }
-
-        if (\in_array($integrationTestName, $casesWithoutTests, true)) {
-            static::assertFalse($integrationTestExists, sprintf('Case "%s" already has an integration test, so it should be removed from "$casesWithoutTests".', $integrationTestName));
-            static::markTestIncomplete(sprintf('Case "%s" has no integration test yet, please help and add it.', $integrationTestName));
         }
 
         static::assertTrue($integrationTestExists, sprintf('There shall be an integration test "%s". How do you know that priority set up is good, if there is no integration test to check it?', $integrationTestName));


### PR DESCRIPTION
Fixer `phpdoc_order` has no priority relation to `phpdoc_no_access` or `phpdoc_no_package` - it does not matter if the tags are sorted or removed first.
