### PR TITLE
ClassAttributesSeparationFixer: do not allow using v2 config

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -195,11 +195,6 @@ class Sample
             (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property` => `none|one` values.'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $option) {
-                    $deprecated = array_intersect($option, self::SUPPORTED_TYPES);
-                    if (\count($deprecated) > 0) {
-                        $option = array_fill_keys($deprecated, self::SPACING_ONE);
-                    }
-
                     foreach ($option as $type => $spacing) {
                         if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
                             throw new InvalidOptionsException(

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\ClassNotation;
 
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -26,6 +27,22 @@ use PhpCsFixer\WhitespacesFixerConfig;
  */
 final class ClassAttributesSeparationFixerTest extends AbstractFixerTestCase
 {
+    /**
+     * @dataProvider provideInvalidElementsCases
+     */
+    public function testInvalidElements(array $elements): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->fixer->configure(['elements' => $elements]);
+    }
+
+    public static function provideInvalidElementsCases(): iterable
+    {
+        yield 'numeric keys' => [['method', 'property']];
+        yield 'wrong key name' => [['methods' => 'one']];
+        yield 'wrong key value' => [['method' => 'two']];
+    }
+
     /**
      * @dataProvider provideCommentBlockStartDetectionCases
      */


### PR DESCRIPTION
In https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5485 usage of deprecated config was dropped, but it still was possible to have it which resulted with fixer doing nothing.