### PR TITLE
YodaStyleFixer - Fix `yoda_style` with `yield` statements

### DIFF
--- a/src/Fixer/ControlStructure/YodaStyleFixer.php
+++ b/src/Fixer/ControlStructure/YodaStyleFixer.php
@@ -451,6 +451,8 @@ return $foo === count($bar);
                 T_THROW,        // throw
                 T_XOR_EQUAL,    // ^=
                 T_COALESCE,     // ??
+                T_YIELD,        // yield
+                T_YIELD_FROM,   // yield from
             ];
 
             // @TODO: drop condition when PHP 7.4+ is required

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -636,6 +636,14 @@ $a#4
                 '<?php $a = $b = null === $c;',
                 '<?php $a = $b = $c === null;',
             ],
+            [
+                '<?php function test() {return yield 1 !== $a [$b];};',
+                '<?php function test() {return yield $a [$b] !== 1;};',
+            ],
+            [
+                '<?php function test() {return yield from [1 !== $a [$b]];};',
+                '<?php function test() {return yield from [$a [$b] !== 1];};',
+            ],
         ];
 
         foreach ($tests as $index => $test) {


### PR DESCRIPTION
This PR:

- [x] Is a current work-in-progress

@SpacePossum As you wrote this fixer, can you help on this one? I'm kind of blocked.

Fix #5810 