### PR TITLE
ClassAttributesSeparationFixer - fix for using visibility for class elements

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -266,7 +266,8 @@ class Sample
             $nextNotWhite = $tokens->getNextNonWhitespace($nextNotWhite);
         }
 
-        if ($tokens[$nextNotWhite]->isGivenKind(T_FUNCTION)) {
+        $functionIndex = $tokens->getTokenNotOfKindsSibling($nextNotWhite - 1, 1, [T_ABSTRACT, T_FINAL, T_PUBLIC, T_PROTECTED, T_PRIVATE, T_STATIC, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]);
+        if ($tokens[$functionIndex]->isGivenKind(T_FUNCTION)) {
             $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, 2);
 
             return;

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -936,12 +936,12 @@ class ezcReflectionMethod extends ReflectionMethod {
     }
 
     /**
-     * @param string      $expected
-     * @param null|string $input
+     * @param string $expected
+     * @param string $input
      *
      * @dataProvider provideConfigCases
      */
-    public function testWithConfig($expected, $input = null, array $config = [])
+    public function testWithConfig($expected, $input, array $config)
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
@@ -1074,6 +1074,75 @@ class ezcReflectionMethod extends ReflectionMethod {
                     }
                 ',
                 ['elements' => ['method' => ClassAttributesSeparationFixer::SPACING_NONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        private $x;
+                        private $y;
+
+                        final function f1() {}
+
+                        final function f2() {}
+                     }
+                ',
+                '<?php
+                    class A
+                    {
+                        private $x;
+                        private $y;
+                        final function f1() {}
+                        final function f2() {}
+                     }
+                ',
+                ['elements' => ['property' => ClassAttributesSeparationFixer::SPACING_NONE, 'method' => ClassAttributesSeparationFixer::SPACING_ONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        const FOO = 1;
+                        const BAR = 2;
+
+                        function f1() {}
+
+                        function f2() {}
+                     }
+                ',
+                '<?php
+                    class A
+                    {
+                        const FOO = 1;
+                        const BAR = 2;
+                        function f1() {}
+                        function f2() {}
+                     }
+                ',
+                ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_NONE, 'method' => ClassAttributesSeparationFixer::SPACING_ONE]],
+            ],
+            [
+                '<?php
+                    class A
+                    {
+                        const FOO = 1;
+                        const BAR = 2;
+
+                        public function f1() {}
+
+                        public function f2() {}
+                     }
+                ',
+                '<?php
+                    class A
+                    {
+                        const FOO = 1;
+                        const BAR = 2;
+                        public function f1() {}
+                        public function f2() {}
+                     }
+                ',
+                ['elements' => ['const' => ClassAttributesSeparationFixer::SPACING_NONE, 'method' => ClassAttributesSeparationFixer::SPACING_ONE]],
             ],
         ];
     }
@@ -1235,13 +1304,13 @@ private $d = 123;
     }
 
     /**
-     * @param string      $expected
-     * @param null|string $input
+     * @param string $expected
+     * @param string $input
      *
      * @dataProvider provideFix71Cases
      * @requires PHP 7.1
      */
-    public function testFix71($expected, $input = null)
+    public function testFix71($expected, $input)
     {
         $this->fixer->configure([
             'elements' => ['method' => ClassAttributesSeparationFixer::SPACING_ONE, 'const' => ClassAttributesSeparationFixer::SPACING_ONE],


### PR DESCRIPTION
In the 2 added test cases, the 1st one (without visibilities) is passing and the 2nd one (with visibilities) is failing.