### PR TITLE
DX: Test that Transformers are adding only CustomTokens that they define and nothing else

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -1,6 +1,7 @@
 {
     "symbol-whitelist" : [
         "LegacyPHPUnit\\TestCase",
+        "PhpCsFixer\\AccessibleObject\\AccessibleObject",
         "PhpCsFixer\\PhpunitConstraintIsIdenticalString\\Constraint\\IsIdenticalString",
         "PhpCsFixer\\Tests\\Test\\Constraint\\SameStringsConstraint",
         "PhpCsFixer\\Tests\\Test\\IsIdenticalConstraint",

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -114,5 +114,6 @@ jobs:
             grep -v tests/Test/IntegrationCaseFactoryInterface.php |
             grep -v tests/Test/InternalIntegrationCaseFactory.php |
             grep -v tests/Test/IsIdenticalConstraint.php |
+            grep -v tests/Test/TokensWithObservedTransformers.php |
             grep -v tests/TestCase.php \
           && (echo "UNKNOWN FILES DETECTED" && exit 1) || echo "NO UNKNOWN FILES"

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
             "tests/Test/IntegrationCaseFactoryInterface.php",
             "tests/Test/InternalIntegrationCaseFactory.php",
             "tests/Test/IsIdenticalConstraint.php",
+            "tests/Test/TokensWithObservedTransformers.php",
             "tests/TestCase.php"
         ]
     },

--- a/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
+++ b/src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php
@@ -46,11 +46,12 @@ final class NoUnneededControlParenthesesFixer extends AbstractFixer implements C
     {
         parent::__construct();
 
-        // To be moved back to compile time property declaration when PHP support of PHP CS Fixer will be 7.0+
+        // @TODO: To be moved back to compile time property declaration when PHP support of PHP CS Fixer will be 7.0+
         if (\defined('T_COALESCE')) {
             self::$loops['clone']['forbiddenContents'][] = [T_COALESCE, '??'];
         }
 
+        // @TODO: To be moved back to compile time property declaration when PHP support of PHP CS Fixer will be 7.0+
         if (\defined('T_YIELD_FROM')) {
             self::$loops['yield_from'] = ['lookupTokens' => T_YIELD_FROM, 'neededSuccessors' => [';', ')']];
         }

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -485,10 +485,12 @@ return $foo === count($bar);
                 T_XOR_EQUAL,    // ^=
             ];
 
+            // @TODO: drop condition when PHP 7.0+ is required
             if (\defined('T_COALESCE')) {
                 $tokens[] = T_COALESCE; // ??
             }
 
+            // @TODO: drop condition when PHP 7.4+ is required
             if (\defined('T_COALESCE_EQUAL')) {
                 $tokens[] = T_COALESCE_EQUAL; // ??=
             }

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -105,10 +105,12 @@ final class SingleSpaceAfterConstructFixer extends AbstractFixer implements Conf
     {
         parent::configure($configuration);
 
+        // @TODO: drop condition when PHP 7.0+ is required
         if (\defined('T_YIELD_FROM')) {
             self::$tokenMap['yield_from'] = T_YIELD_FROM;
         }
 
+        // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_MATCH')) {
             self::$tokenMap['match'] = T_MATCH;
         }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -457,14 +457,17 @@ $foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
             }
         }
 
+        // @TODO: drop condition when PHP 7.0+ is required
         if (!\defined('T_SPACESHIP')) {
             unset($operators['<=>']);
         }
 
+        // @TODO: drop condition when PHP 7.0+ is required
         if (!\defined('T_COALESCE')) {
             unset($operators['??']);
         }
 
+        // @TODO: drop condition when PHP 7.4+ is required
         if (!\defined('T_COALESCE_EQUAL')) {
             unset($operators['??=']);
         }

--- a/src/Fixer/Operator/NewWithBracesFixer.php
+++ b/src/Fixer/Operator/NewWithBracesFixer.php
@@ -95,6 +95,7 @@ final class NewWithBracesFixer extends AbstractFixer
                 [CT::T_BRACE_CLASS_INSTANTIATION_CLOSE],
             ];
 
+            // @TODO: drop condition when PHP 7.0+ is required
             if (\defined('T_SPACESHIP')) {
                 $nextTokenKinds[] = [T_SPACESHIP];
             }

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -71,7 +71,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
     {
         parent::__construct();
 
-        // To be moved back to compile time property declaration when PHP support of PHP CS Fixer will be 7.0+
+        // @TODO: To be moved back to compile time property declaration when PHP support of PHP CS Fixer will be 7.0+
         if (\defined('T_YIELD_FROM')) {
             self::$tokenMap['yield_from'] = T_YIELD_FROM;
         }

--- a/src/Linter/TokenizerLinter.php
+++ b/src/Linter/TokenizerLinter.php
@@ -27,7 +27,12 @@ final class TokenizerLinter implements LinterInterface
 {
     public function __construct()
     {
-        if (false === \defined('TOKEN_PARSE') || false === class_exists(\CompileError::class)) {
+        if (
+            // @TODO: drop condition when PHP 7.0+ is required
+            false === \defined('TOKEN_PARSE')
+            // @TODO: drop condition when PHP 7.3+ is required
+            || false === class_exists(\CompileError::class)
+        ) {
             throw new UnavailableLinterException('Cannot use tokenizer as linter.');
         }
     }

--- a/src/Tokenizer/AbstractTransformer.php
+++ b/src/Tokenizer/AbstractTransformer.php
@@ -43,15 +43,5 @@ abstract class AbstractTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function getCustomTokens()
-    {
-        @trigger_error(sprintf('%s is deprecated and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
-
-        return $this->getDeprecatedCustomTokens();
-    }
-
-    /**
-     * @return int[]
-     */
-    abstract protected function getDeprecatedCustomTokens();
+    abstract public function getCustomTokens();
 }

--- a/src/Tokenizer/Analyzer/CommentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/CommentsAnalyzer.php
@@ -85,6 +85,7 @@ final class CommentsAnalyzer
         do {
             $nextIndex = $tokens->getNextMeaningfulToken($nextIndex);
 
+            // @TODO: drop condition when PHP 8.0+ is required
             if (\defined('T_ATTRIBUTE')) {
                 while (null !== $nextIndex && $tokens[$nextIndex]->isGivenKind(T_ATTRIBUTE)) {
                     $nextIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ATTRIBUTE, $nextIndex);

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -276,6 +276,7 @@ class Tokens extends \SplFixedArray
             ],
         ];
 
+        // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_ATTRIBUTE')) {
             $definitions[self::BLOCK_TYPE_ATTRIBUTE] = [
                 'start' => [T_ATTRIBUTE, '#['],
@@ -1092,7 +1093,7 @@ class Tokens extends \SplFixedArray
         // clear memory
         $this->setSize(0);
 
-        $tokens = \defined('TOKEN_PARSE')
+        $tokens = \defined('TOKEN_PARSE') // @TODO: drop condition when PHP 7.0+ is required
             ? token_get_all($code, TOKEN_PARSE)
             : token_get_all($code);
 
@@ -1102,8 +1103,7 @@ class Tokens extends \SplFixedArray
             $this[$index] = new Token($token);
         }
 
-        $transformers = Transformers::create();
-        $transformers->transform($this);
+        $this->applyTransformers();
 
         $this->foundTokenKinds = [];
 
@@ -1368,6 +1368,15 @@ class Tokens extends \SplFixedArray
         $this->warnPhp8SplFixerArrayChange(__METHOD__);
 
         return parent::valid();
+    }
+
+    /**
+     * @internal
+     */
+    protected function applyTransformers()
+    {
+        $transformers = Transformers::create();
+        $transformers->transform($this);
     }
 
     private function warnPhp8SplFixerArrayChange($method)

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -560,14 +560,17 @@ final class TokensAnalyzer
                 CT::T_TYPE_ALTERNATION => true, // |
             ];
 
+            // @TODO: drop condition when PHP 7.0+ is required
             if (\defined('T_SPACESHIP')) {
                 $arrayOperators[T_SPACESHIP] = true; // <=>
             }
 
+            // @TODO: drop condition when PHP 7.0+ is required
             if (\defined('T_COALESCE')) {
                 $arrayOperators[T_COALESCE] = true;  // ??
             }
 
+            // @TODO: drop condition when PHP 7.4+ is required
             if (\defined('T_COALESCE_EQUAL')) {
                 $arrayOperators[T_COALESCE_EQUAL] = true;  // ??=
             }

--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -54,7 +54,7 @@ final class ArrayTypehintTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_ARRAY_TYPEHINT];
     }

--- a/src/Tokenizer/Transformer/AttributeTransformer.php
+++ b/src/Tokenizer/Transformer/AttributeTransformer.php
@@ -68,7 +68,7 @@ final class AttributeTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [
             CT::T_ATTRIBUTE_CLOSE,

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -81,7 +81,7 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_BRACE_CLASS_INSTANTIATION_OPEN, CT::T_BRACE_CLASS_INSTANTIATION_CLOSE];
     }

--- a/src/Tokenizer/Transformer/ClassConstantTransformer.php
+++ b/src/Tokenizer/Transformer/ClassConstantTransformer.php
@@ -57,7 +57,7 @@ final class ClassConstantTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_CLASS_CONSTANT];
     }

--- a/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
+++ b/src/Tokenizer/Transformer/ConstructorPromotionTransformer.php
@@ -67,7 +67,7 @@ final class ConstructorPromotionTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [
             CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,

--- a/src/Tokenizer/Transformer/CurlyBraceTransformer.php
+++ b/src/Tokenizer/Transformer/CurlyBraceTransformer.php
@@ -61,7 +61,7 @@ final class CurlyBraceTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [
             CT::T_CURLY_CLOSE,

--- a/src/Tokenizer/Transformer/ImportTransformer.php
+++ b/src/Tokenizer/Transformer/ImportTransformer.php
@@ -60,7 +60,7 @@ final class ImportTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_CONST_IMPORT, CT::T_FUNCTION_IMPORT];
     }

--- a/src/Tokenizer/Transformer/NameQualifiedTransformer.php
+++ b/src/Tokenizer/Transformer/NameQualifiedTransformer.php
@@ -58,7 +58,7 @@ final class NameQualifiedTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [];
     }

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -75,7 +75,7 @@ final class NamedArgumentTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [
             CT::T_NAMED_ARGUMENT_COLON,

--- a/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
+++ b/src/Tokenizer/Transformer/NamespaceOperatorTransformer.php
@@ -53,7 +53,7 @@ final class NamespaceOperatorTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_NAMESPACE_OPERATOR];
     }

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -75,7 +75,7 @@ final class NullableTypeTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_NULLABLE_TYPE];
     }

--- a/src/Tokenizer/Transformer/ReturnRefTransformer.php
+++ b/src/Tokenizer/Transformer/ReturnRefTransformer.php
@@ -55,7 +55,7 @@ final class ReturnRefTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_RETURN_REF];
     }

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -70,7 +70,7 @@ final class SquareBraceTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [
             CT::T_ARRAY_SQUARE_BRACE_OPEN,

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -121,7 +121,7 @@ final class TypeAlternationTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_TYPE_ALTERNATION];
     }

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -83,7 +83,7 @@ final class TypeColonTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_TYPE_COLON];
     }

--- a/src/Tokenizer/Transformer/UseTransformer.php
+++ b/src/Tokenizer/Transformer/UseTransformer.php
@@ -88,7 +88,7 @@ final class UseTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [CT::T_USE_TRAIT, CT::T_USE_LAMBDA];
     }

--- a/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
+++ b/src/Tokenizer/Transformer/WhitespacyCommentTransformer.php
@@ -64,7 +64,7 @@ final class WhitespacyCommentTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [];
     }

--- a/src/Tokenizer/TransformerInterface.php
+++ b/src/Tokenizer/TransformerInterface.php
@@ -30,8 +30,6 @@ interface TransformerInterface
      * Get tokens created by Transformer.
      *
      * @return int[]
-     *
-     * @deprecated will be removed in 3.0
      */
     public function getCustomTokens();
 

--- a/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
+++ b/tests/Fixtures/Test/AbstractTransformerTest/FooTransformer.php
@@ -38,7 +38,7 @@ final class FooTransformer extends AbstractTransformer
     /**
      * {@inheritdoc}
      */
-    protected function getDeprecatedCustomTokens()
+    public function getCustomTokens()
     {
         return [];
     }

--- a/tests/Test/AbstractTransformerTestCase.php
+++ b/tests/Test/AbstractTransformerTestCase.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Tests\Test;
 
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TransformerInterface;
 
@@ -64,10 +65,6 @@ abstract class AbstractTransformerTestCase extends TestCase
         static::assertMatchesRegularExpression('/^[a-z]+[a-z_]*[a-z]$/', $name);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation PhpCsFixer\Tokenizer\AbstractTransformer::getCustomTokens is deprecated and will be removed in 3.0.
-     */
     public function testGetCustomTokens()
     {
         $name = $this->transformer->getName();
@@ -120,7 +117,8 @@ abstract class AbstractTransformerTestCase extends TestCase
     protected function doTest($source, array $expectedTokens = [], array $observedKindsOrPrototypes = [])
     {
         Tokens::clearCache();
-        $tokens = Tokens::fromCode($source);
+        $tokens = new TokensWithObservedTransformers();
+        $tokens->setCode($source);
 
         static::assertSame(
             \count($expectedTokens),
@@ -135,6 +133,35 @@ abstract class AbstractTransformerTestCase extends TestCase
             ),
             'Number of expected tokens does not match actual token count.'
         );
+
+        $customTokensOfTransformer = $this->transformer->getCustomTokens();
+        $transformerName = $this->transformer->getName();
+
+        foreach ($tokens->observedModificationsPerTransformer as $appliedTransformerName => $modificationsOfTransformer) {
+            foreach ($modificationsOfTransformer as $modification) {
+                if ($appliedTransformerName === $transformerName) {
+                    static::assertContains(
+                        $modification,
+                        $customTokensOfTransformer,
+                        sprintf(
+                            'Transformation into "%s" must be allowed in self-documentation of the Transformer, currently allowed custom tokens are: %s',
+                            Token::getNameForId($modification),
+                            implode(', ', array_map(function ($ct) { return Token::getNameForId($ct); }, $customTokensOfTransformer))
+                        )
+                    );
+                } else {
+                    static::assertNotContains(
+                        $modification,
+                        $customTokensOfTransformer,
+                        sprintf(
+                            'Transformation into "%s" must NOT be applied by other Transformer than "%s".',
+                            Token::getNameForId($modification),
+                            $transformerName
+                        )
+                    );
+                }
+            }
+        }
 
         foreach ($expectedTokens as $index => $tokenIdOrContent) {
             if (\is_string($tokenIdOrContent)) {

--- a/tests/Test/TokensWithObservedTransformers.php
+++ b/tests/Test/TokensWithObservedTransformers.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Test;
+
+use PhpCsFixer\AccessibleObject\AccessibleObject;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\Transformers;
+
+class TokensWithObservedTransformers extends Tokens
+{
+    /**
+     * @var null|string
+     */
+    public $currentTransformer;
+    public $observedModificationsPerTransformer = [];
+
+    public function offsetSet($index, $newval)
+    {
+        if (null !== $this->currentTransformer) {
+            $this->observedModificationsPerTransformer[$this->currentTransformer][] = $this->extractTokenKind($newval);
+        }
+        parent::offsetSet($index, $newval);
+    }
+
+    /**
+     * @internal
+     */
+    protected function applyTransformers()
+    {
+        $this->observedModificationsPerTransformer = [];
+
+        $transformers = Transformers::create();
+        foreach (AccessibleObject::create($transformers)->items as $transformer) {
+            $this->currentTransformer = $transformer->getName();
+            $this->observedModificationsPerTransformer[$this->currentTransformer] = [];
+
+            foreach ($this as $index => $token) {
+                $transformer->process($this, $token, $index);
+            }
+        }
+
+        $this->currentTransformer = null;
+    }
+
+    /**
+     * @param array|string|Token $token token prototype
+     *
+     * @return int|string
+     */
+    private function extractTokenKind($token)
+    {
+        return $token instanceof Token
+            ? ($token->isArray() ? $token->getId() : $token->getContent())
+            : (\is_array($token) ? $token[0] : $token)
+            ;
+    }
+}

--- a/tests/Tokenizer/AbstractTransformerTest.php
+++ b/tests/Tokenizer/AbstractTransformerTest.php
@@ -32,10 +32,6 @@ final class AbstractTransformerTest extends TestCase
         static::assertSame('foo', $transformer->getName());
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation PhpCsFixer\Tokenizer\AbstractTransformer::getCustomTokens is deprecated and will be removed in 3.0.
-     */
     public function testCustomTokens()
     {
         $transformer = new FooTransformer();

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -151,6 +151,7 @@ final class TokenTest extends TestCase
             yield $index => $test;
         }
 
+        // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_ATTRIBUTE')) {
             yield [new Token([T_ATTRIBUTE, '#[', 1]), false];
         }


### PR DESCRIPTION
The transformer classes are internal, so we can do whatever we want there without BC promise and upcoming BC breaks warnings.

Let's use the `getCustomTokens` method to ensure that Transformer is adding only allowed custom tokens, and no other transformer is adding them.

Unfortunately, to implement this check i had to bypass few things (eg access internals), but I couldn't find a good way to do it without refactoring main Tokenizer class into first-class service.