### PR TITLE
Fix spacing for arrow functions

### DIFF
--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -160,7 +160,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             T_VARIABLE,
         ];
         
-        if (!defined('T_FN')) {
+        if (!\defined('T_FN')) {
             $tokens[] = T_FN;
         }
 

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -160,7 +160,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             T_VARIABLE,
         ];
 
-        if (!\defined('T_FN')) {
+        if (\PHP_VERSION_ID >= 70400 && \defined('T_FN')) {
             $tokens[] = T_FN;
         }
 

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -53,7 +53,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionyTokenKinds(), [T_STRING]));
+        return $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionTokenKinds(), [T_STRING]));
     }
 
     /**
@@ -61,7 +61,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $functionyTokens = $this->getFunctionyTokenKinds();
+        $functionyTokens = $this->getFunctionTokenKinds();
         $languageConstructionTokens = $this->getLanguageConstructionTokenKinds();
         $braceTypes = $this->getBraceAfterVariableKinds();
 
@@ -141,7 +141,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
      *
      * @return int[] Token names
      */
-    private function getFunctionyTokenKinds()
+    private function getFunctionTokenKinds()
     {
         static $tokens = [
             T_ARRAY,
@@ -159,6 +159,10 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             T_UNSET,
             T_VARIABLE,
         ];
+        
+        if (!defined('T_FN')) {
+            $tokens[] = T_FN;
+        }
 
         return $tokens;
     }

--- a/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php
@@ -159,7 +159,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             T_UNSET,
             T_VARIABLE,
         ];
-        
+
         if (!\defined('T_FN')) {
             $tokens[] = T_FN;
         }

--- a/tests/Fixtures/Integration/misc/PHP7_4.test
+++ b/tests/Fixtures/Integration/misc/PHP7_4.test
@@ -46,7 +46,7 @@ class Foo {
     var ?Foo\Bar $qux;
 }
 // https://wiki.php.net/rfc/arrow_functions_v2
-$foo = fn ($v) => (string) $v;
+$foo = fn($v) => (string) $v;
 
 --INPUT--
 <?php

--- a/tests/Fixtures/Integration/misc/PHP8_0.test
+++ b/tests/Fixtures/Integration/misc/PHP8_0.test
@@ -112,7 +112,7 @@ class T_Mixed
 if (1) {
     foo() ?? throw new \Exception();
     $a = $condition && throw new Exception();
-    $callable = fn () => throw new Exception();
+    $callable = fn() => throw new Exception();
     $value = $falsableValue ?: throw new InvalidArgumentException();
 }
 


### PR DESCRIPTION
Now arrow functions spacing is broken and it's working like this:
```php
array_filter([1, 2, 3, 4], fn (int $i): bool => $i % 2 === 0);
```

PHPStorm and other web sources have something like this:
```php
array_filter([1, 2, 3, 4], fn(int $i): bool => $i % 2 === 0);
```

I took care about previous PHP versions (without `T_FN` token) too.