### PR TITLE
Exclude Doctrine documents from final fixer

### DIFF
--- a/doc/rules/class_notation/final_internal_class.rst
+++ b/doc/rules/class_notation/final_internal_class.rst
@@ -33,7 +33,7 @@ of the white list ones are used as well. (case insensitive)
 
 Allowed types: ``array``
 
-Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity']``
+Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity', '@Document', '@ODM\\Document']``
 
 ``consider_absent_docblock_as_internal_class``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Fixer/ClassNotation/FinalInternalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalInternalClassFixer.php
@@ -169,6 +169,8 @@ final class FinalInternalClassFixer extends AbstractFixer implements Configurati
                     '@ORM\Entity',
                     '@ORM\Mapping\Entity',
                     '@Mapping\Entity',
+                    '@Document',
+                    '@ODM\Document',
                 ])
                 ->setNormalizer($annotationsNormalizer)
                 ->getOption(),

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -41,6 +41,8 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
             ['<?php use Doctrine\ORM\Mapping as ORM; /** @ORM\Entity */ class MyEntity {}'],
             ['<?php use Doctrine\ORM\Mapping; /** @Mapping\Entity */ class MyEntity {}'],
             ['<?php use Doctrine\ORM; /** @ORM\Mapping\Entity */ class MyEntity {}'],
+            ['<?php /** @Document */ class MyDocument {}'],
+            ['<?php use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM; /** @ODM\Document */ class MyEntity {}'],
             ['<?php /** @entity */ class MyEntity {}'],
             ['<?php use Doctrine\ORM\Mapping as ORM; /** @orm\entity */ class MyEntity {}'],
             ['<?php abstract class MyAbstract {}'],


### PR DESCRIPTION
Doctrine ORM entities already excluded from FinalClassFixer. I propose also to exclude Doctrine ODM documents.