### PR TITLE
Update PHPStan to 0.12.92

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -9,7 +9,7 @@
         "maglnet/composer-require-checker": "2.0.0",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.10",
-        "phpstan/phpstan": "0.12.91",
+        "phpstan/phpstan": "0.12.92",
         "phpstan/phpstan-phpunit": "0.12.20"
     },
     "config": {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -77,10 +77,6 @@ class Token
             $this->isArray = true;
             $this->id = $token[0];
             $this->content = $token[1];
-
-            if ($token[0] && '' === $token[1]) {
-                throw new \InvalidArgumentException('Cannot set empty content for id-based Token.');
-            }
         } elseif (\is_string($token)) {
             $this->isArray = false;
             $this->content = $token;


### PR DESCRIPTION
Report after update:
```
 ------ --------------------------------------------------------------------------------------------
  Line   src/Tokenizer/Token.php
 ------ --------------------------------------------------------------------------------------------
  81     Result of && is always false.
  81     Strict comparison using === between '' and non-empty-string will always evaluate to false.
 ------ --------------------------------------------------------------------------------------------
```