### PR TITLE
Render link to a source code in rule doc

### DIFF
--- a/doc/rules/alias/array_push.rst
+++ b/doc/rules/alias/array_push.rst
@@ -2,6 +2,8 @@
 Rule ``array_push``
 ===================
 
+`src <../../../src/Fixer/Alias/ArrayPushFixer.php>`_
+
 Converts simple usages of ``array_push($x, $y);`` to ``$x[] = $y;``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/alias/backtick_to_shell_exec.rst
+++ b/doc/rules/alias/backtick_to_shell_exec.rst
@@ -2,6 +2,8 @@
 Rule ``backtick_to_shell_exec``
 ===============================
 
+`src <../../../src/Fixer/Alias/BacktickToShellExecFixer.php>`_
+
 Converts backtick operators to ``shell_exec`` calls.
 
 Description

--- a/doc/rules/alias/ereg_to_preg.rst
+++ b/doc/rules/alias/ereg_to_preg.rst
@@ -2,6 +2,8 @@
 Rule ``ereg_to_preg``
 =====================
 
+`src <../../../src/Fixer/Alias/EregToPregFixer.php>`_
+
 Replace deprecated ``ereg`` regular expression functions with ``preg``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/alias/mb_str_functions.rst
+++ b/doc/rules/alias/mb_str_functions.rst
@@ -2,6 +2,8 @@
 Rule ``mb_str_functions``
 =========================
 
+`src <../../../src/Fixer/Alias/MbStrFunctionsFixer.php>`_
+
 Replace non multibyte-safe functions with corresponding mb function.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/alias/no_alias_functions.rst
+++ b/doc/rules/alias/no_alias_functions.rst
@@ -2,6 +2,8 @@
 Rule ``no_alias_functions``
 ===========================
 
+`src <../../../src/Fixer/Alias/NoAliasFunctionsFixer.php>`_
+
 Master functions shall be used instead of aliases.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/alias/no_alias_language_construct_call.rst
+++ b/doc/rules/alias/no_alias_language_construct_call.rst
@@ -2,6 +2,8 @@
 Rule ``no_alias_language_construct_call``
 =========================================
 
+`src <../../../src/Fixer/Alias/NoAliasLanguageConstructCallFixer.php>`_
+
 Master language constructs shall be used instead of aliases.
 
 Examples

--- a/doc/rules/alias/no_mixed_echo_print.rst
+++ b/doc/rules/alias/no_mixed_echo_print.rst
@@ -2,6 +2,8 @@
 Rule ``no_mixed_echo_print``
 ============================
 
+`src <../../../src/Fixer/Alias/NoMixedEchoPrintFixer.php>`_
+
 Either language construct ``print`` or ``echo`` should be used.
 
 Configuration

--- a/doc/rules/alias/pow_to_exponentiation.rst
+++ b/doc/rules/alias/pow_to_exponentiation.rst
@@ -2,6 +2,8 @@
 Rule ``pow_to_exponentiation``
 ==============================
 
+`src <../../../src/Fixer/Alias/PowToExponentiationFixer.php>`_
+
 Converts ``pow`` to the ``**`` operator.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/alias/random_api_migration.rst
+++ b/doc/rules/alias/random_api_migration.rst
@@ -2,6 +2,8 @@
 Rule ``random_api_migration``
 =============================
 
+`src <../../../src/Fixer/Alias/RandomApiMigrationFixer.php>`_
+
 Replaces ``rand``, ``srand``, ``getrandmax`` functions calls with their ``mt_*``
 analogs.
 

--- a/doc/rules/alias/set_type_to_cast.rst
+++ b/doc/rules/alias/set_type_to_cast.rst
@@ -2,6 +2,8 @@
 Rule ``set_type_to_cast``
 =========================
 
+`src <../../../src/Fixer/Alias/SetTypeToCastFixer.php>`_
+
 Cast shall be used, not ``settype``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/array_notation/array_syntax.rst
+++ b/doc/rules/array_notation/array_syntax.rst
@@ -2,6 +2,8 @@
 Rule ``array_syntax``
 =====================
 
+`src <../../../src/Fixer/ArrayNotation/ArraySyntaxFixer.php>`_
+
 PHP arrays should be declared using the configured syntax.
 
 Configuration

--- a/doc/rules/array_notation/no_multiline_whitespace_around_double_arrow.rst
+++ b/doc/rules/array_notation/no_multiline_whitespace_around_double_arrow.rst
@@ -2,6 +2,8 @@
 Rule ``no_multiline_whitespace_around_double_arrow``
 ====================================================
 
+`src <../../../src/Fixer/ArrayNotation/NoMultilineWhitespaceAroundDoubleArrowFixer.php>`_
+
 Operator ``=>`` should not be surrounded by multi-line whitespaces.
 
 Examples

--- a/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
+++ b/doc/rules/array_notation/no_trailing_comma_in_singleline_array.rst
@@ -2,6 +2,8 @@
 Rule ``no_trailing_comma_in_singleline_array``
 ==============================================
 
+`src <../../../src/Fixer/ArrayNotation/NoTrailingCommaInSinglelineArrayFixer.php>`_
+
 PHP single-line arrays should not have trailing comma.
 
 Examples

--- a/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
+++ b/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
@@ -2,6 +2,8 @@
 Rule ``no_whitespace_before_comma_in_array``
 ============================================
 
+`src <../../../src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php>`_
+
 In array declaration, there MUST NOT be a whitespace before each comma.
 
 Configuration

--- a/doc/rules/array_notation/normalize_index_brace.rst
+++ b/doc/rules/array_notation/normalize_index_brace.rst
@@ -2,6 +2,8 @@
 Rule ``normalize_index_brace``
 ==============================
 
+`src <../../../src/Fixer/ArrayNotation/NormalizeIndexBraceFixer.php>`_
+
 Array index should always be written by using square braces.
 
 Examples

--- a/doc/rules/array_notation/trailing_comma_in_multiline_array.rst
+++ b/doc/rules/array_notation/trailing_comma_in_multiline_array.rst
@@ -2,6 +2,8 @@
 Rule ``trailing_comma_in_multiline_array``
 ==========================================
 
+`src <../../../src/Fixer/ArrayNotation/TrailingCommaInMultilineArrayFixer.php>`_
+
 PHP multi-line arrays should have a trailing comma.
 
 Configuration

--- a/doc/rules/array_notation/trim_array_spaces.rst
+++ b/doc/rules/array_notation/trim_array_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``trim_array_spaces``
 ==========================
 
+`src <../../../src/Fixer/ArrayNotation/TrimArraySpacesFixer.php>`_
+
 Arrays should be formatted like function/method arguments, without leading or
 trailing single line space.
 

--- a/doc/rules/array_notation/whitespace_after_comma_in_array.rst
+++ b/doc/rules/array_notation/whitespace_after_comma_in_array.rst
@@ -2,6 +2,8 @@
 Rule ``whitespace_after_comma_in_array``
 ========================================
 
+`src <../../../src/Fixer/ArrayNotation/WhitespaceAfterCommaInArrayFixer.php>`_
+
 In array declaration, there MUST be a whitespace after each comma.
 
 Examples

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -2,6 +2,8 @@
 Rule ``braces``
 ===============
 
+`src <../../../src/Fixer/Basic/BracesFixer.php>`_
+
 The body of each structure MUST be enclosed by braces. Braces should be properly
 placed. Body of braces should be properly indented.
 

--- a/doc/rules/basic/encoding.rst
+++ b/doc/rules/basic/encoding.rst
@@ -2,6 +2,8 @@
 Rule ``encoding``
 =================
 
+`src <../../../src/Fixer/Basic/EncodingFixer.php>`_
+
 PHP code MUST use only UTF-8 without BOM (remove BOM).
 
 Examples

--- a/doc/rules/basic/non_printable_character.rst
+++ b/doc/rules/basic/non_printable_character.rst
@@ -2,6 +2,8 @@
 Rule ``non_printable_character``
 ================================
 
+`src <../../../src/Fixer/Basic/NonPrintableCharacterFixer.php>`_
+
 Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible
 unicode symbols.
 

--- a/doc/rules/basic/psr0.rst
+++ b/doc/rules/basic/psr0.rst
@@ -2,6 +2,8 @@
 Rule ``psr0``
 =============
 
+`src <../../../src/Fixer/Basic/Psr0Fixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``psr_autoloading`` instead.

--- a/doc/rules/basic/psr4.rst
+++ b/doc/rules/basic/psr4.rst
@@ -2,6 +2,8 @@
 Rule ``psr4``
 =============
 
+`src <../../../src/Fixer/Basic/Psr4Fixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``psr_autoloading`` instead.

--- a/doc/rules/basic/psr_autoloading.rst
+++ b/doc/rules/basic/psr_autoloading.rst
@@ -2,6 +2,8 @@
 Rule ``psr_autoloading``
 ========================
 
+`src <../../../src/Fixer/Basic/PsrAutoloadingFixer.php>`_
+
 Classes must be in a path that matches their namespace, be at least one
 namespace deep and the class name should match the file name.
 

--- a/doc/rules/casing/constant_case.rst
+++ b/doc/rules/casing/constant_case.rst
@@ -2,6 +2,8 @@
 Rule ``constant_case``
 ======================
 
+`src <../../../src/Fixer/Casing/ConstantCaseFixer.php>`_
+
 The PHP constants ``true``, ``false``, and ``null`` MUST be written using the
 correct casing.
 

--- a/doc/rules/casing/lowercase_constants.rst
+++ b/doc/rules/casing/lowercase_constants.rst
@@ -2,6 +2,8 @@
 Rule ``lowercase_constants``
 ============================
 
+`src <../../../src/Fixer/Casing/LowercaseConstantsFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``constant_case`` instead.

--- a/doc/rules/casing/lowercase_keywords.rst
+++ b/doc/rules/casing/lowercase_keywords.rst
@@ -2,6 +2,8 @@
 Rule ``lowercase_keywords``
 ===========================
 
+`src <../../../src/Fixer/Casing/LowercaseKeywordsFixer.php>`_
+
 PHP keywords MUST be in lower case.
 
 Examples

--- a/doc/rules/casing/lowercase_static_reference.rst
+++ b/doc/rules/casing/lowercase_static_reference.rst
@@ -2,6 +2,8 @@
 Rule ``lowercase_static_reference``
 ===================================
 
+`src <../../../src/Fixer/Casing/LowercaseStaticReferenceFixer.php>`_
+
 Class static references ``self``, ``static`` and ``parent`` MUST be in lower
 case.
 

--- a/doc/rules/casing/magic_constant_casing.rst
+++ b/doc/rules/casing/magic_constant_casing.rst
@@ -2,6 +2,8 @@
 Rule ``magic_constant_casing``
 ==============================
 
+`src <../../../src/Fixer/Casing/MagicConstantCasingFixer.php>`_
+
 Magic constants should be referred to using the correct casing.
 
 Examples

--- a/doc/rules/casing/magic_method_casing.rst
+++ b/doc/rules/casing/magic_method_casing.rst
@@ -2,6 +2,8 @@
 Rule ``magic_method_casing``
 ============================
 
+`src <../../../src/Fixer/Casing/MagicMethodCasingFixer.php>`_
+
 Magic method definitions and calls must be using the correct casing.
 
 Examples

--- a/doc/rules/casing/native_function_casing.rst
+++ b/doc/rules/casing/native_function_casing.rst
@@ -2,6 +2,8 @@
 Rule ``native_function_casing``
 ===============================
 
+`src <../../../src/Fixer/Casing/NativeFunctionCasingFixer.php>`_
+
 Function defined by PHP should be called using the correct casing.
 
 Examples

--- a/doc/rules/casing/native_function_type_declaration_casing.rst
+++ b/doc/rules/casing/native_function_type_declaration_casing.rst
@@ -2,6 +2,8 @@
 Rule ``native_function_type_declaration_casing``
 ================================================
 
+`src <../../../src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php>`_
+
 Native type hints for functions should use the correct case.
 
 Examples

--- a/doc/rules/cast_notation/cast_spaces.rst
+++ b/doc/rules/cast_notation/cast_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``cast_spaces``
 ====================
 
+`src <../../../src/Fixer/CastNotation/CastSpacesFixer.php>`_
+
 A single space or none should be between cast and variable.
 
 Configuration

--- a/doc/rules/cast_notation/lowercase_cast.rst
+++ b/doc/rules/cast_notation/lowercase_cast.rst
@@ -2,6 +2,8 @@
 Rule ``lowercase_cast``
 =======================
 
+`src <../../../src/Fixer/CastNotation/LowercaseCastFixer.php>`_
+
 Cast should be written in lower case.
 
 Examples

--- a/doc/rules/cast_notation/modernize_types_casting.rst
+++ b/doc/rules/cast_notation/modernize_types_casting.rst
@@ -2,6 +2,8 @@
 Rule ``modernize_types_casting``
 ================================
 
+`src <../../../src/Fixer/CastNotation/ModernizeTypesCastingFixer.php>`_
+
 Replaces ``intval``, ``floatval``, ``doubleval``, ``strval`` and ``boolval``
 function calls with according type casting operator.
 

--- a/doc/rules/cast_notation/no_short_bool_cast.rst
+++ b/doc/rules/cast_notation/no_short_bool_cast.rst
@@ -2,6 +2,8 @@
 Rule ``no_short_bool_cast``
 ===========================
 
+`src <../../../src/Fixer/CastNotation/NoShortBoolCastFixer.php>`_
+
 Short cast ``bool`` using double exclamation mark should not be used.
 
 Examples

--- a/doc/rules/cast_notation/no_unset_cast.rst
+++ b/doc/rules/cast_notation/no_unset_cast.rst
@@ -2,6 +2,8 @@
 Rule ``no_unset_cast``
 ======================
 
+`src <../../../src/Fixer/CastNotation/NoUnsetCastFixer.php>`_
+
 Variables must be set ``null`` instead of using ``(unset)`` casting.
 
 Examples

--- a/doc/rules/cast_notation/short_scalar_cast.rst
+++ b/doc/rules/cast_notation/short_scalar_cast.rst
@@ -2,6 +2,8 @@
 Rule ``short_scalar_cast``
 ==========================
 
+`src <../../../src/Fixer/CastNotation/ShortScalarCastFixer.php>`_
+
 Cast ``(boolean)`` and ``(integer)`` should be written as ``(bool)`` and
 ``(int)``, ``(double)`` and ``(real)`` as ``(float)``, ``(binary)`` as
 ``(string)``.

--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -2,6 +2,8 @@
 Rule ``class_attributes_separation``
 ====================================
 
+`src <../../../src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php>`_
+
 Class, trait and interface elements must be separated with one or none blank
 line.
 

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -2,6 +2,8 @@
 Rule ``class_definition``
 =========================
 
+`src <../../../src/Fixer/ClassNotation/ClassDefinitionFixer.php>`_
+
 Whitespace around the keywords of a class, trait or interfaces definition should
 be one space.
 

--- a/doc/rules/class_notation/final_class.rst
+++ b/doc/rules/class_notation/final_class.rst
@@ -2,6 +2,8 @@
 Rule ``final_class``
 ====================
 
+`src <../../../src/Fixer/ClassNotation/FinalClassFixer.php>`_
+
 All classes must be final, except abstract ones and Doctrine entities.
 
 Description

--- a/doc/rules/class_notation/final_internal_class.rst
+++ b/doc/rules/class_notation/final_internal_class.rst
@@ -2,6 +2,8 @@
 Rule ``final_internal_class``
 =============================
 
+`src <../../../src/Fixer/ClassNotation/FinalInternalClassFixer.php>`_
+
 Internal classes should be ``final``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/class_notation/final_public_method_for_abstract_class.rst
+++ b/doc/rules/class_notation/final_public_method_for_abstract_class.rst
@@ -2,6 +2,8 @@
 Rule ``final_public_method_for_abstract_class``
 ===============================================
 
+`src <../../../src/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixer.php>`_
+
 All ``public`` methods of ``abstract`` classes should be ``final``.
 
 Description

--- a/doc/rules/class_notation/final_static_access.rst
+++ b/doc/rules/class_notation/final_static_access.rst
@@ -2,6 +2,8 @@
 Rule ``final_static_access``
 ============================
 
+`src <../../../src/Fixer/ClassNotation/FinalStaticAccessFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``self_static_accessor`` instead.

--- a/doc/rules/class_notation/method_separation.rst
+++ b/doc/rules/class_notation/method_separation.rst
@@ -2,6 +2,8 @@
 Rule ``method_separation``
 ==========================
 
+`src <../../../src/Fixer/ClassNotation/MethodSeparationFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``class_attributes_separation`` instead.

--- a/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
+++ b/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
@@ -2,6 +2,8 @@
 Rule ``no_blank_lines_after_class_opening``
 ===========================================
 
+`src <../../../src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php>`_
+
 There should be no empty lines after class opening brace.
 
 Examples

--- a/doc/rules/class_notation/no_null_property_initialization.rst
+++ b/doc/rules/class_notation/no_null_property_initialization.rst
@@ -2,6 +2,8 @@
 Rule ``no_null_property_initialization``
 ========================================
 
+`src <../../../src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php>`_
+
 Properties MUST not be explicitly initialized with ``null`` except when they
 have a type declaration (PHP 7.4).
 

--- a/doc/rules/class_notation/no_php4_constructor.rst
+++ b/doc/rules/class_notation/no_php4_constructor.rst
@@ -2,6 +2,8 @@
 Rule ``no_php4_constructor``
 ============================
 
+`src <../../../src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php>`_
+
 Convert PHP4-style constructors to ``__construct``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/class_notation/no_unneeded_final_method.rst
+++ b/doc/rules/class_notation/no_unneeded_final_method.rst
@@ -2,6 +2,8 @@
 Rule ``no_unneeded_final_method``
 =================================
 
+`src <../../../src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php>`_
+
 A ``final`` class must not have ``final`` methods and ``private`` methods must
 not be ``final``.
 

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -2,6 +2,8 @@
 Rule ``ordered_class_elements``
 ===============================
 
+`src <../../../src/Fixer/ClassNotation/OrderedClassElementsFixer.php>`_
+
 Orders the elements of classes/interfaces/traits.
 
 Configuration

--- a/doc/rules/class_notation/ordered_interfaces.rst
+++ b/doc/rules/class_notation/ordered_interfaces.rst
@@ -2,6 +2,8 @@
 Rule ``ordered_interfaces``
 ===========================
 
+`src <../../../src/Fixer/ClassNotation/OrderedInterfacesFixer.php>`_
+
 Orders the interfaces in an ``implements`` or ``interface extends`` clause.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/class_notation/ordered_traits.rst
+++ b/doc/rules/class_notation/ordered_traits.rst
@@ -2,6 +2,8 @@
 Rule ``ordered_traits``
 =======================
 
+`src <../../../src/Fixer/ClassNotation/OrderedTraitsFixer.php>`_
+
 Trait ``use`` statements must be sorted alphabetically.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/class_notation/protected_to_private.rst
+++ b/doc/rules/class_notation/protected_to_private.rst
@@ -2,6 +2,8 @@
 Rule ``protected_to_private``
 =============================
 
+`src <../../../src/Fixer/ClassNotation/ProtectedToPrivateFixer.php>`_
+
 Converts ``protected`` variables and methods to ``private`` where possible.
 
 Examples

--- a/doc/rules/class_notation/self_accessor.rst
+++ b/doc/rules/class_notation/self_accessor.rst
@@ -2,6 +2,8 @@
 Rule ``self_accessor``
 ======================
 
+`src <../../../src/Fixer/ClassNotation/SelfAccessorFixer.php>`_
+
 Inside class or interface element ``self`` should be preferred to the class name
 itself.
 

--- a/doc/rules/class_notation/self_static_accessor.rst
+++ b/doc/rules/class_notation/self_static_accessor.rst
@@ -2,6 +2,8 @@
 Rule ``self_static_accessor``
 =============================
 
+`src <../../../src/Fixer/ClassNotation/SelfStaticAccessorFixer.php>`_
+
 Inside a ``final`` class or anonymous class ``self`` should be preferred to
 ``static``.
 

--- a/doc/rules/class_notation/single_class_element_per_statement.rst
+++ b/doc/rules/class_notation/single_class_element_per_statement.rst
@@ -2,6 +2,8 @@
 Rule ``single_class_element_per_statement``
 ===========================================
 
+`src <../../../src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php>`_
+
 There MUST NOT be more than one property or constant declared per statement.
 
 Configuration

--- a/doc/rules/class_notation/single_trait_insert_per_statement.rst
+++ b/doc/rules/class_notation/single_trait_insert_per_statement.rst
@@ -2,6 +2,8 @@
 Rule ``single_trait_insert_per_statement``
 ==========================================
 
+`src <../../../src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php>`_
+
 Each trait ``use`` must be done as single statement.
 
 Examples

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -2,6 +2,8 @@
 Rule ``visibility_required``
 ============================
 
+`src <../../../src/Fixer/ClassNotation/VisibilityRequiredFixer.php>`_
+
 Visibility MUST be declared on all properties and methods; ``abstract`` and
 ``final`` MUST be declared before the visibility; ``static`` MUST be declared
 after the visibility.

--- a/doc/rules/class_usage/date_time_immutable.rst
+++ b/doc/rules/class_usage/date_time_immutable.rst
@@ -2,6 +2,8 @@
 Rule ``date_time_immutable``
 ============================
 
+`src <../../../src/Fixer/ClassUsage/DateTimeImmutableFixer.php>`_
+
 Class ``DateTimeImmutable`` should be used instead of ``DateTime``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/comment/comment_to_phpdoc.rst
+++ b/doc/rules/comment/comment_to_phpdoc.rst
@@ -2,6 +2,8 @@
 Rule ``comment_to_phpdoc``
 ==========================
 
+`src <../../../src/Fixer/Comment/CommentToPhpdocFixer.php>`_
+
 Comments with annotation should be docblock when used on structural elements.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/comment/hash_to_slash_comment.rst
+++ b/doc/rules/comment/hash_to_slash_comment.rst
@@ -2,6 +2,8 @@
 Rule ``hash_to_slash_comment``
 ==============================
 
+`src <../../../src/Fixer/Comment/HashToSlashCommentFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``single_line_comment_style`` instead.

--- a/doc/rules/comment/header_comment.rst
+++ b/doc/rules/comment/header_comment.rst
@@ -2,6 +2,8 @@
 Rule ``header_comment``
 =======================
 
+`src <../../../src/Fixer/Comment/HeaderCommentFixer.php>`_
+
 Add, replace or remove header comment.
 
 Configuration

--- a/doc/rules/comment/multiline_comment_opening_closing.rst
+++ b/doc/rules/comment/multiline_comment_opening_closing.rst
@@ -2,6 +2,8 @@
 Rule ``multiline_comment_opening_closing``
 ==========================================
 
+`src <../../../src/Fixer/Comment/MultilineCommentOpeningClosingFixer.php>`_
+
 DocBlocks must start with two asterisks, multiline comments must start with a
 single asterisk, after the opening slash. Both must end with a single asterisk
 before the closing slash.

--- a/doc/rules/comment/no_empty_comment.rst
+++ b/doc/rules/comment/no_empty_comment.rst
@@ -2,6 +2,8 @@
 Rule ``no_empty_comment``
 =========================
 
+`src <../../../src/Fixer/Comment/NoEmptyCommentFixer.php>`_
+
 There should not be any empty comments.
 
 Examples

--- a/doc/rules/comment/no_trailing_whitespace_in_comment.rst
+++ b/doc/rules/comment/no_trailing_whitespace_in_comment.rst
@@ -2,6 +2,8 @@
 Rule ``no_trailing_whitespace_in_comment``
 ==========================================
 
+`src <../../../src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php>`_
+
 There MUST be no trailing spaces inside comment or PHPDoc.
 
 Examples

--- a/doc/rules/comment/single_line_comment_style.rst
+++ b/doc/rules/comment/single_line_comment_style.rst
@@ -2,6 +2,8 @@
 Rule ``single_line_comment_style``
 ==================================
 
+`src <../../../src/Fixer/Comment/SingleLineCommentStyleFixer.php>`_
+
 Single-line comments and multi-line comments with only one line of actual
 content should use the ``//`` syntax.
 

--- a/doc/rules/constant_notation/native_constant_invocation.rst
+++ b/doc/rules/constant_notation/native_constant_invocation.rst
@@ -2,6 +2,8 @@
 Rule ``native_constant_invocation``
 ===================================
 
+`src <../../../src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php>`_
+
 Add leading ``\`` before constant invocation of internal constant to speed up
 resolving. Constant name match is case-sensitive, except for ``null``, ``false``
 and ``true``.

--- a/doc/rules/control_structure/elseif.rst
+++ b/doc/rules/control_structure/elseif.rst
@@ -2,6 +2,8 @@
 Rule ``elseif``
 ===============
 
+`src <../../../src/Fixer/ControlStructure/ElseifFixer.php>`_
+
 The keyword ``elseif`` should be used instead of ``else if`` so that all control
 keywords look like single words.
 

--- a/doc/rules/control_structure/include.rst
+++ b/doc/rules/control_structure/include.rst
@@ -2,6 +2,8 @@
 Rule ``include``
 ================
 
+`src <../../../src/Fixer/ControlStructure/IncludeFixer.php>`_
+
 Include/Require and file path should be divided with a single space. File path
 should not be placed under brackets.
 

--- a/doc/rules/control_structure/no_alternative_syntax.rst
+++ b/doc/rules/control_structure/no_alternative_syntax.rst
@@ -2,6 +2,8 @@
 Rule ``no_alternative_syntax``
 ==============================
 
+`src <../../../src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php>`_
+
 Replace control structure alternative syntax to use braces.
 
 Examples

--- a/doc/rules/control_structure/no_break_comment.rst
+++ b/doc/rules/control_structure/no_break_comment.rst
@@ -2,6 +2,8 @@
 Rule ``no_break_comment``
 =========================
 
+`src <../../../src/Fixer/ControlStructure/NoBreakCommentFixer.php>`_
+
 There must be a comment when fall-through is intentional in a non-empty case
 body.
 

--- a/doc/rules/control_structure/no_superfluous_elseif.rst
+++ b/doc/rules/control_structure/no_superfluous_elseif.rst
@@ -2,6 +2,8 @@
 Rule ``no_superfluous_elseif``
 ==============================
 
+`src <../../../src/Fixer/ControlStructure/NoSuperfluousElseifFixer.php>`_
+
 Replaces superfluous ``elseif`` with ``if``.
 
 Examples

--- a/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
+++ b/doc/rules/control_structure/no_trailing_comma_in_list_call.rst
@@ -2,6 +2,8 @@
 Rule ``no_trailing_comma_in_list_call``
 =======================================
 
+`src <../../../src/Fixer/ControlStructure/NoTrailingCommaInListCallFixer.php>`_
+
 Remove trailing commas in list function calls.
 
 Examples

--- a/doc/rules/control_structure/no_unneeded_control_parentheses.rst
+++ b/doc/rules/control_structure/no_unneeded_control_parentheses.rst
@@ -2,6 +2,8 @@
 Rule ``no_unneeded_control_parentheses``
 ========================================
 
+`src <../../../src/Fixer/ControlStructure/NoUnneededControlParenthesesFixer.php>`_
+
 Removes unneeded parentheses around control statements.
 
 Configuration

--- a/doc/rules/control_structure/no_unneeded_curly_braces.rst
+++ b/doc/rules/control_structure/no_unneeded_curly_braces.rst
@@ -2,6 +2,8 @@
 Rule ``no_unneeded_curly_braces``
 =================================
 
+`src <../../../src/Fixer/ControlStructure/NoUnneededCurlyBracesFixer.php>`_
+
 Removes unneeded curly braces that are superfluous and aren't part of a control
 structure's body.
 

--- a/doc/rules/control_structure/no_useless_else.rst
+++ b/doc/rules/control_structure/no_useless_else.rst
@@ -2,6 +2,8 @@
 Rule ``no_useless_else``
 ========================
 
+`src <../../../src/Fixer/ControlStructure/NoUselessElseFixer.php>`_
+
 There should not be useless ``else`` cases.
 
 Examples

--- a/doc/rules/control_structure/simplified_if_return.rst
+++ b/doc/rules/control_structure/simplified_if_return.rst
@@ -2,6 +2,8 @@
 Rule ``simplified_if_return``
 =============================
 
+`src <../../../src/Fixer/ControlStructure/SimplifiedIfReturnFixer.php>`_
+
 Simplify ``if`` control structures that return the boolean result of their
 condition.
 

--- a/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
+++ b/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
@@ -2,6 +2,8 @@
 Rule ``switch_case_semicolon_to_colon``
 =======================================
 
+`src <../../../src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php>`_
+
 A case should be followed by a colon and not a semicolon.
 
 Examples

--- a/doc/rules/control_structure/switch_case_space.rst
+++ b/doc/rules/control_structure/switch_case_space.rst
@@ -2,6 +2,8 @@
 Rule ``switch_case_space``
 ==========================
 
+`src <../../../src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php>`_
+
 Removes extra spaces between colon and case value.
 
 Examples

--- a/doc/rules/control_structure/switch_continue_to_break.rst
+++ b/doc/rules/control_structure/switch_continue_to_break.rst
@@ -2,6 +2,8 @@
 Rule ``switch_continue_to_break``
 =================================
 
+`src <../../../src/Fixer/ControlStructure/SwitchContinueToBreakFixer.php>`_
+
 Switch case must not be ended with ``continue`` but with ``break``.
 
 Examples

--- a/doc/rules/control_structure/yoda_style.rst
+++ b/doc/rules/control_structure/yoda_style.rst
@@ -2,6 +2,8 @@
 Rule ``yoda_style``
 ===================
 
+`src <../../../src/Fixer/ControlStructure/YodaStyleFixer.php>`_
+
 Write conditions in Yoda style (``true``), non-Yoda style (``['equal' => false,
 'identical' => false, 'less_and_greater' => false]``) or ignore those conditions
 (``null``) based on configuration.

--- a/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_array_assignment.rst
@@ -2,6 +2,8 @@
 Rule ``doctrine_annotation_array_assignment``
 =============================================
 
+`src <../../../src/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixer.php>`_
+
 Doctrine annotations must use configured operator for assignment in arrays.
 
 Configuration

--- a/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_braces.rst
@@ -2,6 +2,8 @@
 Rule ``doctrine_annotation_braces``
 ===================================
 
+`src <../../../src/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixer.php>`_
+
 Doctrine annotations without arguments must use the configured syntax.
 
 Configuration

--- a/doc/rules/doctrine_annotation/doctrine_annotation_indentation.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_indentation.rst
@@ -2,6 +2,8 @@
 Rule ``doctrine_annotation_indentation``
 ========================================
 
+`src <../../../src/Fixer/DoctrineAnnotation/DoctrineAnnotationIndentationFixer.php>`_
+
 Doctrine annotations must be indented with four spaces.
 
 Configuration

--- a/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
+++ b/doc/rules/doctrine_annotation/doctrine_annotation_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``doctrine_annotation_spaces``
 ===================================
 
+`src <../../../src/Fixer/DoctrineAnnotation/DoctrineAnnotationSpacesFixer.php>`_
+
 Fixes spaces in Doctrine annotations.
 
 Description

--- a/doc/rules/function_notation/combine_nested_dirname.rst
+++ b/doc/rules/function_notation/combine_nested_dirname.rst
@@ -2,6 +2,8 @@
 Rule ``combine_nested_dirname``
 ===============================
 
+`src <../../../src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php>`_
+
 Replace multiple nested calls of ``dirname`` by only one call with second
 ``$level`` parameter. Requires PHP >= 7.0.
 

--- a/doc/rules/function_notation/fopen_flag_order.rst
+++ b/doc/rules/function_notation/fopen_flag_order.rst
@@ -2,6 +2,8 @@
 Rule ``fopen_flag_order``
 =========================
 
+`src <../../../src/Fixer/FunctionNotation/FopenFlagOrderFixer.php>`_
+
 Order the flags in ``fopen`` calls, ``b`` and ``t`` must be last.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/fopen_flags.rst
+++ b/doc/rules/function_notation/fopen_flags.rst
@@ -2,6 +2,8 @@
 Rule ``fopen_flags``
 ====================
 
+`src <../../../src/Fixer/FunctionNotation/FopenFlagsFixer.php>`_
+
 The flags in ``fopen`` calls must omit ``t``, and ``b`` must be omitted or
 included consistently.
 

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -2,6 +2,8 @@
 Rule ``function_declaration``
 =============================
 
+`src <../../../src/Fixer/FunctionNotation/FunctionDeclarationFixer.php>`_
+
 Spaces should be properly placed in a function declaration.
 
 Configuration

--- a/doc/rules/function_notation/function_typehint_space.rst
+++ b/doc/rules/function_notation/function_typehint_space.rst
@@ -2,6 +2,8 @@
 Rule ``function_typehint_space``
 ================================
 
+`src <../../../src/Fixer/FunctionNotation/FunctionTypehintSpaceFixer.php>`_
+
 Ensure single space between function's argument and its typehint.
 
 Examples

--- a/doc/rules/function_notation/implode_call.rst
+++ b/doc/rules/function_notation/implode_call.rst
@@ -2,6 +2,8 @@
 Rule ``implode_call``
 =====================
 
+`src <../../../src/Fixer/FunctionNotation/ImplodeCallFixer.php>`_
+
 Function ``implode`` must be called with 2 arguments in the documented order.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/lambda_not_used_import.rst
+++ b/doc/rules/function_notation/lambda_not_used_import.rst
@@ -2,6 +2,8 @@
 Rule ``lambda_not_used_import``
 ===============================
 
+`src <../../../src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php>`_
+
 Lambda must not import variables it doesn't use.
 
 Examples

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -2,6 +2,8 @@
 Rule ``method_argument_space``
 ==============================
 
+`src <../../../src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php>`_
+
 In method arguments and method call, there MUST NOT be a space before each comma
 and there MUST be one space after each comma. Argument lists MAY be split across
 multiple lines, where each subsequent line is indented once. When doing so, the

--- a/doc/rules/function_notation/native_function_invocation.rst
+++ b/doc/rules/function_notation/native_function_invocation.rst
@@ -2,6 +2,8 @@
 Rule ``native_function_invocation``
 ===================================
 
+`src <../../../src/Fixer/FunctionNotation/NativeFunctionInvocationFixer.php>`_
+
 Add leading ``\`` before function invocation to speed up resolving.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/no_spaces_after_function_name.rst
+++ b/doc/rules/function_notation/no_spaces_after_function_name.rst
@@ -2,6 +2,8 @@
 Rule ``no_spaces_after_function_name``
 ======================================
 
+`src <../../../src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php>`_
+
 When making a method or function call, there MUST NOT be a space between the
 method or function name and the opening parenthesis.
 

--- a/doc/rules/function_notation/no_unreachable_default_argument_value.rst
+++ b/doc/rules/function_notation/no_unreachable_default_argument_value.rst
@@ -2,6 +2,8 @@
 Rule ``no_unreachable_default_argument_value``
 ==============================================
 
+`src <../../../src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php>`_
+
 In function arguments there must not be arguments with default values before
 non-default ones.
 

--- a/doc/rules/function_notation/no_useless_sprintf.rst
+++ b/doc/rules/function_notation/no_useless_sprintf.rst
@@ -2,6 +2,8 @@
 Rule ``no_useless_sprintf``
 ===========================
 
+`src <../../../src/Fixer/FunctionNotation/NoUselessSprintfFixer.php>`_
+
 There must be no ``sprintf`` calls with only the first argument.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -2,6 +2,8 @@
 Rule ``nullable_type_declaration_for_default_null_value``
 =========================================================
 
+`src <../../../src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php>`_
+
 Adds or removes ``?`` before type declarations for parameters with a default
 ``null`` value.
 

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_to_param_type``
 =============================
 
+`src <../../../src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php>`_
+
 EXPERIMENTAL: Takes ``@param`` annotations of non-mixed types and adjusts
 accordingly the function signature. Requires PHP >= 7.0.
 

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_to_return_type``
 ==============================
 
+`src <../../../src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php>`_
+
 EXPERIMENTAL: Takes ``@return`` annotation of non-mixed types and adjusts
 accordingly the function signature. Requires PHP >= 7.0.
 

--- a/doc/rules/function_notation/regular_callable_call.rst
+++ b/doc/rules/function_notation/regular_callable_call.rst
@@ -2,6 +2,8 @@
 Rule ``regular_callable_call``
 ==============================
 
+`src <../../../src/Fixer/FunctionNotation/RegularCallableCallFixer.php>`_
+
 Callables must be called without using ``call_user_func*`` when possible.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/return_type_declaration.rst
+++ b/doc/rules/function_notation/return_type_declaration.rst
@@ -2,6 +2,8 @@
 Rule ``return_type_declaration``
 ================================
 
+`src <../../../src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php>`_
+
 There should be one or no space before colon, and one space after it in return
 type declarations, according to configuration.
 

--- a/doc/rules/function_notation/single_line_throw.rst
+++ b/doc/rules/function_notation/single_line_throw.rst
@@ -2,6 +2,8 @@
 Rule ``single_line_throw``
 ==========================
 
+`src <../../../src/Fixer/FunctionNotation/SingleLineThrowFixer.php>`_
+
 Throwing exception must be done in single line.
 
 Examples

--- a/doc/rules/function_notation/static_lambda.rst
+++ b/doc/rules/function_notation/static_lambda.rst
@@ -2,6 +2,8 @@
 Rule ``static_lambda``
 ======================
 
+`src <../../../src/Fixer/FunctionNotation/StaticLambdaFixer.php>`_
+
 Lambdas not (indirect) referencing ``$this`` must be declared ``static``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/use_arrow_functions.rst
+++ b/doc/rules/function_notation/use_arrow_functions.rst
@@ -2,6 +2,8 @@
 Rule ``use_arrow_functions``
 ============================
 
+`src <../../../src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php>`_
+
 Anonymous functions with one-liner return statement must use arrow functions.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/function_notation/void_return.rst
+++ b/doc/rules/function_notation/void_return.rst
@@ -2,6 +2,8 @@
 Rule ``void_return``
 ====================
 
+`src <../../../src/Fixer/FunctionNotation/VoidReturnFixer.php>`_
+
 Add ``void`` return type to functions with missing or empty return statements,
 but priority is given to ``@return`` annotations. Requires PHP >= 7.1.
 

--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -2,6 +2,8 @@
 Rule ``fully_qualified_strict_types``
 =====================================
 
+`src <../../../src/Fixer/Import/FullyQualifiedStrictTypesFixer.php>`_
+
 Transforms imported FQCN parameters and return types in function arguments to
 short version.
 

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -2,6 +2,8 @@
 Rule ``global_namespace_import``
 ================================
 
+`src <../../../src/Fixer/Import/GlobalNamespaceImportFixer.php>`_
+
 Imports or fully qualifies global classes/functions/constants.
 
 Configuration

--- a/doc/rules/import/group_import.rst
+++ b/doc/rules/import/group_import.rst
@@ -2,6 +2,8 @@
 Rule ``group_import``
 =====================
 
+`src <../../../src/Fixer/Import/GroupImportFixer.php>`_
+
 There MUST be group use for the same namespaces.
 
 Examples

--- a/doc/rules/import/no_leading_import_slash.rst
+++ b/doc/rules/import/no_leading_import_slash.rst
@@ -2,6 +2,8 @@
 Rule ``no_leading_import_slash``
 ================================
 
+`src <../../../src/Fixer/Import/NoLeadingImportSlashFixer.php>`_
+
 Remove leading slashes in ``use`` clauses.
 
 Examples

--- a/doc/rules/import/no_unused_imports.rst
+++ b/doc/rules/import/no_unused_imports.rst
@@ -2,6 +2,8 @@
 Rule ``no_unused_imports``
 ==========================
 
+`src <../../../src/Fixer/Import/NoUnusedImportsFixer.php>`_
+
 Unused ``use`` statements must be removed.
 
 Examples

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -2,6 +2,8 @@
 Rule ``ordered_imports``
 ========================
 
+`src <../../../src/Fixer/Import/OrderedImportsFixer.php>`_
+
 Ordering ``use`` statements.
 
 Configuration

--- a/doc/rules/import/single_import_per_statement.rst
+++ b/doc/rules/import/single_import_per_statement.rst
@@ -2,6 +2,8 @@
 Rule ``single_import_per_statement``
 ====================================
 
+`src <../../../src/Fixer/Import/SingleImportPerStatementFixer.php>`_
+
 There MUST be one use keyword per declaration.
 
 Examples

--- a/doc/rules/import/single_line_after_imports.rst
+++ b/doc/rules/import/single_line_after_imports.rst
@@ -2,6 +2,8 @@
 Rule ``single_line_after_imports``
 ==================================
 
+`src <../../../src/Fixer/Import/SingleLineAfterImportsFixer.php>`_
+
 Each namespace use MUST go on its own line and there MUST be one blank line
 after the use statements block.
 

--- a/doc/rules/language_construct/class_keyword_remove.rst
+++ b/doc/rules/language_construct/class_keyword_remove.rst
@@ -2,6 +2,8 @@
 Rule ``class_keyword_remove``
 =============================
 
+`src <../../../src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php>`_
+
 Converts ``::class`` keywords to FQCN strings.
 
 Examples

--- a/doc/rules/language_construct/combine_consecutive_issets.rst
+++ b/doc/rules/language_construct/combine_consecutive_issets.rst
@@ -2,6 +2,8 @@
 Rule ``combine_consecutive_issets``
 ===================================
 
+`src <../../../src/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixer.php>`_
+
 Using ``isset($var) &&`` multiple times should be done in one call.
 
 Examples

--- a/doc/rules/language_construct/combine_consecutive_unsets.rst
+++ b/doc/rules/language_construct/combine_consecutive_unsets.rst
@@ -2,6 +2,8 @@
 Rule ``combine_consecutive_unsets``
 ===================================
 
+`src <../../../src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php>`_
+
 Calling ``unset`` on multiple items should be done in one call.
 
 Examples

--- a/doc/rules/language_construct/declare_equal_normalize.rst
+++ b/doc/rules/language_construct/declare_equal_normalize.rst
@@ -2,6 +2,8 @@
 Rule ``declare_equal_normalize``
 ================================
 
+`src <../../../src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php>`_
+
 Equal sign in declare statement should be surrounded by spaces or not following
 configuration.
 

--- a/doc/rules/language_construct/dir_constant.rst
+++ b/doc/rules/language_construct/dir_constant.rst
@@ -2,6 +2,8 @@
 Rule ``dir_constant``
 =====================
 
+`src <../../../src/Fixer/LanguageConstruct/DirConstantFixer.php>`_
+
 Replaces ``dirname(__FILE__)`` expression with equivalent ``__DIR__`` constant.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/language_construct/error_suppression.rst
+++ b/doc/rules/language_construct/error_suppression.rst
@@ -2,6 +2,8 @@
 Rule ``error_suppression``
 ==========================
 
+`src <../../../src/Fixer/LanguageConstruct/ErrorSuppressionFixer.php>`_
+
 Error control operator should be added to deprecation notices and/or removed
 from other cases.
 

--- a/doc/rules/language_construct/explicit_indirect_variable.rst
+++ b/doc/rules/language_construct/explicit_indirect_variable.rst
@@ -2,6 +2,8 @@
 Rule ``explicit_indirect_variable``
 ===================================
 
+`src <../../../src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php>`_
+
 Add curly braces to indirect variables to make them clear to understand.
 Requires PHP >= 7.0.
 

--- a/doc/rules/language_construct/function_to_constant.rst
+++ b/doc/rules/language_construct/function_to_constant.rst
@@ -2,6 +2,8 @@
 Rule ``function_to_constant``
 =============================
 
+`src <../../../src/Fixer/LanguageConstruct/FunctionToConstantFixer.php>`_
+
 Replace core functions calls returning constants with the constants.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/language_construct/is_null.rst
+++ b/doc/rules/language_construct/is_null.rst
@@ -2,6 +2,8 @@
 Rule ``is_null``
 ================
 
+`src <../../../src/Fixer/LanguageConstruct/IsNullFixer.php>`_
+
 Replaces ``is_null($var)`` expression with ``null === $var``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/language_construct/no_unset_on_property.rst
+++ b/doc/rules/language_construct/no_unset_on_property.rst
@@ -2,6 +2,8 @@
 Rule ``no_unset_on_property``
 =============================
 
+`src <../../../src/Fixer/LanguageConstruct/NoUnsetOnPropertyFixer.php>`_
+
 Properties should be set to ``null`` instead of using ``unset``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/language_construct/silenced_deprecation_error.rst
+++ b/doc/rules/language_construct/silenced_deprecation_error.rst
@@ -2,6 +2,8 @@
 Rule ``silenced_deprecation_error``
 ===================================
 
+`src <../../../src/Fixer/LanguageConstruct/SilencedDeprecationErrorFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``error_suppression`` instead.

--- a/doc/rules/language_construct/single_space_after_construct.rst
+++ b/doc/rules/language_construct/single_space_after_construct.rst
@@ -2,6 +2,8 @@
 Rule ``single_space_after_construct``
 =====================================
 
+`src <../../../src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php>`_
+
 Ensures a single space after language constructs.
 
 Configuration

--- a/doc/rules/list_notation/list_syntax.rst
+++ b/doc/rules/list_notation/list_syntax.rst
@@ -2,6 +2,8 @@
 Rule ``list_syntax``
 ====================
 
+`src <../../../src/Fixer/ListNotation/ListSyntaxFixer.php>`_
+
 List (``array`` destructuring) assignment should be declared using the
 configured syntax. Requires PHP >= 7.1.
 

--- a/doc/rules/namespace_notation/blank_line_after_namespace.rst
+++ b/doc/rules/namespace_notation/blank_line_after_namespace.rst
@@ -2,6 +2,8 @@
 Rule ``blank_line_after_namespace``
 ===================================
 
+`src <../../../src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php>`_
+
 There MUST be one blank line after the namespace declaration.
 
 Examples

--- a/doc/rules/namespace_notation/clean_namespace.rst
+++ b/doc/rules/namespace_notation/clean_namespace.rst
@@ -2,6 +2,8 @@
 Rule ``clean_namespace``
 ========================
 
+`src <../../../src/Fixer/NamespaceNotation/CleanNamespaceFixer.php>`_
+
 Namespace must not contain spacing, comments or PHPDoc.
 
 Examples

--- a/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
+++ b/doc/rules/namespace_notation/no_blank_lines_before_namespace.rst
@@ -2,6 +2,8 @@
 Rule ``no_blank_lines_before_namespace``
 ========================================
 
+`src <../../../src/Fixer/NamespaceNotation/NoBlankLinesBeforeNamespaceFixer.php>`_
+
 There should be no blank lines before a namespace declaration.
 
 Examples

--- a/doc/rules/namespace_notation/no_leading_namespace_whitespace.rst
+++ b/doc/rules/namespace_notation/no_leading_namespace_whitespace.rst
@@ -2,6 +2,8 @@
 Rule ``no_leading_namespace_whitespace``
 ========================================
 
+`src <../../../src/Fixer/NamespaceNotation/NoLeadingNamespaceWhitespaceFixer.php>`_
+
 The namespace declaration line shouldn't contain leading whitespace.
 
 Examples

--- a/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
+++ b/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
@@ -2,6 +2,8 @@
 Rule ``single_blank_line_before_namespace``
 ===========================================
 
+`src <../../../src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php>`_
+
 There should be exactly one blank line before a namespace declaration.
 
 Examples

--- a/doc/rules/naming/no_homoglyph_names.rst
+++ b/doc/rules/naming/no_homoglyph_names.rst
@@ -2,6 +2,8 @@
 Rule ``no_homoglyph_names``
 ===========================
 
+`src <../../../src/Fixer/Naming/NoHomoglyphNamesFixer.php>`_
+
 Replace accidental usage of homoglyphs (non ascii characters) in names.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/operator/binary_operator_spaces.rst
+++ b/doc/rules/operator/binary_operator_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``binary_operator_spaces``
 ===============================
 
+`src <../../../src/Fixer/Operator/BinaryOperatorSpacesFixer.php>`_
+
 Binary operators should be surrounded by space as configured.
 
 Configuration

--- a/doc/rules/operator/concat_space.rst
+++ b/doc/rules/operator/concat_space.rst
@@ -2,6 +2,8 @@
 Rule ``concat_space``
 =====================
 
+`src <../../../src/Fixer/Operator/ConcatSpaceFixer.php>`_
+
 Concatenation should be spaced according configuration.
 
 Configuration

--- a/doc/rules/operator/increment_style.rst
+++ b/doc/rules/operator/increment_style.rst
@@ -2,6 +2,8 @@
 Rule ``increment_style``
 ========================
 
+`src <../../../src/Fixer/Operator/IncrementStyleFixer.php>`_
+
 Pre- or post-increment and decrement operators should be used if possible.
 
 Configuration

--- a/doc/rules/operator/logical_operators.rst
+++ b/doc/rules/operator/logical_operators.rst
@@ -2,6 +2,8 @@
 Rule ``logical_operators``
 ==========================
 
+`src <../../../src/Fixer/Operator/LogicalOperatorsFixer.php>`_
+
 Use ``&&`` and ``||`` logical operators instead of ``and`` and ``or``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/operator/new_with_braces.rst
+++ b/doc/rules/operator/new_with_braces.rst
@@ -2,6 +2,8 @@
 Rule ``new_with_braces``
 ========================
 
+`src <../../../src/Fixer/Operator/NewWithBracesFixer.php>`_
+
 All instances created with new keyword must be followed by braces.
 
 Examples

--- a/doc/rules/operator/not_operator_with_space.rst
+++ b/doc/rules/operator/not_operator_with_space.rst
@@ -2,6 +2,8 @@
 Rule ``not_operator_with_space``
 ================================
 
+`src <../../../src/Fixer/Operator/NotOperatorWithSpaceFixer.php>`_
+
 Logical NOT operators (``!``) should have leading and trailing whitespaces.
 
 Examples

--- a/doc/rules/operator/not_operator_with_successor_space.rst
+++ b/doc/rules/operator/not_operator_with_successor_space.rst
@@ -2,6 +2,8 @@
 Rule ``not_operator_with_successor_space``
 ==========================================
 
+`src <../../../src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php>`_
+
 Logical NOT operators (``!``) should have one trailing whitespace.
 
 Examples

--- a/doc/rules/operator/object_operator_without_whitespace.rst
+++ b/doc/rules/operator/object_operator_without_whitespace.rst
@@ -2,6 +2,8 @@
 Rule ``object_operator_without_whitespace``
 ===========================================
 
+`src <../../../src/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixer.php>`_
+
 There should not be space before or after object operators ``->`` and ``?->``.
 
 Examples

--- a/doc/rules/operator/operator_linebreak.rst
+++ b/doc/rules/operator/operator_linebreak.rst
@@ -2,6 +2,8 @@
 Rule ``operator_linebreak``
 ===========================
 
+`src <../../../src/Fixer/Operator/OperatorLinebreakFixer.php>`_
+
 Operators - when multiline - must always be at the beginning or at the end of
 the line.
 

--- a/doc/rules/operator/pre_increment.rst
+++ b/doc/rules/operator/pre_increment.rst
@@ -2,6 +2,8 @@
 Rule ``pre_increment``
 ======================
 
+`src <../../../src/Fixer/Operator/PreIncrementFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``increment_style`` instead.

--- a/doc/rules/operator/standardize_increment.rst
+++ b/doc/rules/operator/standardize_increment.rst
@@ -2,6 +2,8 @@
 Rule ``standardize_increment``
 ==============================
 
+`src <../../../src/Fixer/Operator/StandardizeIncrementFixer.php>`_
+
 Increment and decrement operators should be used if possible.
 
 Examples

--- a/doc/rules/operator/standardize_not_equals.rst
+++ b/doc/rules/operator/standardize_not_equals.rst
@@ -2,6 +2,8 @@
 Rule ``standardize_not_equals``
 ===============================
 
+`src <../../../src/Fixer/Operator/StandardizeNotEqualsFixer.php>`_
+
 Replace all ``<>`` with ``!=``.
 
 Examples

--- a/doc/rules/operator/ternary_operator_spaces.rst
+++ b/doc/rules/operator/ternary_operator_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``ternary_operator_spaces``
 ================================
 
+`src <../../../src/Fixer/Operator/TernaryOperatorSpacesFixer.php>`_
+
 Standardize spaces around ternary operator.
 
 Examples

--- a/doc/rules/operator/ternary_to_elvis_operator.rst
+++ b/doc/rules/operator/ternary_to_elvis_operator.rst
@@ -2,6 +2,8 @@
 Rule ``ternary_to_elvis_operator``
 ==================================
 
+`src <../../../src/Fixer/Operator/TernaryToElvisOperatorFixer.php>`_
+
 Use the Elvis operator ``?:`` where possible.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/operator/ternary_to_null_coalescing.rst
+++ b/doc/rules/operator/ternary_to_null_coalescing.rst
@@ -2,6 +2,8 @@
 Rule ``ternary_to_null_coalescing``
 ===================================
 
+`src <../../../src/Fixer/Operator/TernaryToNullCoalescingFixer.php>`_
+
 Use ``null`` coalescing operator ``??`` where possible. Requires PHP >= 7.0.
 
 Examples

--- a/doc/rules/operator/unary_operator_spaces.rst
+++ b/doc/rules/operator/unary_operator_spaces.rst
@@ -2,6 +2,8 @@
 Rule ``unary_operator_spaces``
 ==============================
 
+`src <../../../src/Fixer/Operator/UnaryOperatorSpacesFixer.php>`_
+
 Unary operators should be placed adjacent to their operands.
 
 Examples

--- a/doc/rules/php_tag/blank_line_after_opening_tag.rst
+++ b/doc/rules/php_tag/blank_line_after_opening_tag.rst
@@ -2,6 +2,8 @@
 Rule ``blank_line_after_opening_tag``
 =====================================
 
+`src <../../../src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php>`_
+
 Ensure there is no code on the same line as the PHP open tag and it is followed
 by a blank line.
 

--- a/doc/rules/php_tag/echo_tag_syntax.rst
+++ b/doc/rules/php_tag/echo_tag_syntax.rst
@@ -2,6 +2,8 @@
 Rule ``echo_tag_syntax``
 ========================
 
+`src <../../../src/Fixer/PhpTag/EchoTagSyntaxFixer.php>`_
+
 Replaces short-echo ``<?=`` with long format ``<?php echo``/``<?php print``
 syntax, or vice-versa.
 

--- a/doc/rules/php_tag/full_opening_tag.rst
+++ b/doc/rules/php_tag/full_opening_tag.rst
@@ -2,6 +2,8 @@
 Rule ``full_opening_tag``
 =========================
 
+`src <../../../src/Fixer/PhpTag/FullOpeningTagFixer.php>`_
+
 PHP code must use the long ``<?php`` tags or short-echo ``<?=`` tags and not
 other tag variations.
 

--- a/doc/rules/php_tag/linebreak_after_opening_tag.rst
+++ b/doc/rules/php_tag/linebreak_after_opening_tag.rst
@@ -2,6 +2,8 @@
 Rule ``linebreak_after_opening_tag``
 ====================================
 
+`src <../../../src/Fixer/PhpTag/LinebreakAfterOpeningTagFixer.php>`_
+
 Ensure there is no code on the same line as the PHP open tag.
 
 Examples

--- a/doc/rules/php_tag/no_closing_tag.rst
+++ b/doc/rules/php_tag/no_closing_tag.rst
@@ -2,6 +2,8 @@
 Rule ``no_closing_tag``
 =======================
 
+`src <../../../src/Fixer/PhpTag/NoClosingTagFixer.php>`_
+
 The closing ``?>`` tag MUST be omitted from files containing only PHP.
 
 Examples

--- a/doc/rules/php_tag/no_short_echo_tag.rst
+++ b/doc/rules/php_tag/no_short_echo_tag.rst
@@ -2,6 +2,8 @@
 Rule ``no_short_echo_tag``
 ==========================
 
+`src <../../../src/Fixer/PhpTag/NoShortEchoTagFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``echo_tag_syntax`` instead.

--- a/doc/rules/php_unit/php_unit_construct.rst
+++ b/doc/rules/php_unit/php_unit_construct.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_construct``
 ===========================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitConstructFixer.php>`_
+
 PHPUnit assertion method calls like ``->assertSame(true, $foo)`` should be
 written with dedicated method like ``->assertTrue($foo)``.
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_dedicate_assert``
 =================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitDedicateAssertFixer.php>`_
+
 PHPUnit assertions like ``assertInternalType``, ``assertFileExists``, should be
 used over ``assertTrue``.
 

--- a/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
+++ b/doc/rules/php_unit/php_unit_dedicate_assert_internal_type.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_dedicate_assert_internal_type``
 ===============================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php>`_
+
 PHPUnit assertions like ``assertIsArray`` should be used over
 ``assertInternalType``.
 

--- a/doc/rules/php_unit/php_unit_expectation.rst
+++ b/doc/rules/php_unit/php_unit_expectation.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_expectation``
 =============================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitExpectationFixer.php>`_
+
 Usages of ``->setExpectedException*`` methods MUST be replaced by
 ``->expectException*`` methods.
 

--- a/doc/rules/php_unit/php_unit_fqcn_annotation.rst
+++ b/doc/rules/php_unit/php_unit_fqcn_annotation.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_fqcn_annotation``
 =================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitFqcnAnnotationFixer.php>`_
+
 PHPUnit annotations should be a FQCNs including a root namespace.
 
 Examples

--- a/doc/rules/php_unit/php_unit_internal_class.rst
+++ b/doc/rules/php_unit/php_unit_internal_class.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_internal_class``
 ================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitInternalClassFixer.php>`_
+
 All PHPUnit test classes should be marked as internal.
 
 Configuration

--- a/doc/rules/php_unit/php_unit_method_casing.rst
+++ b/doc/rules/php_unit/php_unit_method_casing.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_method_casing``
 ===============================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php>`_
+
 Enforce camel (or snake) case for PHPUnit test methods, following configuration.
 
 Configuration

--- a/doc/rules/php_unit/php_unit_mock.rst
+++ b/doc/rules/php_unit/php_unit_mock.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_mock``
 ======================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitMockFixer.php>`_
+
 Usages of ``->getMock`` and ``->getMockWithoutInvokingTheOriginalConstructor``
 methods MUST be replaced by ``->createMock`` or ``->createPartialMock`` methods.
 

--- a/doc/rules/php_unit/php_unit_mock_short_will_return.rst
+++ b/doc/rules/php_unit/php_unit_mock_short_will_return.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_mock_short_will_return``
 ========================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitMockShortWillReturnFixer.php>`_
+
 Usage of PHPUnit's mock e.g. ``->will($this->returnValue(..))`` must be replaced
 by its shorter equivalent such as ``->willReturn(...)``.
 

--- a/doc/rules/php_unit/php_unit_namespaced.rst
+++ b/doc/rules/php_unit/php_unit_namespaced.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_namespaced``
 ============================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitNamespacedFixer.php>`_
+
 PHPUnit classes MUST be used in namespaced version, e.g.
 ``\PHPUnit\Framework\TestCase`` instead of ``\PHPUnit_Framework_TestCase``.
 

--- a/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
+++ b/doc/rules/php_unit/php_unit_no_expectation_annotation.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_no_expectation_annotation``
 ===========================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php>`_
+
 Usages of ``@expectedException*`` annotations MUST be replaced by
 ``->setExpectedException*`` methods.
 

--- a/doc/rules/php_unit/php_unit_ordered_covers.rst
+++ b/doc/rules/php_unit/php_unit_ordered_covers.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_ordered_covers``
 ================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitOrderedCoversFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``phpdoc_order_by_value`` instead.

--- a/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst
+++ b/doc/rules/php_unit/php_unit_set_up_tear_down_visibility.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_set_up_tear_down_visibility``
 =============================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitSetUpTearDownVisibilityFixer.php>`_
+
 Changes the visibility of the ``setUp()`` and ``tearDown()`` functions of
 PHPUnit to ``protected``, to match the PHPUnit TestCase.
 

--- a/doc/rules/php_unit/php_unit_size_class.rst
+++ b/doc/rules/php_unit/php_unit_size_class.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_size_class``
 ============================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitSizeClassFixer.php>`_
+
 All PHPUnit test cases should have ``@small``, ``@medium`` or ``@large``
 annotation to enable run time limits.
 

--- a/doc/rules/php_unit/php_unit_strict.rst
+++ b/doc/rules/php_unit/php_unit_strict.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_strict``
 ========================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitStrictFixer.php>`_
+
 PHPUnit methods like ``assertSame`` should be used instead of ``assertEquals``.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/php_unit/php_unit_test_annotation.rst
+++ b/doc/rules/php_unit/php_unit_test_annotation.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_test_annotation``
 =================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitTestAnnotationFixer.php>`_
+
 Adds or removes @test annotations from tests, following configuration.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_test_case_static_method_calls``
 ===============================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixer.php>`_
+
 Calls to ``PHPUnit\Framework\TestCase`` static methods must all be of the same
 type, either ``$this->``, ``self::`` or ``static::``.
 

--- a/doc/rules/php_unit/php_unit_test_class_requires_covers.rst
+++ b/doc/rules/php_unit/php_unit_test_class_requires_covers.rst
@@ -2,6 +2,8 @@
 Rule ``php_unit_test_class_requires_covers``
 ============================================
 
+`src <../../../src/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixer.php>`_
+
 Adds a default ``@coversNothing`` annotation to PHPUnit test classes that have
 no ``@covers*`` annotation.
 

--- a/doc/rules/phpdoc/align_multiline_comment.rst
+++ b/doc/rules/phpdoc/align_multiline_comment.rst
@@ -2,6 +2,8 @@
 Rule ``align_multiline_comment``
 ================================
 
+`src <../../../src/Fixer/Phpdoc/AlignMultilineCommentFixer.php>`_
+
 Each line of multi-line DocComments must have an asterisk [PSR-5] and must be
 aligned with the first one.
 

--- a/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
+++ b/doc/rules/phpdoc/general_phpdoc_annotation_remove.rst
@@ -2,6 +2,8 @@
 Rule ``general_phpdoc_annotation_remove``
 =========================================
 
+`src <../../../src/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixer.php>`_
+
 Configured annotations should be omitted from PHPDoc.
 
 Configuration

--- a/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
+++ b/doc/rules/phpdoc/general_phpdoc_tag_rename.rst
@@ -2,6 +2,8 @@
 Rule ``general_phpdoc_tag_rename``
 ==================================
 
+`src <../../../src/Fixer/Phpdoc/GeneralPhpdocTagRenameFixer.php>`_
+
 Renames PHPDoc tags.
 
 Configuration

--- a/doc/rules/phpdoc/no_blank_lines_after_phpdoc.rst
+++ b/doc/rules/phpdoc/no_blank_lines_after_phpdoc.rst
@@ -2,6 +2,8 @@
 Rule ``no_blank_lines_after_phpdoc``
 ====================================
 
+`src <../../../src/Fixer/Phpdoc/NoBlankLinesAfterPhpdocFixer.php>`_
+
 There should not be blank lines between docblock and the documented element.
 
 Examples

--- a/doc/rules/phpdoc/no_empty_phpdoc.rst
+++ b/doc/rules/phpdoc/no_empty_phpdoc.rst
@@ -2,6 +2,8 @@
 Rule ``no_empty_phpdoc``
 ========================
 
+`src <../../../src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php>`_
+
 There should not be empty PHPDoc blocks.
 
 Examples

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -2,6 +2,8 @@
 Rule ``no_superfluous_phpdoc_tags``
 ===================================
 
+`src <../../../src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php>`_
+
 Removes ``@param``, ``@return`` and ``@var`` tags that don't provide any useful
 information.
 

--- a/doc/rules/phpdoc/phpdoc_add_missing_param_annotation.rst
+++ b/doc/rules/phpdoc/phpdoc_add_missing_param_annotation.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_add_missing_param_annotation``
 ============================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php>`_
+
 PHPDoc should contain ``@param`` for all params.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_align.rst
+++ b/doc/rules/phpdoc/phpdoc_align.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_align``
 =====================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocAlignFixer.php>`_
+
 All items of the given phpdoc tags must be either left-aligned or (by default)
 aligned vertically.
 

--- a/doc/rules/phpdoc/phpdoc_annotation_without_dot.rst
+++ b/doc/rules/phpdoc/phpdoc_annotation_without_dot.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_annotation_without_dot``
 ======================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocAnnotationWithoutDotFixer.php>`_
+
 PHPDoc annotation descriptions should not be a sentence.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_indent.rst
+++ b/doc/rules/phpdoc/phpdoc_indent.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_indent``
 ======================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocIndentFixer.php>`_
+
 Docblocks should have the same indentation as the documented subject.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_inline_tag.rst
+++ b/doc/rules/phpdoc/phpdoc_inline_tag.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_inline_tag``
 ==========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocInlineTagFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``general_phpdoc_tag_rename``,

--- a/doc/rules/phpdoc/phpdoc_inline_tag_normalizer.rst
+++ b/doc/rules/phpdoc/phpdoc_inline_tag_normalizer.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_inline_tag_normalizer``
 =====================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocInlineTagNormalizerFixer.php>`_
+
 Fixes PHPDoc inline tags.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_line_span``
 =========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocLineSpanFixer.php>`_
+
 Changes doc blocks from single to multi line, or reversed. Works for class
 constants, properties and methods only.
 

--- a/doc/rules/phpdoc/phpdoc_no_access.rst
+++ b/doc/rules/phpdoc/phpdoc_no_access.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_no_access``
 =========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocNoAccessFixer.php>`_
+
 ``@access`` annotations should be omitted from PHPDoc.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_no_alias_tag.rst
+++ b/doc/rules/phpdoc/phpdoc_no_alias_tag.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_no_alias_tag``
 ============================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocNoAliasTagFixer.php>`_
+
 No alias PHPDoc tags should be used.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_no_empty_return.rst
+++ b/doc/rules/phpdoc/phpdoc_no_empty_return.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_no_empty_return``
 ===============================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocNoEmptyReturnFixer.php>`_
+
 ``@return void`` and ``@return null`` annotations should be omitted from PHPDoc.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_no_package.rst
+++ b/doc/rules/phpdoc/phpdoc_no_package.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_no_package``
 ==========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocNoPackageFixer.php>`_
+
 ``@package`` and ``@subpackage`` annotations should be omitted from PHPDoc.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_no_useless_inheritdoc.rst
+++ b/doc/rules/phpdoc/phpdoc_no_useless_inheritdoc.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_no_useless_inheritdoc``
 =====================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php>`_
+
 Classy that does not inherit must not have ``@inheritdoc`` tags.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_order``
 =====================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocOrderFixer.php>`_
+
 Annotations in PHPDoc should be ordered so that ``@param`` annotations come
 first, then ``@throws`` annotations, then ``@return`` annotations.
 

--- a/doc/rules/phpdoc/phpdoc_order_by_value.rst
+++ b/doc/rules/phpdoc/phpdoc_order_by_value.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_order_by_value``
 ==============================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php>`_
+
 Order phpdoc tags by value.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_return_self_reference.rst
+++ b/doc/rules/phpdoc/phpdoc_return_self_reference.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_return_self_reference``
 =====================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php>`_
+
 The type of ``@return`` annotations of methods returning a reference to itself
 must the configured one.
 

--- a/doc/rules/phpdoc/phpdoc_scalar.rst
+++ b/doc/rules/phpdoc/phpdoc_scalar.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_scalar``
 ======================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocScalarFixer.php>`_
+
 Scalar types should always be written in the same form. ``int`` not ``integer``,
 ``bool`` not ``boolean``, ``float`` not ``real`` or ``double``.
 

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_separation``
 ==========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocSeparationFixer.php>`_
+
 Annotations in PHPDoc should be grouped together so that annotations of the same
 type immediately follow each other, and annotations of a different type are
 separated by a single blank line.

--- a/doc/rules/phpdoc/phpdoc_single_line_var_spacing.rst
+++ b/doc/rules/phpdoc/phpdoc_single_line_var_spacing.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_single_line_var_spacing``
 =======================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocSingleLineVarSpacingFixer.php>`_
+
 Single line ``@var`` PHPDoc should have proper spacing.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_summary.rst
+++ b/doc/rules/phpdoc/phpdoc_summary.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_summary``
 =======================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocSummaryFixer.php>`_
+
 PHPDoc summary should end in either a full stop, exclamation mark, or question
 mark.
 

--- a/doc/rules/phpdoc/phpdoc_tag_casing.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_casing.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_tag_casing``
 ==========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTagCasingFixer.php>`_
+
 Fixes casing of PHPDoc tags.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_tag_type.rst
+++ b/doc/rules/phpdoc/phpdoc_tag_type.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_tag_type``
 ========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTagTypeFixer.php>`_
+
 Forces PHPDoc tags to be either regular annotations or inline.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_to_comment.rst
+++ b/doc/rules/phpdoc/phpdoc_to_comment.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_to_comment``
 ==========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocToCommentFixer.php>`_
+
 Docblocks should only be used on structural elements.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_trim.rst
+++ b/doc/rules/phpdoc/phpdoc_trim.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_trim``
 ====================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTrimFixer.php>`_
+
 PHPDoc should start and end with content, excluding the very first and last line
 of the docblocks.
 

--- a/doc/rules/phpdoc/phpdoc_trim_consecutive_blank_line_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_trim_consecutive_blank_line_separation.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_trim_consecutive_blank_line_separation``
 ======================================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTrimConsecutiveBlankLineSeparationFixer.php>`_
+
 Removes extra blank lines after summary and after description in PHPDoc.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_types.rst
+++ b/doc/rules/phpdoc/phpdoc_types.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_types``
 =====================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTypesFixer.php>`_
+
 The correct case must be used for standard PHP types in PHPDoc.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_types_order.rst
+++ b/doc/rules/phpdoc/phpdoc_types_order.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_types_order``
 ===========================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php>`_
+
 Sorts PHPDoc types.
 
 Configuration

--- a/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst
+++ b/doc/rules/phpdoc/phpdoc_var_annotation_correct_order.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_var_annotation_correct_order``
 ============================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocVarAnnotationCorrectOrderFixer.php>`_
+
 ``@var`` and ``@type`` annotations must have type and name in the correct order.
 
 Examples

--- a/doc/rules/phpdoc/phpdoc_var_without_name.rst
+++ b/doc/rules/phpdoc/phpdoc_var_without_name.rst
@@ -2,6 +2,8 @@
 Rule ``phpdoc_var_without_name``
 ================================
 
+`src <../../../src/Fixer/Phpdoc/PhpdocVarWithoutNameFixer.php>`_
+
 ``@var`` and ``@type`` annotations of classy properties should not contain the
 name.
 

--- a/doc/rules/return_notation/blank_line_before_return.rst
+++ b/doc/rules/return_notation/blank_line_before_return.rst
@@ -2,6 +2,8 @@
 Rule ``blank_line_before_return``
 =================================
 
+`src <../../../src/Fixer/ReturnNotation/BlankLineBeforeReturnFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``blank_line_before_statement`` instead.

--- a/doc/rules/return_notation/no_useless_return.rst
+++ b/doc/rules/return_notation/no_useless_return.rst
@@ -2,6 +2,8 @@
 Rule ``no_useless_return``
 ==========================
 
+`src <../../../src/Fixer/ReturnNotation/NoUselessReturnFixer.php>`_
+
 There should not be an empty ``return`` statement at the end of a function.
 
 Examples

--- a/doc/rules/return_notation/return_assignment.rst
+++ b/doc/rules/return_notation/return_assignment.rst
@@ -2,6 +2,8 @@
 Rule ``return_assignment``
 ==========================
 
+`src <../../../src/Fixer/ReturnNotation/ReturnAssignmentFixer.php>`_
+
 Local, dynamic and directly referenced variables should not be assigned and
 directly returned by a function or method.
 

--- a/doc/rules/return_notation/simplified_null_return.rst
+++ b/doc/rules/return_notation/simplified_null_return.rst
@@ -2,6 +2,8 @@
 Rule ``simplified_null_return``
 ===============================
 
+`src <../../../src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php>`_
+
 A return statement wishing to return ``void`` should not return ``null``.
 
 Examples

--- a/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/multiline_whitespace_before_semicolons.rst
@@ -2,6 +2,8 @@
 Rule ``multiline_whitespace_before_semicolons``
 ===============================================
 
+`src <../../../src/Fixer/Semicolon/MultilineWhitespaceBeforeSemicolonsFixer.php>`_
+
 Forbid multi-line whitespace before the closing semicolon or move the semicolon
 to the new line for chained calls.
 

--- a/doc/rules/semicolon/no_empty_statement.rst
+++ b/doc/rules/semicolon/no_empty_statement.rst
@@ -2,6 +2,8 @@
 Rule ``no_empty_statement``
 ===========================
 
+`src <../../../src/Fixer/Semicolon/NoEmptyStatementFixer.php>`_
+
 Remove useless (semicolon) statements.
 
 Examples

--- a/doc/rules/semicolon/no_multiline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/no_multiline_whitespace_before_semicolons.rst
@@ -2,6 +2,8 @@
 Rule ``no_multiline_whitespace_before_semicolons``
 ==================================================
 
+`src <../../../src/Fixer/Semicolon/NoMultilineWhitespaceBeforeSemicolonsFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``multiline_whitespace_before_semicolons`` instead.

--- a/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
+++ b/doc/rules/semicolon/no_singleline_whitespace_before_semicolons.rst
@@ -2,6 +2,8 @@
 Rule ``no_singleline_whitespace_before_semicolons``
 ===================================================
 
+`src <../../../src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php>`_
+
 Single-line whitespace before closing semicolon are prohibited.
 
 Examples

--- a/doc/rules/semicolon/semicolon_after_instruction.rst
+++ b/doc/rules/semicolon/semicolon_after_instruction.rst
@@ -2,6 +2,8 @@
 Rule ``semicolon_after_instruction``
 ====================================
 
+`src <../../../src/Fixer/Semicolon/SemicolonAfterInstructionFixer.php>`_
+
 Instructions must be terminated with a semicolon.
 
 Examples

--- a/doc/rules/semicolon/space_after_semicolon.rst
+++ b/doc/rules/semicolon/space_after_semicolon.rst
@@ -2,6 +2,8 @@
 Rule ``space_after_semicolon``
 ==============================
 
+`src <../../../src/Fixer/Semicolon/SpaceAfterSemicolonFixer.php>`_
+
 Fix whitespace after a semicolon.
 
 Configuration

--- a/doc/rules/strict/declare_strict_types.rst
+++ b/doc/rules/strict/declare_strict_types.rst
@@ -2,6 +2,8 @@
 Rule ``declare_strict_types``
 =============================
 
+`src <../../../src/Fixer/Strict/DeclareStrictTypesFixer.php>`_
+
 Force strict types declaration in all files. Requires PHP >= 7.0.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/strict/strict_comparison.rst
+++ b/doc/rules/strict/strict_comparison.rst
@@ -2,6 +2,8 @@
 Rule ``strict_comparison``
 ==========================
 
+`src <../../../src/Fixer/Strict/StrictComparisonFixer.php>`_
+
 Comparisons should be strict.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/strict/strict_param.rst
+++ b/doc/rules/strict/strict_param.rst
@@ -2,6 +2,8 @@
 Rule ``strict_param``
 =====================
 
+`src <../../../src/Fixer/Strict/StrictParamFixer.php>`_
+
 Functions should be used with ``$strict`` param set to ``true``.
 
 Description

--- a/doc/rules/string_notation/escape_implicit_backslashes.rst
+++ b/doc/rules/string_notation/escape_implicit_backslashes.rst
@@ -2,6 +2,8 @@
 Rule ``escape_implicit_backslashes``
 ====================================
 
+`src <../../../src/Fixer/StringNotation/EscapeImplicitBackslashesFixer.php>`_
+
 Escape implicit backslashes in strings and heredocs to ease the understanding of
 which are special chars interpreted by PHP and which not.
 

--- a/doc/rules/string_notation/explicit_string_variable.rst
+++ b/doc/rules/string_notation/explicit_string_variable.rst
@@ -2,6 +2,8 @@
 Rule ``explicit_string_variable``
 =================================
 
+`src <../../../src/Fixer/StringNotation/ExplicitStringVariableFixer.php>`_
+
 Converts implicit variables into explicit ones in double-quoted strings or
 heredoc syntax.
 

--- a/doc/rules/string_notation/heredoc_to_nowdoc.rst
+++ b/doc/rules/string_notation/heredoc_to_nowdoc.rst
@@ -2,6 +2,8 @@
 Rule ``heredoc_to_nowdoc``
 ==========================
 
+`src <../../../src/Fixer/StringNotation/HeredocToNowdocFixer.php>`_
+
 Convert ``heredoc`` to ``nowdoc`` where possible.
 
 Examples

--- a/doc/rules/string_notation/no_binary_string.rst
+++ b/doc/rules/string_notation/no_binary_string.rst
@@ -2,6 +2,8 @@
 Rule ``no_binary_string``
 =========================
 
+`src <../../../src/Fixer/StringNotation/NoBinaryStringFixer.php>`_
+
 There should not be a binary flag before strings.
 
 Examples

--- a/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
+++ b/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
@@ -2,6 +2,8 @@
 Rule ``no_trailing_whitespace_in_string``
 =========================================
 
+`src <../../../src/Fixer/StringNotation/NoTrailingWhitespaceInStringFixer.php>`_
+
 There must be no trailing whitespace in strings.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/string_notation/simple_to_complex_string_variable.rst
+++ b/doc/rules/string_notation/simple_to_complex_string_variable.rst
@@ -2,6 +2,8 @@
 Rule ``simple_to_complex_string_variable``
 ==========================================
 
+`src <../../../src/Fixer/StringNotation/SimpleToComplexStringVariableFixer.php>`_
+
 Converts explicit variables in double-quoted strings and heredoc syntax from
 simple to complex format (``${`` to ``{$``).
 

--- a/doc/rules/string_notation/single_quote.rst
+++ b/doc/rules/string_notation/single_quote.rst
@@ -2,6 +2,8 @@
 Rule ``single_quote``
 =====================
 
+`src <../../../src/Fixer/StringNotation/SingleQuoteFixer.php>`_
+
 Convert double quotes to single quotes for simple strings.
 
 Configuration

--- a/doc/rules/string_notation/string_line_ending.rst
+++ b/doc/rules/string_notation/string_line_ending.rst
@@ -2,6 +2,8 @@
 Rule ``string_line_ending``
 ===========================
 
+`src <../../../src/Fixer/StringNotation/StringLineEndingFixer.php>`_
+
 All multi-line strings must use correct line ending.
 
 .. warning:: Using this rule is risky.

--- a/doc/rules/whitespace/array_indentation.rst
+++ b/doc/rules/whitespace/array_indentation.rst
@@ -2,6 +2,8 @@
 Rule ``array_indentation``
 ==========================
 
+`src <../../../src/Fixer/Whitespace/ArrayIndentationFixer.php>`_
+
 Each element of an array must be indented exactly once.
 
 Examples

--- a/doc/rules/whitespace/blank_line_before_statement.rst
+++ b/doc/rules/whitespace/blank_line_before_statement.rst
@@ -2,6 +2,8 @@
 Rule ``blank_line_before_statement``
 ====================================
 
+`src <../../../src/Fixer/Whitespace/BlankLineBeforeStatementFixer.php>`_
+
 An empty line feed must precede any configured statement.
 
 Configuration

--- a/doc/rules/whitespace/compact_nullable_typehint.rst
+++ b/doc/rules/whitespace/compact_nullable_typehint.rst
@@ -2,6 +2,8 @@
 Rule ``compact_nullable_typehint``
 ==================================
 
+`src <../../../src/Fixer/Whitespace/CompactNullableTypehintFixer.php>`_
+
 Remove extra spaces in a nullable typehint.
 
 Description

--- a/doc/rules/whitespace/heredoc_indentation.rst
+++ b/doc/rules/whitespace/heredoc_indentation.rst
@@ -2,6 +2,8 @@
 Rule ``heredoc_indentation``
 ============================
 
+`src <../../../src/Fixer/Whitespace/HeredocIndentationFixer.php>`_
+
 Heredoc/nowdoc content must be properly indented. Requires PHP >= 7.3.
 
 Configuration

--- a/doc/rules/whitespace/indentation_type.rst
+++ b/doc/rules/whitespace/indentation_type.rst
@@ -2,6 +2,8 @@
 Rule ``indentation_type``
 =========================
 
+`src <../../../src/Fixer/Whitespace/IndentationTypeFixer.php>`_
+
 Code MUST use configured indentation type.
 
 Examples

--- a/doc/rules/whitespace/line_ending.rst
+++ b/doc/rules/whitespace/line_ending.rst
@@ -2,6 +2,8 @@
 Rule ``line_ending``
 ====================
 
+`src <../../../src/Fixer/Whitespace/LineEndingFixer.php>`_
+
 All PHP files must use same line ending.
 
 Examples

--- a/doc/rules/whitespace/method_chaining_indentation.rst
+++ b/doc/rules/whitespace/method_chaining_indentation.rst
@@ -2,6 +2,8 @@
 Rule ``method_chaining_indentation``
 ====================================
 
+`src <../../../src/Fixer/Whitespace/MethodChainingIndentationFixer.php>`_
+
 Method chaining MUST be properly indented. Method chaining with different levels
 of indentation is not supported.
 

--- a/doc/rules/whitespace/no_extra_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_blank_lines.rst
@@ -2,6 +2,8 @@
 Rule ``no_extra_blank_lines``
 =============================
 
+`src <../../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php>`_
+
 Removes extra blank lines and/or blank lines following configuration.
 
 Configuration

--- a/doc/rules/whitespace/no_extra_consecutive_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_consecutive_blank_lines.rst
@@ -2,6 +2,8 @@
 Rule ``no_extra_consecutive_blank_lines``
 =========================================
 
+`src <../../../src/Fixer/Whitespace/NoExtraConsecutiveBlankLinesFixer.php>`_
+
 .. warning:: This rule is deprecated and will be removed on next major version.
 
    You should use ``no_extra_blank_lines`` instead.

--- a/doc/rules/whitespace/no_spaces_around_offset.rst
+++ b/doc/rules/whitespace/no_spaces_around_offset.rst
@@ -2,6 +2,8 @@
 Rule ``no_spaces_around_offset``
 ================================
 
+`src <../../../src/Fixer/Whitespace/NoSpacesAroundOffsetFixer.php>`_
+
 There MUST NOT be spaces around offset braces.
 
 Configuration

--- a/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
+++ b/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
@@ -2,6 +2,8 @@
 Rule ``no_spaces_inside_parenthesis``
 =====================================
 
+`src <../../../src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php>`_
+
 There MUST NOT be a space after the opening parenthesis. There MUST NOT be a
 space before the closing parenthesis.
 

--- a/doc/rules/whitespace/no_trailing_whitespace.rst
+++ b/doc/rules/whitespace/no_trailing_whitespace.rst
@@ -2,6 +2,8 @@
 Rule ``no_trailing_whitespace``
 ===============================
 
+`src <../../../src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php>`_
+
 Remove trailing whitespace at the end of non-blank lines.
 
 Examples

--- a/doc/rules/whitespace/no_whitespace_in_blank_line.rst
+++ b/doc/rules/whitespace/no_whitespace_in_blank_line.rst
@@ -2,6 +2,8 @@
 Rule ``no_whitespace_in_blank_line``
 ====================================
 
+`src <../../../src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php>`_
+
 Remove trailing whitespace at the end of blank lines.
 
 Examples

--- a/doc/rules/whitespace/single_blank_line_at_eof.rst
+++ b/doc/rules/whitespace/single_blank_line_at_eof.rst
@@ -2,6 +2,8 @@
 Rule ``single_blank_line_at_eof``
 =================================
 
+`src <../../../src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php>`_
+
 A PHP file without end tag must always end with a single empty line feed.
 
 Examples

--- a/src/Documentation/DocumentationGenerator.php
+++ b/src/Documentation/DocumentationGenerator.php
@@ -71,6 +71,17 @@ final class DocumentationGenerator
     }
 
     /**
+     * @return string
+     */
+    public function makeRelativePathToDoc(string $absolutePath, int $docDepth)
+    {
+        $rootPath = \dirname($this->getFixersDocumentationDirectoryPath(), 2);
+        $relativePath = str_repeat('../', 1 + $docDepth).preg_replace('~^' . preg_quote(str_replace('\\', '/', $rootPath), '~') . '/?~', '', str_replace('\\', '/', $absolutePath)); // @TODO
+
+        return $relativePath;
+    }
+
+    /**
      * @param AbstractFixer[] $fixers
      *
      * @return string
@@ -173,6 +184,9 @@ RST;
         $titleLine = str_repeat('=', \strlen($title));
 
         $doc = "{$titleLine}\n{$title}\n{$titleLine}";
+
+        $srcPath = (new \ReflectionClass($fixer))->getFileName();
+        $doc .= "\n\n`src <{$this->makeRelativePathToDoc($srcPath, 2)}>`_";
 
         if ($fixer instanceof DeprecatedFixerInterface) {
             $doc .= "\n\n.. warning:: This rule is deprecated and will be removed on next major version.";


### PR DESCRIPTION
Having a source link to the source code of each rule is useful for developer to see how the rule works and for possible improvements/fixes. Currently, as the rule names are different than the fixer class names, it is quite hard to find the source codes easily.

WIP/TODO

- Please advise how to format
- Also for Rule set doc pages
- Please advise how to compute a relative pathes