### PR TITLE
Add failing test for TernaryToElvisOperatorFixer

### DIFF
--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -498,4 +498,25 @@ EOT
             ],
         ];
     }
+
+    /**
+     * @param string $input
+     *
+     * @dataProvider provideDoNotFix80Cases
+     * @requires PHP 8.0
+     */
+    public function test80DoNotFix($input)
+    {
+        $this->doTest($input);
+    }
+
+    public function provideDoNotFix80Cases()
+    {
+        return [
+            ['<?php
+
+function test(#[TestAttribute] ?User $user) {}
+'],
+        ];
+    }
 }


### PR DESCRIPTION
Original bug report: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5533#issuecomment-813569382

I don't know how to fix this, but I've created a test that reproduces the #5533 issue. It does not fail, but times out and is marked as risky:

```
There was 1 risky test:

1) PhpCsFixer\Tests\Fixer\Operator\TernaryToElvisOperatorFixerTest::test80DoNotFix with data set #0 ('<?php\n\nfunction test(#[Test...) {}\n')
Execution aborted after 10 seconds
```