### PR TITLE
ClassAttributesSeparationFixer - fix for properties with type alternation

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -304,7 +304,7 @@ class Sample
      */
     private function fixSpaceAboveClassElement(Tokens $tokens, $classStartIndex, $elementIndex, $spacing)
     {
-        static $methodAttr = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT];
+        static $methodAttr = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION];
 
         $nonWhiteAbove = null;
 

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -74,9 +74,9 @@ final class TypeAlternationTransformer extends AbstractTransformer
         $prevToken = $tokens[$prevIndex];
 
         if ($prevToken->isGivenKind([
-            CT::T_TYPE_COLON, // `|` is part of a function return type union `foo(): A|B`
-            CT::T_TYPE_ALTERNATION, // `|` is part of a union (chain) `| X | Y`
-            T_VAR, T_PUBLIC, T_PROTECTED, T_PRIVATE, // `|` is part of class property `var X|Y $a;`
+            CT::T_TYPE_COLON, // `:` is part of a function return type `foo(): A`
+            CT::T_TYPE_ALTERNATION, // `|` is part of a union (chain) `X | Y`
+            T_STATIC, T_VAR, T_PUBLIC, T_PROTECTED, T_PRIVATE, // `var $a;`, `private $a` or `public static $a`
         ])) {
             $this->replaceToken($tokens, $index);
 

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1416,7 +1416,7 @@ class User3
 }',
         ];
 
-        yield [
+        yield 'constructor property promotion' => [
             '<?php
             class Foo {
                 private array $foo;
@@ -1438,6 +1438,26 @@ class User3
                     protected float $y = 0.0,
                     private float $z = 0.0,
                 ) {}
+            }',
+        ];
+
+        yield 'typed properties' => [
+            '<?php
+            class Foo {
+                private static int | float | null $a;
+
+                private static int | float | null $b;
+
+                private int | float | null $c;
+
+                private int | float | null $d;
+            }',
+            '<?php
+            class Foo {
+                private static int | float | null $a;
+                private static int | float | null $b;
+                private int | float | null $c;
+                private int | float | null $d;
             }',
         ];
     }

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -211,5 +211,20 @@ class Number
                 73 => CT::T_TYPE_ALTERNATION,
             ],
         ];
+
+        yield 'typed static properties' => [
+            '<?php
+            class Foo {
+                private static int | null $bar;
+
+                private static int | float | string | null $baz;
+            }',
+            [
+                14 => CT::T_TYPE_ALTERNATION,
+                27 => CT::T_TYPE_ALTERNATION,
+                31 => CT::T_TYPE_ALTERNATION,
+                35 => CT::T_TYPE_ALTERNATION,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Commented part in test can be commented out after https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5550 fix.