### PR TITLE
Add support for nullsafe object operator ("?->")

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -29,7 +29,8 @@
         "T_MATCH",
         "T_NAME_FULLY_QUALIFIED",
         "T_NAME_QUALIFIED",
-        "T_NAME_RELATIVE"
+        "T_NAME_RELATIVE",
+        "T_NULLSAFE_OBJECT_OPERATOR"
     ],
     "php-core-extensions" : [
         "dom", "mbstring", "Phar",

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -354,7 +354,7 @@ Operator
 - `not_operator_with_successor_space <./operator/not_operator_with_successor_space.rst>`_
     Logical NOT operators (``!``) should have one trailing whitespace.
 - `object_operator_without_whitespace <./operator/object_operator_without_whitespace.rst>`_
-    There should not be space before or after object ``T_OBJECT_OPERATOR`` ``->``.
+    There should not be space before or after object operators ``->`` and ``?->``.
 - `operator_linebreak <./operator/operator_linebreak.rst>`_
     Operators - when multiline - must always be at the beginning or at the end of the line.
 - `pre_increment <./operator/pre_increment.rst>`_ *(deprecated)*

--- a/doc/rules/operator/object_operator_without_whitespace.rst
+++ b/doc/rules/operator/object_operator_without_whitespace.rst
@@ -2,7 +2,7 @@
 Rule ``object_operator_without_whitespace``
 ===========================================
 
-There should not be space before or after object ``T_OBJECT_OPERATOR`` ``->``.
+There should not be space before or after object operators ``->`` and ``?->``.
 
 Examples
 --------

--- a/src/Fixer/AbstractIncrementOperatorFixer.php
+++ b/src/Fixer/AbstractIncrementOperatorFixer.php
@@ -42,7 +42,7 @@ abstract class AbstractIncrementOperatorFixer extends AbstractFixer
             return $this->findStart($tokens, $index);
         }
 
-        if ($prevToken->isGivenKind(T_OBJECT_OPERATOR)) {
+        if ($prevToken->isObjectOperator()) {
             return $this->findStart($tokens, $prevIndex);
         }
 

--- a/src/Fixer/Alias/PowToExponentiationFixer.php
+++ b/src/Fixer/Alias/PowToExponentiationFixer.php
@@ -184,11 +184,11 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
      */
     private function isParenthesisNeeded(Tokens $tokens, $argumentStartIndex, $argumentEndIndex)
     {
-        static $allowedKinds = [
-            T_DNUMBER, T_LNUMBER, T_VARIABLE, T_STRING, T_OBJECT_OPERATOR, T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_CAST,
-            T_INT_CAST, T_INC, T_DEC, T_NS_SEPARATOR, T_WHITESPACE, T_DOUBLE_COLON, T_LINE, T_COMMENT, T_DOC_COMMENT,
-            CT::T_NAMESPACE_OPERATOR,
-        ];
+        static $allowedKinds = null;
+
+        if (null === $allowedKinds) {
+            $allowedKinds = $this->getAllowedKinds();
+        }
 
         for ($i = $argumentStartIndex; $i <= $argumentEndIndex; ++$i) {
             if ($tokens[$i]->isGivenKind($allowedKinds) || $tokens->isEmptyAt($i)) {
@@ -220,5 +220,20 @@ final class PowToExponentiationFixer extends AbstractFunctionReferenceFixer
         }
 
         return false;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getAllowedKinds()
+    {
+        return array_merge(
+            [
+                T_DNUMBER, T_LNUMBER, T_VARIABLE, T_STRING, T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_CAST,
+                T_INT_CAST, T_INC, T_DEC, T_NS_SEPARATOR, T_WHITESPACE, T_DOUBLE_COLON, T_LINE, T_COMMENT, T_DOC_COMMENT,
+                CT::T_NAMESPACE_OPERATOR,
+            ],
+            Token::getObjectOperatorKinds()
+        );
     }
 }

--- a/src/Fixer/Casing/ConstantCaseFixer.php
+++ b/src/Fixer/Casing/ConstantCaseFixer.php
@@ -119,24 +119,30 @@ final class ConstantCaseFixer extends AbstractFixer implements ConfigurationDefi
      */
     private function isNeighbourAccepted(Tokens $tokens, $index)
     {
-        static $forbiddenTokens = [
-            T_AS,
-            T_CLASS,
-            T_CONST,
-            T_EXTENDS,
-            T_IMPLEMENTS,
-            T_INSTANCEOF,
-            T_INSTEADOF,
-            T_INTERFACE,
-            T_NEW,
-            T_NS_SEPARATOR,
-            T_OBJECT_OPERATOR,
-            T_PAAMAYIM_NEKUDOTAYIM,
-            T_TRAIT,
-            T_USE,
-            CT::T_USE_TRAIT,
-            CT::T_USE_LAMBDA,
-        ];
+        static $forbiddenTokens = null;
+
+        if (null === $forbiddenTokens) {
+            $forbiddenTokens = array_merge(
+                [
+                    T_AS,
+                    T_CLASS,
+                    T_CONST,
+                    T_EXTENDS,
+                    T_IMPLEMENTS,
+                    T_INSTANCEOF,
+                    T_INSTEADOF,
+                    T_INTERFACE,
+                    T_NEW,
+                    T_NS_SEPARATOR,
+                    T_PAAMAYIM_NEKUDOTAYIM,
+                    T_TRAIT,
+                    T_USE,
+                    CT::T_USE_TRAIT,
+                    CT::T_USE_LAMBDA,
+                ],
+                Token::getObjectOperatorKinds()
+            );
+        }
 
         $token = $tokens[$index];
 

--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -86,7 +86,7 @@ class Foo extends Bar
             }
 
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$prevIndex]->isGivenKind([T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_NAMESPACE, T_NS_SEPARATOR, T_OBJECT_OPERATOR, T_PRIVATE, T_PROTECTED, T_PUBLIC])) {
+            if ($tokens[$prevIndex]->isGivenKind([T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_NAMESPACE, T_NS_SEPARATOR, T_PRIVATE, T_PROTECTED, T_PUBLIC]) || $tokens[$prevIndex]->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/Casing/MagicMethodCasingFixer.php
+++ b/src/Fixer/Casing/MagicMethodCasingFixer.php
@@ -75,7 +75,7 @@ $foo->__INVOKE(1);
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_STRING) && $tokens->isAnyTokenKindsFound([T_FUNCTION, T_OBJECT_OPERATOR, T_DOUBLE_COLON]);
+        return $tokens->isTokenKindFound(T_STRING) && $tokens->isAnyTokenKindsFound(array_merge([T_FUNCTION, T_DOUBLE_COLON], Token::getObjectOperatorKinds()));
     }
 
     /**
@@ -175,7 +175,7 @@ $foo->__INVOKE(1);
     private function isMethodCall(Tokens $tokens, $index)
     {
         $prevIndex = $tokens->getPrevMeaningfulToken($index);
-        if (!$tokens[$prevIndex]->equals([T_OBJECT_OPERATOR, '->'])) {
+        if (!$tokens[$prevIndex]->isObjectOperator()) {
             return false; // not a "simple" method call
         }
 

--- a/src/Fixer/Casing/NativeFunctionCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionCasingFixer.php
@@ -78,7 +78,7 @@ final class NativeFunctionCasingFixer extends AbstractFixer
             }
 
             $functionNamePrefix = $tokens->getPrevMeaningfulToken($index);
-            if ($tokens[$functionNamePrefix]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR, T_FUNCTION, CT::T_RETURN_REF])) {
+            if ($tokens[$functionNamePrefix]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_FUNCTION, CT::T_RETURN_REF]) || $tokens[$functionNamePrefix]->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/ClassNotation/SelfAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfAccessorFixer.php
@@ -150,7 +150,7 @@ class Sample
                 }
                 $prevToken = $tokens[$tokens->getPrevMeaningfulToken($classStartIndex)];
             }
-            if ($prevToken->isGivenKind([T_OBJECT_OPERATOR, T_STRING])) {
+            if ($prevToken->isGivenKind(T_STRING) || $prevToken->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/ClassUsage/DateTimeImmutableFixer.php
+++ b/src/Fixer/ClassUsage/DateTimeImmutableFixer.php
@@ -128,7 +128,7 @@ final class DateTimeImmutableFixer extends AbstractFixer
             if (!$tokens[$prevPrevIndex]->isGivenKind(T_STRING)) {
                 $isUsedWithLeadingBackslash = true;
             }
-        } elseif (!$tokens[$prevIndex]->isGivenKind([T_DOUBLE_COLON, T_OBJECT_OPERATOR])) {
+        } elseif (!$tokens[$prevIndex]->isGivenKind(T_DOUBLE_COLON) && !$tokens[$prevIndex]->isObjectOperator()) {
             $isUsedAlone = true;
         }
 
@@ -147,7 +147,7 @@ final class DateTimeImmutableFixer extends AbstractFixer
     private function fixFunctionUsage(Tokens $tokens, $index, $replacement)
     {
         $prevIndex = $tokens->getPrevMeaningfulToken($index);
-        if ($tokens[$prevIndex]->isGivenKind([T_DOUBLE_COLON, T_NEW, T_OBJECT_OPERATOR])) {
+        if ($tokens[$prevIndex]->isGivenKind([T_DOUBLE_COLON, T_NEW]) || $tokens[$prevIndex]->isObjectOperator()) {
             return;
         }
         if ($tokens[$prevIndex]->isGivenKind(T_NS_SEPARATOR)) {

--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -600,7 +600,7 @@ return $foo === count($bar);
             }
 
             // $a-> or a-> (as in $b->a->c)
-            if ($current->isGivenKind([T_STRING, T_VARIABLE]) && $next->isGivenKind(T_OBJECT_OPERATOR)) {
+            if ($current->isGivenKind([T_STRING, T_VARIABLE]) && $next->isObjectOperator()) {
                 $index = $tokens->getNextMeaningfulToken($nextIndex);
                 $expectString = true;
 
@@ -623,7 +623,7 @@ return $foo === count($bar);
 
                 $index = $tokens->getNextMeaningfulToken($index);
 
-                if (!$tokens[$index]->equalsAny([[T_OBJECT_OPERATOR, '->'], '[', [CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN, '{']])) {
+                if (!$tokens[$index]->equalsAny(['[', [CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN, '{']]) && !$tokens[$index]->isObjectOperator()) {
                     return false;
                 }
 
@@ -647,7 +647,7 @@ return $foo === count($bar);
 
                 $index = $tokens->getNextMeaningfulToken($index);
 
-                if (!$tokens[$index]->isGivenKind(T_OBJECT_OPERATOR)) {
+                if (!$tokens[$index]->isObjectOperator()) {
                     return false;
                 }
 

--- a/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
+++ b/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
@@ -32,7 +32,7 @@ final class SingleLineThrowFixer extends AbstractFixer
     /**
      * @internal
      */
-    const REMOVE_WHITESPACE_AROUND_TOKENS = ['(', [T_OBJECT_OPERATOR], [T_DOUBLE_COLON]];
+    const REMOVE_WHITESPACE_AROUND_TOKENS = ['(', [T_DOUBLE_COLON]];
 
     /**
      * @internal
@@ -131,7 +131,7 @@ final class SingleLineThrowFixer extends AbstractFixer
 
             $prevIndex = $tokens->getNonEmptySibling($index, -1);
 
-            if ($tokens[$prevIndex]->equalsAny(array_merge(self::REMOVE_WHITESPACE_AFTER_TOKENS, self::REMOVE_WHITESPACE_AROUND_TOKENS))) {
+            if ($this->isPreviousTokenToClear($tokens[$prevIndex])) {
                 $tokens->clearAt($index);
 
                 continue;
@@ -140,7 +140,7 @@ final class SingleLineThrowFixer extends AbstractFixer
             $nextIndex = $tokens->getNonEmptySibling($index, 1);
 
             if (
-                $tokens[$nextIndex]->equalsAny(array_merge(self::REMOVE_WHITESPACE_AROUND_TOKENS, self::REMOVE_WHITESPACE_BEFORE_TOKENS))
+                $this->isNextTokenToClear($tokens[$nextIndex])
                 && !$tokens[$prevIndex]->isGivenKind(T_FUNCTION)
             ) {
                 $tokens->clearAt($index);
@@ -150,5 +150,33 @@ final class SingleLineThrowFixer extends AbstractFixer
 
             $tokens[$index] = new Token([T_WHITESPACE, ' ']);
         }
+    }
+
+    /**
+     * @return bool
+     */
+    private function isPreviousTokenToClear(Token $token)
+    {
+        static $tokens = null;
+
+        if (null === $tokens) {
+            $tokens = array_merge(self::REMOVE_WHITESPACE_AFTER_TOKENS, self::REMOVE_WHITESPACE_AROUND_TOKENS);
+        }
+
+        return $token->equalsAny($tokens) || $token->isObjectOperator();
+    }
+
+    /**
+     * @return bool
+     */
+    private function isNextTokenToClear(Token $token)
+    {
+        static $tokens = null;
+
+        if (null === $tokens) {
+            $tokens = array_merge(self::REMOVE_WHITESPACE_AROUND_TOKENS, self::REMOVE_WHITESPACE_BEFORE_TOKENS);
+        }
+
+        return $token->equalsAny($tokens) || $token->isObjectOperator();
     }
 }

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -145,7 +145,8 @@ final class NoUnusedImportsFixer extends AbstractFixer
 
                 if (
                     0 === strcasecmp($shortName, $token->getContent())
-                    && !$prevMeaningfulToken->isGivenKind([T_NS_SEPARATOR, T_CONST, T_OBJECT_OPERATOR, T_DOUBLE_COLON])
+                    && !$prevMeaningfulToken->isGivenKind([T_NS_SEPARATOR, T_CONST, T_DOUBLE_COLON])
+                    && !$prevMeaningfulToken->isObjectOperator()
                 ) {
                     return true;
                 }

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -70,13 +70,13 @@ EOT
 
             $prevIndex = $tokens->getPrevMeaningfulToken($index);
             $prevToken = $tokens[$prevIndex];
-            if (!$prevToken->equals('$') && !$prevToken->isGivenKind(T_OBJECT_OPERATOR)) {
+            if (!$prevToken->equals('$') && !$prevToken->isObjectOperator()) {
                 continue;
             }
 
             $openingBrace = CT::T_DYNAMIC_VAR_BRACE_OPEN;
             $closingBrace = CT::T_DYNAMIC_VAR_BRACE_CLOSE;
-            if ($prevToken->isGivenKind(T_OBJECT_OPERATOR)) {
+            if ($prevToken->isObjectOperator()) {
                 $openingBrace = CT::T_DYNAMIC_PROP_BRACE_OPEN;
                 $closingBrace = CT::T_DYNAMIC_PROP_BRACE_CLOSE;
             }

--- a/src/Fixer/Operator/IncrementStyleFixer.php
+++ b/src/Fixer/Operator/IncrementStyleFixer.php
@@ -161,7 +161,7 @@ final class IncrementStyleFixer extends AbstractIncrementOperatorFixer implement
             $nextToken = $tokens[$nextIndex];
         }
 
-        if ($nextToken->isGivenKind(T_OBJECT_OPERATOR)) {
+        if ($nextToken->isObjectOperator()) {
             return $this->findEnd($tokens, $nextIndex);
         }
 

--- a/src/Fixer/Operator/NewWithBracesFixer.php
+++ b/src/Fixer/Operator/NewWithBracesFixer.php
@@ -133,7 +133,7 @@ final class NewWithBracesFixer extends AbstractFixer
             }
 
             // new statement with () - nothing to do
-            if ($nextToken->equals('(') || $nextToken->isGivenKind(T_OBJECT_OPERATOR)) {
+            if ($nextToken->equals('(') || $nextToken->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
+++ b/src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Fixer\Operator;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -29,7 +30,7 @@ final class ObjectOperatorWithoutWhitespaceFixer extends AbstractFixer
     public function getDefinition()
     {
         return new FixerDefinition(
-            'There should not be space before or after object `T_OBJECT_OPERATOR` `->`.',
+            'There should not be space before or after object operators `->` and `?->`.',
             [new CodeSample("<?php \$a  ->  b;\n")]
         );
     }
@@ -39,7 +40,7 @@ final class ObjectOperatorWithoutWhitespaceFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_OBJECT_OPERATOR);
+        return $tokens->isAnyTokenKindsFound(Token::getObjectOperatorKinds());
     }
 
     /**
@@ -47,9 +48,9 @@ final class ObjectOperatorWithoutWhitespaceFixer extends AbstractFixer
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        // [Structure] there should not be space before or after T_OBJECT_OPERATOR
+        // [Structure] there should not be space before or after "->" or "?->"
         foreach ($tokens as $index => $token) {
-            if (!$token->isGivenKind(T_OBJECT_OPERATOR)) {
+            if (!$token->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/Operator/OperatorLinebreakFixer.php
+++ b/src/Fixer/Operator/OperatorLinebreakFixer.php
@@ -37,11 +37,6 @@ final class OperatorLinebreakFixer extends AbstractFixer implements Configuratio
     const BOOLEAN_OPERATORS = [[T_BOOLEAN_AND], [T_BOOLEAN_OR], [T_LOGICAL_AND], [T_LOGICAL_OR], [T_LOGICAL_XOR]];
 
     /**
-     * @internal
-     */
-    const NON_BOOLEAN_OPERATORS = ['%', '&', '*', '+', '-', '.', '/', ':', '<', '=', '>', '?', '^', '|', [T_AND_EQUAL], [T_CONCAT_EQUAL], [T_DIV_EQUAL], [T_DOUBLE_ARROW], [T_IS_EQUAL], [T_IS_GREATER_OR_EQUAL], [T_IS_IDENTICAL], [T_IS_NOT_EQUAL], [T_IS_NOT_IDENTICAL], [T_IS_SMALLER_OR_EQUAL], [T_MINUS_EQUAL], [T_MOD_EQUAL], [T_MUL_EQUAL], [T_OBJECT_OPERATOR], [T_OR_EQUAL], [T_PAAMAYIM_NEKUDOTAYIM], [T_PLUS_EQUAL], [T_POW], [T_POW_EQUAL], [T_SL], [T_SL_EQUAL], [T_SR], [T_SR_EQUAL], [T_XOR_EQUAL]];
-
-    /**
      * @var string
      */
     private $position = 'beginning';
@@ -87,7 +82,7 @@ function foo() {
 
         $this->operators = self::BOOLEAN_OPERATORS;
         if (!$this->configuration['only_booleans']) {
-            $this->operators = array_merge($this->operators, self::NON_BOOLEAN_OPERATORS);
+            $this->operators = array_merge($this->operators, self::getNonBooleanOperators());
             if (\PHP_VERSION_ID >= 70000) {
                 $this->operators[] = [T_COALESCE];
                 $this->operators[] = [T_SPACESHIP];
@@ -316,5 +311,19 @@ function foo() {
         }
 
         return false;
+    }
+
+    private static function getNonBooleanOperators()
+    {
+        return array_merge(
+            [
+                '%', '&', '*', '+', '-', '.', '/', ':', '<', '=', '>', '?', '^', '|',
+                [T_AND_EQUAL], [T_CONCAT_EQUAL], [T_DIV_EQUAL], [T_DOUBLE_ARROW], [T_IS_EQUAL], [T_IS_GREATER_OR_EQUAL],
+                [T_IS_IDENTICAL], [T_IS_NOT_EQUAL], [T_IS_NOT_IDENTICAL], [T_IS_SMALLER_OR_EQUAL], [T_MINUS_EQUAL],
+                [T_MOD_EQUAL], [T_MUL_EQUAL], [T_OR_EQUAL], [T_PAAMAYIM_NEKUDOTAYIM], [T_PLUS_EQUAL], [T_POW],
+                [T_POW_EQUAL], [T_SL], [T_SL_EQUAL], [T_SR], [T_SR_EQUAL], [T_XOR_EQUAL],
+            ],
+            array_map(function ($id) { return [$id]; }, Token::getObjectOperatorKinds())
+        );
     }
 }

--- a/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
@@ -181,11 +181,23 @@ final class MyTest extends \PHPUnit_Framework_TestCase
      */
     protected function applyPhpUnitClassFix(Tokens $tokens, $startIndex, $endIndex)
     {
+        foreach (Token::getObjectOperatorKinds() as $objectOperator) {
+            $this->applyPhpUnitClassFixWithObjectOperator($tokens, $startIndex, $endIndex, $objectOperator);
+        }
+    }
+
+    /**
+     * @param int $startIndex
+     * @param int $endIndex
+     * @param int $objectOperator
+     */
+    private function applyPhpUnitClassFixWithObjectOperator(Tokens $tokens, $startIndex, $endIndex, $objectOperator)
+    {
         $argumentsAnalyzer = new ArgumentsAnalyzer();
 
         $oldMethodSequence = [
-            new Token([T_VARIABLE, '$this']),
-            new Token([T_OBJECT_OPERATOR, '->']),
+            [T_VARIABLE, '$this'],
+            [$objectOperator],
             [T_STRING],
         ];
 

--- a/src/Fixer/PhpUnit/PhpUnitMockFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMockFixer.php
@@ -99,7 +99,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
         $argumentsAnalyzer = new ArgumentsAnalyzer();
 
         for ($index = $startIndex; $index < $endIndex; ++$index) {
-            if (!$tokens[$index]->isGivenKind(T_OBJECT_OPERATOR)) {
+            if (!$tokens[$index]->isObjectOperator()) {
                 continue;
             }
 

--- a/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
@@ -237,8 +237,8 @@ function foo () {
             return null;
         }
 
-        // -> or ::
-        if (!$tokens[--$index]->isGivenKind([T_OBJECT_OPERATOR, T_DOUBLE_COLON])) {
+        // ->, ?-> or ::
+        if (!$tokens[--$index]->isObjectOperator() && !$tokens[$index]->isGivenKind(T_DOUBLE_COLON)) {
             return null;
         }
 

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -53,7 +53,7 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isTokenKindFound(T_OBJECT_OPERATOR);
+        return $tokens->isAnyTokenKindsFound(Token::getObjectOperatorKinds());
     }
 
     /**
@@ -64,7 +64,7 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
         $lineEnding = $this->whitespacesConfig->getLineEnding();
 
         for ($index = 1, $count = \count($tokens); $index < $count; ++$index) {
-            if (!$tokens[$index]->isGivenKind(T_OBJECT_OPERATOR)) {
+            if (!$tokens[$index]->isObjectOperator()) {
                 continue;
             }
 
@@ -121,7 +121,7 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
     }
 
     /**
-     * @param int $index position of the T_OBJECT_OPERATOR token
+     * @param int $index position of the object operator token ("->" or "?->")
      *
      * @return bool
      */
@@ -186,7 +186,7 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
      */
     private function currentLineRequiresExtraIndentLevel(Tokens $tokens, $start, $end)
     {
-        if ($tokens[$start + 1]->isGivenKind(T_OBJECT_OPERATOR)) {
+        if ($tokens[$start + 1]->isObjectOperator()) {
             return false;
         }
 

--- a/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
@@ -56,7 +56,7 @@ final class FunctionsAnalyzer
             $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
         }
 
-        $possibleKind = [T_DOUBLE_COLON, T_FUNCTION, CT::T_NAMESPACE_OPERATOR, T_NEW, T_OBJECT_OPERATOR, CT::T_RETURN_REF, T_STRING];
+        $possibleKind = array_merge([T_DOUBLE_COLON, T_FUNCTION, CT::T_NAMESPACE_OPERATOR, T_NEW, CT::T_RETURN_REF, T_STRING], Token::getObjectOperatorKinds());
 
         // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_ATTRIBUTE')) {
@@ -203,9 +203,9 @@ final class FunctionsAnalyzer
             return false;
         }
 
-        return $tokens[$operatorIndex]->equals([T_OBJECT_OPERATOR, '->']) && $tokens[$referenceIndex]->equals([T_VARIABLE, '$this'], false)
-            || $tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STRING, 'self'], false)
-            || $tokens[$operatorIndex]->equals([T_DOUBLE_COLON, '::']) && $tokens[$referenceIndex]->equals([T_STATIC, 'static'], false);
+        return $tokens[$operatorIndex]->isObjectOperator() && $tokens[$referenceIndex]->equals([T_VARIABLE, '$this'], false)
+            || $tokens[$operatorIndex]->isGivenKind(T_DOUBLE_COLON) && $tokens[$referenceIndex]->equals([T_STRING, 'self'], false)
+            || $tokens[$operatorIndex]->isGivenKind(T_DOUBLE_COLON) && $tokens[$referenceIndex]->equals([T_STATIC, 'static'], false);
     }
 
     private function buildFunctionsAnalysis(Tokens $tokens)

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -115,6 +115,25 @@ class Token
     }
 
     /**
+     * Get object operator tokens kinds: T_OBJECT_OPERATOR and (if available) T_NULLSAFE_OBJECT_OPERATOR.
+     *
+     * @return int[]
+     */
+    public static function getObjectOperatorKinds()
+    {
+        static $objectOperators = null;
+
+        if (null === $objectOperators) {
+            $objectOperators = [T_OBJECT_OPERATOR];
+            if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+                $objectOperators[] = T_NULLSAFE_OBJECT_OPERATOR;
+            }
+        }
+
+        return $objectOperators;
+    }
+
+    /**
      * Clear token at given index.
      *
      * Clearing means override token by empty string.
@@ -422,6 +441,16 @@ class Token
         static $commentTokens = [T_COMMENT, T_DOC_COMMENT];
 
         return $this->isGivenKind($commentTokens);
+    }
+
+    /**
+     * Check if token is one of object operator tokens: T_OBJECT_OPERATOR or T_NULLSAFE_OBJECT_OPERATOR.
+     *
+     * @return bool
+     */
+    public function isObjectOperator()
+    {
+        return $this->isGivenKind(self::getObjectOperatorKinds());
     }
 
     /**

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -326,7 +326,7 @@ final class TokensAnalyzer
 
         $prevIndex = $this->tokens->getPrevMeaningfulToken($index);
 
-        if ($this->tokens[$prevIndex]->isGivenKind([T_AS, T_CLASS, T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_GOTO, CT::T_GROUP_IMPORT_BRACE_OPEN, T_INTERFACE, T_OBJECT_OPERATOR, T_TRAIT, CT::T_TYPE_COLON])) {
+        if ($this->tokens[$prevIndex]->isGivenKind([T_AS, T_CLASS, T_CONST, T_DOUBLE_COLON, T_FUNCTION, T_GOTO, CT::T_GROUP_IMPORT_BRACE_OPEN, T_INTERFACE, T_TRAIT, CT::T_TYPE_COLON]) || $this->tokens[$prevIndex]->isObjectOperator()) {
             return false;
         }
 

--- a/src/Tokenizer/Transformer/CurlyBraceTransformer.php
+++ b/src/Tokenizer/Transformer/CurlyBraceTransformer.php
@@ -122,7 +122,7 @@ final class CurlyBraceTransformer extends AbstractTransformer
 
     private function transformIntoDynamicPropBraces(Tokens $tokens, Token $token, $index)
     {
-        if (!$token->isGivenKind(T_OBJECT_OPERATOR)) {
+        if (!$token->isObjectOperator()) {
             return;
         }
 
@@ -181,7 +181,7 @@ final class CurlyBraceTransformer extends AbstractTransformer
 
         if (
             $tokens[$prevIndex]->isGivenKind(T_STRING)
-            && !$tokens[$tokens->getPrevMeaningfulToken($prevIndex)]->isGivenKind(T_OBJECT_OPERATOR)
+            && !$tokens[$tokens->getPrevMeaningfulToken($prevIndex)]->isObjectOperator()
         ) {
             return;
         }

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -255,5 +255,11 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
                 '<?php array_push($a5{1*3}[2+1], $b7{2+1});',
             ];
         }
+
+        if (\PHP_VERSION_ID >= 80000) {
+            yield [
+                '<?php array_push($b?->c[2], $b19);',
+            ];
+        }
     }
 }

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -314,4 +314,26 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @requires PHP 8.0
+     * @dataProvider provideFix80Cases
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases()
+    {
+        return [
+            [
+                '<?php echo $a[2^3+1]?->test(1,2)** $b[2+$c];',
+                '<?php echo pow($a[2^3+1]?->test(1,2), $b[2+$c]);',
+            ],
+        ];
+    }
 }

--- a/tests/Fixer/Casing/ConstantCaseFixerTest.php
+++ b/tests/Fixer/Casing/ConstantCaseFixerTest.php
@@ -197,4 +197,23 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string      $expected
+     * @param null|string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input = null)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases()
+    {
+        return [
+            ['<?php class Foo { public function Bar() { return $this?->False; } }'],
+        ];
+    }
 }

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -217,4 +217,12 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest('<?php $foo?->Self();');
+    }
 }

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -355,4 +355,15 @@ function __Tostring() {}',
             '<?php $foo->__INVOKE(1, );'
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php $foo?->__invoke(1, );',
+            '<?php $foo?->__INVOKE(1, );'
+        );
+    }
 }

--- a/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
@@ -188,4 +188,12 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest('<?php $a?->STRTOLOWER(1,);');
+    }
 }

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -1174,5 +1174,95 @@ class Foo
 }
 EOF
         ];
+
+        yield [
+            '<?php
+class Foo
+{
+    public function __construct()
+    {
+    }
+}',
+            '<?php
+class Foo
+{
+    public function Foo()
+    {
+    }
+}',
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    public function __construct()
+    {
+        $this?->__construct();
+    }
+}',
+            '<?php
+class Foo
+{
+    public function Foo()
+    {
+        $this?->__construct();
+    }
+}',
+        ];
+
+        yield [
+            '<?php
+class Foo extends Bar
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}',
+            '<?php
+class Foo extends Bar
+{
+    public function Foo()
+    {
+        $this?->Bar();
+    }
+}',
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    /**
+     * Constructor
+     */
+    public function __construct($bar = 1, $baz = null)
+    {
+        var_dump(1);
+    }
+}
+',
+            '<?php
+class Foo
+{
+    /**
+     * Constructor
+     */
+    public function __construct($bar = 1, $baz = null)
+    {
+        var_dump(1);
+    }
+
+    /**
+     * PHP-4 Constructor
+     */
+    function Foo($bar = 1, $baz = null)
+    {
+        $this?->__construct($bar, $baz);
+    }
+}
+',
+        ];
     }
 }

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -228,5 +228,9 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
         yield [
             '<?php class Foo { function bar() { $x instanceof (Foo()); } }',
         ];
+
+        yield [
+            '<?php class Foo { protected $foo; function bar() { return $this?->foo::find(2); } }',
+        ];
     }
 }

--- a/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
+++ b/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
@@ -171,4 +171,21 @@ final class DateTimeImmutableFixerTest extends AbstractFixerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected)
+    {
+        $this->doTest($expected);
+    }
+
+    public function provideFix80Cases()
+    {
+        yield ['<?php $foo?->DateTime();'];
+        yield ['<?php $foo?->date_create();'];
+    }
 }

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -1038,14 +1038,15 @@ while (2 !== $b = array_pop($c));
     }
 
     /**
-     * @param string $expected
-     * @param string $input
+     * @param string      $expected
+     * @param null|string $input
      *
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
      */
-    public function testFix80($expected, $input)
+    public function testFix80($expected, $input = null, array $config = [])
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
@@ -1060,6 +1061,23 @@ if ($a = true === $obj instanceof (foo())) {
 if ($a = $obj instanceof (foo()) === true) {
     echo 1;
 }',
+        ];
+
+        yield [
+            '<?php $i = $this?->getStuff() === $myVariable;',
+            '<?php $i = $myVariable === $this?->getStuff();',
+            ['equal' => true, 'identical' => true, 'always_move_variable' => true],
+        ];
+
+        yield [
+            '<?php 42 === $a->b[5]?->c;',
+            '<?php $a->b[5]?->c === 42;',
+        ];
+
+        yield [
+            '<?php return $this->myObject1?->{$index}+$b === "";',
+            //null,
+            //['equal' => true, 'identical' => true]
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -660,4 +660,12 @@ class Foo {}
             ['strict' => true]
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFixWithNullSafeObjectOperator()
+    {
+        $this->doTest('<?php $x?->count();');
+    }
 }

--- a/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
+++ b/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
@@ -243,5 +243,16 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
 1
 );",
         ];
+
+        if (\PHP_VERSION_ID >= 80000) {
+            yield [
+                '<?php throw $this?->getExceptionFactory()?->createAnException("Foo");',
+                '<?php throw $this
+                    ?->getExceptionFactory()
+                    ?->createAnException(
+                    "Foo"
+                );',
+            ];
+        }
     }
 }

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1182,4 +1182,26 @@ use /**/A\B/**/;
 '
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php
+
+
+$x = $foo?->bar;
+$y = foo?->bar();
+',
+            '<?php
+
+use Foo\Bar;
+
+$x = $foo?->bar;
+$y = foo?->bar();
+'
+        );
+    }
 }

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -70,4 +70,30 @@ $foo
             ],
         ];
     }
+
+    /**
+     * @param mixed $expected
+     * @param mixed $input
+     *
+     * @dataProvider provideTestFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideTestFix80Cases()
+    {
+        return [
+            [
+                '<?php echo $foo?->{$bar}["baz"];',
+                '<?php echo $foo?->$bar["baz"];',
+            ],
+            [
+                '<?php echo $foo?->{$bar}["baz"]();',
+                '<?php echo $foo?->$bar["baz"]();',
+            ],
+        ];
+    }
 }

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -360,5 +360,12 @@ $foo = "B";
 
 $a = new ($foo."ar");',
         ];
+
+        yield [
+            '<?php
+                    $bar1 = new $foo[0]?->bar();
+                    $bar2 = new $foo[0][1]?->bar();
+                ',
+        ];
     }
 }

--- a/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
+++ b/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
@@ -78,4 +78,29 @@ final class ObjectOperatorWithoutWhitespaceFixerTest extends AbstractFixerTestCa
             ],
         ];
     }
+
+    /**
+     * @param string $expected
+     * @param string $input
+     *
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80($expected, $input)
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix80Cases()
+    {
+        yield [
+            '<?php $object?->method();',
+            '<?php $object?->   method();',
+        ];
+
+        yield [
+            '<?php $object?->method();',
+            '<?php $object   ?->   method();',
+        ];
+    }
 }

--- a/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
+++ b/tests/Fixer/Operator/OperatorLinebreakFixerTest.php
@@ -481,7 +481,7 @@ switch ($foo) {
             ',
         ];
 
-        $operator = [
+        $operators = [
             '+', '-', '*', '/', '%', '**', // Arithmetic
             '+=', '-=', '*=', '/=', '%=', '**=', // Arithmetic assignment
             '=', // Assignment
@@ -495,11 +495,15 @@ switch ($foo) {
         ];
 
         if (\PHP_VERSION_ID >= 70000) {
-            $operator[] = '??';
-            $operator[] = '<=>';
+            $operators[] = '??';
+            $operators[] = '<=>';
         }
 
-        foreach ($operator as $operator) {
+        if (\PHP_VERSION_ID >= 80000) {
+            $operators[] = '?->';
+        }
+
+        foreach ($operators as $operator) {
             yield sprintf('handle %s operator', $operator) => [
                 sprintf('<?php
                     $foo

--- a/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitExpectationFixerTest.php
@@ -469,4 +469,35 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        function testFnc()
+        {
+            aaa();
+            $this?->expectException("RuntimeException");
+            $this->expectExceptionMessage("message");
+            $this->expectExceptionCode(123);
+            zzz();
+        }
+    }',
+            '<?php
+    final class MyTest extends \PHPUnit_Framework_TestCase
+    {
+        function testFnc()
+        {
+            aaa();
+            $this?->setExpectedException("RuntimeException", "message", 123);
+            zzz();
+        }
+    }'
+        );
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockFixerTest.php
@@ -149,4 +149,29 @@ final class PhpUnitMockFixerTest extends AbstractFixerTestCase
     }'
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php
+    class FooTest extends TestCase
+    {
+        public function testFoo()
+        {
+            $this?->createMock("Foo");
+        }
+    }',
+            '<?php
+    class FooTest extends TestCase
+    {
+        public function testFoo()
+        {
+            $this?->getMock("Foo");
+        }
+    }'
+        );
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixerTest.php
@@ -276,4 +276,25 @@ class FooTest extends TestCase {
 }'
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php
+class FooTest extends TestCase {
+    public function testFoo() {
+        $someMock?->method("someMethod")?->willReturn(10);
+    }
+}',
+            '<?php
+class FooTest extends TestCase {
+    public function testFoo() {
+        $someMock?->method("someMethod")?->will($this?->returnValue(10));
+    }
+}'
+        );
+    }
 }

--- a/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
+++ b/tests/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixerTest.php
@@ -906,4 +906,27 @@ Service
             ],
         ];
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->fixer->configure(['strategy' => MultilineWhitespaceBeforeSemicolonsFixer::STRATEGY_NEW_LINE_FOR_CHAINED_CALLS]);
+        $this->doTest(
+            '<?php
+
+                $foo?->method1()
+                    ?->method2()
+                    ?->method3()
+                ;
+                ',
+            '<?php
+
+                $foo?->method1()
+                    ?->method2()
+                    ?->method3();
+                '
+        );
+    }
 }

--- a/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
@@ -284,4 +284,28 @@ $foo
 '
         );
     }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testFix80()
+    {
+        $this->doTest(
+            '<?php
+
+    $user?->setEmail("voff.web@gmail.com")
+        ?->setPassword("233434")
+        ?->setEmailConfirmed(false)
+        ?->setEmailConfirmationCode("123456");
+',
+            '<?php
+
+    $user?->setEmail("voff.web@gmail.com")
+
+     ?->setPassword("233434")
+        ?->setEmailConfirmed(false)
+?->setEmailConfirmationCode("123456");
+'
+        );
+    }
 }

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -385,6 +385,11 @@ class Foo {}
 ',
             3,
         ];
+        yield [
+            false,
+            '<?php $x?->count();',
+            3,
+        ];
     }
 
     /**
@@ -773,6 +778,14 @@ class Foo {}
             sprintf($template, 'Bar::'),
             24,
         ];
+
+        if (\PHP_VERSION_ID >= 80000) {
+            yield [
+                true,
+                sprintf($template, '$this?->'),
+                24,
+            ];
+        }
     }
 
     /**

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -158,6 +158,35 @@ final class TokenTest extends TestCase
     }
 
     /**
+     * @param bool $isObjectOperator
+     *
+     * @dataProvider provideIsObjectOperatorCases
+     */
+    public function testIsObjectOperator(Token $token, $isObjectOperator)
+    {
+        static::assertSame($isObjectOperator, $token->isObjectOperator());
+    }
+
+    public function provideIsObjectOperatorCases()
+    {
+        $tests = [
+            [$this->getBraceToken(), false],
+            [$this->getForeachToken(), false],
+            [new Token([T_COMMENT, '/* comment */']), false],
+            [new Token([T_DOUBLE_COLON, '::']), false],
+            [new Token([T_OBJECT_OPERATOR, '->']), true],
+        ];
+
+        foreach ($tests as $index => $test) {
+            yield $index => $test;
+        }
+
+        if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+            yield [new Token([T_NULLSAFE_OBJECT_OPERATOR, '?->']), true];
+        }
+    }
+
+    /**
      * @group legacy
      * @expectedDeprecation PhpCsFixer\Tokenizer\Token::isEmpty is deprecated and will be removed in 3.0.
      */

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -1022,6 +1022,23 @@ $a(1,2);',
     }
 
     /**
+     * @requires PHP 8.0
+     */
+    public function testIsConstantInvocationForNullSafeObjectOperator()
+    {
+        $tokens = Tokens::fromCode('<?php $a?->b?->c;');
+
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_STRING)) {
+                continue;
+            }
+            static::assertFalse($tokensAnalyzer->isConstantInvocation($index));
+        }
+    }
+
+    /**
      * @param string $source
      *
      * @dataProvider provideIsUnarySuccessorOperatorCases

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -214,4 +214,45 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
             ],
         ];
     }
+
+    /**
+     * @param string $source
+     *
+     * @dataProvider provideProcess80Cases
+     * @requires PHP 8.0
+     */
+    public function testProcess80($source, array $expectedTokens = [])
+    {
+        $this->doTest(
+            $source,
+            $expectedTokens,
+            [
+                T_CURLY_OPEN,
+                CT::T_CURLY_CLOSE,
+                T_DOLLAR_OPEN_CURLY_BRACES,
+                CT::T_DOLLAR_CLOSE_CURLY_BRACES,
+                CT::T_DYNAMIC_PROP_BRACE_OPEN,
+                CT::T_DYNAMIC_PROP_BRACE_CLOSE,
+                CT::T_DYNAMIC_VAR_BRACE_OPEN,
+                CT::T_DYNAMIC_VAR_BRACE_CLOSE,
+                CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN,
+                CT::T_ARRAY_INDEX_CURLY_BRACE_CLOSE,
+                CT::T_GROUP_IMPORT_BRACE_OPEN,
+                CT::T_GROUP_IMPORT_BRACE_CLOSE,
+            ]
+        );
+    }
+
+    public static function provideProcess80Cases()
+    {
+        return [
+            'dynamic property brace open/close' => [
+                '<?php $foo?->{$bar};',
+                [
+                    3 => CT::T_DYNAMIC_PROP_BRACE_OPEN,
+                    5 => CT::T_DYNAMIC_PROP_BRACE_CLOSE,
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
The difference where you can use `T_OBJECT_OPERATOR`, but cannot `T_NULLSAFE_OBJECT_OPERATOR` is write context (see: https://3v4l.org/PJZJo).

Current list of files having `T_OBJECT_OPERATOR`:
```
$ git grep -l T_OBJECT_OPERATOR
src/Fixer/Alias/ArrayPushFixer.php // `T_OBJECT_OPERATOR` always used in write context
src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php // `T_OBJECT_OPERATOR` always used in write context
src/Fixer/PhpUnit/PhpUnitExpectationFixer.php // `T_OBJECT_OPERATOR` used to create token
src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php // `T_OBJECT_OPERATOR` used to create token
src/Tokenizer/Token.php // This is actually handling pair of `T_OBJECT_OPERATOR` and `T_NULLSAFE_OBJECT_OPERATOR`
tests/Test/AbstractFixerTestCase.php // Used to search through our codebase
tests/Tokenizer/TokenTest.php
```

Initial list of files having `T_OBJECT_OPERATOR` (there was no single occurrence of `T_NULLSAFE_OBJECT_OPERATOR`):
```
$ git grep -l T_OBJECT_OPERATOR
doc/rules/index.rst
doc/rules/operator/object_operator_without_whitespace.rst
src/Fixer/AbstractIncrementOperatorFixer.php
src/Fixer/Alias/ArrayPushFixer.php
src/Fixer/Alias/PowToExponentiationFixer.php
src/Fixer/Casing/ConstantCaseFixer.php
src/Fixer/Casing/LowercaseStaticReferenceFixer.php
src/Fixer/Casing/MagicMethodCasingFixer.php
src/Fixer/Casing/NativeFunctionCasingFixer.php
src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
src/Fixer/ClassNotation/SelfAccessorFixer.php
src/Fixer/ClassUsage/DateTimeImmutableFixer.php
src/Fixer/ControlStructure/YodaStyleFixer.php
src/Fixer/FunctionNotation/SingleLineThrowFixer.php
src/Fixer/Import/NoUnusedImportsFixer.php
src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php
src/Fixer/Operator/IncrementStyleFixer.php
src/Fixer/Operator/NewWithBracesFixer.php
src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php
src/Fixer/Operator/OperatorLinebreakFixer.php
src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
src/Fixer/PhpUnit/PhpUnitMockFixer.php
src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php
src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php
src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php
src/Fixer/Whitespace/MethodChainingIndentationFixer.php
src/Tokenizer/Analyzer/FunctionsAnalyzer.php
src/Tokenizer/Token.php
src/Tokenizer/TokensAnalyzer.php
src/Tokenizer/Transformer/CurlyBraceTransformer.php
tests/Test/AbstractFixerTestCase.php
tests/Tokenizer/TokenTest.php
```

Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5584