### PR TITLE
PhpdocAddMissingParamAnnotation: fix and extend

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -130,6 +130,7 @@ function f9(string $foo, $bar, $baz) {}
             // Step back to check comment at next iteration
             if ($tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
                 --$index;
+
                 continue;
             }
 

--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -129,7 +129,7 @@ function f9(string $foo, $bar, $baz) {}
 
             // Step back to check comment at next iteration
             if ($tokens[$index]->isGivenKind(T_DOC_COMMENT)) {
-                $index--;
+                --$index;
                 continue;
             }
 
@@ -140,14 +140,14 @@ function f9(string $foo, $bar, $baz) {}
                 T_PROTECTED,
                 T_PUBLIC,
                 T_STATIC,
-                T_RETURN
+                T_RETURN,
             ])) {
                 $index = $tokens->getNextMeaningfulToken($index);
             }
 
             $tokenKinds = [T_FUNCTION];
             // To fix PhpDoc of closures/arrow functions in most used case: `return function(int $x){...};`
-            if (PHP_VERSION_ID >= 70400) {
+            if (\PHP_VERSION_ID >= 70400) {
                 $tokenKinds[] = T_FN;
             }
             if (!$tokens[$index]->isGivenKind($tokenKinds)) {
@@ -200,7 +200,7 @@ function f9(string $foo, $bar, $baz) {}
                 $type = $argument['type'] ?: 'mixed';
 
                 if ('mixed' !== $type && ('?' === $type[0] || 'null' === strtolower($argument['default']))) {
-                    $type = ltrim($type, '?') . '|null';
+                    $type = ltrim($type, '?').'|null';
                 }
 
                 $newLines[] = new Line(sprintf(


### PR DESCRIPTION
1.Fixes:
~~~php
/**
 * Doc header
 * ADDS TAG HERE
 */
/**
 * Function description.
 */
function fixMe($id = null) {
}
~~~
~~~php
  /**
   * Function description.
   * @param ?int $id SET INVALID TYPE
   */
  function test2(?int $id) {
  }
  /**
   * Function description.
   * @param null|mixed $id SET INVALID TYPE
   */
  function test3($id = null) {
  }
~~~
2. Optional ignore one-line PhpDoc's (option `skip_inline_phpdocs`)
3. Fix  arrow/closure PhpDoc's,  in case as  `/** ... */ return fn($a)`, it's better than nothing :)
4. Fix skip structures "without" methods (exceptions, interfaces and etc.)