### PR TITLE
DX: UtilsTest - add missing teardown

### DIFF
--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -30,6 +30,18 @@ final class UtilsTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    private $originalValueOfFutureMode;
+
+    protected function doSetUp()
+    {
+        $this->originalValueOfFutureMode = getenv('PHP_CS_FIXER_FUTURE_MODE');
+    }
+
+    protected function doTearDown()
+    {
+        putenv("PHP_CS_FIXER_FUTURE_MODE={$this->originalValueOfFutureMode}");
+    }
+
     /**
      * @param string $expected Camel case string
      * @param string $input    Input string


### PR DESCRIPTION
showing the issue:
```
ker@dus:~/github/PHP-CS-Fixer λ git du
diff --git a/tests/UtilsTest.php b/tests/UtilsTest.php
index 122db36c7..4a0db6acc 100644
--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -298,6 +298,7 @@ public function provideCalculateBitmaskCases()
     public function testTriggerDeprecationWhenFutureModeIsOff()
     {
         putenv('PHP_CS_FIXER_FUTURE_MODE=0');
+        var_dump(["method" => __METHOD__, "PHP_CS_FIXER_FUTURE_MODE env var" => getenv('PHP_CS_FIXER_FUTURE_MODE')]);
 
         $this->expectDeprecation('The message');
 
@@ -307,6 +308,7 @@ public function testTriggerDeprecationWhenFutureModeIsOff()
     public function testTriggerDeprecationWhenFutureModeIsOn()
     {
         putenv('PHP_CS_FIXER_FUTURE_MODE=1');
+        var_dump(["method" => __METHOD__, "PHP_CS_FIXER_FUTURE_MODE env var" => getenv('PHP_CS_FIXER_FUTURE_MODE')]);
 
         $this->expectException(\DomainException::class);
         $this->expectExceptionMessage('The message');
@@ -314,6 +316,12 @@ public function testTriggerDeprecationWhenFutureModeIsOn()
         Utils::triggerDeprecation('The message', \DomainException::class);
     }
 
+    public function testXXX()
+    {
+        var_dump(["method" => __METHOD__, "PHP_CS_FIXER_FUTURE_MODE env var" => getenv('PHP_CS_FIXER_FUTURE_MODE')]);
+        $this->assertTrue(true);
+    }
+
     private function createFixerDouble($name, $priority)
     {
         $fixer = $this->prophesize(FixerInterface::class);

```

execution:
```
ker@dus:~/github/PHP-CS-Fixer λ vendor/bin/phpunit tests/UtilsTest.php 
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing PhpCsFixer\Tests\UtilsTest
......................................Rarray(2) {
  ["method"]=>
  string(69) "PhpCsFixer\Tests\UtilsTest::testTriggerDeprecationWhenFutureModeIsOff"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(1) "0"
}
Rarray(2) {
  ["method"]=>
  string(68) "PhpCsFixer\Tests\UtilsTest::testTriggerDeprecationWhenFutureModeIsOn"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(1) "1"
}
R                                                                                                                                                                                                                           41 / 41 (100%)array(2) {
  ["method"]=>
  string(35) "PhpCsFixer\Tests\UtilsTest::testXXX"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(1) "1"
}
```

as we see, the new method `testXXX` is having non-default env-variable, because the previously executed method changed *the global state*

after fix:
```
ker@dus:~/github/PHP-CS-Fixer λ vendor/bin/phpunit tests/UtilsTest.php 
PHPUnit 9.5.4 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

Testing PhpCsFixer\Tests\UtilsTest
......................................Rarray(2) {
  ["method"]=>
  string(69) "PhpCsFixer\Tests\UtilsTest::testTriggerDeprecationWhenFutureModeIsOff"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(1) "0"
}
Rarray(2) {
  ["method"]=>
  string(68) "PhpCsFixer\Tests\UtilsTest::testTriggerDeprecationWhenFutureModeIsOn"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(1) "1"
}
R                                                                                                                                                                                                                           41 / 41 (100%)array(2) {
  ["method"]=>
  string(35) "PhpCsFixer\Tests\UtilsTest::testXXX"
  ["PHP_CS_FIXER_FUTURE_MODE env var"]=>
  string(0) ""
}
```