### PR TITLE
DX: remove PHPStan exceptions for "tests" from phpstan.neon

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,31 +36,16 @@ parameters:
                 - src/Config.php
                 - src/Tokenizer/Token.php
         -
-            message: '/^Parameter #1 \$fixers of method PhpCsFixer\\Config::registerCustomFixers\(\) expects iterable<PhpCsFixer\\Fixer\\FixerInterface>, string given\.$/'
-            path: tests/ConfigTest.php
-        -
-            message: '/^Parameter #1 \$options of method PhpCsFixer\\FixerConfiguration\\FixerConfigurationResolverRootless::resolve\(\) expects array<string, mixed>, array<int, string> given\.$/'
-            path: tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
-        -
             message: '/^Parameter #1 \$function of function register_shutdown_function expects callable\(\): void, array\(\$this\(PhpCsFixer\\FileRemoval\), ''clean''\) given\.$/'
             path: src/FileRemoval.php
-        -
-            message: '/^Parameter #1 \$finder of method PhpCsFixer\\Config::setFinder\(\) expects iterable<string>, int given\.$/'
-            path: tests/ConfigTest.php
         - # https://github.com/phpstan/phpstan/issues/1215
             message: '/^Strict comparison using === between false and string will always evaluate to false\.$/'
             path: src/Fixer/StringNotation/NoTrailingWhitespaceInStringFixer.php
-        -
-            message: '/^Property .*::\$indicator .* does not accept null\.$/'
-            path: tests/Indicator/PhpUnitTestCaseIndicatorTest.php
         -
             message: '/^Constant T_ATTRIBUTE not found\.$/'
             path: src/Tokenizer/Transformer/AttributeTransformer.php
         -
             message: '/^\$this\(PhpCsFixer\\Tokenizer\\Tokens\) does not accept PhpCsFixer\\Tokenizer\\Token\|null\.$/'
             path: src/Tokenizer/Tokens.php
-        -
-            message: '/^Class Test\dConfig not found\.$/'
-            path: tests/Console/ConfigurationResolverTest.php
 
     tipsOfTheDay: false

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -193,7 +193,7 @@ final class ConfigTest extends TestCase
         $this->expectExceptionMessageMatches('/^Argument must be an array or a Traversable, got "\w+"\.$/');
 
         $config = new Config();
-        $config->registerCustomFixers('foo');
+        $config->registerCustomFixers('foo'); // @phpstan-ignore-line to avoid `expects iterable<PhpCsFixer\Fixer\FixerInterface>, string given`
     }
 
     /**
@@ -259,7 +259,7 @@ final class ConfigTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/^Argument must be an array or a Traversable, got "integer"\.$/');
 
-        $config->setFinder(123);
+        $config->setFinder(123); // @phpstan-ignore-line to avoid `expects iterable<string>, int given`
     }
 
     /**

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -205,7 +205,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver = $this->createConfigurationResolver(['path' => [$dir.\DIRECTORY_SEPARATOR.'foo.php']]);
 
         static::assertSame($dir.\DIRECTORY_SEPARATOR.'.php_cs.dist', $resolver->getConfigFile());
-        static::assertInstanceOf(\Test1Config::class, $resolver->getConfig());
+        static::assertInstanceOf(\Test1Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test1Config not found.`
     }
 
     public function testResolveConfigFileSpecified()
@@ -215,7 +215,7 @@ final class ConfigurationResolverTest extends TestCase
         $resolver = $this->createConfigurationResolver(['config' => $file]);
 
         static::assertSame($file, $resolver->getConfigFile());
-        static::assertInstanceOf(\Test4Config::class, $resolver->getConfig());
+        static::assertInstanceOf(\Test4Config::class, $resolver->getConfig()); // @phpstan-ignore-line to avoid `Class Test4Config not found.`
     }
 
     /**

--- a/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
+++ b/tests/FixerConfiguration/FixerConfigurationResolverRootlessTest.php
@@ -44,6 +44,6 @@ final class FixerConfigurationResolverRootlessTest extends TestCase
 
         static::assertSame($options, $configuration->getOptions());
 
-        $configuration->resolve(['baz', 'qux']);
+        $configuration->resolve(['baz' => 'qux']);
     }
 }

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -25,7 +25,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 final class PhpUnitTestCaseIndicatorTest extends TestCase
 {
     /**
-     * @var PhpUnitTestCaseIndicator
+     * @var null|PhpUnitTestCaseIndicator
      */
     private $indicator;
 


### PR DESCRIPTION
After [#5626](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5626/files) it got me thinking that PHPStan is not always able to detect errors properly - sometimes because it runs on single PHP version with single set of dependencies, sometimes because there is some dynamic behaviour. So it may be not bad idea to use `@phpstan-ignore-line` as it's not really exception, but false positive case.

Nonetheless, in this PR all the PHPStan exceptions are removed from phpstan.neon and fixed or handled via `@phpstan-ignore-line` annotation.