### PR TITLE
NoAlternativeSyntaxFixer - Add option to not fix non-monolithic PHP code

### DIFF
--- a/doc/rules/control_structure/no_alternative_syntax.rst
+++ b/doc/rules/control_structure/no_alternative_syntax.rst
@@ -4,11 +4,25 @@ Rule ``no_alternative_syntax``
 
 Replace control structure alternative syntax to use braces.
 
+Configuration
+-------------
+
+``fix_non_monolithic_code``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Whether to also fix code with inline HTML.
+
+Allowed types: ``bool``
+
+Default value: ``true``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -21,35 +35,17 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-   -while(true):echo 'red';endwhile;
-   +while(true) { echo 'red';}
-
-Example #3
-~~~~~~~~~~
+With configuration: ``['fix_non_monolithic_code' => true]``.
 
 .. code-block:: diff
 
    --- Original
    +++ New
-    <?php
-   -for(;;):echo 'xc';endfor;
-   +for(;;) { echo 'xc';}
-
-Example #4
-~~~~~~~~~~
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-   -foreach(array('a') as $item):echo 'xc';endforeach;
-   +foreach(array('a') as $item) { echo 'xc';}
+   -<?php if ($condition): ?>
+   +<?php if ($condition) { ?>
+    Lorem ipsum.
+   -<?php endif; ?>
+   +<?php } ?>
 
 Rule sets
 ---------
@@ -57,7 +53,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_alternative_syntax`` rule.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_alternative_syntax`` rule with the default config.
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_alternative_syntax`` rule.
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_alternative_syntax`` rule with the default config.

--- a/src/Console/WarningsDetector.php
+++ b/src/Console/WarningsDetector.php
@@ -41,7 +41,7 @@ final class WarningsDetector
 
     public function detectOldMajor(): void
     {
-        // @TODO 3.99 to be activated with new MAJOR release
+        // @TODO 3.99 to be activated with new MAJOR release 4.0
         // $currentMajorVersion = \intval(explode('.', Application::VERSION)[0], 10);
         // $nextMajorVersion = $currentMajorVersion + 1;
         // $this->warnings[] = "You are running PHP CS Fixer v{$currentMajorVersion}, which is not maintained anymore. Please update to v{$nextMajorVersion}.";

--- a/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
+++ b/src/Fixer/ControlStructure/NoAlternativeSyntaxFixer.php
@@ -15,6 +15,10 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\ControlStructure;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -24,7 +28,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 /**
  * @author Eddilbert Macharia <edd.cowan@gmail.com>
  */
-final class NoAlternativeSyntaxFixer extends AbstractFixer
+final class NoAlternativeSyntaxFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     /**
      * {@inheritdoc}
@@ -38,13 +42,8 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer
                     "<?php\nif(true):echo 't';else:echo 'f';endif;\n"
                 ),
                 new CodeSample(
-                    "<?php\nwhile(true):echo 'red';endwhile;\n"
-                ),
-                new CodeSample(
-                    "<?php\nfor(;;):echo 'xc';endfor;\n"
-                ),
-                new CodeSample(
-                    "<?php\nforeach(array('a') as \$item):echo 'xc';endforeach;\n"
+                    "<?php if (\$condition): ?>\nLorem ipsum.\n<?php endif; ?>\n",
+                    ['fix_non_monolithic_code' => true]
                 ),
             ]
         );
@@ -55,7 +54,7 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->hasAlternativeSyntax();
+        return $tokens->hasAlternativeSyntax() && ($this->configuration['fix_non_monolithic_code'] || $tokens->isMonolithicPhp());
     }
 
     /**
@@ -66,6 +65,19 @@ final class NoAlternativeSyntaxFixer extends AbstractFixer
     public function getPriority(): int
     {
         return 42;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('fix_non_monolithic_code', 'Whether to also fix code with inline HTML.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(true) // @TODO change to "false" on next major 4.0
+                ->getOption(),
+        ]);
     }
 
     /**

--- a/tests/Fixer/ControlStructure/NoAlternativeSyntaxFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoAlternativeSyntaxFixerTest.php
@@ -28,99 +28,150 @@ final class NoAlternativeSyntaxFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $input = null, ?array $configuration = null): void
     {
+        if (null !== $configuration) {
+            $this->fixer->configure($configuration);
+        }
+
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public function provideFixCases(): \Generator
     {
-        return [
-            [
-                '<?php
-                    declare(ticks = 1) {
-                    }
-                ',
-                '<?php
-                    declare(ticks = 1) :
-                    enddeclare;
-                ',
-            ],
-            [
-                '<?php
-        switch ($foo) {
-            case 1:
-        }
+        yield [
+            '<?php
+                declare(ticks = 1) {
+                }
+            ',
+            '<?php
+                declare(ticks = 1) :
+                enddeclare;
+            ',
+        ];
 
-        switch ($foo)   {
-            case 1:
-        }    ?>',
-                '<?php
-        switch ($foo):
-            case 1:
-        endswitch;
+        yield [
+            '<?php
+    switch ($foo) {
+        case 1:
+    }
 
-        switch ($foo)   :
-            case 1:
-        endswitch    ?>',
-            ],
-            [
-                '<?php
-                    if ($some1) {
-                        if ($some2) {
-                            if ($some3) {
-                                $test = true;
-                            }
+    switch ($foo)   {
+        case 1:
+    }    ?>',
+            '<?php
+    switch ($foo):
+        case 1:
+    endswitch;
+
+    switch ($foo)   :
+        case 1:
+    endswitch    ?>',
+        ];
+
+        yield [
+            '<?php
+                if ($some1) {
+                    if ($some2) {
+                        if ($some3) {
+                            $test = true;
                         }
                     }
-                ',
-                '<?php
-                    if ($some1) :
-                        if ($some2) :
-                            if ($some3) :
-                                $test = true;
-                            endif;
+                }
+            ',
+            '<?php
+                if ($some1) :
+                    if ($some2) :
+                        if ($some3) :
+                            $test = true;
                         endif;
                     endif;
-                ',
-            ],
-            ['<?php if ($some) { $test = true; } else { $test = false; }'],
-            [
-                '<?php if ($some) /* foo */ { $test = true; } else { $test = false; }',
-                '<?php if ($some) /* foo */ : $test = true; else :$test = false; endif;',
-            ],
-            [
-                '<?php if ($some) { $test = true; } else { $test = false; }',
-                '<?php if ($some) : $test = true; else :$test = false; endif;',
-            ],
-            [
-                '<?php if ($some) { if($test){echo $test;}$test = true; } else { $test = false; }',
-                '<?php if ($some) : if($test){echo $test;}$test = true; else : $test = false; endif;',
-            ],
-            [
-                '<?php foreach (array("d") as $item) { echo $item;}',
-                '<?php foreach (array("d") as $item):echo $item;endforeach;',
-            ],
-            [
-                '<?php foreach (array("d") as $item) { if($item){echo $item;}}',
-                '<?php foreach (array("d") as $item):if($item){echo $item;}endforeach;',
-            ],
-            [
-                '<?php while (true) { echo "c";}',
-                '<?php while (true):echo "c";endwhile;',
-            ],
-            [
-                '<?php foreach (array("d") as $item) { while ($item) { echo "dd";}}',
-                '<?php foreach (array("d") as $item):while ($item):echo "dd";endwhile;endforeach;',
-            ],
-            [
-                '<?php foreach (array("d") as $item) { while ($item) { echo "dd" ; } }',
-                '<?php foreach (array("d") as $item): while ($item) : echo "dd" ; endwhile; endforeach;',
-            ],
-            [
-                '<?php if ($some) { $test = true; } elseif ($some !== "test") { $test = false; }',
-                '<?php if ($some) : $test = true; elseif ($some !== "test") : $test = false; endif;',
-            ],
+                endif;
+            ',
+        ];
+
+        yield [
+            '<?php if ($some) { $test = true; } else { $test = false; }',
+        ];
+
+        yield [
+            '<?php if ($some) /* foo */ { $test = true; } else { $test = false; }',
+            '<?php if ($some) /* foo */ : $test = true; else :$test = false; endif;',
+        ];
+
+        yield [
+            '<?php if ($some) { $test = true; } else { $test = false; }',
+            '<?php if ($some) : $test = true; else :$test = false; endif;',
+        ];
+
+        yield [
+            '<?php if ($some) { if($test){echo $test;}$test = true; } else { $test = false; }',
+            '<?php if ($some) : if($test){echo $test;}$test = true; else : $test = false; endif;',
+        ];
+
+        yield [
+            '<?php foreach (array("d") as $item) { echo $item;}',
+            '<?php foreach (array("d") as $item):echo $item;endforeach;',
+        ];
+
+        yield [
+            '<?php foreach (array("d") as $item) { if($item){echo $item;}}',
+            '<?php foreach (array("d") as $item):if($item){echo $item;}endforeach;',
+        ];
+
+        yield [
+            '<?php while (true) { echo "c";}',
+            '<?php while (true):echo "c";endwhile;',
+        ];
+
+        yield [
+            '<?php foreach (array("d") as $item) { while ($item) { echo "dd";}}',
+            '<?php foreach (array("d") as $item):while ($item):echo "dd";endwhile;endforeach;',
+        ];
+
+        yield [
+            '<?php foreach (array("d") as $item) { while ($item) { echo "dd" ; } }',
+            '<?php foreach (array("d") as $item): while ($item) : echo "dd" ; endwhile; endforeach;',
+        ];
+
+        yield [
+            '<?php if ($some) { $test = true; } elseif ($some !== "test") { $test = false; }',
+            '<?php if ($some) : $test = true; elseif ($some !== "test") : $test = false; endif;',
+        ];
+
+        yield [
+            '<?php if ($condition) { ?><p>This is visible.</p><?php } ?>',
+            '<?php if ($condition): ?><p>This is visible.</p><?php endif; ?>',
+        ];
+
+        yield [
+            '<?php if ($condition): ?><p>This is visible.</p><?php endif; ?>',
+            null,
+            ['fix_non_monolithic_code' => false],
+        ];
+
+        yield [
+            '<?php if (true) { ?>Text display.<?php } ?>',
+            '<?php if (true): ?>Text display.<?php endif; ?>',
+            ['fix_non_monolithic_code' => true],
+        ];
+
+        yield [
+            '<?php if (true): ?>Text display.<?php endif; ?>',
+            null,
+            ['fix_non_monolithic_code' => false],
+        ];
+
+        yield [
+            '<?php if ($condition) { ?><?= "xd"; ?><?php } ?>',
+            '<?php if ($condition): ?><?= "xd"; ?><?php endif; ?>',
+            ['fix_non_monolithic_code' => true],
+        ];
+
+        yield [
+            '<?php if ($condition): ?><?= "xd"; ?><?php endif; ?>',
+            null,
+            ['fix_non_monolithic_code' => false],
         ];
     }
 }


### PR DESCRIPTION
The alternative syntax for control structures is especially useful when mixed with HTML or used in templating. When the code involved is big it can get tricky to keep track of the `{` and `}`. This is where `endif`, `endforeach`, etc. comes advantageous. These alternates give you a better way to match code blocks when mixed with HTML contents.

This PR adds an option to exclude fixing this "non-monolithic" code.