### PR TITLE
switch_case_semicolon_to_colon should skip match/default statements

### DIFF
--- a/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
+++ b/src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php
@@ -71,8 +71,11 @@ final class SwitchCaseSemicolonToColonFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens as $index => $token) {
-            if ($token->isGivenKind([T_CASE, T_DEFAULT])) {
+            if ($token->isGivenKind(T_CASE)) {
                 $this->fixSwitchCase($tokens, $index);
+            }
+            if ($token->isGivenKind(T_DEFAULT)) {
+                $this->fixSwitchDefault($tokens, $index);
             }
         }
     }
@@ -103,6 +106,22 @@ final class SwitchCaseSemicolonToColonFixer extends AbstractFixer
                 }
 
                 --$ternariesCount;
+            }
+        } while (++$index);
+
+        if ($tokens[$index]->equals(';')) {
+            $tokens[$index] = new Token(':');
+        }
+    }
+
+    /**
+     * @param int $index
+     */
+    protected function fixSwitchDefault(Tokens $tokens, $index)
+    {
+        do {
+            if ($tokens[$index]->equalsAny([':', ';', [T_DOUBLE_ARROW]])) {
+                break;
             }
         } while (++$index);
 

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -67,6 +67,20 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php
+                switch ($a) {
+                    case ["foo" => "bar"]:
+                        break;
+                }
+                ',
+                '<?php
+                switch ($a) {
+                    case ["foo" => "bar"];
+                        break;
+                }
+                ',
+            ],
+            [
+                '<?php
                     switch ($a) {
                         case 42:
                             break;
@@ -256,6 +270,58 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
                     case $b ? f(function () { return; }) : new class {public function A(){echo 1;}} ;
                         break;
                 }
+                ',
+            ],
+        ];
+    }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8
+     */
+    public function testFix80($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        return [
+            'Simple match' => [
+                '<?php
+                    echo match ($a) {
+                        default => "foo",
+                    };
+                ',
+            ],
+            'Match in switch' => [
+                '<?php
+                    switch ($foo) {
+                        case "bar":
+                            echo match ($a) {
+                                default => "foo",
+                            };
+                            break;
+                    }
+                ',
+            ],
+            'Match in case value' => [
+                '<?php
+                    switch ($foo) {
+                        case match ($bar) {
+                            default => "foo",
+                        }: echo "It works!";
+                    }
+                ',
+                '<?php
+                    switch ($foo) {
+                        case match ($bar) {
+                            default => "foo",
+                        }; echo "It works!";
+                    }
                 ',
             ],
         ];


### PR DESCRIPTION
Fixes #5446.