### PR TITLE
DX: do not enforce time limits for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: :pcntl
           coverage: ${{ steps.code-coverage-driver.outputs.result }}
           tools: flex
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: :pcntl
           coverage: ${{ steps.code-coverage-driver.outputs.result }}
           tools: flex
         env:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,11 +15,9 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    enforceTimeLimit="true"
     failOnWarning="true"
     processIsolation="false"
     stopOnFailure="false"
-    timeoutForSmallTests="2"
     verbose="false"
 >
     <testsuites>


### PR DESCRIPTION
Since:
>  PHP extension pcntl is required for enforcing time limits

and playing with time limits is [not helpig](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5429) much, let's try to not use `pcntl `.