### PR TITLE
PSR2: require visibility only for properties and methods

### DIFF
--- a/doc/ruleSets/PSR2.rst
+++ b/doc/ruleSets/PSR2.rst
@@ -35,3 +35,5 @@ Rules
 - `switch_case_semicolon_to_colon <./../rules/control_structure/switch_case_semicolon_to_colon.rst>`_
 - `switch_case_space <./../rules/control_structure/switch_case_space.rst>`_
 - `visibility_required <./../rules/class_notation/visibility_required.rst>`_
+  config:
+  ``['elements' => ['method', 'property']]``

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -93,7 +93,9 @@ The rule is part of the following rule sets:
   ``['elements' => ['const', 'method', 'property']]``
 
 @PSR2
-  Using the `@PSR2 <./../../ruleSets/PSR2.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
+  Using the `@PSR2 <./../../ruleSets/PSR2.rst>`_ rule set will enable the ``visibility_required`` rule with the config below:
+
+  ``['elements' => ['method', 'property']]``
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.

--- a/src/RuleSet/Sets/PSR2Set.php
+++ b/src/RuleSet/Sets/PSR2Set.php
@@ -53,7 +53,7 @@ final class PSR2Set extends AbstractRuleSetDescription
             'single_line_after_imports' => true,
             'switch_case_semicolon_to_colon' => true,
             'switch_case_space' => true,
-            'visibility_required' => true,
+            'visibility_required' => ['elements' => ['method', 'property']],
         ];
     }
 

--- a/tests/Fixtures/Integration/set/@PSR2.test-in.php
+++ b/tests/Fixtures/Integration/set/@PSR2.test-in.php
@@ -4,6 +4,8 @@ use FooInterfaceA, FooInterfaceB;
 use BarClass as Bar;
 use OtherVendor\OtherPackage\BazClass;
 class Foo extends Bar implements FooInterfaceA{
+    const SOME_CONST = 42;
+
     var $aaa = 1, $bbb = 2;
 
     public function sampleFunction($a, $arg1, $arg2, $arg3, $foo, $b = null)

--- a/tests/Fixtures/Integration/set/@PSR2.test-out.php
+++ b/tests/Fixtures/Integration/set/@PSR2.test-out.php
@@ -8,6 +8,8 @@ use OtherVendor\OtherPackage\BazClass;
 
 class Foo extends Bar implements FooInterfaceA
 {
+    const SOME_CONST = 42;
+
     public $aaa = 1;
     public $bbb = 2;
 

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -210,7 +210,7 @@ final class RuleSetTest extends TestCase
                 'strict_comparison' => true,
                 'switch_case_semicolon_to_colon' => true,
                 'switch_case_space' => true,
-                'visibility_required' => true,
+                'visibility_required' => ['elements' => ['method', 'property']],
             ],
             $ruleSet->getRules()
         );
@@ -249,7 +249,7 @@ final class RuleSetTest extends TestCase
                 'single_line_after_imports' => true,
                 'switch_case_semicolon_to_colon' => true,
                 'switch_case_space' => true,
-                'visibility_required' => true,
+                'visibility_required' => ['elements' => ['method', 'property']],
             ],
             $ruleSet->getRules()
         );


### PR DESCRIPTION
Not for constants.