### PR TITLE
DX: PHPUnit - disable verbose by default

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
     processIsolation="false"
     stopOnFailure="false"
     timeoutForSmallTests="2"
-    verbose="true"
+    verbose="false"
 >
     <testsuites>
         <testsuite name="all">


### PR DESCRIPTION
the outcome length is insane nowadays (like "skipped 1k+ tests on php5.6" and each of them listed)