### PR TITLE
DX: make doc examples prettier

### DIFF
--- a/doc/rules/alias/array_push.rst
+++ b/doc/rules/alias/array_push.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -array_push($x, $y);
    +$x[] = $y;

--- a/doc/rules/alias/backtick_to_shell_exec.rst
+++ b/doc/rules/alias/backtick_to_shell_exec.rst
@@ -20,7 +20,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$plain = `ls -lah`;
    -$withVar = `ls -lah $var1 ${var2} {$var3} {$var4[0]} {$var5->call()}`;

--- a/doc/rules/alias/ereg_to_preg.rst
+++ b/doc/rules/alias/ereg_to_preg.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $x = ereg('[A-Z]');
    +<?php $x = preg_match('/[A-Z]/D');
 

--- a/doc/rules/alias/mb_str_functions.rst
+++ b/doc/rules/alias/mb_str_functions.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,13 +1,13 @@
     <?php
    -$a = strlen($a);
    -$a = strpos($a, $b);

--- a/doc/rules/alias/no_alias_functions.rst
+++ b/doc/rules/alias/no_alias_functions.rst
@@ -34,7 +34,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,22 +1,22 @@
     <?php
    -$a = chop($b);
    -close($b);
@@ -87,7 +86,6 @@ With configuration: ``['sets' => ['@mbreg']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     $a = is_double($b);
    -mbereg_search_getregs();

--- a/doc/rules/alias/no_alias_language_construct_call.rst
+++ b/doc/rules/alias/no_alias_language_construct_call.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -die;
    +exit;

--- a/doc/rules/alias/no_mixed_echo_print.rst
+++ b/doc/rules/alias/no_mixed_echo_print.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php print 'example';
    +<?php echo 'example';
 
@@ -41,7 +40,6 @@ With configuration: ``['use' => 'print']``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php echo('example');
    +<?php print('example');
 

--- a/doc/rules/alias/pow_to_exponentiation.rst
+++ b/doc/rules/alias/pow_to_exponentiation.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    - pow($a, 1);
    + $a** 1;

--- a/doc/rules/alias/random_api_migration.rst
+++ b/doc/rules/alias/random_api_migration.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = getrandmax();
    -$a = rand($b, $c);
@@ -51,7 +50,6 @@ With configuration: ``['replacements' => ['getrandmax' => 'mt_getrandmax']]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = getrandmax();
    +$a = mt_getrandmax();
@@ -67,7 +65,6 @@ With configuration: ``['replacements' => ['rand' => 'random_int']]``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $a = rand($b, $c);
    +<?php $a = random_int($b, $c);
 

--- a/doc/rules/alias/set_type_to_cast.rst
+++ b/doc/rules/alias/set_type_to_cast.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -settype($foo, "integer");
    -settype($bar, "string");

--- a/doc/rules/array_notation/array_syntax.rst
+++ b/doc/rules/array_notation/array_syntax.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -[1,2];
    +array(1,2);
@@ -42,7 +41,6 @@ With configuration: ``['syntax' => 'short']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -array(1,2);
    +[1,2];

--- a/doc/rules/array_notation/no_multiline_whitespace_around_double_arrow.rst
+++ b/doc/rules/array_notation/no_multiline_whitespace_around_double_arrow.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,2 @@
     <?php
    -$a = array(1
    -

--- a/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
+++ b/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = array('sample',  );
    +$a = array('sample');

--- a/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
+++ b/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $x = array(1 , "2");
    +<?php $x = array(1, "2");
 
@@ -41,7 +40,6 @@ With configuration: ``['after_heredoc' => true]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,5 @@
     <?php
         $x = [<<<EOD
     foo

--- a/doc/rules/array_notation/normalize_index_brace.rst
+++ b/doc/rules/array_notation/normalize_index_brace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -echo $sample{$index};
    +echo $sample[$index];

--- a/doc/rules/array_notation/trailing_comma_in_multiline_array.rst
+++ b/doc/rules/array_notation/trailing_comma_in_multiline_array.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     array(
         1,
@@ -45,7 +44,8 @@ With configuration: ``['after_heredoc' => true]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,5 @@
+    <?php
+        $x = [
             'foo',
             <<<EOD
                 bar

--- a/doc/rules/array_notation/trim_array_spaces.rst
+++ b/doc/rules/array_notation/trim_array_spaces.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$sample = array( );
    -$sample = array( 'a', 'b' );

--- a/doc/rules/array_notation/whitespace_after_comma_in_array.rst
+++ b/doc/rules/array_notation/whitespace_after_comma_in_array.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$sample = array(1,'a',$b,);
    +$sample = array(1, 'a', $b, );

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -69,7 +69,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,25 +1,27 @@
     <?php
 
    -class Foo {
@@ -119,7 +118,6 @@ With configuration: ``['allow_single_line_closure' => true]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,5 @@
     <?php
     $positive = function ($item) { return $item >= 0; };
     $negative = function ($item) {
@@ -136,7 +134,6 @@ With configuration: ``['position_after_functions_and_oop_constructs' => 'same']`
 
    --- Original
    +++ New
-   @@ -1,27 +1,25 @@
     <?php
 
    -class Foo

--- a/doc/rules/basic/encoding.rst
+++ b/doc/rules/basic/encoding.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
    -﻿<?php
    +<?php
 

--- a/doc/rules/basic/non_printable_character.rst
+++ b/doc/rules/basic/non_printable_character.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php echo "​Hello World !";
    +<?php echo "Hello World !";
 
@@ -46,7 +45,6 @@ With configuration: ``['use_escape_sequences_in_strings' => true]``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php echo "​Hello World !";
    +<?php echo "\u{200b}Hello\u{2007}World\u{a0}!";
 

--- a/doc/rules/basic/psr0.rst
+++ b/doc/rules/basic/psr0.rst
@@ -38,7 +38,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     namespace PhpCsFixer\FIXER\Basic;
    -class InvalidName {}
@@ -53,7 +52,6 @@ With configuration: ``['dir' => './src']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -namespace PhpCsFixer\FIXER\Basic;
    -class InvalidName {}

--- a/doc/rules/basic/psr4.rst
+++ b/doc/rules/basic/psr4.rst
@@ -23,7 +23,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     namespace PhpCsFixer\FIXER\Basic;
    -class InvalidName {}

--- a/doc/rules/basic/psr_autoloading.rst
+++ b/doc/rules/basic/psr_autoloading.rst
@@ -34,7 +34,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     namespace PhpCsFixer\FIXER\Basic;
    -class InvalidName {}
@@ -49,7 +48,6 @@ With configuration: ``['dir' => './src']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -namespace PhpCsFixer\FIXER\Basic;
    -class InvalidName {}

--- a/doc/rules/casing/constant_case.rst
+++ b/doc/rules/casing/constant_case.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = FALSE;
    -$b = True;
@@ -47,7 +46,6 @@ With configuration: ``['case' => 'upper']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     $a = FALSE;
    -$b = True;

--- a/doc/rules/casing/lowercase_constants.rst
+++ b/doc/rules/casing/lowercase_constants.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = FALSE;
    -$b = True;

--- a/doc/rules/casing/lowercase_keywords.rst
+++ b/doc/rules/casing/lowercase_keywords.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,11 +1,11 @@
     <?php
    -    FOREACH($a AS $B) {
    -        TRY {

--- a/doc/rules/casing/lowercase_static_reference.rst
+++ b/doc/rules/casing/lowercase_static_reference.rst
@@ -15,7 +15,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,16 +3,16 @@
+    <?php
+    class Foo extends Bar
     {
         public function baz1()
         {
@@ -43,7 +44,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     class Foo extends Bar
     {

--- a/doc/rules/casing/magic_constant_casing.rst
+++ b/doc/rules/casing/magic_constant_casing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -echo __dir__;
    +echo __DIR__;

--- a/doc/rules/casing/magic_method_casing.rst
+++ b/doc/rules/casing/magic_method_casing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     class Foo
     {
@@ -31,7 +30,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo->__INVOKE(1);
    +$foo->__invoke(1);

--- a/doc/rules/casing/native_function_casing.rst
+++ b/doc/rules/casing/native_function_casing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -STRLEN($str);
    +strlen($str);

--- a/doc/rules/casing/native_function_type_declaration_casing.rst
+++ b/doc/rules/casing/native_function_type_declaration_casing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     class Bar {
    -    public function Foo(CALLABLE $bar)
@@ -31,7 +30,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -function Foo(INT $a): Bool
    +function Foo(int $a): bool
@@ -46,7 +44,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -function Foo(Iterable $a): VOID
    +function Foo(iterable $a): void
@@ -61,7 +58,6 @@ Example #4
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -function Foo(Object $a)
    +function Foo(object $a)

--- a/doc/rules/cast_notation/cast_spaces.rst
+++ b/doc/rules/cast_notation/cast_spaces.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$bar = ( string )  $a;
    -$foo = (int)$b;
@@ -44,7 +43,6 @@ With configuration: ``['space' => 'single']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$bar = ( string )  $a;
    -$foo = (int)$b;
@@ -60,7 +58,6 @@ With configuration: ``['space' => 'none']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$bar = ( string )  $a;
    -$foo = (int) $b;

--- a/doc/rules/cast_notation/lowercase_cast.rst
+++ b/doc/rules/cast_notation/lowercase_cast.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,14 +1,14 @@
     <?php
    -    $a = (BOOLEAN) $b;
    -    $a = (BOOL) $b;
@@ -50,7 +49,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,13 +1,13 @@
     <?php
    -    $a = (BOOLEAN) $b;
    -    $a = (BOOL) $b;

--- a/doc/rules/cast_notation/modernize_types_casting.rst
+++ b/doc/rules/cast_notation/modernize_types_casting.rst
@@ -20,7 +20,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
    -    $a = intval($b);
    -    $a = floatval($b);

--- a/doc/rules/cast_notation/no_short_bool_cast.rst
+++ b/doc/rules/cast_notation/no_short_bool_cast.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = !!$b;
    +$a = (bool)$b;

--- a/doc/rules/cast_notation/no_unset_cast.rst
+++ b/doc/rules/cast_notation/no_unset_cast.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = (unset) $b;
    +$a =  null;

--- a/doc/rules/cast_notation/short_scalar_cast.rst
+++ b/doc/rules/cast_notation/short_scalar_cast.rst
@@ -16,7 +16,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
    -$a = (boolean) $b;
    -$a = (integer) $b;
@@ -37,7 +36,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
    -$a = (boolean) $b;
    -$a = (integer) $b;

--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -29,7 +29,9 @@ Example #1
 
    --- Original
    +++ New
-   @@ -4,9 +4,8 @@
+    <?php
+    final class Sample
+    {
         protected function foo()
         {
         }
@@ -50,7 +52,6 @@ With configuration: ``['elements' => ['property' => 'one']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,8 @@
     <?php
     class Sample
    -{private $a; // a is awesome
@@ -70,7 +71,7 @@ With configuration: ``['elements' => ['const' => 'one']]``.
 
    --- Original
    +++ New
-   @@ -2,6 +2,7 @@
+    <?php
     class Sample
     {
         const A = 1;

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -53,7 +53,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,13 +1,13 @@
     <?php
 
    -class  Foo  extends  Bar  implements  Baz,  BarBaz
@@ -80,7 +79,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
 
    -$foo = new  class  extends  Bar  implements  Baz,  BarBaz {};
@@ -95,7 +93,6 @@ With configuration: ``['single_line' => true]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,4 @@
     <?php
 
    -class Foo
@@ -113,7 +110,6 @@ With configuration: ``['single_item_single_line' => true]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,4 @@
     <?php
 
    -class Foo
@@ -131,7 +127,6 @@ With configuration: ``['multi_line_extends_each_single_line' => true]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,7 @@
     <?php
 
     interface Bar extends

--- a/doc/rules/class_notation/final_class.rst
+++ b/doc/rules/class_notation/final_class.rst
@@ -31,7 +31,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -class MyApp {}
    +final class MyApp {}

--- a/doc/rules/class_notation/final_internal_class.rst
+++ b/doc/rules/class_notation/final_internal_class.rst
@@ -58,7 +58,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,6 +2,6 @@
+    <?php
     /**
      * @internal
      */
@@ -76,12 +76,18 @@ With configuration: ``['annotation_include' => ['@Custom'], 'annotation_exclude'
 
    --- Original
    +++ New
-   @@ -2,5 +2,5 @@
+    <?php
     /**
      * @CUSTOM
      */
    -class A{}
    +final class A{}
+
+    /**
+     * @CUSTOM
+     * @not-fix
+     */
+    class B{}
 
 Rule sets
 ---------

--- a/doc/rules/class_notation/final_public_method_for_abstract_class.rst
+++ b/doc/rules/class_notation/final_public_method_for_abstract_class.rst
@@ -24,7 +24,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,6 +2,6 @@
+    <?php
 
     abstract class AbstractMachine
     {

--- a/doc/rules/class_notation/final_static_access.rst
+++ b/doc/rules/class_notation/final_static_access.rst
@@ -18,7 +18,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,6 +3,6 @@
+    <?php
+    final class Sample
     {
         public function getFoo()
         {

--- a/doc/rules/class_notation/method_separation.rst
+++ b/doc/rules/class_notation/method_separation.rst
@@ -18,7 +18,9 @@ Example #1
 
    --- Original
    +++ New
-   @@ -4,7 +4,8 @@
+    <?php
+    final class Sample
+    {
         protected function foo()
         {
         }

--- a/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
+++ b/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,7 @@
     <?php
     final class Sample
     {

--- a/doc/rules/class_notation/no_null_property_initialization.rst
+++ b/doc/rules/class_notation/no_null_property_initialization.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     class Foo {
    -    public $foo = null;

--- a/doc/rules/class_notation/no_php4_constructor.rst
+++ b/doc/rules/class_notation/no_php4_constructor.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     class Foo
     {

--- a/doc/rules/class_notation/no_unneeded_final_method.rst
+++ b/doc/rules/class_notation/no_unneeded_final_method.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,12 +1,12 @@
     <?php
     final class Foo
     {
@@ -60,12 +59,16 @@ With configuration: ``['private_methods' => false]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     final class Foo
     {
    -    final private function baz() {}
    +    private function baz() {}
+    }
+
+    class Bar
+    {
+        final private function bar1() {}
     }
 
 Rule sets

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -39,7 +39,10 @@ Example #1
 
    --- Original
    +++ New
-   @@ -5,26 +5,26 @@
+    <?php
+    final class Example
+    {
+        use BarTrait;
         use BazTrait;
         const C1 = 1;
         const C2 = 2;
@@ -85,7 +88,6 @@ With configuration: ``['order' => ['method_private', 'method_public']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     class Example
     {
@@ -103,7 +105,6 @@ With configuration: ``['order' => ['method_public'], 'sort_algorithm' => 'alpha'
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     class Example
     {

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -43,7 +43,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -final class ExampleA implements Gamma, Alpha, Beta {}
@@ -61,7 +60,6 @@ With configuration: ``['direction' => 'descend']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -final class ExampleA implements Gamma, Alpha, Beta {}
@@ -79,7 +77,6 @@ With configuration: ``['order' => 'length']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -final class ExampleA implements MuchLonger, Short, Longer {}
@@ -97,7 +94,6 @@ With configuration: ``['order' => 'length', 'direction' => 'descend']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -final class ExampleA implements MuchLonger, Short, Longer {}

--- a/doc/rules/class_notation/ordered_traits.rst
+++ b/doc/rules/class_notation/ordered_traits.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php class Foo { 
    -use Z; use A; }
    +use A; use Z; }

--- a/doc/rules/class_notation/protected_to_private.rst
+++ b/doc/rules/class_notation/protected_to_private.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
     <?php
     final class Sample
     {

--- a/doc/rules/class_notation/self_accessor.rst
+++ b/doc/rules/class_notation/self_accessor.rst
@@ -20,7 +20,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,10 +2,10 @@
+    <?php
     class Sample
     {
         const BAZ = 1;

--- a/doc/rules/class_notation/self_static_accessor.rst
+++ b/doc/rules/class_notation/self_static_accessor.rst
@@ -15,13 +15,22 @@ Example #1
 
    --- Original
    +++ New
-   @@ -5,6 +5,6 @@
+    <?php
+    final class Sample
+    {
+        private static $A = 1;
 
         public function getBar()
         {
    -        return static::class.static::test().static::$A;
    +        return self::class.self::test().self::$A;
         }
+
+        private static function test()
+        {
+            return 'test';
+        }
+    }
 
 Example #2
 ~~~~~~~~~~
@@ -30,7 +39,8 @@ Example #2
 
    --- Original
    +++ New
-   @@ -3,6 +3,6 @@
+    <?php
+    final class Foo
     {
         public function bar()
         {
@@ -46,7 +56,8 @@ Example #3
 
    --- Original
    +++ New
-   @@ -3,6 +3,6 @@
+    <?php
+    final class Foo
     {
         public function isBar()
         {
@@ -62,7 +73,7 @@ Example #4
 
    --- Original
    +++ New
-   @@ -2,6 +2,6 @@
+    <?php
     $a = new class() {
         public function getBar()
         {

--- a/doc/rules/class_notation/single_class_element_per_statement.rst
+++ b/doc/rules/class_notation/single_class_element_per_statement.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,8 @@
     <?php
     final class Example
     {
@@ -49,7 +48,7 @@ With configuration: ``['elements' => ['property']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,6 @@
+    <?php
     final class Example
     {
         const FOO_1 = 1, FOO_2 = 2;

--- a/doc/rules/class_notation/single_trait_insert_per_statement.rst
+++ b/doc/rules/class_notation/single_trait_insert_per_statement.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     final class Example
     {

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -30,7 +30,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,10 +1,10 @@
     <?php
     class Sample
     {
@@ -54,7 +53,6 @@ With configuration: ``['elements' => ['const']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     class Sample
     {

--- a/doc/rules/class_usage/date_time_immutable.rst
+++ b/doc/rules/class_usage/date_time_immutable.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -new DateTime();
    +new DateTimeImmutable();

--- a/doc/rules/comment/comment_to_phpdoc.rst
+++ b/doc/rules/comment/comment_to_phpdoc.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php /* header */ $x = true; /* @var bool $isFoo */ $isFoo = true;
    +<?php /* header */ $x = true; /** @var bool $isFoo */ $isFoo = true;
 
@@ -46,7 +45,7 @@ With configuration: ``['ignored_tags' => ['todo']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,5 @@
+    <?php
     // @todo do something later
     $foo = 1;
 

--- a/doc/rules/comment/hash_to_slash_comment.rst
+++ b/doc/rules/comment/hash_to_slash_comment.rst
@@ -18,6 +18,5 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php # comment
    +<?php // comment

--- a/doc/rules/comment/header_comment.rst
+++ b/doc/rules/comment/header_comment.rst
@@ -57,7 +57,6 @@ With configuration: ``['header' => 'Made with love.']``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,10 @@
     <?php
     declare(strict_types=1);
 
@@ -78,7 +77,6 @@ With configuration: ``['header' => 'Made with love.', 'comment_type' => 'PHPDoc'
 
    --- Original
    +++ New
-   @@ -1,6 +1,10 @@
     <?php
    +/**
    + * Made with love.
@@ -99,7 +97,6 @@ With configuration: ``['header' => 'Made with love.', 'comment_type' => 'comment
 
    --- Original
    +++ New
-   @@ -1,6 +1,10 @@
     <?php
     declare(strict_types=1);
 

--- a/doc/rules/comment/multiline_comment_opening_closing.rst
+++ b/doc/rules/comment/multiline_comment_opening_closing.rst
@@ -16,7 +16,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,13 +1,13 @@
     <?php
 
    -/******

--- a/doc/rules/comment/no_empty_comment.rst
+++ b/doc/rules/comment/no_empty_comment.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -//
    -#

--- a/doc/rules/comment/no_trailing_whitespace_in_comment.rst
+++ b/doc/rules/comment/no_trailing_whitespace_in_comment.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -// This is 
    -// a comment. 

--- a/doc/rules/comment/single_line_comment_style.rst
+++ b/doc/rules/comment/single_line_comment_style.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
    -/* asterisk comment */
    +// asterisk comment
@@ -38,6 +37,12 @@ Example #1
    -# hash comment
    +// hash comment
     $b = 2;
+
+    /*
+     * multi-line
+     * comment
+     */
+    $c = 3;
 
 Example #2
 ~~~~~~~~~~
@@ -48,7 +53,6 @@ With configuration: ``['comment_types' => ['asterisk']]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,7 @@
     <?php
    -/* first comment */
    +// first comment
@@ -60,6 +64,12 @@ With configuration: ``['comment_types' => ['asterisk']]``.
    +// second comment
     $b = 2;
 
+    /*
+     * third
+     * comment
+     */
+    $c = 3;
+
 Example #3
 ~~~~~~~~~~
 
@@ -69,7 +79,6 @@ With configuration: ``['comment_types' => ['hash']]``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php # comment
    +<?php // comment
 

--- a/doc/rules/constant_notation/native_constant_invocation.rst
+++ b/doc/rules/constant_notation/native_constant_invocation.rst
@@ -72,7 +72,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php var_dump(PHP_VERSION, M_PI, MY_CUSTOM_PI);
    +<?php var_dump(\PHP_VERSION, \M_PI, MY_CUSTOM_PI);
 
@@ -85,7 +84,6 @@ With configuration: ``['scope' => 'namespaced']``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     namespace space1 {
    -    echo PHP_VERSION;
@@ -104,7 +102,6 @@ With configuration: ``['include' => ['MY_CUSTOM_PI']]``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php var_dump(PHP_VERSION, M_PI, MY_CUSTOM_PI);
    +<?php var_dump(\PHP_VERSION, \M_PI, \MY_CUSTOM_PI);
 
@@ -117,7 +114,6 @@ With configuration: ``['fix_built_in' => false, 'include' => ['MY_CUSTOM_PI']]``
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php var_dump(PHP_VERSION, M_PI, MY_CUSTOM_PI);
    +<?php var_dump(PHP_VERSION, M_PI, \MY_CUSTOM_PI);
 
@@ -130,7 +126,6 @@ With configuration: ``['exclude' => ['M_PI']]``.
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php var_dump(PHP_VERSION, M_PI, MY_CUSTOM_PI);
    +<?php var_dump(\PHP_VERSION, M_PI, MY_CUSTOM_PI);
 

--- a/doc/rules/control_structure/elseif.rst
+++ b/doc/rules/control_structure/elseif.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     if ($a) {
    -} else if ($b) {

--- a/doc/rules/control_structure/include.rst
+++ b/doc/rules/control_structure/include.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -require ("sample1.php");
    -require_once  "sample2.php";

--- a/doc/rules/control_structure/no_alternative_syntax.rst
+++ b/doc/rules/control_structure/no_alternative_syntax.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -if(true):echo 't';else:echo 'f';endif;
    +if(true) { echo 't';} else { echo 'f';}
@@ -26,7 +25,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -while(true):echo 'red';endwhile;
    +while(true) { echo 'red';}
@@ -38,7 +36,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -for(;;):echo 'xc';endfor;
    +for(;;) { echo 'xc';}
@@ -50,7 +47,6 @@ Example #4
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -foreach(array('a') as $item):echo 'xc';endforeach;
    +foreach(array('a') as $item) { echo 'xc';}

--- a/doc/rules/control_structure/no_break_comment.rst
+++ b/doc/rules/control_structure/no_break_comment.rst
@@ -35,7 +35,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,10 +2,10 @@
+    <?php
     switch ($foo) {
         case 1:
             foo();
@@ -57,7 +57,7 @@ With configuration: ``['comment_text' => 'some comment']``.
 
    --- Original
    +++ New
-   @@ -2,6 +2,7 @@
+    <?php
     switch ($foo) {
         case 1:
             foo();

--- a/doc/rules/control_structure/no_superfluous_elseif.rst
+++ b/doc/rules/control_structure/no_superfluous_elseif.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,7 @@
     <?php
     if ($a) {
         return 1;

--- a/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
+++ b/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -list($a, $b,) = foo();
    +list($a, $b) = foo();

--- a/doc/rules/control_structure/no_unneeded_control_parentheses.rst
+++ b/doc/rules/control_structure/no_unneeded_control_parentheses.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
     <?php
    -while ($x) { while ($y) { break (2); } }
    -clone($a);
@@ -56,7 +55,6 @@ With configuration: ``['statements' => ['break', 'continue']]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
     <?php
    -while ($x) { while ($y) { break (2); } }
    +while ($x) { while ($y) { break 2; } }

--- a/doc/rules/control_structure/no_unneeded_curly_braces.rst
+++ b/doc/rules/control_structure/no_unneeded_curly_braces.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
    -<?php {
    +<?php 
         echo 1;
@@ -53,7 +52,6 @@ With configuration: ``['namespaces' => true]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -namespace Foo {
    +namespace Foo;

--- a/doc/rules/control_structure/no_useless_else.rst
+++ b/doc/rules/control_structure/no_useless_else.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     if ($a) {
         return 1;

--- a/doc/rules/control_structure/simplified_if_return.rst
+++ b/doc/rules/control_structure/simplified_if_return.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -if ($foo) { return true; } return false;
    +return (bool) ($foo)      ;

--- a/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
+++ b/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
         switch ($a) {
    -        case 1;

--- a/doc/rules/control_structure/switch_case_space.rst
+++ b/doc/rules/control_structure/switch_case_space.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
         switch($a) {
    -        case 1   :

--- a/doc/rules/control_structure/switch_continue_to_break.rst
+++ b/doc/rules/control_structure/switch_continue_to_break.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     switch ($foo) {
         case 1:
@@ -29,7 +28,8 @@ Example #2
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    switch ($foo) {
         case 1:
             while($bar) {
                 do {
@@ -38,7 +38,6 @@ Example #2
                 } while(false);
 
                 if ($foo + 1 > 3) {
-   @@ -10,6 +10,6 @@
                     continue;
                 }
 

--- a/doc/rules/control_structure/yoda_style.rst
+++ b/doc/rules/control_structure/yoda_style.rst
@@ -58,7 +58,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -    if ($a === null) {
    +    if (null === $a) {
@@ -74,7 +73,6 @@ With configuration: ``['equal' => true, 'identical' => false, 'less_and_greater'
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -    $b = $c != 1;  // equal
    -    $a = 1 === $b; // identical
@@ -91,7 +89,6 @@ With configuration: ``['always_move_variable' => true]``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -return $foo === count($bar);
    +return count($bar) === $foo;
@@ -105,7 +102,6 @@ With configuration: ``['equal' => false, 'identical' => false, 'less_and_greater
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
         // Enforce non-Yoda style.
    -    if (null === $a) {

--- a/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
@@ -37,7 +37,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @Foo({bar : "baz"})
@@ -54,7 +53,6 @@ With configuration: ``['operator' => ':']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @Foo({bar = "baz"})

--- a/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
@@ -37,7 +37,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @Foo()
@@ -54,7 +53,6 @@ With configuration: ``['syntax' => 'with_braces']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @Foo

--- a/doc/rules/doctrine_annotation/doctrine_annotation_indentation.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_indentation.rst
@@ -37,7 +37,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     /**
    - *  @Foo(
@@ -58,7 +57,6 @@ With configuration: ``['indent_mixed_lines' => true]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     /**
    - *  @Foo({@Bar,

--- a/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
@@ -132,7 +132,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,15 +1,15 @@
     <?php
     /**
    - * @Foo ( )
@@ -161,7 +160,6 @@ With configuration: ``['after_array_assignments_equals' => false, 'before_array_
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @Foo(foo = "foo", bar = {"foo":"foo", "bar"="bar"})

--- a/doc/rules/function_notation/combine_nested_dirname.rst
+++ b/doc/rules/function_notation/combine_nested_dirname.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -dirname(dirname(dirname($path)));
    +dirname($path, 3);

--- a/doc/rules/function_notation/fopen_flag_order.rst
+++ b/doc/rules/function_notation/fopen_flag_order.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = fopen($foo, 'br+');
    +$a = fopen($foo, 'r+b');

--- a/doc/rules/function_notation/fopen_flags.rst
+++ b/doc/rules/function_notation/fopen_flags.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = fopen($foo, 'rwt');
    +$a = fopen($foo, 'rwb');
@@ -47,7 +46,6 @@ With configuration: ``['b_mode' => false]``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = fopen($foo, 'rwt');
    +$a = fopen($foo, 'rw');

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -28,7 +28,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,13 +2,13 @@
+    <?php
 
     class Foo
     {
@@ -54,7 +54,6 @@ With configuration: ``['closure_function_spacing' => 'none']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$f = function () {};
    +$f = function() {};
@@ -68,7 +67,6 @@ With configuration: ``['closure_function_spacing' => 'none']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$f = fn () => null;
    +$f = fn() => null;

--- a/doc/rules/function_notation/function_typehint_space.rst
+++ b/doc/rules/function_notation/function_typehint_space.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample(array$a)
    +function sample(array $a)
@@ -27,7 +26,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample(array  $a)
    +function sample(array $a)

--- a/doc/rules/function_notation/implode_call.rst
+++ b/doc/rules/function_notation/implode_call.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -implode($pieces, '');
    +implode('', $pieces);
@@ -30,7 +29,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -implode($pieces);
    +implode('', $pieces);

--- a/doc/rules/function_notation/lambda_not_used_import.rst
+++ b/doc/rules/function_notation/lambda_not_used_import.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = function() use ($bar) {};
    +$foo = function() {};

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -61,7 +61,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample($a=10,$b=20,$c=30) {}
    -sample(1,  2);
@@ -77,7 +76,6 @@ With configuration: ``['keep_multiple_spaces_after_comma' => false]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample($a=10,$b=20,$c=30) {}
    -sample(1,  2);
@@ -93,7 +91,6 @@ With configuration: ``['keep_multiple_spaces_after_comma' => true]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample($a=10,$b=20,$c=30) {}
    +function sample($a=10, $b=20, $c=30) {}
@@ -108,7 +105,6 @@ With configuration: ``['on_multiline' => 'ensure_fully_multiline']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,10 @@
     <?php
    -function sample($a=10,
    -    $b=20,$c=30) {}
@@ -133,7 +129,6 @@ With configuration: ``['on_multiline' => 'ensure_single_line']``.
 
    --- Original
    +++ New
-   @@ -1,10 +1,3 @@
     <?php
    -function sample(
    -    $a=10,
@@ -156,7 +151,6 @@ With configuration: ``['on_multiline' => 'ensure_fully_multiline', 'keep_multipl
 
    --- Original
    +++ New
-   @@ -1,7 +1,12 @@
     <?php
    -function sample($a=10,
    -    $b=20,$c=30) {}
@@ -183,7 +177,6 @@ With configuration: ``['on_multiline' => 'ensure_fully_multiline', 'keep_multipl
 
    --- Original
    +++ New
-   @@ -1,7 +1,12 @@
     <?php
    -function sample($a=10,
    -    $b=20,$c=30) {}
@@ -212,7 +205,7 @@ With configuration: ``['after_heredoc' => true]``.
 
    --- Original
    +++ New
-   @@ -2,7 +2,6 @@
+    <?php
     sample(
         <<<EOD
             foo

--- a/doc/rules/function_notation/native_function_invocation.rst
+++ b/doc/rules/function_notation/native_function_invocation.rst
@@ -61,7 +61,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,9 +2,9 @@
+    <?php
 
     function baz($options)
     {
@@ -83,7 +83,7 @@ With configuration: ``['exclude' => ['json_encode']]``.
 
    --- Original
    +++ New
-   @@ -2,9 +2,9 @@
+    <?php
 
     function baz($options)
     {
@@ -104,7 +104,6 @@ With configuration: ``['scope' => 'all']``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     namespace space1 {
    -    echo count([1]);
@@ -124,7 +123,6 @@ With configuration: ``['scope' => 'namespaced']``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     namespace space1 {
    -    echo count([1]);
@@ -143,7 +141,6 @@ With configuration: ``['include' => ['myGlobalFunction']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -myGlobalFunction();
    +\myGlobalFunction();
@@ -158,7 +155,6 @@ With configuration: ``['include' => ['@all']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -myGlobalFunction();
    -count();
@@ -174,7 +170,6 @@ With configuration: ``['include' => ['@internal']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     myGlobalFunction();
    -count();
@@ -189,7 +184,6 @@ With configuration: ``['include' => ['@compiler_optimized']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     $a .= str_repeat($a, 4);
    -$c = get_class($d);

--- a/doc/rules/function_notation/no_spaces_after_function_name.rst
+++ b/doc/rules/function_notation/no_spaces_after_function_name.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -require ('sample.php');
    -echo (test (3));

--- a/doc/rules/function_notation/no_unreachable_default_argument_value.rst
+++ b/doc/rules/function_notation/no_unreachable_default_argument_value.rst
@@ -21,7 +21,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -function example($foo = "two words", $bar) {}
    +function example($foo, $bar) {}

--- a/doc/rules/function_notation/no_useless_sprintf.rst
+++ b/doc/rules/function_notation/no_useless_sprintf.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = sprintf('bar');
    +$foo = 'bar';

--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -35,7 +35,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample(string $str = null)
    +function sample(?string $str = null)
@@ -50,7 +49,6 @@ With configuration: ``['use_nullable_type_declaration' => false]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample(?string $str = null)
    +function sample(string $str = null)

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -23,7 +23,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     /** @param string $bar */
@@ -38,7 +37,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     /** @param string|null $bar */

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -38,7 +38,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     /** @return \My\Bar */
@@ -55,7 +54,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     /** @return void */
@@ -72,7 +70,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     /** @return object */
@@ -89,7 +86,6 @@ With configuration: ``['scalar_types' => false]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /** @return Foo */
    -function foo() {}
@@ -106,7 +102,8 @@ Example #5
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    final class Foo {
         /**
          * @return static
          */

--- a/doc/rules/function_notation/regular_callable_call.rst
+++ b/doc/rules/function_notation/regular_callable_call.rst
@@ -21,7 +21,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
    -    call_user_func("var_dump", 1, 2);
    +    var_dump(1, 2);
@@ -39,7 +38,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -call_user_func(function ($a, $b) { var_dump($a, $b); }, 1, 2);
    +(function ($a, $b) { var_dump($a, $b); })(1, 2);

--- a/doc/rules/function_notation/return_type_declaration.rst
+++ b/doc/rules/function_notation/return_type_declaration.rst
@@ -34,7 +34,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -function foo(int $a):string {};
    +function foo(int $a): string {};
@@ -48,7 +47,6 @@ With configuration: ``['space_before' => 'none']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -function foo(int $a):string {};
    +function foo(int $a): string {};
@@ -62,7 +60,6 @@ With configuration: ``['space_before' => 'one']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -function foo(int $a):string {};
    +function foo(int $a) : string {};

--- a/doc/rules/function_notation/single_line_throw.rst
+++ b/doc/rules/function_notation/single_line_throw.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,2 @@
     <?php
    -throw new Exception(
    -    'Error.',

--- a/doc/rules/function_notation/static_lambda.rst
+++ b/doc/rules/function_notation/static_lambda.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = function () use ($b)
    +$a = static function () use ($b)

--- a/doc/rules/function_notation/use_arrow_functions.rst
+++ b/doc/rules/function_notation/use_arrow_functions.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,2 @@
     <?php
    -foo(function ($a) use ($b) {
    -    return $a + $b;

--- a/doc/rules/function_notation/void_return.rst
+++ b/doc/rules/function_notation/void_return.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -function foo($a) {};
    +function foo($a): void {};

--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -15,7 +15,9 @@ Example #1
 
    --- Original
    +++ New
-   @@ -4,7 +4,7 @@
+    <?php
+
+    use Foo\Bar;
 
     class SomeClass
     {
@@ -32,7 +34,10 @@ Example #2
 
    --- Original
    +++ New
-   @@ -5,7 +5,7 @@
+    <?php
+
+    use Foo\Bar;
+    use Foo\Bar\Baz;
 
     class SomeClass
     {

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -46,7 +46,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
 
     namespace Foo;
@@ -64,7 +63,6 @@ With configuration: ``['import_classes' => true, 'import_constants' => true, 'im
 
    --- Original
    +++ New
-   @@ -1,9 +1,12 @@
     <?php
 
     namespace Foo;
@@ -91,7 +89,11 @@ With configuration: ``['import_classes' => false, 'import_constants' => false, '
 
    --- Original
    +++ New
-   @@ -6,8 +6,8 @@
+    <?php
+
+    namespace Foo;
+
+    use DateTimeImmutable;
     use function count;
     use const M_PI;
 

--- a/doc/rules/import/group_import.rst
+++ b/doc/rules/import/group_import.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,2 @@
     <?php
    -use Foo\Bar;
    -use Foo\Baz;

--- a/doc/rules/import/no_leading_import_slash.rst
+++ b/doc/rules/import/no_leading_import_slash.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     namespace Foo;
    -use \Bar;

--- a/doc/rules/import/no_unused_imports.rst
+++ b/doc/rules/import/no_unused_imports.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     use \DateTime;
    -use \Exception;

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -42,7 +42,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -use Z; use A;
    +use A; use Z;
@@ -56,7 +55,6 @@ With configuration: ``['sort_algorithm' => 'length']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    +use Bar;
    +use Acme;
@@ -75,7 +73,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    +use AAA;
    +use const AAB;
@@ -92,7 +89,6 @@ With configuration: ``['sort_algorithm' => 'length', 'imports_order' => ['const'
 
    --- Original
    +++ New
-   @@ -1,10 +1,10 @@
     <?php
    +use const BBB;
     use const AAAA;
@@ -116,7 +112,6 @@ With configuration: ``['sort_algorithm' => 'alpha', 'imports_order' => ['const',
 
    --- Original
    +++ New
-   @@ -1,10 +1,10 @@
     <?php
    +use const AAAA;
     use const BBB;
@@ -140,7 +135,7 @@ With configuration: ``['sort_algorithm' => 'none', 'imports_order' => ['const', 
 
    --- Original
    +++ New
-   @@ -2,9 +2,9 @@
+    <?php
     use const BBB;
     use const AAAA;
 

--- a/doc/rules/import/single_import_per_statement.rst
+++ b/doc/rules/import/single_import_per_statement.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,4 @@
     <?php
    -use Foo, Sample, Sample\Sample as Sample2;
    +use Foo;

--- a/doc/rules/import/single_line_after_imports.rst
+++ b/doc/rules/import/single_line_after_imports.rst
@@ -15,7 +15,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,6 +3,7 @@
+    <?php
+    namespace Foo;
 
     use Bar;
     use Baz;
@@ -31,7 +32,9 @@ Example #2
 
    --- Original
    +++ New
-   @@ -4,7 +4,6 @@
+    <?php
+    namespace Foo;
+
     use Bar;
     use Baz;
 

--- a/doc/rules/language_construct/class_keyword_remove.rst
+++ b/doc/rules/language_construct/class_keyword_remove.rst
@@ -14,7 +14,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,4 +2,4 @@
+    <?php
 
     use Foo\Bar\Baz;
 

--- a/doc/rules/language_construct/combine_consecutive_issets.rst
+++ b/doc/rules/language_construct/combine_consecutive_issets.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = isset($a) && isset($b);
    +$a = isset($a, $b)  ;

--- a/doc/rules/language_construct/combine_consecutive_unsets.rst
+++ b/doc/rules/language_construct/combine_consecutive_unsets.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -unset($a); unset($b);
    +unset($a, $b); 

--- a/doc/rules/language_construct/declare_equal_normalize.rst
+++ b/doc/rules/language_construct/declare_equal_normalize.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -declare(ticks =  1);
    +declare(ticks=1);
@@ -43,7 +42,6 @@ With configuration: ``['space' => 'single']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -declare(ticks=1);
    +declare(ticks = 1);

--- a/doc/rules/language_construct/dir_constant.rst
+++ b/doc/rules/language_construct/dir_constant.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = dirname(__FILE__);
    +$a = __DIR__;

--- a/doc/rules/language_construct/error_suppression.rst
+++ b/doc/rules/language_construct/error_suppression.rst
@@ -52,7 +52,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -trigger_error('Warning.', E_USER_DEPRECATED);
    +@trigger_error('Warning.', E_USER_DEPRECATED);
@@ -66,7 +65,6 @@ With configuration: ``['noise_remaining_usages' => true]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -@mkdir($dir);
    -@unlink($path);
@@ -82,7 +80,6 @@ With configuration: ``['noise_remaining_usages' => true, 'noise_remaining_usages
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -@mkdir($dir);
    +mkdir($dir);

--- a/doc/rules/language_construct/explicit_indirect_variable.rst
+++ b/doc/rules/language_construct/explicit_indirect_variable.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -echo $$foo;
    -echo $$foo['bar'];

--- a/doc/rules/language_construct/function_to_constant.rst
+++ b/doc/rules/language_construct/function_to_constant.rst
@@ -32,7 +32,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,12 +1,12 @@
     <?php
    -echo phpversion();
    -echo pi();
@@ -59,14 +58,12 @@ With configuration: ``['functions' => ['get_called_class', 'get_class_this', 'ph
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -echo phpversion();
    +echo PHP_VERSION;
     echo pi();
     class Foo
     {
-   @@ -6,7 +6,7 @@
         public function Bar()
         {
             echo get_class();

--- a/doc/rules/language_construct/is_null.rst
+++ b/doc/rules/language_construct/is_null.rst
@@ -34,7 +34,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = is_null($b);
    +$a = null === $b;

--- a/doc/rules/language_construct/no_unset_on_property.rst
+++ b/doc/rules/language_construct/no_unset_on_property.rst
@@ -22,7 +22,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -unset($this->a);
    +$this->a = null;

--- a/doc/rules/language_construct/silenced_deprecation_error.rst
+++ b/doc/rules/language_construct/silenced_deprecation_error.rst
@@ -22,7 +22,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -trigger_error('Warning.', E_USER_DEPRECATED);
    +@trigger_error('Warning.', E_USER_DEPRECATED);

--- a/doc/rules/language_construct/single_space_after_construct.rst
+++ b/doc/rules/language_construct/single_space_after_construct.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
 
    -throw  new  \Exception();
@@ -43,7 +42,6 @@ With configuration: ``['constructs' => ['echo']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
 
    -echo  "Hello!";
@@ -58,7 +56,6 @@ With configuration: ``['constructs' => ['yield_from']]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
 
    -yield  from  baz();

--- a/doc/rules/list_notation/list_syntax.rst
+++ b/doc/rules/list_notation/list_syntax.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -[$sample] = $array;
    +list($sample) = $array;
@@ -43,7 +42,6 @@ With configuration: ``['syntax' => 'short']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -list($sample) = $array;
    +[$sample] = $array;

--- a/doc/rules/namespace_notation/blank_line_after_namespace.rst
+++ b/doc/rules/namespace_notation/blank_line_after_namespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     namespace Sample\Sample;
 
@@ -28,7 +27,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,3 +1,4 @@
     <?php
     namespace Sample\Sample;
    +

--- a/doc/rules/namespace_notation/clean_namespace.rst
+++ b/doc/rules/namespace_notation/clean_namespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -namespace Foo \ Bar;
    +namespace Foo\Bar;
@@ -26,7 +25,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -echo foo /* comment */ \ bar();
    +echo foo\bar();

--- a/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
+++ b/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,2 @@
     <?php
    -
    -

--- a/doc/rules/namespace_notation/no_leading_namespace_whitespace.rst
+++ b/doc/rules/namespace_notation/no_leading_namespace_whitespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    - namespace Test8a;
    -    namespace Test8b;

--- a/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
+++ b/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1,3 @@
    -<?php  namespace A {}
    +<?php
    +
@@ -27,7 +26,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,4 +1,3 @@
     <?php
 
    -

--- a/doc/rules/naming/no_homoglyph_names.rst
+++ b/doc/rules/naming/no_homoglyph_names.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $nаmе = 'wrong "a" character';
    +<?php $name = 'wrong "a" character';
 

--- a/doc/rules/operator/binary_operator_spaces.rst
+++ b/doc/rules/operator/binary_operator_spaces.rst
@@ -60,7 +60,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a= 1  + $b^ $d !==  $e or   $f;
    +$a = 1 + $b ^ $d !== $e or $f;
@@ -74,7 +73,6 @@ With configuration: ``['operators' => ['=' => 'align', 'xor' => null]]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     $aa=  1;
    -$b=2;
@@ -93,7 +91,6 @@ With configuration: ``['operators' => ['+=' => 'align_single_space']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
    -$a = $b +=$c;
    -$d = $ee+=$f;
@@ -114,7 +111,6 @@ With configuration: ``['operators' => ['===' => 'align_single_space_minimal']]``
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = $b===$c;
    -$d = $f   ===  $g;
@@ -132,7 +128,6 @@ With configuration: ``['operators' => ['|' => 'no_space']]``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION | JSON_PRETTY_PRINT);
    +$foo = \json_encode($bar, JSON_PRESERVE_ZERO_FRACTION|JSON_PRETTY_PRINT);
@@ -146,7 +141,6 @@ With configuration: ``['operators' => ['=>' => 'single_space']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     $array = [
    -    "foo"            =>   1,
@@ -164,7 +158,6 @@ With configuration: ``['operators' => ['=>' => 'align']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     $array = [
    -    "foo" => 12,
@@ -181,7 +174,6 @@ With configuration: ``['operators' => ['=>' => 'align_single_space']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     $array = [
    -    "foo" => 12,
@@ -198,7 +190,6 @@ With configuration: ``['operators' => ['=>' => 'align_single_space_minimal']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     $array = [
    -    "foo" => 12,

--- a/doc/rules/operator/concat_space.rst
+++ b/doc/rules/operator/concat_space.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = 'bar' . 3 . 'baz'.'qux';
    +$foo = 'bar'. 3 .'baz'.'qux';
@@ -42,7 +41,6 @@ With configuration: ``['spacing' => 'none']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = 'bar' . 3 . 'baz'.'qux';
    +$foo = 'bar'. 3 .'baz'.'qux';
@@ -56,7 +54,6 @@ With configuration: ``['spacing' => 'one']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = 'bar' . 3 . 'baz'.'qux';
    +$foo = 'bar' . 3 . 'baz' . 'qux';

--- a/doc/rules/operator/increment_style.rst
+++ b/doc/rules/operator/increment_style.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$a++;
    -$b--;
@@ -44,7 +43,6 @@ With configuration: ``['style' => 'post']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -++$a;
    ---$b;

--- a/doc/rules/operator/logical_operators.rst
+++ b/doc/rules/operator/logical_operators.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
 
    -if ($a == "foo" and ($b == "bar" or $c == "baz")) {

--- a/doc/rules/operator/new_with_braces.rst
+++ b/doc/rules/operator/new_with_braces.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $x = new X;
    +<?php $x = new X();
 

--- a/doc/rules/operator/not_operator_with_space.rst
+++ b/doc/rules/operator/not_operator_with_space.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -if (!$bar) {

--- a/doc/rules/operator/not_operator_with_successor_space.rst
+++ b/doc/rules/operator/not_operator_with_successor_space.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
    -if (!$bar) {

--- a/doc/rules/operator/object_operator_without_whitespace.rst
+++ b/doc/rules/operator/object_operator_without_whitespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $a  ->  b;
    +<?php $a->b;
 

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -38,7 +38,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     function foo() {
    -    return $bar ||
@@ -56,7 +55,6 @@ With configuration: ``['position' => 'end']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     function foo() {
    -    return $bar

--- a/doc/rules/operator/pre_increment.rst
+++ b/doc/rules/operator/pre_increment.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -$a++;
    -$b--;

--- a/doc/rules/operator/standardize_increment.rst
+++ b/doc/rules/operator/standardize_increment.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$i += 1;
    +++$i;
@@ -26,7 +25,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$i -= 1;
    +--$i;

--- a/doc/rules/operator/standardize_not_equals.rst
+++ b/doc/rules/operator/standardize_not_equals.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = $b <> $c;
    +$a = $b != $c;

--- a/doc/rules/operator/ternary_operator_spaces.rst
+++ b/doc/rules/operator/ternary_operator_spaces.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $a = $a   ?1 :0;
    +<?php $a = $a ? 1 : 0;
 

--- a/doc/rules/operator/ternary_to_elvis_operator.rst
+++ b/doc/rules/operator/ternary_to_elvis_operator.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$foo = $foo ? $foo : 1;
    +$foo = $foo ?  : 1;
@@ -30,7 +29,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $foo = $bar[a()] ? $bar[a()] : 1; # "risky" sample, "a()" only gets called once after fixing
    +<?php $foo = $bar[a()] ?  : 1; # "risky" sample, "a()" only gets called once after fixing
 

--- a/doc/rules/operator/ternary_to_null_coalescing.rst
+++ b/doc/rules/operator/ternary_to_null_coalescing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$sample = isset($a) ? $a : $b;
    +$sample = $a ?? $b;

--- a/doc/rules/operator/unary_operator_spaces.rst
+++ b/doc/rules/operator/unary_operator_spaces.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
    -$sample ++;
    --- $sample;

--- a/doc/rules/php_tag/blank_line_after_opening_tag.rst
+++ b/doc/rules/php_tag/blank_line_after_opening_tag.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,4 @@
    -<?php $a = 1;
    +<?php
    +

--- a/doc/rules/php_tag/echo_tag_syntax.rst
+++ b/doc/rules/php_tag/echo_tag_syntax.rst
@@ -47,7 +47,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
    -<?=1?>
    +<?php echo 1?>
     <?php print '2' . '3'; ?>
@@ -63,7 +62,6 @@ With configuration: ``['format' => 'long']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
    -<?=1?>
    +<?php echo 1?>
     <?php print '2' . '3'; ?>
@@ -79,7 +77,6 @@ With configuration: ``['format' => 'long', 'long_function' => 'print']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
    -<?=1?>
    +<?php print 1?>
     <?php print '2' . '3'; ?>
@@ -95,7 +92,6 @@ With configuration: ``['format' => 'short']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?=1?>
    -<?php print '2' . '3'; ?>
    -<?php /* comment */ echo '2' . '3'; ?>
@@ -112,7 +108,6 @@ With configuration: ``['format' => 'short', 'shorten_simple_statements_only' => 
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?=1?>
    -<?php print '2' . '3'; ?>
    -<?php /* comment */ echo '2' . '3'; ?>

--- a/doc/rules/php_tag/full_opening_tag.rst
+++ b/doc/rules/php_tag/full_opening_tag.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
    -<?
    +<?php
 

--- a/doc/rules/php_tag/linebreak_after_opening_tag.rst
+++ b/doc/rules/php_tag/linebreak_after_opening_tag.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,3 @@
    -<?php $a = 1;
    +<?php
    +$a = 1;

--- a/doc/rules/php_tag/no_closing_tag.rst
+++ b/doc/rules/php_tag/no_closing_tag.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     class Sample
     {

--- a/doc/rules/php_tag/no_short_echo_tag.rst
+++ b/doc/rules/php_tag/no_short_echo_tag.rst
@@ -18,6 +18,5 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?= "foo";
    +<?php echo "foo";

--- a/doc/rules/php_unit/php_unit_construct.rst
+++ b/doc/rules/php_unit/php_unit_construct.rst
@@ -33,7 +33,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
     <?php
     final class FooTest extends \PHPUnit_Framework_TestCase {
         public function testSomething() {
@@ -57,7 +56,7 @@ With configuration: ``['assertions' => ['assertSame', 'assertNotSame']]``.
 
    --- Original
    +++ New
-   @@ -2,8 +2,8 @@
+    <?php
     final class FooTest extends \PHPUnit_Framework_TestCase {
         public function testSomething() {
             $this->assertEquals(false, $b);

--- a/doc/rules/php_unit/php_unit_dedicate_assert.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert.rst
@@ -44,7 +44,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testSomeTest()
         {
@@ -64,7 +65,8 @@ With configuration: ``['target' => '5.6']``.
 
    --- Original
    +++ New
-   @@ -3,8 +3,8 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testSomeTest()
         {

--- a/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
@@ -34,7 +34,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    final class MyTest extends \PHPUnit\Framework\TestCase
     {
         public function testMe()
         {
@@ -54,7 +55,8 @@ With configuration: ``['target' => '7.5']``.
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    final class MyTest extends \PHPUnit\Framework\TestCase
     {
         public function testMe()
         {

--- a/doc/rules/php_unit/php_unit_expectation.rst
+++ b/doc/rules/php_unit/php_unit_expectation.rst
@@ -34,7 +34,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,13 +3,17 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {
@@ -64,7 +65,8 @@ With configuration: ``['target' => '8.4']``.
 
    --- Original
    +++ New
-   @@ -3,13 +3,16 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {
@@ -93,7 +95,8 @@ With configuration: ``['target' => '5.6']``.
 
    --- Original
    +++ New
-   @@ -3,13 +3,16 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {
@@ -122,7 +125,8 @@ With configuration: ``['target' => '5.2']``.
 
    --- Original
    +++ New
-   @@ -3,7 +3,9 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {
@@ -132,6 +136,13 @@ With configuration: ``['target' => '5.2']``.
    +        $this->expectExceptionCode(123);
             foo();
         }
+
+        public function testBar()
+        {
+            $this->setExpectedExceptionRegExp("RuntimeException", "/Msg.*/", 123);
+            bar();
+        }
+    }
 
 Rule sets
 ---------

--- a/doc/rules/php_unit/php_unit_fqcn_annotation.rst
+++ b/doc/rules/php_unit/php_unit_fqcn_annotation.rst
@@ -14,7 +14,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,12 +2,12 @@
+    <?php
     final class MyTest extends \PHPUnit_Framework_TestCase
     {
         /**

--- a/doc/rules/php_unit/php_unit_internal_class.rst
+++ b/doc/rules/php_unit/php_unit_internal_class.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,5 @@
     <?php
    +/**
    + * @internal
@@ -44,7 +43,6 @@ With configuration: ``['types' => ['final']]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,7 @@
     <?php
     class MyTest extends TestCase {}
    +/**

--- a/doc/rules/php_unit/php_unit_method_casing.rst
+++ b/doc/rules/php_unit/php_unit_method_casing.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     class MyTest extends \PhpUnit\FrameWork\TestCase
     {
@@ -45,7 +44,6 @@ With configuration: ``['case' => 'snake_case']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     class MyTest extends \PhpUnit\FrameWork\TestCase
     {

--- a/doc/rules/php_unit/php_unit_mock.rst
+++ b/doc/rules/php_unit/php_unit_mock.rst
@@ -34,7 +34,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,9 +3,9 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {
@@ -57,7 +58,8 @@ With configuration: ``['target' => '5.4']``.
 
    --- Original
    +++ New
-   @@ -3,7 +3,7 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testFoo()
         {

--- a/doc/rules/php_unit/php_unit_mock_short_will_return.rst
+++ b/doc/rules/php_unit/php_unit_mock_short_will_return.rst
@@ -20,7 +20,9 @@ Example #1
 
    --- Original
    +++ New
-   @@ -4,10 +4,10 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
         public function testSomeTest()
         {
             $someMock = $this->createMock(Some::class);

--- a/doc/rules/php_unit/php_unit_namespaced.rst
+++ b/doc/rules/php_unit/php_unit_namespaced.rst
@@ -47,7 +47,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
    -final class MyTest extends \PHPUnit_Framework_TestCase
    +final class MyTest extends \PHPUnit\Framework\TestCase
@@ -68,11 +67,15 @@ With configuration: ``['target' => '4.8']``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -final class MyTest extends \PHPUnit_Framework_TestCase
    +final class MyTest extends \PHPUnit\Framework\TestCase
     {
+        public function testSomething()
+        {
+            PHPUnit_Framework_Assert::assertTrue(true);
+        }
+    }
 
 Rule sets
 ---------

--- a/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
+++ b/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
@@ -43,7 +43,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,12 +2,11 @@
+    <?php
     final class MyTest extends \PHPUnit_Framework_TestCase
     {
         /**
@@ -68,7 +68,7 @@ With configuration: ``['target' => '3.2']``.
 
    --- Original
    +++ New
-   @@ -2,11 +2,11 @@
+    <?php
     final class MyTest extends \PHPUnit_Framework_TestCase
     {
         /**
@@ -81,6 +81,16 @@ With configuration: ``['target' => '3.2']``.
    +
             bbb();
         }
+
+        /**
+         * @expectedException FooException
+         * @expectedExceptionMessageRegExp /foo.*$/
+         */
+        function testCcc()
+        {
+            ccc();
+        }
+    }
 
 Rule sets
 ---------

--- a/doc/rules/php_unit/php_unit_ordered_covers.rst
+++ b/doc/rules/php_unit/php_unit_ordered_covers.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     /**
    + * @covers Bar

--- a/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst
+++ b/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst
@@ -20,7 +20,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,13 +2,13 @@
+    <?php
     final class MyTest extends \PHPUnit_Framework_TestCase
     {
         private $hello;

--- a/doc/rules/php_unit/php_unit_size_class.rst
+++ b/doc/rules/php_unit/php_unit_size_class.rst
@@ -35,7 +35,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,5 @@
     <?php
    +/**
    + * @small
@@ -51,7 +50,6 @@ With configuration: ``['group' => 'medium']``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,5 @@
     <?php
    +/**
    + * @medium

--- a/doc/rules/php_unit/php_unit_strict.rst
+++ b/doc/rules/php_unit/php_unit_strict.rst
@@ -33,7 +33,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,9 +3,9 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testSomeTest()
         {
@@ -57,7 +58,10 @@ With configuration: ``['assertions' => ['assertEquals']]``.
 
    --- Original
    +++ New
-   @@ -5,7 +5,7 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        public function testSomeTest()
         {
             $this->assertAttributeEquals(a(), b());
             $this->assertAttributeNotEquals(a(), b());

--- a/doc/rules/php_unit/php_unit_test_annotation.rst
+++ b/doc/rules/php_unit/php_unit_test_annotation.rst
@@ -44,7 +44,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,6 +2,6 @@
+    <?php
     class Test extends \PhpUnit\FrameWork\TestCase
     {
         /**
@@ -63,7 +63,6 @@ With configuration: ``['style' => 'annotation']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,7 @@
     <?php
     class Test extends \PhpUnit\FrameWork\TestCase
     {

--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -44,7 +44,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,8 +3,8 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
     {
         public function testMe()
         {
@@ -65,7 +66,9 @@ With configuration: ``['call_type' => 'this']``.
 
    --- Original
    +++ New
-   @@ -4,7 +4,7 @@
+    <?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
         public function testMe()
         {
             $this->assertSame(1, 2);

--- a/doc/rules/php_unit/php_unit_test_class_requires_covers.rst
+++ b/doc/rules/php_unit/php_unit_test_class_requires_covers.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,7 @@
     <?php
    +
    +/**
@@ -23,6 +22,11 @@ Example #1
    + */
     final class MyTest extends \PHPUnit_Framework_TestCase
     {
+        public function testSomeTest()
+        {
+            $this->assertSame(a(), b());
+        }
+    }
 
 Rule sets
 ---------

--- a/doc/rules/phpdoc/align_multiline_comment.rst
+++ b/doc/rules/phpdoc/align_multiline_comment.rst
@@ -31,7 +31,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
         /**
    -            * This is a DOC Comment
@@ -52,7 +51,6 @@ With configuration: ``['comment_type' => 'phpdocs_like']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
         /*
    -            * This is a doc-like multiline comment
@@ -69,7 +67,6 @@ With configuration: ``['comment_type' => 'all_multiline']``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
         /*
    -            * This is a doc-like multiline comment

--- a/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
+++ b/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
@@ -28,7 +28,6 @@ With configuration: ``['annotations' => ['author']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,5 @@
     <?php
     /**
      * @internal
@@ -45,7 +44,6 @@ With configuration: ``['annotations' => ['package', 'subpackage']]``.
 
    --- Original
    +++ New
-   @@ -1,8 +1,6 @@
     <?php
     /**
      * @author John Doe

--- a/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
+++ b/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
@@ -55,7 +55,6 @@ With configuration: ``['replacements' => ['inheritDocs' => 'inheritDoc']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @inheritDocs
@@ -73,7 +72,6 @@ With configuration: ``['replacements' => ['inheritDocs' => 'inheritDoc'], 'fix_a
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
      * @inheritDocs
@@ -90,7 +88,6 @@ With configuration: ``['replacements' => ['inheritDocs' => 'inheritDoc'], 'fix_i
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @inheritDocs
@@ -107,7 +104,6 @@ With configuration: ``['replacements' => ['inheritDocs' => 'inheritDoc'], 'case_
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @inheritDocs

--- a/doc/rules/phpdoc/no_blank_lines_after_phpdoc.rst
+++ b/doc/rules/phpdoc/no_blank_lines_after_phpdoc.rst
@@ -14,7 +14,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,6 +3,4 @@
+    <?php
+
     /**
      * This is the bar class.
      */

--- a/doc/rules/phpdoc/no_empty_phpdoc.rst
+++ b/doc/rules/phpdoc/no_empty_phpdoc.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php /**  */
    +<?php 
 

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -49,7 +49,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,6 @@
     <?php
     class Foo {
         /**
@@ -68,7 +67,6 @@ With configuration: ``['allow_mixed' => true]``.
 
    --- Original
    +++ New
-   @@ -1,8 +1,7 @@
     <?php
     class Foo {
         /**
@@ -87,7 +85,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,10 +1,7 @@
     <?php
     class Foo {
         /**
@@ -108,7 +105,6 @@ With configuration: ``['remove_inheritdoc' => true]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     class Foo {
         /**
@@ -127,7 +123,6 @@ With configuration: ``['allow_unused_params' => true]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,7 @@
     <?php
     class Foo {
         /**

--- a/doc/rules/phpdoc/phpdoc_add_missing_param_annotation.rst
+++ b/doc/rules/phpdoc/phpdoc_add_missing_param_annotation.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,8 @@
     <?php
     /**
      * @param int $bar
@@ -47,7 +46,6 @@ With configuration: ``['only_untyped' => true]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,8 @@
     <?php
     /**
      * @param int $bar
@@ -66,7 +64,6 @@ With configuration: ``['only_untyped' => false]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,9 @@
     <?php
     /**
      * @param int $bar

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -38,7 +38,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     /**
    - * @param  EngineInterface $templating
@@ -62,7 +61,6 @@ With configuration: ``['align' => 'vertical']``.
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     /**
    - * @param  EngineInterface $templating
@@ -86,7 +84,6 @@ With configuration: ``['align' => 'left']``.
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     /**
    - * @param  EngineInterface $templating

--- a/doc/rules/phpdoc/phpdoc_annotation_without_dot.rst
+++ b/doc/rules/phpdoc/phpdoc_annotation_without_dot.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * @param string $bar Some string.

--- a/doc/rules/phpdoc/phpdoc_indent.rst
+++ b/doc/rules/phpdoc/phpdoc_indent.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,8 @@
     <?php
     class DocBlocks
     {

--- a/doc/rules/phpdoc/phpdoc_inline_tag.rst
+++ b/doc/rules/phpdoc/phpdoc_inline_tag.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     /**
    - * @{TUTORIAL}

--- a/doc/rules/phpdoc/phpdoc_inline_tag_normalizer.rst
+++ b/doc/rules/phpdoc/phpdoc_inline_tag_normalizer.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     /**
    - * @{TUTORIAL}
@@ -47,7 +46,6 @@ With configuration: ``['tags' => ['TUTORIAL']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     /**
    - * @{TUTORIAL}

--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -47,7 +47,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,8 @@
     <?php
 
     class Foo{
@@ -67,7 +66,6 @@ With configuration: ``['property' => 'single']``.
 
    --- Original
    +++ New
-   @@ -1,8 +1,6 @@
     <?php
 
     class Foo{

--- a/doc/rules/phpdoc/phpdoc_no_access.rst
+++ b/doc/rules/phpdoc/phpdoc_no_access.rst
@@ -14,7 +14,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,7 +3,6 @@
+    <?php
+    class Foo
     {
         /**
          * @internal

--- a/doc/rules/phpdoc/phpdoc_no_alias_tag.rst
+++ b/doc/rules/phpdoc/phpdoc_no_alias_tag.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,10 +1,10 @@
     <?php
     /**
      * @property string $foo
@@ -51,7 +50,8 @@ With configuration: ``['replacements' => ['link' => 'website']]``.
 
    --- Original
    +++ New
-   @@ -3,8 +3,8 @@
+    <?php
+    /**
      * @property string $foo
      * @property-read string $bar
      *

--- a/doc/rules/phpdoc/phpdoc_no_empty_return.rst
+++ b/doc/rules/phpdoc/phpdoc_no_empty_return.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     /**
    - * @return null
@@ -28,7 +27,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     /**
    - * @return void

--- a/doc/rules/phpdoc/phpdoc_no_package.rst
+++ b/doc/rules/phpdoc/phpdoc_no_package.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,9 +1,7 @@
     <?php
     /**
      * @internal

--- a/doc/rules/phpdoc/phpdoc_no_useless_inheritdoc.rst
+++ b/doc/rules/phpdoc/phpdoc_no_useless_inheritdoc.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -/** {@inheritdoc} */
    +/** */
@@ -29,7 +28,7 @@ Example #2
 
    --- Original
    +++ New
-   @@ -2,9 +2,9 @@
+    <?php
     class Sample
     {
         /**

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -15,7 +15,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,9 +2,9 @@
+    <?php
     /**
      * Hello there!
      *

--- a/doc/rules/phpdoc/phpdoc_order_by_value.rst
+++ b/doc/rules/phpdoc/phpdoc_order_by_value.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     /**
    + * @covers Bar
@@ -47,7 +46,6 @@ With configuration: ``['annotations' => ['author']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     /**
    + * @author Alice

--- a/doc/rules/phpdoc/phpdoc_return_self_reference.rst
+++ b/doc/rules/phpdoc/phpdoc_return_self_reference.rst
@@ -29,7 +29,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,7 +2,7 @@
+    <?php
     class Sample
     {
         /**
@@ -38,13 +38,18 @@ Example #1
          */
         public function test1()
         {
-   @@ -10,5 +10,5 @@
+            return $this;
         }
 
         /**
    -     * @return $self
    +     * @return self
          */
+        public function test2()
+        {
+            return $this;
+        }
+    }
 
 Example #2
 ~~~~~~~~~~
@@ -55,7 +60,7 @@ With configuration: ``['replacements' => ['this' => 'self']]``.
 
    --- Original
    +++ New
-   @@ -2,7 +2,7 @@
+    <?php
     class Sample
     {
         /**
@@ -64,6 +69,17 @@ With configuration: ``['replacements' => ['this' => 'self']]``.
          */
         public function test1()
         {
+            return $this;
+        }
+
+        /**
+         * @return $self
+         */
+        public function test2()
+        {
+            return $this;
+        }
+    }
 
 Rule sets
 ---------

--- a/doc/rules/phpdoc/phpdoc_scalar.rst
+++ b/doc/rules/phpdoc/phpdoc_scalar.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,12 +1,12 @@
     <?php
     /**
    - * @param integer $a
@@ -56,13 +55,17 @@ With configuration: ``['types' => ['boolean']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
      * @param integer $a
    - * @param boolean $b
    + * @param bool $b
      * @param real $c
+     */
+    function sample($a, $b, $c)
+    {
+        return sample2($a, $b, $c);
+    }
 
 Rule sets
 ---------

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -16,7 +16,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,11 +1,12 @@
     <?php
     /**
      * Description.

--- a/doc/rules/phpdoc/phpdoc_single_line_var_spacing.rst
+++ b/doc/rules/phpdoc/phpdoc_single_line_var_spacing.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
    -<?php /**@var   MyClass   $a   */
    +<?php /** @var MyClass $a */
     $a = test();

--- a/doc/rules/phpdoc/phpdoc_summary.rst
+++ b/doc/rules/phpdoc/phpdoc_summary.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
    - * Foo function is great

--- a/doc/rules/phpdoc/phpdoc_tag_casing.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_casing.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @inheritdoc
@@ -44,7 +43,6 @@ With configuration: ``['tags' => ['foo']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     /**
      * @inheritdoc

--- a/doc/rules/phpdoc/phpdoc_tag_type.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_type.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * {@api}
@@ -44,7 +43,6 @@ With configuration: ``['tags' => ['inheritdoc' => 'inline']]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @inheritdoc

--- a/doc/rules/phpdoc/phpdoc_to_comment.rst
+++ b/doc/rules/phpdoc/phpdoc_to_comment.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,7 +1,7 @@
     <?php
     $first = true;// needed because by default first docblock is never fixed.
 

--- a/doc/rules/phpdoc/phpdoc_trim.rst
+++ b/doc/rules/phpdoc/phpdoc_trim.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,8 +1,5 @@
     <?php
     /**
    - *

--- a/doc/rules/phpdoc/phpdoc_trim_consecutive_blank_line_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_trim_consecutive_blank_line_separation.rst
@@ -14,7 +14,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,16 +2,13 @@
+    <?php
     /**
      * Summary.
      *

--- a/doc/rules/phpdoc/phpdoc_types.rst
+++ b/doc/rules/phpdoc/phpdoc_types.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     /**
    - * @param STRING|String[] $bar
@@ -47,7 +46,6 @@ With configuration: ``['groups' => ['simple', 'alias']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     /**
    - * @param BOOL $foo

--- a/doc/rules/phpdoc/phpdoc_types_order.rst
+++ b/doc/rules/phpdoc/phpdoc_types_order.rst
@@ -37,7 +37,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @param string|null $bar
@@ -53,7 +52,6 @@ With configuration: ``['null_adjustment' => 'always_last']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @param null|string $bar
@@ -69,7 +67,6 @@ With configuration: ``['sort_algorithm' => 'alpha']``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @param null|string|int|\Foo $bar
@@ -85,7 +82,6 @@ With configuration: ``['sort_algorithm' => 'alpha', 'null_adjustment' => 'always
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @param null|string|int|\Foo $bar
@@ -101,7 +97,6 @@ With configuration: ``['sort_algorithm' => 'alpha', 'null_adjustment' => 'none']
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
     /**
    - * @param null|string|int|\Foo $bar

--- a/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst
+++ b/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -/** @var $foo int */
    +/** @var int $foo */

--- a/doc/rules/phpdoc/phpdoc_var_without_name.rst
+++ b/doc/rules/phpdoc/phpdoc_var_without_name.rst
@@ -15,7 +15,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,12 +2,12 @@
+    <?php
     final class Foo
     {
         /**

--- a/doc/rules/return_notation/blank_line_before_return.rst
+++ b/doc/rules/return_notation/blank_line_before_return.rst
@@ -18,7 +18,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,5 +2,6 @@
+    <?php
     function A()
     {
         echo 1;

--- a/doc/rules/return_notation/no_useless_return.rst
+++ b/doc/rules/return_notation/no_useless_return.rst
@@ -14,7 +14,8 @@ Example #1
 
    --- Original
    +++ New
-   @@ -3,5 +3,5 @@
+    <?php
+    function example($b) {
         if ($b) {
             return;
         }

--- a/doc/rules/return_notation/return_assignment.rst
+++ b/doc/rules/return_notation/return_assignment.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     function a() {
    -    $a = 1;

--- a/doc/rules/return_notation/simplified_null_return.rst
+++ b/doc/rules/return_notation/simplified_null_return.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php return null;
    +<?php return;
 
@@ -25,7 +24,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -function foo() { return null; }
    +function foo() { return; }

--- a/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
@@ -30,7 +30,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     function foo () {
    -    return 1 + 2
@@ -47,7 +46,6 @@ With configuration: ``['strategy' => 'new_line_for_chained_calls']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
                             $this->method1()
                                 ->method2()

--- a/doc/rules/semicolon/no_empty_statement.rst
+++ b/doc/rules/semicolon/no_empty_statement.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $a = 1;;
    +<?php $a = 1;
 
@@ -25,7 +24,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php echo 1;2;
    +<?php echo 1;
 
@@ -36,7 +34,6 @@ Example #3
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php while(foo()){
    -    continue 1;
    +    continue ;

--- a/doc/rules/semicolon/no_multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/no_multiline_whitespace_before_semicolons.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,4 @@
     <?php
     function foo () {
    -    return 1 + 2

--- a/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $this->foo() ;
    +<?php $this->foo();
 

--- a/doc/rules/semicolon/semicolon_after_instruction.rst
+++ b/doc/rules/semicolon/semicolon_after_instruction.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php echo 1 ?>
    +<?php echo 1; ?>
 

--- a/doc/rules/semicolon/space_after_semicolon.rst
+++ b/doc/rules/semicolon/space_after_semicolon.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
    -                        sample();     $test = 1;
    -                        sample();$test = 2;
@@ -47,7 +46,6 @@ With configuration: ``['remove_in_empty_for_expressions' => true]``.
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -for ($i = 0; ; ++$i) {
    +for ($i = 0;; ++$i) {

--- a/doc/rules/strict/declare_strict_types.rst
+++ b/doc/rules/strict/declare_strict_types.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php
    +<?php declare(strict_types=1);
    \ No newline at end of file

--- a/doc/rules/strict/strict_comparison.rst
+++ b/doc/rules/strict/strict_comparison.rst
@@ -18,7 +18,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = 1== $b;
    +$a = 1=== $b;

--- a/doc/rules/strict/strict_param.rst
+++ b/doc/rules/strict/strict_param.rst
@@ -25,7 +25,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     $a = array_keys($b);
    -$a = array_search($b, $c);

--- a/doc/rules/string_notation/escape_implicit_backslashes.rst
+++ b/doc/rules/string_notation/escape_implicit_backslashes.rst
@@ -62,7 +62,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,8 +2,8 @@
+    <?php
 
     $singleQuoted = 'String with \" and My\Prefix\\';
 
@@ -83,7 +83,6 @@ With configuration: ``['single_quoted' => true]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,9 @@
     <?php
 
    -$singleQuoted = 'String with \" and My\Prefix\\';
@@ -106,7 +105,10 @@ With configuration: ``['double_quoted' => false]``.
 
    --- Original
    +++ New
-   @@ -5,5 +5,5 @@
+    <?php
+
+    $singleQuoted = 'String with \" and My\Prefix\\';
+
     $doubleQuoted = "Interpret my \n but not my \a";
 
     $hereDoc = <<<HEREDOC
@@ -123,7 +125,7 @@ With configuration: ``['heredoc_syntax' => false]``.
 
    --- Original
    +++ New
-   @@ -2,8 +2,8 @@
+    <?php
 
     $singleQuoted = 'String with \" and My\Prefix\\';
 

--- a/doc/rules/string_notation/explicit_string_variable.rst
+++ b/doc/rules/string_notation/explicit_string_variable.rst
@@ -30,7 +30,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -$a = "My name is $name !";
    -$b = "I live in $state->country !";

--- a/doc/rules/string_notation/heredoc_to_nowdoc.rst
+++ b/doc/rules/string_notation/heredoc_to_nowdoc.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
    -<?php $a = <<<"TEST"
    +<?php $a = <<<'TEST'
     Foo

--- a/doc/rules/string_notation/no_binary_string.rst
+++ b/doc/rules/string_notation/no_binary_string.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1 +1 @@
    -<?php $a = b'foo';
    +<?php $a = 'foo';
 
@@ -25,7 +24,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
    -<?php $a = b<<<EOT
    +<?php $a = <<<EOT
     foo

--- a/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
+++ b/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
    -<?php $a = '  
    -    foo 
    +<?php $a = '

--- a/doc/rules/string_notation/simple_to_complex_string_variable.rst
+++ b/doc/rules/string_notation/simple_to_complex_string_variable.rst
@@ -21,7 +21,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     $name = 'World';
    -echo "Hello ${name}!";
@@ -34,7 +33,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
     $name = 'World';
     echo <<<TEST

--- a/doc/rules/string_notation/single_quote.rst
+++ b/doc/rules/string_notation/single_quote.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
 
    -$a = "sample";
@@ -44,7 +43,6 @@ With configuration: ``['strings_containing_single_quote_chars' => true]``.
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
 
    -$a = "sample";

--- a/doc/rules/string_notation/string_line_ending.rst
+++ b/doc/rules/string_notation/string_line_ending.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
    -<?php $a = 'my^M
    +<?php $a = 'my
     multi

--- a/doc/rules/whitespace/array_indentation.rst
+++ b/doc/rules/whitespace/array_indentation.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,6 +1,6 @@
     <?php
     $foo = [
    -   'bar' => [

--- a/doc/rules/whitespace/blank_line_before_statement.rst
+++ b/doc/rules/whitespace/blank_line_before_statement.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
     function A() {
         echo 1;
@@ -45,7 +44,7 @@ With configuration: ``['statements' => ['break']]``.
 
    --- Original
    +++ New
-   @@ -2,7 +2,8 @@
+    <?php
     switch ($foo) {
         case 42:
             $bar->process();
@@ -64,7 +63,7 @@ With configuration: ``['statements' => ['continue']]``.
 
    --- Original
    +++ New
-   @@ -2,6 +2,7 @@
+    <?php
     foreach ($foo as $bar) {
         if ($bar->isTired()) {
             $bar->sleep();
@@ -82,7 +81,6 @@ With configuration: ``['statements' => ['do']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
     $i = 0;
    +
@@ -99,7 +97,8 @@ With configuration: ``['statements' => ['exit']]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,6 @@
+    <?php
+    if ($foo === false) {
         exit(0);
     } else {
         $bar = 9000;
@@ -116,7 +115,10 @@ With configuration: ``['statements' => ['goto']]``.
 
    --- Original
    +++ New
-   @@ -5,5 +5,6 @@
+    <?php
+    a:
+
+    if ($foo === false) {
         goto a;
     } else {
         $bar = 9000;
@@ -133,7 +135,6 @@ With configuration: ``['statements' => ['if']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
     $a = 9000;
    +
@@ -150,7 +151,7 @@ With configuration: ``['statements' => ['return']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,6 @@
+    <?php
 
     if (true) {
         $foo = $bar;
@@ -167,7 +168,6 @@ With configuration: ``['statements' => ['switch']]``.
 
    --- Original
    +++ New
-   @@ -1,6 +1,7 @@
     <?php
     $a = 9000;
    +
@@ -185,7 +185,6 @@ With configuration: ``['statements' => ['throw']]``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,6 @@
     <?php
     if (null === $a) {
         $foo->bar();
@@ -202,7 +201,6 @@ With configuration: ``['statements' => ['try']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,8 @@
     <?php
     $a = 9000;
    +
@@ -221,7 +219,7 @@ With configuration: ``['statements' => ['yield']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,6 @@
+    <?php
 
     if (true) {
         $foo = $bar;

--- a/doc/rules/whitespace/compact_nullable_typehint.rst
+++ b/doc/rules/whitespace/compact_nullable_typehint.rst
@@ -19,7 +19,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -function sample(? string $str): ? string
    +function sample(?string $str): ?string

--- a/doc/rules/whitespace/heredoc_indentation.rst
+++ b/doc/rules/whitespace/heredoc_indentation.rst
@@ -29,7 +29,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
         $a = <<<EOD
    -abc
@@ -48,7 +47,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
         $a = <<<'EOD'
    -abc
@@ -67,7 +65,6 @@ With configuration: ``['indentation' => 'same_as_start']``.
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
         $a = <<<'EOD'
    -abc

--- a/doc/rules/whitespace/indentation_type.rst
+++ b/doc/rules/whitespace/indentation_type.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php
 
     if (true) {

--- a/doc/rules/whitespace/line_ending.rst
+++ b/doc/rules/whitespace/line_ending.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,5 +1,5 @@
     <?php $b = " $a ^M
    - 123"; $a = <<<TEST^M
    -AAAAA ^M

--- a/doc/rules/whitespace/method_chaining_indentation.rst
+++ b/doc/rules/whitespace/method_chaining_indentation.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
     $user->setEmail('voff.web@gmail.com')
    -         ->setPassword('233434');

--- a/doc/rules/whitespace/no_extra_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_blank_lines.rst
@@ -28,7 +28,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,5 +2,4 @@
+    <?php
 
     $foo = array("foo");
 
@@ -44,7 +44,9 @@ With configuration: ``['tokens' => ['break']]``.
 
    --- Original
    +++ New
-   @@ -4,7 +4,6 @@
+    <?php
+
+    switch ($foo) {
         case 41:
             echo "foo";
             break;
@@ -62,7 +64,8 @@ With configuration: ``['tokens' => ['continue']]``.
 
    --- Original
    +++ New
-   @@ -3,6 +3,5 @@
+    <?php
+
     for ($i = 0; $i < 9000; ++$i) {
         if (true) {
             continue;
@@ -79,7 +82,6 @@ With configuration: ``['tokens' => ['curly_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     for ($i = 0; $i < 9000; ++$i) {
@@ -97,7 +99,7 @@ With configuration: ``['tokens' => ['extra']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,4 @@
+    <?php
 
     $foo = array("foo");
 
@@ -113,7 +115,6 @@ With configuration: ``['tokens' => ['parenthesis_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     $foo = array(
@@ -131,7 +132,8 @@ With configuration: ``['tokens' => ['return']]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,4 @@
+    <?php
+
     function foo($bar)
     {
         return $bar;
@@ -147,7 +149,6 @@ With configuration: ``['tokens' => ['square_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     $foo = [
@@ -165,7 +166,8 @@ With configuration: ``['tokens' => ['throw']]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,4 @@
+    <?php
+
     function foo($bar)
     {
         throw new \Exception("Hello!");
@@ -181,7 +183,8 @@ With configuration: ``['tokens' => ['use']]``.
 
    --- Original
    +++ New
-   @@ -3,9 +3,8 @@
+    <?php
+
     namespace Foo;
 
     use Bar\Baz;
@@ -201,7 +204,8 @@ With configuration: ``['tokens' => ['use_trait']]``.
 
    --- Original
    +++ New
-   @@ -3,6 +3,5 @@
+    <?php
+
     class Foo
     {
         use Bar;
@@ -218,7 +222,6 @@ With configuration: ``['tokens' => ['switch', 'case', 'default']]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,6 @@
     <?php
     switch($a) {
    -

--- a/doc/rules/whitespace/no_extra_consecutive_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_consecutive_blank_lines.rst
@@ -32,7 +32,7 @@ Example #1
 
    --- Original
    +++ New
-   @@ -2,5 +2,4 @@
+    <?php
 
     $foo = array("foo");
 
@@ -48,7 +48,9 @@ With configuration: ``['tokens' => ['break']]``.
 
    --- Original
    +++ New
-   @@ -4,7 +4,6 @@
+    <?php
+
+    switch ($foo) {
         case 41:
             echo "foo";
             break;
@@ -66,7 +68,8 @@ With configuration: ``['tokens' => ['continue']]``.
 
    --- Original
    +++ New
-   @@ -3,6 +3,5 @@
+    <?php
+
     for ($i = 0; $i < 9000; ++$i) {
         if (true) {
             continue;
@@ -83,7 +86,6 @@ With configuration: ``['tokens' => ['curly_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     for ($i = 0; $i < 9000; ++$i) {
@@ -101,7 +103,7 @@ With configuration: ``['tokens' => ['extra']]``.
 
    --- Original
    +++ New
-   @@ -2,5 +2,4 @@
+    <?php
 
     $foo = array("foo");
 
@@ -117,7 +119,6 @@ With configuration: ``['tokens' => ['parenthesis_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     $foo = array(
@@ -135,7 +136,8 @@ With configuration: ``['tokens' => ['return']]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,4 @@
+    <?php
+
     function foo($bar)
     {
         return $bar;
@@ -151,7 +153,6 @@ With configuration: ``['tokens' => ['square_brace_block']]``.
 
    --- Original
    +++ New
-   @@ -1,7 +1,5 @@
     <?php
 
     $foo = [
@@ -169,7 +170,8 @@ With configuration: ``['tokens' => ['throw']]``.
 
    --- Original
    +++ New
-   @@ -3,5 +3,4 @@
+    <?php
+
     function foo($bar)
     {
         throw new \Exception("Hello!");
@@ -185,7 +187,8 @@ With configuration: ``['tokens' => ['use']]``.
 
    --- Original
    +++ New
-   @@ -3,9 +3,8 @@
+    <?php
+
     namespace Foo;
 
     use Bar\Baz;
@@ -205,7 +208,8 @@ With configuration: ``['tokens' => ['use_trait']]``.
 
    --- Original
    +++ New
-   @@ -3,6 +3,5 @@
+    <?php
+
     class Foo
     {
         use Bar;
@@ -222,7 +226,6 @@ With configuration: ``['tokens' => ['switch', 'case', 'default']]``.
 
    --- Original
    +++ New
-   @@ -1,9 +1,6 @@
     <?php
     switch($a) {
    -

--- a/doc/rules/whitespace/no_spaces_around_offset.rst
+++ b/doc/rules/whitespace/no_spaces_around_offset.rst
@@ -28,7 +28,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$sample = $b [ 'a' ] [ 'b' ];
    +$sample = $b['a']['b'];
@@ -42,7 +41,6 @@ With configuration: ``['positions' => ['inside']]``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$sample = $b [ 'a' ] [ 'b' ];
    +$sample = $b ['a'] ['b'];
@@ -56,7 +54,6 @@ With configuration: ``['positions' => ['outside']]``.
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$sample = $b [ 'a' ] [ 'b' ];
    +$sample = $b[ 'a' ][ 'b' ];

--- a/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
+++ b/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
@@ -15,7 +15,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -if ( $a ) {
    -    foo( );
@@ -30,7 +29,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,4 +1,4 @@
     <?php
    -function foo( $bar, $baz )
    +function foo($bar, $baz)

--- a/doc/rules/whitespace/no_trailing_whitespace.rst
+++ b/doc/rules/whitespace/no_trailing_whitespace.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = 1;     
    +$a = 1;

--- a/doc/rules/whitespace/no_whitespace_in_blank_line.rst
+++ b/doc/rules/whitespace/no_whitespace_in_blank_line.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,3 +1,3 @@
     <?php
    -   
    +

--- a/doc/rules/whitespace/single_blank_line_at_eof.rst
+++ b/doc/rules/whitespace/single_blank_line_at_eof.rst
@@ -14,7 +14,6 @@ Example #1
 
    --- Original
    +++ New
-   @@ -1,2 +1,2 @@
     <?php
    -$a = 1;
    \ No newline at end of file
@@ -27,7 +26,6 @@ Example #2
 
    --- Original
    +++ New
-   @@ -1,3 +1,2 @@
     <?php
     $a = 1;
    -

--- a/src/Documentation/DocumentationGenerator.php
+++ b/src/Documentation/DocumentationGenerator.php
@@ -51,6 +51,7 @@ final class DocumentationGenerator
     public function __construct()
     {
         $this->differ = new Differ(new UnifiedDiffOutputBuilder([
+            'contextLines' => 1024, // number large enough to have all lines in diff
             'fromFile' => 'Original',
             'toFile' => 'New',
         ]));
@@ -514,6 +515,7 @@ RST;
         $fixer->fix($file, $tokens);
 
         $diff = $this->differ->diff($old, $tokens->generateCode());
+        $diff = Preg::replace('/@@[ \+\-\d,]+@@\n/', '', $diff);
         $diff = Preg::replace('/\r/', '^M', $diff);
         $diff = Preg::replace('/^ $/m', '', $diff);
         $diff = Preg::replace('/\n$/', '', $diff);


### PR DESCRIPTION
- Makes all diff for doc examples having whote file content.
- Removes the line numbers e.g. `@@ -1,2 +1,2 @@` from diffs.

All interesting changes are in `src/Documentation/DocumentationGenerator.php` file.

Ping @julienfalque for review.