### PR TITLE
SingleLineThrowFixer - fix handling anonymous classes

### DIFF
--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -126,7 +126,7 @@ class Foo
      * {@inheritdoc}
      *
      * Must run before ArrayIndentationFixer, MethodArgumentSpaceFixer, MethodChainingIndentationFixer.
-     * Must run after ClassAttributesSeparationFixer, ClassDefinitionFixer, ElseifFixer, LineEndingFixer, MethodSeparationFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleSpaceAfterConstructFixer, SingleTraitInsertPerStatementFixer.
+     * Must run after ClassAttributesSeparationFixer, ClassDefinitionFixer, ElseifFixer, LineEndingFixer, MethodSeparationFixer, NoAlternativeSyntaxFixer, NoEmptyStatementFixer, NoUselessElseFixer, SingleLineThrowFixer, SingleSpaceAfterConstructFixer, SingleTraitInsertPerStatementFixer.
      */
     public function getPriority()
     {

--- a/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
+++ b/src/Fixer/FunctionNotation/SingleLineThrowFixer.php
@@ -63,12 +63,12 @@ final class SingleLineThrowFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run before ConcatSpaceFixer.
+     * Must run before BracesFixer, ConcatSpaceFixer.
      */
     public function getPriority()
     {
         // must be fun before ConcatSpaceFixer
-        return 1;
+        return 36;
     }
 
     /**
@@ -81,18 +81,15 @@ final class SingleLineThrowFixer extends AbstractFixer
                 continue;
             }
 
-            /** @var int $openingBraceCandidateIndex */
-            $openingBraceCandidateIndex = $tokens->getNextTokenOfKind($index, [';', '(']);
+            /** @var int $endCandidateIndex */
+            $endCandidateIndex = $tokens->getNextTokenOfKind($index, [';', '(', '{']);
 
-            while ($tokens[$openingBraceCandidateIndex]->equals('(')) {
-                /** @var int $closingBraceIndex */
-                $closingBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openingBraceCandidateIndex);
-
-                /** @var int $openingBraceCandidateIndex */
-                $openingBraceCandidateIndex = $tokens->getNextTokenOfKind($closingBraceIndex, [';', '(']);
+            while ($tokens[$endCandidateIndex]->equals('(')) {
+                $closingBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $endCandidateIndex);
+                $endCandidateIndex = $tokens->getNextTokenOfKind($closingBraceIndex, [';', '(', '{']);
             }
 
-            $this->trimNewLines($tokens, $index, $openingBraceCandidateIndex);
+            $this->trimNewLines($tokens, $index, $endCandidateIndex);
         }
     }
 

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -266,6 +266,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['single_import_per_statement'], $fixers['no_singleline_whitespace_before_semicolons']],
             [$fixers['single_import_per_statement'], $fixers['no_unused_imports']],
             [$fixers['single_import_per_statement'], $fixers['space_after_semicolon']],
+            [$fixers['single_line_throw'], $fixers['braces']],
             [$fixers['single_line_throw'], $fixers['concat_space']],
             [$fixers['single_space_after_construct'], $fixers['braces']],
             [$fixers['single_space_after_construct'], $fixers['function_declaration']],

--- a/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
+++ b/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
@@ -46,20 +46,20 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
                     "Foo"
                 );'];
 
-        yield ['<?php throw new Exception("Foo", 0);'];
+        yield ['<?php throw new Exception("Foo.", 0);'];
 
         yield [
-            '<?php throw new Exception("Foo", 0);',
+            '<?php throw new Exception("Foo.", 0);',
             '<?php throw new Exception(
-                "Foo",
+                "Foo.",
                 0
             );',
         ];
 
         yield [
-            '<?php throw new Exception("Foo" . "Bar");',
+            '<?php throw new Exception("Foo." . "Bar");',
             '<?php throw new Exception(
-                "Foo"
+                "Foo."
                 .
                 "Bar"
             );',
@@ -75,24 +75,24 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php throw new Exception(sprintf("Error with number %s", 42));',
+            '<?php throw new Exception(sprintf(\'Error with number "%s".\', 42));',
             '<?php throw new Exception(sprintf(
-                "Error with number %s",
+                \'Error with number "%s".\',
                 42
             ));',
         ];
 
         yield [
-            '<?php throw new SomeVendor\\Exception("Foo");',
+            '<?php throw new SomeVendor\\Exception("Foo.");',
             '<?php throw new SomeVendor\\Exception(
-                "Foo"
+                "Foo."
             );',
         ];
 
         yield [
-            '<?php throw new \SomeVendor\\Exception("Foo");',
+            '<?php throw new \SomeVendor\\Exception("Foo.");',
             '<?php throw new \SomeVendor\\Exception(
-                "Foo"
+                "Foo."
             );',
         ];
 
@@ -141,21 +141,21 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php throw new Exception("Foo", 0);',
+            '<?php throw new Exception("Foo.", 0);',
             '<?php throw
                 new
                     Exception
                         (
-                            "Foo"
+                            "Foo."
                                 ,
                             0
                         );',
         ];
 
         yield [
-            '<?php throw new $exceptionName("Foo");',
+            '<?php throw new $exceptionName("Foo.");',
             '<?php throw new $exceptionName(
-                "Foo"
+                "Foo."
             );',
         ];
 
@@ -167,15 +167,15 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            '<?php throw clone $exceptionName("Foo");',
+            '<?php throw clone $exceptionName("Foo.");',
             '<?php throw clone $exceptionName(
-                "Foo"
+                "Foo."
             );',
         ];
 
         yield [
-            '<?php throw new WeirdException("Foo", -20, "An elephant", 1, 2, 3, 4, 5, 6, 7, 8);',
-            '<?php throw new WeirdException("Foo", -20, "An elephant",
+            '<?php throw new WeirdException("Foo.", -20, "An elephant", 1, 2, 3, 4, 5, 6, 7, 8);',
+            '<?php throw new WeirdException("Foo.", -20, "An elephant",
 
                 1,
         2,
@@ -186,20 +186,20 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         yield [
             '<?php
                 if ($foo) {
-                    throw new Exception("It is foo", 1);
+                    throw new Exception("It is foo.", 1);
                 } else {
-                    throw new \Exception("It is not foo", 0);
+                    throw new \Exception("It is not foo.", 0);
                 }
             ',
             '<?php
                 if ($foo) {
                     throw new Exception(
-                        "It is foo",
+                        "It is foo.",
                         1
                     );
                 } else {
                     throw new \Exception(
-                        "It is not foo", 0
+                        "It is not foo.", 0
                     );
                 }
             ',
@@ -238,11 +238,41 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
-            "<?php throw new Exception('a'. 1);",
-            "<?php throw new Exception('a'.
+            "<?php throw new Exception('Message.'. 1);",
+            "<?php throw new Exception('Message.'.
 1
 );",
         ];
+
+        if (\PHP_VERSION_ID >= 70000) {
+            yield [
+                '<?php throw new class() extends Exception {
+                    protected $message = "Custom message";
+                }
+            ;',
+                '<?php throw
+                new class()
+                extends Exception
+                {
+                    protected $message = "Custom message";
+                }
+            ;',
+            ];
+
+            yield [
+                '<?php throw new class extends Exception {
+                    protected $message = "Custom message";
+                }
+            ;',
+                '<?php throw
+                new class
+                extends Exception
+                {
+                    protected $message = "Custom message";
+                }
+            ;',
+            ];
+        }
 
         if (\PHP_VERSION_ID >= 80000) {
             yield [

--- a/tests/Fixtures/Integration/priority/single_line_throw,braces.test
+++ b/tests/Fixtures/Integration/priority/single_line_throw,braces.test
@@ -1,0 +1,20 @@
+--TEST--
+Integration of fixers: single_line_throw,braces.
+--RULESET--
+{"braces": true, "single_line_throw": true}
+--REQUIREMENTS--
+{"php": 70000}
+--EXPECT--
+<?php
+throw new class() extends Exception {
+    protected $message = "Custom message";
+};
+
+--INPUT--
+<?php
+throw
+    new class()
+        extends Exception
+        {
+            protected $message = "Custom message";
+        };


### PR DESCRIPTION
Is this a right solution or `SingleLineThrowFixer` should not remove new lines from anonymous class definition?

Ping @nicolas-grekas for an opinion (as you are the person who originally [requested](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3988) this fixer).