### PR TITLE
RegularCallableCallFixer - fix for function name with escaped slash

### DIFF
--- a/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
+++ b/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
@@ -118,7 +118,7 @@ call_user_func(static function ($a, $b) { var_dump($a, $b); }, 1, 2);
                 return; // first argument is an expression like `call_user_func("foo"."bar", ...)`, not supported!
             }
 
-            $newCallTokens = Tokens::fromCode('<?php '.substr($firstArgToken->getContent(), 1, -1).'();');
+            $newCallTokens = Tokens::fromCode('<?php '.substr(str_replace('\\\\', '\\', $firstArgToken->getContent()), 1, -1).'();');
             $newCallTokensSize = $newCallTokens->count();
             $newCallTokens->clearAt(0);
             $newCallTokens->clearRange($newCallTokensSize - 3, $newCallTokensSize - 1);

--- a/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
@@ -205,6 +205,16 @@ final class RegularCallableCallFixerTest extends AbstractFixerTestCase
                 }
             ',
         ];
+
+        yield 'function name with escaped slash' => [
+            '<?php \pack(...$args);',
+            '<?php call_user_func_array("\\\\pack", $args);',
+        ];
+
+        yield 'function call_user_func_array with leading slash' => [
+            '<?php \pack(...$args);',
+            '<?php \call_user_func_array("\\\\pack", $args);',
+        ];
     }
 
     /**


### PR DESCRIPTION
Reference: https://github.com/aws/aws-sdk-php/blob/3.180.1/src/Crypto/Polyfill/ByteArray.php#L256