### PR TITLE
DX: make integration tests matching entries in FixerFactoryTest

### DIFF
--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -447,7 +447,7 @@ final class FixerFactoryTest extends TestCase
         $fixerName2 = $matches[2];
 
         static::assertTrue(
-            isset($priorityCases[$fixerName1][$fixerName2]) || isset($priorityCases[$fixerName2][$fixerName1]),
+            isset($priorityCases[$fixerName1][$fixerName2]),
             sprintf('Missing priority test entry for file "%s".', $fileName)
         );
     }

--- a/tests/Fixtures/Integration/priority/array_indentation,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/array_indentation,binary_operator_spaces.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: binary_operator_spaces,array_indentation.
+Integration of fixers: array_indentation,binary_operator_spaces.
 --RULESET--
 {"binary_operator_spaces": {"default": "align_single_space"}, "array_indentation": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/braces,array_indentation.test
+++ b/tests/Fixtures/Integration/priority/braces,array_indentation.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: array_indentation,braces.
+Integration of fixers: braces,array_indentation.
 --RULESET--
 {"array_indentation": true, "braces": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/echo_tag_syntax,no_mixed_echo_print.test
+++ b/tests/Fixtures/Integration/priority/echo_tag_syntax,no_mixed_echo_print.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: no_mixed_echo_print,echo_tag_syntax.
+Integration of fixers: echo_tag_syntax,no_mixed_echo_print.
 --RULESET--
 {"no_mixed_echo_print": {"use":"print"}, "echo_tag_syntax": {"format":"long"}}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/no_short_echo_tag,no_mixed_echo_print.test
+++ b/tests/Fixtures/Integration/priority/no_short_echo_tag,no_mixed_echo_print.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: no_mixed_echo_print,no_short_echo_tag.
+Integration of fixers: no_short_echo_tag,no_mixed_echo_print.
 --RULESET--
 {"no_mixed_echo_print": {"use":"print"}, "no_short_echo_tag": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,no_trailing_whitespace.test
+++ b/tests/Fixtures/Integration/priority/no_unneeded_control_parentheses,no_trailing_whitespace.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: no_trailing_whitespace,no_unneeded_control_parentheses.
+Integration of fixers: no_unneeded_control_parentheses,no_trailing_whitespace.
 --RULESET--
 {"no_trailing_whitespace": true, "no_unneeded_control_parentheses": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/phpdoc_add_missing_param_annotation,no_empty_phpdoc.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_add_missing_param_annotation,no_empty_phpdoc.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: no_empty_phpdoc,phpdoc_add_missing_param_annotation.
+Integration of fixers: phpdoc_add_missing_param_annotation,no_empty_phpdoc.
 --RULESET--
 {"no_empty_phpdoc": true, "phpdoc_add_missing_param_annotation": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/phpdoc_scalar,phpdoc_to_return_type.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_scalar,phpdoc_to_return_type.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: phpdoc_to_return_type,phpdoc_scalar.
+Integration of fixers: phpdoc_scalar,phpdoc_to_return_type.
 --RULESET--
 {"phpdoc_to_return_type": {"scalar_types": true}, "phpdoc_scalar": true}
 --REQUIREMENTS--

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: fully_qualified_strict_types,phpdoc_to_return_type.
+Integration of fixers: phpdoc_to_return_type,fully_qualified_strict_types.
 --RULESET--
 {"fully_qualified_strict_types": true, "phpdoc_to_return_type": true}
 --REQUIREMENTS--

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_type_declaration.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: return_type_declaration,phpdoc_to_return_type.
+Integration of fixers: phpdoc_to_return_type,return_type_declaration.
 --RULESET--
 {"return_type_declaration": {"space_before": "one"}, "phpdoc_to_return_type": true}
 --REQUIREMENTS--

--- a/tests/Fixtures/Integration/priority/single_line_throw,concat_space.test
+++ b/tests/Fixtures/Integration/priority/single_line_throw,concat_space.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: concat_space,single_line_throw.
+Integration of fixers: single_line_throw,concat_space.
 --RULESET--
 {"concat_space": {"spacing": "none"}, "single_line_throw": true}
 --EXPECT--

--- a/tests/Fixtures/Integration/priority/standardize_increment,increment_style.test
+++ b/tests/Fixtures/Integration/priority/standardize_increment,increment_style.test
@@ -1,5 +1,5 @@
 --TEST--
-Integration of fixers: increment_style,standardize_increment.
+Integration of fixers: standardize_increment,increment_style.
 --RULESET--
 {"increment_style": {"style": "post"}, "standardize_increment": true}
 --EXPECT--


### PR DESCRIPTION
Do not allow file names with the swapped order.

There are 203 files with names having the order matching the priority and 11 files (updated in this PR) having the order swapped.