### PR TITLE
FunctionsAnalyzer::isTheSameClassCall - fix for $this with double colon following

### DIFF
--- a/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/FunctionsAnalyzer.php
@@ -197,15 +197,16 @@ final class FunctionsAnalyzer
         if (!$tokens->offsetExists($operatorIndex)) {
             return false;
         }
+        if (!$tokens[$operatorIndex]->isObjectOperator() && !$tokens[$operatorIndex]->isGivenKind(T_DOUBLE_COLON)) {
+            return false;
+        }
 
         $referenceIndex = $tokens->getPrevMeaningfulToken($operatorIndex);
         if (!$tokens->offsetExists($referenceIndex)) {
             return false;
         }
 
-        return $tokens[$operatorIndex]->isObjectOperator() && $tokens[$referenceIndex]->equals([T_VARIABLE, '$this'], false)
-            || $tokens[$operatorIndex]->isGivenKind(T_DOUBLE_COLON) && $tokens[$referenceIndex]->equals([T_STRING, 'self'], false)
-            || $tokens[$operatorIndex]->isGivenKind(T_DOUBLE_COLON) && $tokens[$referenceIndex]->equals([T_STATIC, 'static'], false);
+        return $tokens[$referenceIndex]->equalsAny([[T_VARIABLE, '$this'], [T_STRING, 'self'], [T_STATIC, 'static']], false);
     }
 
     private function buildFunctionsAnalysis(Tokens $tokens)

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -480,6 +480,24 @@ EOF
                     'call_type' => PhpUnitTestCaseStaticMethodCallsFixer::CALL_TYPE_THIS,
                 ],
             ],
+            'handle $this with double colon following' => [
+                '<?php
+                class FooTest extends TestCase
+                {
+                    public function testFoo()
+                    {
+                        static::assertTrue(true);
+                    }
+                }',
+                '<?php
+                class FooTest extends TestCase
+                {
+                    public function testFoo()
+                    {
+                        $this::assertTrue(true);
+                    }
+                }',
+            ],
         ];
     }
 

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -786,6 +786,12 @@ class Foo {}
                 24,
             ];
         }
+
+        yield [
+            true,
+            sprintf($template, '$this::'),
+            24,
+        ];
     }
 
     /**


### PR DESCRIPTION
Do not ask how I've found it 😀 