### PR TITLE
DX: update PHPStan

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -9,8 +9,8 @@
         "maglnet/composer-require-checker": "2.0.0",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.10",
-        "phpstan/phpstan": "^0.12.90",
-        "phpstan/phpstan-phpunit": "^0.12.20"
+        "phpstan/phpstan": "0.12.91",
+        "phpstan/phpstan-phpunit": "0.12.20"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -565,6 +565,7 @@ final class FixerFactoryTest extends TestCase
                 $expectedMessage .= sprintf("\n     * Must run before %s.", implode(', ', $priorityMap['before']));
             }
 
+            // @phpstan-ignore-next-line to avoid `Comparison operation ">" between int<1, max> and 0 is always true.`
             if (\count($priorityMap['after']) > 0) {
                 sort($priorityMap['after']);
                 $expectedMessage .= sprintf("\n     * Must run after %s.", implode(', ', $priorityMap['after']));


### PR DESCRIPTION
I wonder if we should drop a caret from `composer.json` to avoid such surprises as the needed update is related to new PHPStan version.

// cc @keradus @SpacePossum @julienfalque 