### PR TITLE
Fix quoting in exception message

### DIFF
--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -356,7 +356,7 @@ final class ConfigurationResolver
                 );
 
                 if (\count($riskyFixers)) {
-                    throw new InvalidConfigurationException(sprintf('The rules contain risky fixers (%s), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?', implode('", "', $riskyFixers)));
+                    throw new InvalidConfigurationException(sprintf('The rules contain risky fixers ("%s"), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?', implode('", "', $riskyFixers)));
                 }
             }
         }


### PR DESCRIPTION
This PR improves consistency by quote-wrapping a list within an exception message.
I believe that this was a typo, as all the presented lists are wrapped in quote in the codebase:

```
src/Cache/Cache.php|120| implode('", "', $missingKeys)
src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php|250| throw new InvalidOptionsException(sprintf('Unknown set "%s", known sets are "%s".', $functionName, implode('", "', $sets)));
src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php|156| implode('", "', array_keys($default))
src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php|164| implode('", "', self::$toTypes)
src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php|365| implode('", "', array_keys($thisFixer->staticMethods)),
src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php|376| implode('", "', array_keys($thisFixer->allowedValues)),
src/Fixer/Import/OrderedImportsFixer.php|259| implode('", "', $missing)
src/Fixer/Import/OrderedImportsFixer.php|268| implode('", "', $unknown)
src/Fixer/Operator/BinaryOperatorSpacesFixer.php|292| implode('", "', self::$supportedOperators),
src/Fixer/Operator/BinaryOperatorSpacesFixer.php|303| implode('", "', self::$allowedValues),
src/Fixer/ClassNotation/FinalInternalClassFixer.php|48| throw new InvalidFixerConfigurationException($this->getName(), sprintf('Annotation cannot be used in both the include and exclude list, got duplicates: "%s".', implode('", "', array_keys($intersect))));
src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php|216| implode('", "', self::SUPPORTED_TYPES),
src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php|227| implode('", "', self::SUPPORTED_SPACINGS),
src/Console/ConfigurationResolver.php|299| implode('", "', array_keys($mapper)),
src/Console/ConfigurationResolver.php|359| throw new InvalidConfigurationException(sprintf('The rules contain risky fixers ("%s"), but they are not allowed to run. Perhaps you forget to use --allow-risky=yes option?', implode('", "', $riskyFixers)));
src/Console/ConfigurationResolver.php|446| implode('", "', $progressTypes)
src/Console/ConfigurationResolver.php|484| throw new InvalidConfigurationException(sprintf('The format "%s" is not defined, supported are "%s".', $format, implode('", "', $formats)));
src/Console/ConfigurationResolver.php|821| implode('", "', $modes)
src/FixerFactory.php|250| $message .= sprintf("\n- \"%s\" with \"%s\"", $fixer, implode('", "', $report[$fixer]));
```

Thanks!