### PR TITLE
PhpdocTagTypeFixer: Do not modify array shapes

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -345,6 +345,12 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
  *
  */',
             ],
+            [
+                '<?php
+/**
+ * @return array{0: float, 1: int}
+ */',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR

* [x] adds a failing test that shows that the `PhpdocTagTypeFixer` modifies array shapes

💁‍♂️ For reference, see

- https://phpstan.org/writing-php-code/phpdoc-types#array-shapes
- https://psalm.dev/docs/annotating_code/type_syntax/array_types/#object-like-arrays

Perhaps @SpacePossum can take a look?