### PR TITLE
Token - add handling json_encode crash

### DIFF
--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -598,7 +598,19 @@ class Token
             $options = Utils::calculateBitmask($options);
         }
 
-        return json_encode($this->toArray(), $options);
+        $jsonResult = json_encode($this->toArray(), $options);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            $jsonResult = json_encode(
+                [
+                    'errorDescription' => 'Can not encode Tokens to JSON.',
+                    'rawErrorMessage' => json_last_error_msg(),
+                ],
+                $options
+            );
+        }
+
+        return $jsonResult;
     }
 
     /**


### PR DESCRIPTION
#5519 will crash without it, as we would be returning false (indicating json_encode error) instead of string