### PR TITLE
NoMixedEchoPrintFixer: fix for conditions without curly brackets

### DIFF
--- a/src/Fixer/Alias/NoMixedEchoPrintFixer.php
+++ b/src/Fixer/Alias/NoMixedEchoPrintFixer.php
@@ -153,7 +153,7 @@ final class NoMixedEchoPrintFixer extends AbstractFixer implements Configuration
     {
         $prevToken = $tokens[$tokens->getPrevMeaningfulToken($index)];
 
-        if (!$prevToken->equalsAny([';', '{', '}', [T_OPEN_TAG]])) {
+        if (!$prevToken->equalsAny([';', '{', '}', ')', [T_OPEN_TAG], [T_ELSE]])) {
             return;
         }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5539

In separate PR I will refactor other test cases to have more shared snippets to convert in both ways, I didn't want to do that in this PR to make this PR simpler.