### PR TITLE
SingleSpaceAfterConstructFixer - do not touch multi line implements

### DIFF
--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -218,7 +218,7 @@ yield  from  baz();
                 continue;
             }
 
-            if ($token->isGivenKind(T_EXTENDS) && $this->isMultilineExtendsWithMoreThanOneAncestor($tokens, $index)) {
+            if ($token->isGivenKind([T_EXTENDS, T_IMPLEMENTS]) && $this->isMultilineExtendsOrImplementsWithMoreThanOneAncestor($tokens, $index)) {
                 continue;
             }
 
@@ -298,7 +298,7 @@ yield  from  baz();
      *
      * @return bool
      */
-    private function isMultilineExtendsWithMoreThanOneAncestor(Tokens $tokens, $index)
+    private function isMultilineExtendsOrImplementsWithMoreThanOneAncestor(Tokens $tokens, $index)
     {
         $hasMoreThanOneAncestor = false;
 

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -1544,6 +1544,13 @@ foo; foo: echo "Bar";',
                 '<?php class Foo implements /* foo */\Countable {}',
                 '<?php class Foo implements  /* foo */\Countable {}',
             ],
+            [
+                '<?php class Foo implements
+                    \Countable,
+                    Bar,
+                    Baz
+                {}',
+            ],
         ];
     }
 


### PR DESCRIPTION
for ref.: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5362#issuecomment-748965233

thanks @localheinz  :)