### PR TITLE
Forbid execution under PHP 8.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           tools: flex
         env:
           fail-fast: false # disabled as old PHP version cannot run flex
+          update: ${{ matrix.php-version == '8.0' }} # force update to 8.0.1+, ref https://github.com/shivammathur/setup-php/issues/394#issuecomment-760461251
 
       - name: Get Composer cache directory
         id: composer-cache

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -25,6 +25,14 @@ if (defined('HHVM_VERSION_ID')) {
     }
 } elseif (!defined('PHP_VERSION_ID') || \PHP_VERSION_ID < 50600 || \PHP_VERSION_ID >= 70500) {
     fwrite(STDERR, "PHP needs to be a minimum version of PHP 5.6.0 and maximum version of PHP 7.4.*.\n");
+    fwrite(STDERR, 'Current PHP version: '.PHP_VERSION.".\n");
+
+    if (defined('PHP_VERSION_ID') && \PHP_VERSION_ID === 80000) {
+        fwrite(STDERR, "PHP CS Fixer is not able run on PHP 8.0.0 due to bug in PHP tokenizer (https://bugs.php.net/bug.php?id=80462).\n");
+        fwrite(STDERR, "Update PHP version to unblock execution.\n");
+
+        exit(1);
+    }
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {
         fwrite(STDERR, "Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Execution may be unstable.\n");


### PR DESCRIPTION
To be merged when PHP 8.0.1 is released

ref https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5399#discussion_r549422178
> PHP 8.0.1 is scheduled to be released on January 7th.
