### PR TITLE
NoNullPropertyInitializationFixer - fix static properties as well

### DIFF
--- a/doc/rules/class_notation/no_null_property_initialization.rst
+++ b/doc/rules/class_notation/no_null_property_initialization.rst
@@ -21,6 +21,19 @@ Example #1
    +    public $foo;
     }
 
+Example #2
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class Foo {
+   -    public static $foo = null;
+   +    public static $foo;
+    }
+
 Rule sets
 ---------
 

--- a/src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
+++ b/src/Fixer/ClassNotation/NoNullPropertyInitializationFixer.php
@@ -37,6 +37,13 @@ class Foo {
 }
 '
                 ),
+                new CodeSample(
+                    '<?php
+class Foo {
+    public static $foo = null;
+}
+'
+                ),
             ]
         );
     }
@@ -46,7 +53,7 @@ class Foo {
      */
     public function isCandidate(Tokens $tokens)
     {
-        return $tokens->isAnyTokenKindsFound([T_CLASS, T_TRAIT]) && $tokens->isAnyTokenKindsFound([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR]);
+        return $tokens->isAnyTokenKindsFound([T_CLASS, T_TRAIT]) && $tokens->isAnyTokenKindsFound([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR, T_STATIC]);
     }
 
     /**
@@ -54,13 +61,55 @@ class Foo {
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
+        $inClass = [];
+        $classLevel = 0;
+
         for ($index = 0, $count = $tokens->count(); $index < $count; ++$index) {
-            if (!$tokens[$index]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR])) {
+            if ($tokens[$index]->isClassy()) {
+                ++$classLevel;
+                $inClass[$classLevel] = 1;
+
+                $index = $tokens->getNextTokenOfKind($index, ['{']);
+
+                continue;
+            }
+
+            if (0 === $classLevel) {
+                continue;
+            }
+
+            if ($tokens[$index]->equals('{')) {
+                ++$inClass[$classLevel];
+
+                continue;
+            }
+
+            if ($tokens[$index]->equals('}')) {
+                --$inClass[$classLevel];
+
+                if (0 === $inClass[$classLevel]) {
+                    unset($inClass[$classLevel]);
+                    --$classLevel;
+                }
+
+                continue;
+            }
+
+            // Ensure we are in a class but not in a method in case there are static variables defined
+            if (1 !== $inClass[$classLevel]) {
+                continue;
+            }
+
+            if (!$tokens[$index]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_VAR, T_STATIC])) {
                 continue;
             }
 
             while (true) {
                 $varTokenIndex = $index = $tokens->getNextMeaningfulToken($index);
+
+                if ($tokens[$index]->isGivenKind(T_STATIC)) {
+                    $varTokenIndex = $index = $tokens->getNextMeaningfulToken($index);
+                }
 
                 if (!$tokens[$index]->isGivenKind(T_VARIABLE)) {
                     break;

--- a/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
@@ -136,7 +136,113 @@ null;#13
 ',
             ],
             [
+                '<?php class Foo { public static $bar; }',
+                '<?php class Foo { public static $bar = null; }',
+            ],
+            [
+                '<?php class Foo { protected static $bar; }',
+                '<?php class Foo { protected static $bar = null; }',
+            ],
+            [
+                '<?php class Foo { private static $bar; }',
+                '<?php class Foo { private static $bar = null; }',
+            ],
+            [
+                '<?php class Foo { static $bar; }',
+                '<?php class Foo { static $bar = null; }',
+            ],
+            [
+                '<?php class Foo { STATIC $bar; }',
+                '<?php class Foo { STATIC $bar = null; }',
+            ],
+            [
+                '<?php class Foo { public static $bar; }',
+                '<?php class Foo { public static $bar = NULL; }',
+            ],
+            [
+                '<?php class Foo { PUblic STatic $bar; }',
+                '<?php class Foo { PUblic STatic $bar = nuLL; }',
+            ],
+            [
+                '<?php trait Foo { public static $bar; }',
+                '<?php trait Foo { public static $bar = nuLL; }',
+            ],
+            [
+                '<?php class Foo { public static $bar; }',
+                '<?php class Foo { public static $bar = \null; }',
+            ],
+            [
+                '<?php class Foo {/* */public/* */static/* A */$bar/* B *//** C */;/* D */}',
+                '<?php class Foo {/* */public/* */static/* A */$bar/* B */=/** C */null;/* D */}',
+            ],
+            [
+                '<?php class Foo { public static $bar; protected static $baz; }',
+                '<?php class Foo { public static $bar = null; protected static $baz = null; }',
+            ],
+            [
+                '<?php class Foo { public static $bar = \'null\'; }',
+            ],
+            [
+                '<?php class Foo { public static function bar() { return null; } }',
+            ],
+            [
+                '<?php class Foo { protected static $bar, $baz, $qux; }',
+                '<?php class Foo { protected static $bar = null, $baz = null, $qux = null; }',
+            ],
+            [
+                '<?php class Foo { protected static $bar, $baz = \'baz\', $qux; }',
+                '<?php class Foo { protected static $bar, $baz = \'baz\', $qux = null; }',
+            ],
+            [
+                '<?php trait Foo { public static $bar; } abstract class Bar { protected static $bar, $baz = \'baz\', $qux; }',
+                '<?php trait Foo { public static $bar = null; } abstract class Bar { protected static $bar, $baz = \'baz\', $qux = null; }',
+            ],
+            [
+                '<?php class Foo { public function foo() { return null; } public static $bar; public function baz() { return null; } }',
+                '<?php class Foo { public function foo() { return null; } public static $bar = null; public function baz() { return null; } }',
+            ],
+            [
+                '<?php class#1
+Foo#2
+{#3
+protected#4
+static#4.5
+$bar#5
+#6
+,#7
+$baz#8
+#9
+,#10
+$qux#11
+#12
+;#13
+}
+',
+                '<?php class#1
+Foo#2
+{#3
+protected#4
+static#4.5
+$bar#5
+=#6
+null,#7
+$baz#8
+=#9
+null,#10
+$qux#11
+=#12
+null;#13
+}
+',
+            ],
+            [
                 '<?php class Foo { const FOO = null; }',
+            ],
+            [
+                '<?php class Foo { public function foo() { static $foo = null; } }',
+            ],
+            [
+                '<?php function foo() { static $foo = null; }',
             ],
         ];
     }
@@ -167,6 +273,24 @@ null;#13
             [
                 '<?php class Foo { public function foo() { return new class() { private $bar; }; } } trait Baz { public $baz; }',
                 '<?php class Foo { public function foo() { return new class() { private $bar = null; }; } } trait Baz { public $baz = null; }',
+            ],
+            [
+                '<?php new class () { public static $bar; };',
+                '<?php new class () { public static $bar = null; };',
+            ],
+            [
+                '<?php class Foo { public function foo() { return new class() { private static $bar; }; } }',
+                '<?php class Foo { public function foo() { return new class() { private static $bar = null; }; } }',
+            ],
+            [
+                '<?php class Foo { public function foo() { return new class() { private static $bar; }; } } trait Baz { public static $baz; }',
+                '<?php class Foo { public function foo() { return new class() { private static $bar = null; }; } } trait Baz { public static $baz = null; }',
+            ],
+            [
+                '<?php class Foo { public function foo() { return new class() { public function foo() { static $foo = null; } }; } }',
+            ],
+            [
+                '<?php function foo() { return new class() { public function foo() { static $foo = null; } }; }',
             ],
         ];
     }
@@ -215,6 +339,16 @@ null;#13
         yield [
             '<?php class Foo { protected ? array $bar = null; }',
         ];
+
+        yield [
+            '<?php class Foo { protected static ?int $bar = null; }',
+        ];
+        yield [
+            '<?php class Foo { protected static ? string $bar = null; }',
+        ];
+        yield [
+            '<?php class Foo { protected static ? array $bar = null; }',
+        ];
     }
 
     /**
@@ -240,6 +374,16 @@ null;#13
         yield [
             '<?php class Foo { public $bar/* oh hai! */; }',
             '<?php class Foo { public $bar = \/* oh hai! */null; }',
+        ];
+
+        yield [
+            '<?php class Foo { public static $bar; }',
+            '<?php class Foo { public static $bar = \     null; }',
+        ];
+
+        yield [
+            '<?php class Foo { public static $bar/* oh hai! */; }',
+            '<?php class Foo { public static $bar = \/* oh hai! */null; }',
         ];
     }
 


### PR DESCRIPTION
The `NoNullPropertyInitializationFixer` doesn't fix properties with a default `null` value if they are static. This PR fixes the issue.

I added some extra logic to check if the token is inside a class, but not a method to avoid modifying static variables:

```php
class Foo
{
    static $bar = null; // This is fixed

    public function foo()
    {
        static $baz = null; // This is skipped
    }
}
```