### PR TITLE
Fix order of BracesFixer and ClassDefinitionFixer

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -126,7 +126,7 @@ class Foo
      * {@inheritdoc}
      *
      * Must run before ArrayIndentationFixer, MethodArgumentSpaceFixer, MethodChainingIndentationFixer.
-     * Must run after ClassAttributesSeparationFixer, ElseifFixer, LineEndingFixer, MethodSeparationFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleSpaceAfterConstructFixer, SingleTraitInsertPerStatementFixer.
+     * Must run after ClassAttributesSeparationFixer, ClassDefinitionFixer, ElseifFixer, LineEndingFixer, MethodSeparationFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleSpaceAfterConstructFixer, SingleTraitInsertPerStatementFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -99,6 +99,16 @@ interface Bar extends
 
     /**
      * {@inheritdoc}
+     *
+     * Must run before BracesFixer.
+     */
+    public function getPriority()
+    {
+        return 36;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens)
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -76,6 +76,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['braces'], $fixers['method_chaining_indentation']],
             [$fixers['class_attributes_separation'], $fixers['braces']],
             [$fixers['class_attributes_separation'], $fixers['indentation_type']],
+            [$fixers['class_definition'], $fixers['braces']],
             [$fixers['class_keyword_remove'], $fixers['no_unused_imports']],
             [$fixers['combine_consecutive_issets'], $fixers['multiline_whitespace_before_semicolons']],
             [$fixers['combine_consecutive_issets'], $fixers['no_singleline_whitespace_before_semicolons']],

--- a/tests/Fixtures/Integration/priority/class_definition,braces.test
+++ b/tests/Fixtures/Integration/priority/class_definition,braces.test
@@ -1,0 +1,15 @@
+--TEST--
+Integration of fixers: class_definition,braces.
+--RULESET--
+{"class_definition": true, "braces": {"position_after_functions_and_oop_constructs": "same"}}
+--EXPECT--
+<?php
+
+class Foo {
+}
+
+--INPUT--
+<?php
+
+class Foo{
+}


### PR DESCRIPTION
If BracesFixer is configured with "position_after_functions_and_oop_constructs": "same", it would be overwritten by ClassDefinitionFixer putting the brace on the next line unless the ClassDefinitionFixer is run before BracesFixer.

It seems ClassDefinitionFixer was previously run implicitly before BracesFixer, but 701708e74d44f5a9e98aa02d1380b4d342f8f8ee changed the priority of BracesFixer from negative to positive and the order of the two fixers were reversed.