### PR TITLE
CommentToPhpdocFixer - fix for single line comments starting with more than 2 slashes

### DIFF
--- a/src/Fixer/Comment/CommentToPhpdocFixer.php
+++ b/src/Fixer/Comment/CommentToPhpdocFixer.php
@@ -210,7 +210,11 @@ final class CommentToPhpdocFixer extends AbstractFixer implements ConfigurationD
             if (false !== strpos($tokens[$index]->getContent(), '*/')) {
                 return;
             }
-            $newContent .= $indent.' *'.$this->getMessage($tokens[$index]->getContent()).$this->whitespacesConfig->getLineEnding();
+            $message = $this->getMessage($tokens[$index]->getContent());
+            if ('' !== trim(substr($message, 0, 1))) {
+                $message = ' '.$message;
+            }
+            $newContent .= $indent.' *'.$message.$this->whitespacesConfig->getLineEnding();
         }
 
         for ($index = $startIndex; $index <= $count; ++$index) {

--- a/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
+++ b/tests/Fixer/Comment/CommentToPhpdocFixerTest.php
@@ -311,6 +311,30 @@ EOT
                 ,
                 ['ignored_tags' => ['todo']],
             ],
+            [
+                '<?php // header
+                /** /@foo */
+                namespace Foo\Bar;
+',
+                '<?php // header
+                ///@foo
+                namespace Foo\Bar;
+',
+            ],
+            [
+                '<?php // header
+                /**
+                 * / @foo
+                 * / @bar
+                 */
+                namespace Foo\Bar;
+',
+                '<?php // header
+                /// @foo
+                /// @bar
+                namespace Foo\Bar;
+',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Reference: https://github.com/google/flatbuffers/blob/v1.12.0/php/FlatbufferBuilder.php#L18