### PR TITLE
Add missing --dev in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in a dedicated `composer.json` file in your project, for example in the
 
 ```console
 $ mkdir --parents tools/php-cs-fixer
-$ composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+$ composer require --dev --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
 ```
 
 For more details and other installation methods, see


### PR DESCRIPTION
I guess it was just missing for no reason? I don't see any reason to install php-cs-fixer as a production dependency.