### PR TITLE
DX: update checkbashisms

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -20,7 +20,7 @@ cd "$(dirname "$0")"
 
 mkdir -p bin
 
-VERSION_CB="2.20.5"
+VERSION_CB="2.21.1"
 VERSION_SC="stable"
 
 echo λλλ checkbashisms


### PR DESCRIPTION
somehow, 2.20 disappeared from https://deb.debian.org/debian/pool/main/d/devscripts/