### PR TITLE
NullableTypeDeclarationForDefaultNullValueFixer - fix handling promoted properties

### DIFF
--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -139,6 +139,22 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
             }
 
             $argumentTypeInfo = $argumentInfo->getTypeAnalysis();
+
+            if (
+                \PHP_VERSION_ID >= 80000
+                && false === $this->configuration['use_nullable_type_declaration']
+            ) {
+                $visibility = $tokens[$tokens->getPrevMeaningfulToken($argumentTypeInfo->getStartIndex())];
+
+                if ($visibility->isGivenKind([
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
+                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
+                ])) {
+                    continue;
+                }
+            }
+
             if (true === $this->configuration['use_nullable_type_declaration']) {
                 if (!$argumentTypeInfo->isNullable() && 'mixed' !== $argumentTypeInfo->getName()) {
                     $tokens->insertAt($argumentTypeInfo->getStartIndex(), new Token([CT::T_NULLABLE_TYPE, '?']));

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -406,25 +406,52 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
     }
 
     /**
-     * @param string      $expected
-     * @param null|string $input
+     * @param null|string $expected
+     * @param string      $input
      *
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
      */
-    public function testFix80($expected, $input = null)
+    public function testFix80($input, $expected = null)
     {
+        if (null === $expected) {
+            $this->doTest($input);
+        } else {
+            $this->doTest($expected, $input);
+        }
+    }
+
+    /**
+     * @param null|string $input
+     * @param string      $expected
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFixInverse80($expected, $input = null)
+    {
+        $this->fixer->configure(['use_nullable_type_declaration' => false]);
+
         $this->doTest($expected, $input);
     }
 
     public function provideFix80Cases()
     {
         yield 'trailing comma' => [
-            '<?php function foo(?string $param = null,) {}',
             '<?php function foo(string $param = null,) {}',
+            '<?php function foo(?string $param = null,) {}',
         ];
 
         yield 'property promotion' => [
+            '<?php class Foo {
+                public function __construct(
+                    public ?string $paramA = null,
+                    protected ?string $paramB = null,
+                    private ?string $paramC = null,
+                    string $paramD = null,
+                    $a = []
+                ) {}
+            }',
             '<?php class Foo {
                 public function __construct(
                     public ?string $paramA = null,


### PR DESCRIPTION
Fixes #5547

**Before:**
```diff
  public function __construct(
-     public ?array $x = null,
-     ?array $y = null,
+     public array $x = null,
+     array $y = null,
  ) { }
```
**After:**
```diff
  public function __construct(
      public ?array $x = null,
-     ?array $y = null,
+     array $y = null,
  ) { }
```