### PR TITLE
PhpdocScalarFixer - Fix description

### DIFF
--- a/doc/rules/phpdoc/phpdoc_scalar.rst
+++ b/doc/rules/phpdoc/phpdoc_scalar.rst
@@ -11,7 +11,7 @@ Configuration
 ``types``
 ~~~~~~~~~
 
-A map of types to fix.
+A list of types to fix.
 
 Allowed values: a subset of ``['boolean', 'callback', 'double', 'integer', 'real', 'str']``
 

--- a/src/Fixer/Phpdoc/PhpdocScalarFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocScalarFixer.php
@@ -104,7 +104,7 @@ function sample($a, $b, $c)
     protected function createConfigurationDefinition()
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('types', 'A map of types to fix.'))
+            (new FixerOptionBuilder('types', 'A list of types to fix.'))
                 ->setAllowedValues([new AllowedValueSubset(array_keys(self::$types))])
                 ->setDefault(['boolean', 'double', 'integer', 'real', 'str']) // TODO 3.0 add "callback"
                 ->getOption(),


### PR DESCRIPTION
This PR

* [x] fixes the description of the `types` option of the `PhpdocScalarFixer`