### PR TITLE
Always stop when "PHP_CS_FIXER_FUTURE_MODE" is used

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -118,13 +118,10 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
         }
 
         if (null === $configuration) {
-            $message = 'Passing NULL to set default configuration is deprecated and will not be supported in 3.0, use an empty array instead.';
-
-            if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-            }
-
-            @trigger_error($message, E_USER_DEPRECATED);
+            Utils::triggerDeprecation(
+                'Passing NULL to set default configuration is deprecated and will not be supported in 3.0, use an empty array instead.',
+                \InvalidArgumentException::class
+            );
 
             $configuration = [];
         }
@@ -136,19 +133,16 @@ abstract class AbstractFixer implements FixerInterface, DefinedFixerInterface
 
             $name = $option->getName();
             if (\array_key_exists($name, $configuration)) {
-                $message = sprintf(
-                    'Option "%s" for rule "%s" is deprecated and will be removed in version %d.0. %s',
-                    $name,
-                    $this->getName(),
-                    Application::getMajorVersion() + 1,
-                    str_replace('`', '"', $option->getDeprecationMessage())
+                Utils::triggerDeprecation(
+                    sprintf(
+                        'Option "%s" for rule "%s" is deprecated and will be removed in version %d.0. %s',
+                        $name,
+                        $this->getName(),
+                        Application::getMajorVersion() + 1,
+                        str_replace('`', '"', $option->getDeprecationMessage())
+                    ),
+                    \InvalidArgumentException::class
                 );
-
-                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                    throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-                }
-
-                @trigger_error($message, E_USER_DEPRECATED);
             }
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -46,7 +46,7 @@ class Config implements ConfigInterface
      */
     public static function create()
     {
-        @trigger_error(__METHOD__.' is deprecated since 2.17 and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated since 2.17 and will be removed in 3.0.');
 
         return new static();
     }

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -446,13 +446,10 @@ final class ConfigurationResolver
                         implode('", "', $progressTypes)
                     ));
                 } elseif (\in_array($progressType, ['estimating', 'estimating-max', 'run-in'], true)) {
-                    $message = 'Passing `estimating`, `estimating-max` or `run-in` is deprecated and will not be supported in 3.0, use `none` or `dots` instead.';
-
-                    if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                        throw new \InvalidArgumentException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-                    }
-
-                    @trigger_error($message, E_USER_DEPRECATED);
+                    Utils::triggerDeprecation(
+                        'Passing `estimating`, `estimating-max` or `run-in` is deprecated and will not be supported in 3.0, use `none` or `dots` instead.',
+                        \InvalidArgumentException::class
+                    );
                 }
 
                 $this->progress = $progressType;
@@ -786,13 +783,7 @@ final class ConfigurationResolver
                     ? sprintf(' and will be removed in version %d.0.', Application::getMajorVersion() + 1)
                     : sprintf('. Use %s instead.', str_replace('`', '"', Utils::naturalLanguageJoinWithBackticks($successors)));
 
-                $message = "Rule \"{$fixerName}\" is deprecated{$messageEnd}";
-
-                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                    throw new \RuntimeException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-                }
-
-                @trigger_error($message, E_USER_DEPRECATED);
+                Utils::triggerDeprecation("Rule \"{$fixerName}\" is deprecated{$messageEnd}");
             }
         }
     }
@@ -938,13 +929,10 @@ final class ConfigurationResolver
             return false;
         }
 
-        $message = sprintf('Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".', $optionName, $value);
-
-        if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-            throw new InvalidConfigurationException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-        }
-
-        @trigger_error($message, E_USER_DEPRECATED);
+        Utils::triggerDeprecation(
+            sprintf('Expected "yes" or "no" for option "%s", other values are deprecated and support will be removed in 3.0. Got "%s", this implicitly set the option to "false".', $optionName, $value),
+            InvalidConfigurationException::class
+        );
 
         return false;
     }

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -24,6 +24,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Options;
 
@@ -193,8 +194,7 @@ class Sample
                 ->setNormalizer(static function (Options $options, $values) {
                     $deprecated = array_intersect($values, self::SUPPORTED_TYPES);
                     if (\count($deprecated) > 0) {
-                        $message = 'A list of elements is deprecated, use a dictionary of `const|method|property` => `none|one` instead.';
-                        @trigger_error($message, E_USER_DEPRECATED);
+                        Utils::triggerDeprecation('A list of elements is deprecated, use a dictionary of `const|method|property` => `none|one` instead.');
 
                         return array_fill_keys($deprecated, self::SPACING_ONE);
                     }

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -26,6 +26,7 @@ use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Options;
 
 /**
@@ -42,7 +43,7 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurat
      */
     public function fixSpace(Tokens $tokens, $index)
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
         $this->fixSpace2($tokens, $index);
     }
 

--- a/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
+++ b/src/Fixer/Operator/AlignDoubleArrowFixerHelper.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractAlignFixerHelper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
 
 /**
  * @author Carlos Cirello <carlos.cirello.nl@gmail.com>
@@ -37,12 +38,11 @@ final class AlignDoubleArrowFixerHelper extends AbstractAlignFixerHelper
 
     public function __construct()
     {
-        @trigger_error(
+        Utils::triggerDeprecation(
             sprintf(
                 'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
                 __CLASS__
-            ),
-            E_USER_DEPRECATED
+            )
         );
     }
 

--- a/src/Fixer/Operator/AlignEqualsFixerHelper.php
+++ b/src/Fixer/Operator/AlignEqualsFixerHelper.php
@@ -16,6 +16,7 @@ use PhpCsFixer\AbstractAlignFixerHelper;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Utils;
 
 /**
  * @author Carlos Cirello <carlos.cirello.nl@gmail.com>
@@ -27,12 +28,11 @@ final class AlignEqualsFixerHelper extends AbstractAlignFixerHelper
 {
     public function __construct()
     {
-        @trigger_error(
+        Utils::triggerDeprecation(
             sprintf(
                 'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
                 __CLASS__
-            ),
-            E_USER_DEPRECATED
+            )
         );
     }
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -25,6 +25,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
@@ -554,17 +555,14 @@ $array = [
             }
         }
 
-        $message = sprintf(
-            'Given configuration is deprecated and will be removed in 3.0. Use configuration %s as replacement for %s.',
-            HelpCommand::toString($newConfig),
-            HelpCommand::toString($configuration)
+        Utils::triggerDeprecation(
+            sprintf(
+                'Given configuration is deprecated and will be removed in 3.0. Use configuration %s as replacement for %s.',
+                HelpCommand::toString($newConfig),
+                HelpCommand::toString($configuration)
+            ),
+            InvalidFixerConfigurationException::class
         );
-
-        if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-            throw new InvalidFixerConfigurationException($this->getName(), "{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-        }
-
-        @trigger_error($message, E_USER_DEPRECATED);
 
         return $newConfig;
     }

--- a/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php
@@ -23,6 +23,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -88,7 +89,7 @@ final class BlankLineBeforeStatementFixer extends AbstractFixer implements Confi
 
         foreach ($this->configuration['statements'] as $key) {
             if ('die' === $key) {
-                @trigger_error('Option "die" is deprecated, use "exit" instead.', E_USER_DEPRECATED);
+                Utils::triggerDeprecation('Option "die" is deprecated, use "exit" instead.');
             }
 
             $this->fixTokenMap[$key] = self::$tokenMap[$key];

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -26,6 +26,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Options;
 
 /**
@@ -319,13 +320,10 @@ switch($a) {
                 ->setNormalizer(static function (Options $options, $tokens) use ($that) {
                     foreach ($tokens as &$token) {
                         if ('useTrait' === $token) {
-                            $message = "Token \"useTrait\" in option \"tokens\" for rule \"{$that->getName()}\" is deprecated and will be removed in 3.0, use \"use_trait\" instead.";
-
-                            if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                                throw new InvalidConfigurationException("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-                            }
-
-                            @trigger_error($message, E_USER_DEPRECATED);
+                            Utils::triggerDeprecation(
+                                "Token \"useTrait\" in option \"tokens\" for rule \"{$that->getName()}\" is deprecated and will be removed in 3.0, use \"use_trait\" instead.",
+                                InvalidConfigurationException::class
+                            );
                             $token = 'use_trait';
 
                             break;

--- a/src/FixerConfiguration/FixerConfigurationResolver.php
+++ b/src/FixerConfiguration/FixerConfigurationResolver.php
@@ -12,6 +12,7 @@
 
 namespace PhpCsFixer\FixerConfiguration;
 
+use PhpCsFixer\Utils;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -67,7 +68,7 @@ final class FixerConfigurationResolver implements FixerConfigurationResolverInte
                         throw new InvalidOptionsException(sprintf('Aliased option "%s"/"%s" is passed multiple times.', $name, $alias));
                     }
 
-                    @trigger_error(sprintf('Option "%s" is deprecated, use "%s" instead.', $alias, $name), E_USER_DEPRECATED);
+                    Utils::triggerDeprecation(sprintf('Option "%s" is deprecated, use "%s" instead.', $alias, $name));
 
                     $options[$name] = $options[$alias];
                     unset($options[$alias]);

--- a/src/FixerConfiguration/FixerConfigurationResolverRootless.php
+++ b/src/FixerConfiguration/FixerConfigurationResolverRootless.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\FixerConfiguration;
 
+use PhpCsFixer\Utils;
+
 /**
  * @internal
  *
@@ -82,13 +84,7 @@ final class FixerConfigurationResolverRootless implements FixerConfigurationReso
             $passedNames = array_keys($options);
 
             if (!empty(array_diff($passedNames, $names))) {
-                $message = "Passing \"{$this->root}\" at the root of the configuration for rule \"{$this->fixerName}\" is deprecated and will not be supported in 3.0, use \"{$this->root}\" => array(...) option instead.";
-
-                if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                    throw new \RuntimeException("{$message}. This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
-                }
-
-                @trigger_error($message, E_USER_DEPRECATED);
+                Utils::triggerDeprecation("Passing \"{$this->root}\" at the root of the configuration for rule \"{$this->fixerName}\" is deprecated and will not be supported in 3.0, use \"{$this->root}\" => array(...) option instead.");
 
                 $options = [$this->root => $options];
             }

--- a/src/FixerDefinition/FixerDefinition.php
+++ b/src/FixerDefinition/FixerDefinition.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\FixerDefinition;
 
+use PhpCsFixer\Utils;
+
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  */
@@ -41,9 +43,9 @@ final class FixerDefinition implements FixerDefinitionInterface
         $riskyDescription = null
     ) {
         if (6 === \func_num_args()) {
-            @trigger_error('Arguments #5 and #6 of FixerDefinition::__construct() are deprecated and will be removed in 3.0, use argument #4 instead.', E_USER_DEPRECATED);
+            Utils::triggerDeprecation('Arguments #5 and #6 of FixerDefinition::__construct() are deprecated and will be removed in 3.0, use argument #4 instead.');
         } elseif (5 === \func_num_args()) {
-            @trigger_error('Argument #5 of FixerDefinition::__construct() is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+            Utils::triggerDeprecation('Argument #5 of FixerDefinition::__construct() is deprecated and will be removed in 3.0.');
         } else {
             $riskyDescription = $configurationDescription;
             $configurationDescription = null;
@@ -69,14 +71,14 @@ final class FixerDefinition implements FixerDefinitionInterface
 
     public function getConfigurationDescription()
     {
-        @trigger_error(sprintf('%s is deprecated and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        Utils::triggerDeprecation(sprintf('%s is deprecated and will be removed in 3.0.', __METHOD__));
 
         return $this->configurationDescription;
     }
 
     public function getDefaultConfiguration()
     {
-        @trigger_error(sprintf('%s is deprecated and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        Utils::triggerDeprecation(sprintf('%s is deprecated and will be removed in 3.0.', __METHOD__));
 
         return $this->defaultConfiguration;
     }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\RuleSet;
 
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Utils;
 
 /**
  * Set of rules to be used by fixer.
@@ -51,12 +52,10 @@ class RuleSet implements RuleSetInterface
             if (true !== $value && false !== $value && !\is_array($value)) {
                 // @TODO drop me on 3.0
                 if (null === $value) {
-                    $messageForNullIssue = 'To disable the rule, use "FALSE" instead of "NULL".';
-                    if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
-                        throw new InvalidFixerConfigurationException($name, $messageForNullIssue);
-                    }
-
-                    @trigger_error($messageForNullIssue, E_USER_DEPRECATED);
+                    Utils::triggerDeprecation(
+                        'To disable the rule, use "FALSE" instead of "NULL".',
+                        InvalidFixerConfigurationException::class
+                    );
 
                     continue;
                 }
@@ -107,7 +106,7 @@ class RuleSet implements RuleSetInterface
      */
     public static function create(array $set = [])
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0, use the constructor.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0, use the constructor.');
 
         return new self($set);
     }
@@ -117,7 +116,7 @@ class RuleSet implements RuleSetInterface
      */
     public function getSetDefinitionNames()
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0, use PhpCsFixer\RuleSet\RuleSets::getSetDefinitionNames.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0, use PhpCsFixer\RuleSet\RuleSets::getSetDefinitionNames.');
 
         return RuleSets::getSetDefinitionNames();
     }

--- a/src/Test/AbstractFixerTestCase.php
+++ b/src/Test/AbstractFixerTestCase.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Test;
 
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase as BaseAbstractFixerTestCase;
+use PhpCsFixer\Utils;
 
 /**
  * @TODO 3.0 While removing, remove loading `tests/Test` from `autoload` section of `composer.json`.
@@ -23,12 +24,11 @@ abstract class AbstractFixerTestCase extends BaseAbstractFixerTestCase
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {
-        @trigger_error(
+        Utils::triggerDeprecation(
             sprintf(
                 'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
                 __CLASS__
-            ),
-            E_USER_DEPRECATED
+            )
         );
 
         parent::__construct($name, $data, $dataName);

--- a/src/Test/AbstractIntegrationTestCase.php
+++ b/src/Test/AbstractIntegrationTestCase.php
@@ -13,6 +13,7 @@
 namespace PhpCsFixer\Test;
 
 use PhpCsFixer\Tests\Test\AbstractIntegrationTestCase as BaseAbstractIntegrationTestCase;
+use PhpCsFixer\Utils;
 
 /**
  * @TODO 3.0 While removing, remove loading `tests/Test` from `autoload` section of `composer.json`.
@@ -23,12 +24,11 @@ abstract class AbstractIntegrationTestCase extends BaseAbstractIntegrationTestCa
 {
     public function __construct($name = null, array $data = [], $dataName = '')
     {
-        @trigger_error(
+        Utils::triggerDeprecation(
             sprintf(
                 'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
                 __CLASS__
-            ),
-            E_USER_DEPRECATED
+            )
         );
 
         parent::__construct($name, $data, $dataName);

--- a/src/Test/AccessibleObject.php
+++ b/src/Test/AccessibleObject.php
@@ -12,6 +12,8 @@
 
 namespace PhpCsFixer\Test;
 
+use PhpCsFixer\Utils;
+
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
@@ -27,12 +29,11 @@ final class AccessibleObject
      */
     public function __construct($object)
     {
-        @trigger_error(
+        Utils::triggerDeprecation(
             sprintf(
                 'The "%s" class is deprecated and will be removed in 3.0 version. Use "php-cs-fixer/accessible-object" package instead.',
                 __CLASS__
-            ),
-            E_USER_DEPRECATED
+            )
         );
 
         $this->object = $object;
@@ -42,7 +43,7 @@ final class AccessibleObject
     public function __call($name, array $arguments)
     {
         if (!method_exists($this->object, $name)) {
-            throw new \LogicException(sprintf('Cannot call non existing method %s->%s.', \get_class($this->object), $name));
+            throw new \LogicException(sprintf('Cannot call non existing method "%s"->%s.', \get_class($this->object), $name));
         }
 
         $method = $this->reflection->getMethod($name);
@@ -65,7 +66,7 @@ final class AccessibleObject
     public function __get($name)
     {
         if (!property_exists($this->object, $name)) {
-            throw new \LogicException(sprintf('Cannot get non existing property %s->%s.', \get_class($this->object), $name));
+            throw new \LogicException(sprintf('Cannot get non existing property "%s"->%s.', \get_class($this->object), $name));
         }
 
         $property = $this->reflection->getProperty($name);
@@ -77,7 +78,7 @@ final class AccessibleObject
     public function __set($name, $value)
     {
         if (!property_exists($this->object, $name)) {
-            throw new \LogicException(sprintf('Cannot set non existing property %s->%s = %s.', \get_class($this->object), $name, var_export($value, true)));
+            throw new \LogicException(sprintf('Cannot set non existing property "%s"->%s = "%s".', \get_class($this->object), $name, var_export($value, true)));
         }
 
         $property = $this->reflection->getProperty($name);

--- a/src/Test/IntegrationCase.php
+++ b/src/Test/IntegrationCase.php
@@ -14,6 +14,7 @@ namespace PhpCsFixer\Test;
 
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\Tests\Test\IntegrationCase as BaseIntegrationCase;
+use PhpCsFixer\Utils;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -55,13 +56,8 @@ final class IntegrationCase
             $expectedCode,
             $inputCode
         );
-        @trigger_error(
-            sprintf(
-                'The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.',
-                __CLASS__
-            ),
-            E_USER_DEPRECATED
-        );
+
+        Utils::triggerDeprecation(sprintf('The "%s" class is deprecated. You should stop using it, as it will be removed in 3.0 version.', __CLASS__));
     }
 
     public function hasInputCode()
@@ -121,13 +117,7 @@ final class IntegrationCase
      */
     public function shouldCheckPriority()
     {
-        @trigger_error(
-            sprintf(
-                'The "%s" method is deprecated. You should stop using it, as it will be removed in 3.0 version.',
-                __METHOD__
-            ),
-            E_USER_DEPRECATED
-        );
+        Utils::triggerDeprecation(sprintf('The "%s" method is deprecated. You should stop using it, as it will be removed in 3.0 version.', __METHOD__));
 
         $settings = $this->base->getSettings();
 

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -123,7 +123,7 @@ class Token
      */
     public function clear()
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
         Tokens::setLegacyMode(true);
 
         $this->content = '';
@@ -138,7 +138,7 @@ class Token
      */
     public function clearChanged()
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
         Tokens::setLegacyMode(true);
 
         $this->changed = false;
@@ -397,7 +397,7 @@ class Token
      */
     public function isChanged()
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
 
         return $this->changed;
     }
@@ -433,7 +433,7 @@ class Token
      */
     public function isEmpty()
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
 
         return null === $this->id && ('' === $this->content || null === $this->content);
     }
@@ -519,7 +519,7 @@ class Token
      */
     public function override($other)
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
         Tokens::setLegacyMode(true);
 
         $prototype = $other instanceof self ? $other->getPrototype() : $other;
@@ -550,7 +550,7 @@ class Token
      */
     public function setContent($content)
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0.');
         Tokens::setLegacyMode(true);
 
         if ($this->content === $content) {
@@ -562,7 +562,7 @@ class Token
 
         // setting empty content is clearing the token
         if ('' === $content) {
-            @trigger_error(__METHOD__.' shall not be used to clear token, use Tokens::clearAt instead.', E_USER_DEPRECATED);
+            Utils::triggerDeprecation(__METHOD__.' shall not be used to clear token, use Tokens::clearAt instead.');
             $this->id = null;
             $this->isArray = false;
         }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -461,9 +461,9 @@ class Tokens extends \SplFixedArray
     {
         if (3 === \func_num_args()) {
             if ($findEnd) {
-                @trigger_error('Argument #3 of Tokens::findBlockEnd is deprecated and will be removed in 3.0, you can safely drop the argument.', E_USER_DEPRECATED);
+                Utils::triggerDeprecation('Argument #3 of Tokens::findBlockEnd is deprecated and will be removed in 3.0, you can safely drop the argument.');
             } else {
-                @trigger_error('Argument #3 of Tokens::findBlockEnd is deprecated and will be removed in 3.0, use Tokens::findBlockStart instead.', E_USER_DEPRECATED);
+                Utils::triggerDeprecation('Argument #3 of Tokens::findBlockEnd is deprecated and will be removed in 3.0, use Tokens::findBlockStart instead.');
             }
         }
 
@@ -1020,7 +1020,7 @@ class Tokens extends \SplFixedArray
      */
     public function overrideAt($index, $token)
     {
-        @trigger_error(__METHOD__.' is deprecated and will be removed in 3.0, use offsetSet instead.', E_USER_DEPRECATED);
+        Utils::triggerDeprecation(__METHOD__.' is deprecated and will be removed in 3.0, use offsetSet instead.');
         self::$isLegacyMode = true;
 
         $this[$index]->override($token);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -182,4 +182,19 @@ final class Utils
 
         return $last;
     }
+
+    /**
+     * Handle triggering deprecation error.
+     *
+     * @param string $message
+     * @param string $exceptionClass
+     */
+    public static function triggerDeprecation($message, $exceptionClass = \RuntimeException::class)
+    {
+        if (getenv('PHP_CS_FIXER_FUTURE_MODE')) {
+            throw new $exceptionClass("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
+        }
+
+        @trigger_error($message, E_USER_DEPRECATED);
+    }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -15,6 +15,7 @@ namespace PhpCsFixer\Tests;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Utils;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -27,6 +28,8 @@ use PhpCsFixer\Utils;
  */
 final class UtilsTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @param string $expected Camel case string
      * @param string $input    Input string
@@ -287,6 +290,28 @@ final class UtilsTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testTriggerDeprecationWhenFutureModeIsOff()
+    {
+        putenv('PHP_CS_FIXER_FUTURE_MODE=0');
+
+        $this->expectDeprecation('The message');
+
+        Utils::triggerDeprecation('The message', \DomainException::class);
+    }
+
+    public function testTriggerDeprecationWhenFutureModeIsOn()
+    {
+        putenv('PHP_CS_FIXER_FUTURE_MODE=1');
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('The message');
+
+        Utils::triggerDeprecation('The message', \DomainException::class);
     }
 
     private function createFixerDouble($name, $priority)


### PR DESCRIPTION
Deprecations are not always stopping application when `PHP_CS_FIXER_FUTURE_MODE` is on.

We can see that in [first commit](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5601/commits/053c5d530895aab89cfabce55ee2aa26d7b75fcf) where rules with deprecation configuration was added the build have passed - and we run fixer with `PHP_CS_FIXER_FUTURE_MODE` flag: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.18.5/.github/workflows/ci.yml#L146

The [second commit](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5601/commits/64ca575114174557961070a8531d9978e392ef62) is moving all `trigger_error` calls to `Utils::triggerDeprecation` and there we decide basing on `PHP_CS_FIXER_FUTURE_MODE` if throw an exception.

3rd and 4th commits are restoring config and makes fabbot happy, respectively.