### PR TITLE
doc(config): change set's name

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -12,7 +12,7 @@ is a good practice to add that file into your ``.gitignore`` file.
 With the ``--config`` option you can specify the path to the
 ``.php-cs-fixer.php`` file.
 
-The example below will add two rules to the default list of PSR2 set rules:
+The example below will add two rules to the default list of PSR12 set rules:
 
 .. code-block:: php
 


### PR DESCRIPTION
The PSR12 set exists (https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/src/RuleSet/Sets/PSR12Set.php), but here we say:
> The example below will add two rules to the default list of **PSR2** set rules.

Which is wrong. 
I've fixed the set to `PSR2`, but maybe you want to use `PSR12` instead.

Let me know!