### PR TITLE
DX: Drop speedtrap PHPUnit listener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
         "justinrainbow/json-schema": "^5.0",
         "keradus/cli-executor": "^1.4",
         "mikey179/vfsstream": "^1.6",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -40,15 +40,6 @@
     </filter>
 
     <listeners>
-        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener">
-            <arguments>
-                <array>
-                    <element key="slowThreshold">
-                        <integer>100</integer>
-                    </element>
-                </array>
-            </arguments>
-        </listener>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
 


### PR DESCRIPTION
PHPUnit now manages time of execution on its own, no need for plugin.

trying to solve random test timeouts at Travis, maybe there is a conflict between native mechanism and plugin.