### PR TITLE
PhpUnitNoExpectationAnnotationFixer - fix "expectedException" annotation with message below

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixer.php
@@ -246,6 +246,10 @@ final class MyTest extends \PHPUnit_Framework_TestCase
     {
         $params = [];
         $exceptionClass = ltrim($annotations['expectedException'], '\\');
+        if (false !== strpos($exceptionClass, '*')) {
+            $exceptionClass = substr($exceptionClass, 0, strpos($exceptionClass, '*'));
+        }
+        $exceptionClass = trim($exceptionClass);
 
         if ($this->configuration['use_class_const']) {
             $params[] = "\\{$exceptionClass}::class";

--- a/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNoExpectationAnnotationFixerTest.php
@@ -644,6 +644,33 @@ EOT
         }
     }',
             ],
+            'expecting exception with message below' => [
+                '<?php
+    class MyTest extends TestCase
+    {
+        /**
+         */
+        public function testSomething()
+        {
+            $this->setExpectedException(\Foo\Bar::class);
+
+            $this->initialize();
+        }
+    }',
+                '<?php
+    class MyTest extends TestCase
+    {
+        /**
+         * @expectedException Foo\Bar
+         *
+         * Testing stuff.
+         */
+        public function testSomething()
+        {
+            $this->initialize();
+        }
+    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Reference: https://github.com/thephpleague/omnipay-common/blob/v3.0.5/tests/Omnipay/Common/Message/AbstractRequestTest.php#L167