### PR TITLE
Fix typo in markdown

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -25,8 +25,8 @@ The ``--format`` option for the output format. Supported formats are ``txt`` (de
 
 NOTE: the output for the following formats are generated in accordance with schemas
 
-* ``checkstyle` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
-* ``json` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
+* ``checkstyle`` follows the common `"checkstyle" XML schema </doc/schemas/fix/checkstyle.xsd>`_
+* ``json`` follows the `own JSON schema </doc/schemas/fix/schema.json>`_
 * ``junit`` follows the `JUnit XML schema from Jenkins </doc/schemas/fix/junit-10.xsd>`_
 * ``xml`` follows the `own XML schema </doc/schemas/fix/xml.xsd>`_
 


### PR DESCRIPTION
A simply fix of the quotes in the markdown file. 

Can be merged on review. Simple.