### PR TITLE
PhpdocToCommentFixer - Add `ignored_tags` option

### DIFF
--- a/doc/rules/phpdoc/phpdoc_to_comment.rst
+++ b/doc/rules/phpdoc/phpdoc_to_comment.rst
@@ -4,11 +4,25 @@ Rule ``phpdoc_to_comment``
 
 Docblocks should only be used on structural elements.
 
+Configuration
+-------------
+
+``ignored_tags``
+~~~~~~~~~~~~~~~~
+
+List of ignored tags (matched case insensitively)
+
+Allowed types: ``array``
+
+Default value: ``[]``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -17,8 +31,31 @@ Example #1
     <?php
     $first = true;// needed because by default first docblock is never fixed.
 
-   -/** This should not be a docblock */
-   +/* This should not be a docblock */
+   -/** This should be a comment */
+   +/* This should be a comment */
+    foreach($connections as $key => $sqlite) {
+        $sqlite->open($path);
+    }
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['ignored_tags' => ['todo']]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    $first = true;// needed because by default first docblock is never fixed.
+
+   -/** This should be a comment */
+   +/* This should be a comment */
+    foreach($connections as $key => $sqlite) {
+        $sqlite->open($path);
+    }
+
+    /** @todo This should be a PHPDoc as the tag is on "ignored_tags" list */
     foreach($connections as $key => $sqlite) {
         $sqlite->open($path);
     }
@@ -29,7 +66,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_to_comment`` rule.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_to_comment`` rule with the default config.
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``phpdoc_to_comment`` rule.
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``phpdoc_to_comment`` rule with the default config.

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -28,8 +28,9 @@ final class PhpdocToCommentFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideDocblocksCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -546,6 +547,136 @@ echo 123;
 /** @var ClassLoader $loader */
 $loader = require __DIR__.\'/../vendor/autoload.php\';
 ',
+        ];
+
+        $cases[] = [
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** @todo Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            null,
+            ['ignored_tags' => ['todo']],
+        ];
+
+        $cases[] = [
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/* Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @todo Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @todo Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            ['ignored_tags' => ['todo']],
+        ];
+
+        $cases[] = [
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/* Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @fix-me Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @fix-me Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            ['ignored_tags' => ['fix-me']],
+        ];
+
+        $cases[] = [
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/* @todoNot Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @TODO Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** @todoNot Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/** @TODO Do not convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            ['ignored_tags' => ['todo']],
+        ];
+
+        $cases[] = [
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/* Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/**
+ * @deprecated This tag is not in the list but the next one is
+ * @todo This should be a PHPDoc as the tag is on "ignored_tags" list
+ */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            '<?php
+$first = true;// needed because by default first docblock is never fixed.
+
+/** Convert this */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}
+
+/**
+ * @deprecated This tag is not in the list but the next one is
+ * @todo This should be a PHPDoc as the tag is on "ignored_tags" list
+ */
+foreach($connections as $key => $sqlite) {
+    $sqlite->open($path);
+}',
+            ['ignored_tags' => ['todo']],
         ];
 
         return $cases;


### PR DESCRIPTION
Sometimes, the docblock are necessary inside the code. This is the case for
```
/** @psalm-suppress */
```

This option allow to ignore some comments.

Closes: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5505