### PR TITLE
Fix doc, "run-in" show-progress option is no longer present

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -88,7 +88,7 @@ The ``--show-progress`` option allows you to choose the way process progress is 
 * ``none``: disables progress output;
 * ``dots``: same as ``estimating`` but using all terminal columns instead of default 80.
 
-If the option is not provided, it defaults to ``run-in`` unless a config file that disables output is used, in which case it defaults to ``none``. This option has no effect if the verbosity of the command is less than ``verbose``.
+If the option is not provided, it defaults to ``dots`` unless a config file that disables output is used, in which case it defaults to ``none``. This option has no effect if the verbosity of the command is less than ``verbose``.
 
 .. code-block:: console
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2228672/117791995-2f40cf80-b24b-11eb-8b6c-56c5f37e8e47.png)

![image](https://user-images.githubusercontent.com/2228672/117792029-35cf4700-b24b-11eb-86f2-8d2979094b05.png)

For some reasons, progress is correctly displayed with txt (default) format, but when `dots` progress optin is specified, the `Legend` line in the output is on a different place - why, please explain.