### PR TITLE
NoBreakCommentFixer - fix for "default" in "match"

### DIFF
--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -117,22 +117,29 @@ switch ($foo) {
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        for ($position = \count($tokens) - 1; $position >= 0; --$position) {
-            if ($tokens[$position]->isGivenKind([T_CASE, T_DEFAULT])) {
-                $this->fixCase($tokens, $position);
+        for ($index = \count($tokens) - 1; $index >= 0; --$index) {
+            if (!$tokens[$index]->isGivenKind([T_CASE, T_DEFAULT])) {
+                continue;
             }
+
+            $caseColonIndex = $tokens->getNextTokenOfKind($index, [':', ';', [T_DOUBLE_ARROW]]);
+
+            if ($tokens[$caseColonIndex]->isGivenKind(T_DOUBLE_ARROW)) {
+                continue; // this is "default" from "match"
+            }
+
+            $this->fixCase($tokens, $caseColonIndex);
         }
     }
 
     /**
-     * @param int $casePosition
+     * @param int $caseColonIndex
      */
-    private function fixCase(Tokens $tokens, $casePosition)
+    private function fixCase(Tokens $tokens, $caseColonIndex)
     {
         $empty = true;
         $fallThrough = true;
         $commentPosition = null;
-        $caseColonIndex = $tokens->getNextTokenOfKind($casePosition, [':', ';']);
 
         for ($i = $caseColonIndex + 1, $max = \count($tokens); $i < $max; ++$i) {
             if ($tokens[$i]->isGivenKind([T_SWITCH, T_IF, T_ELSE, T_ELSEIF, T_FOR, T_FOREACH, T_WHILE, T_DO, T_FUNCTION, T_CLASS])) {
@@ -218,12 +225,12 @@ switch ($foo) {
     }
 
     /**
-     * @param int $casePosition
+     * @param int $index
      */
-    private function insertCommentAt(Tokens $tokens, $casePosition)
+    private function insertCommentAt(Tokens $tokens, $index)
     {
         $lineEnding = $this->whitespacesConfig->getLineEnding();
-        $newlinePosition = $this->ensureNewLineAt($tokens, $casePosition);
+        $newlinePosition = $this->ensureNewLineAt($tokens, $index);
         $newlineToken = $tokens[$newlinePosition];
         $nbNewlines = substr_count($newlineToken->getContent(), $lineEnding);
 

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1186,13 +1186,13 @@ switch ($foo) {
     }
 
     /**
-     * @param string $input
-     * @param string $expected
+     * @param string      $expected
+     * @param null|string $input
      *
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
      */
-    public function testFix80($expected, $input)
+    public function testFix80($expected, $input = null)
     {
         $this->doTest($expected, $input);
     }
@@ -1231,6 +1231,23 @@ switch ($foo) {
                     default:
                         echo "PHP8";
                 }
+            ',
+        ];
+
+        yield [
+            '<?php
+                match ($foo) {
+                    1 => "a",
+                    default => "b"
+                };
+                match ($bar) {
+                    2 => "c",
+                    default => "d"
+                };
+                match ($baz) {
+                    3 => "e",
+                    default => "f"
+                };
             ',
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5797