### PR TITLE
DX: add test to make sure SingleSpaceAfterConstructFixer runs before FunctionDeclarationFixer

### DIFF
--- a/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
@@ -103,6 +103,7 @@ $f = fn () => null;
      * {@inheritdoc}
      *
      * Must run before MethodArgumentSpaceFixer.
+     * Must run after SingleSpaceAfterConstructFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -178,7 +178,7 @@ yield  from  baz();
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer.
+     * Must run before BracesFixer, FunctionDeclarationFixer.
      */
     public function getPriority()
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -268,6 +268,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['single_import_per_statement'], $fixers['space_after_semicolon']],
             [$fixers['single_line_throw'], $fixers['concat_space']],
             [$fixers['single_space_after_construct'], $fixers['braces']],
+            [$fixers['single_space_after_construct'], $fixers['function_declaration']],
             [$fixers['single_trait_insert_per_statement'], $fixers['braces']],
             [$fixers['single_trait_insert_per_statement'], $fixers['space_after_semicolon']],
             [$fixers['standardize_increment'], $fixers['increment_style']],

--- a/tests/Fixtures/Integration/priority/single_space_after_construct,function_declaration.test
+++ b/tests/Fixtures/Integration/priority/single_space_after_construct,function_declaration.test
@@ -1,0 +1,13 @@
+--TEST--
+Integration of fixers: single_space_after_construct,function_declaration.
+--RULESET--
+{"function_declaration": {"closure_function_spacing": "none"}, "single_space_after_construct": true}
+--EXPECT--
+<?php
+
+function() {};
+
+--INPUT--
+<?php
+
+function () {};


### PR DESCRIPTION
To prevent regression reported in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5568.