### PR TITLE
Updated the link to netbeans plugins page

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you need to apply code styles that are not supported by the tool, you can
 Dedicated plugins exist for:
 
 * [Atom](https://github.com/Glavin001/atom-beautify)
-* [NetBeans](http://plugins.netbeans.org/plugin/49042/php-cs-fixer)
+* [NetBeans](https://plugins.netbeans.apache.org/catalogue/?id=36)
 * [PhpStorm](https://medium.com/@valeryan/how-to-configure-phpstorm-to-use-php-cs-fixer-1844991e521f)
 * [Sublime Text](https://github.com/benmatselby/sublime-phpcs)
 * [Vim](https://github.com/stephpy/vim-php-cs-fixer)


### PR DESCRIPTION
The existing link is dead as netbeans.org is no longer the official domain for netbeans.