### PR TITLE
Utils - save only unique deprecations to avoid memory issues

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -105,8 +105,7 @@ final class Application extends BaseApplication
             null !== $stdErr
             && $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE
         ) {
-            $triggeredDeprecations = array_unique(Utils::getTriggeredDeprecations());
-            sort($triggeredDeprecations);
+            $triggeredDeprecations = Utils::getTriggeredDeprecations();
             if ($triggeredDeprecations) {
                 $stdErr->writeln('');
                 $stdErr->writeln($stdErr->isDecorated() ? '<bg=yellow;fg=black;>Detected deprecations in use:</>' : 'Detected deprecations in use:');

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -24,6 +24,9 @@ use PhpCsFixer\Tokenizer\Token;
  */
 final class Utils
 {
+    /**
+     * @var array<string,true>
+     */
     private static $deprecations = [];
 
     /**
@@ -197,12 +200,15 @@ final class Utils
             throw new $exceptionClass("{$message} This check was performed as `PHP_CS_FIXER_FUTURE_MODE` env var is set.");
         }
 
-        self::$deprecations[] = $message;
+        self::$deprecations[$message] = true;
         @trigger_error($message, E_USER_DEPRECATED);
     }
 
     public static function getTriggeredDeprecations()
     {
-        return self::$deprecations;
+        $triggeredDeprecations = array_keys(self::$deprecations);
+        sort($triggeredDeprecations);
+
+        return $triggeredDeprecations;
     }
 }


### PR DESCRIPTION
With the #5674 merged, we have run into exhaustion of allowed memory pretty quickly, see https://github.com/shopsys/shopsys/pull/2308/checks?check_run_id=2511509379

Even though it would be better for us to fix all the deprecations, and we definitely plan to do it in the future, it will be rather time consuming and we would like to use the newer version in the meantime.

I propose to save the deprecation message only if it's unique. Because `array_unique` is called on the result afterwards, I see no issues with this approach.