### PR TITLE
Change wording from "merge" to "intersect"

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -11,8 +11,8 @@ problems as possible on a given file or files in a given directory and its subdi
     $ php php-cs-fixer.phar fix /path/to/file
 
 By default ``--path-mode`` is set to ``override``, which means, that if you specify the path to a file or a directory via
-command arguments, then the paths provided to a ``Finder`` in config file will be ignored. You can use ``--path-mode=intersection``
-to merge paths from the config file and from the argument:
+command arguments, then the paths provided to a ``Finder`` in config file will be ignored. You can also use ``--path-mode=intersection``,
+which will use the intersection of the paths from the config file and from the argument:
 
 .. code-block:: console
 


### PR DESCRIPTION
Since using the ``--path-mode=intersection`` does not merge the paths in the config file and the paths provided by the command argument and is instead intersecting both, I thought it would be a good idea to change this here to make it more clear.

https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/44f7ac87dbd123edec69f26df670e2c475d0bad8/src/Console/ConfigurationResolver.php#L863