### PR TITLE
Allow PHP_CS_FIXER_IGNORE_ENV for PHP 8.0.0 check

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -35,8 +35,6 @@ if (defined('HHVM_VERSION_ID')) {
     if (defined('PHP_VERSION_ID') && \PHP_VERSION_ID === 80000) {
         fwrite(STDERR, "PHP CS Fixer is not able run on PHP 8.0.0 due to bug in PHP tokenizer (https://bugs.php.net/bug.php?id=80462).\n");
         fwrite(STDERR, "Update PHP version to unblock execution.\n");
-
-        exit(1);
     }
 
     if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {


### PR DESCRIPTION
There may be use-cases where the bug in PHP's tokenizer is not an issue (for example because the nullsafe operator is not used in the analyzed code). It should therefore be possible to disable the check like the general version check.