### PR TITLE
DX: benchmark.sh - ensure deps are updated to enable script working across less-similar branches

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -19,6 +19,7 @@ do
     git checkout "$BRANCH" > /dev/null 2>&1 &&
     git reset --hard > /dev/null 2>&1 &&
     printf '%s' "$BRANCH"
+    composer update -q
     (for _ in $(seq 1 10); do php php-cs-fixer fix --dry-run 2> /dev/null ; done) | grep -i seconds | awk '
     {
         total += $5;


### PR DESCRIPTION
```
ker@dus:~/github/PHP-CS-Fixer λ bash benchmark.sh 2.19 3.0
2.19 mean:45.3485 total:453.4850 rounds:10
3.0  mean:31.7666 total:317.6665 rounds:10
```

~30% improvement, huh?