### PR TITLE
Don't fail on passing diff-format option. Just ignore it.

### DIFF
--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -112,6 +112,7 @@ final class FixCommand extends Command
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
                     new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
                     new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, dots).'),
+                    new InputOption('diff-format', '', InputOption::VALUE_OPTIONAL, 'Ignored option. Always equals to "udiff".'),
                 ]
             )
             ->setDescription('Fixes a directory or a file.')

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -999,7 +999,7 @@ final class ConfigurationResolverTest extends TestCase
 
         $options = $definition->getOptions();
         static::assertSame(
-            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress'],
+            ['path-mode', 'allow-risky', 'config', 'dry-run', 'rules', 'using-cache', 'cache-file', 'diff', 'format', 'stop-on-violation', 'show-progress', 'diff-format'],
             array_keys($options),
             'Expected options mismatch, possibly test needs updating.'
         );


### PR DESCRIPTION
Preserve backward compatibility.

This change restores the integration with PhpStorm that is hard to restore on our side since it requires tool versioning which is not implemented for any other supported quality tool and besides has a lot of drawbacks.

The main problem is getting the correct version of the tool since it should be updated sometimes (for example, the composer package was updated) but not frequent enough (we run the tool on almost every typing to get an on-the-fly report) since
we support execution of tool via Docker/Docker-Compose/SSH/WSL and so calling `--version` might not be fast.

See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5600.