### PR TITLE
Add parallel capabilities to FixCommand

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -83,6 +83,11 @@ class Config implements ConfigInterface
      */
     private $usingCache = true;
 
+    /**
+     * @var int
+     */
+    private $parallel = 1;
+
     public function __construct(string $name = 'default')
     {
         $this->name = $name;
@@ -154,6 +159,14 @@ class Config implements ConfigInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParallel(): int
+    {
+        return $this->parallel;
     }
 
     /**
@@ -256,6 +269,16 @@ class Config implements ConfigInterface
     public function setLineEnding(string $lineEnding): ConfigInterface
     {
         $this->lineEnding = $lineEnding;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParallel(int $parallel): ConfigInterface
+    {
+        $this->parallel = $parallel;
 
         return $this;
     }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -64,6 +64,11 @@ interface ConfigInterface
     public function getName(): string;
 
     /**
+     * Get number processes to use.
+     */
+    public function getParallel(): int;
+
+    /**
      * Get configured PHP executable, if any.
      */
     public function getPhpExecutable(): ?string;
@@ -108,6 +113,11 @@ interface ConfigInterface
     public function setIndent(string $indent): self;
 
     public function setLineEnding(string $lineEnding): self;
+
+    /**
+     * Set number of processes to use.
+     */
+    public function setParallel(int $parallel): self;
 
     /**
      * Set PHP executable.

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -217,6 +217,7 @@ EOF
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'To output results in other formats.'),
                     new InputOption('stop-on-violation', '', InputOption::VALUE_NONE, 'Stop execution on first violation.'),
                     new InputOption('show-progress', '', InputOption::VALUE_REQUIRED, 'Type of progress indicator (none, dots).'),
+                    new InputOption('parallel', '', InputOption::VALUE_REQUIRED, 'Number of processes to use.'),
                 ]
             )
             ->setDescription('Fixes a directory or a file.')
@@ -253,6 +254,7 @@ EOF
                 'stop-on-violation' => $input->getOption('stop-on-violation'),
                 'verbosity' => $verbosity,
                 'show-progress' => $input->getOption('show-progress'),
+                'parallel' => $input->getOption('parallel'),
             ],
             getcwd(),
             $this->toolInfo
@@ -269,6 +271,8 @@ EOF
             if (OutputInterface::VERBOSITY_VERBOSE <= $verbosity) {
                 $stdErr->writeln($this->getApplication()->getLongVersion());
                 $stdErr->writeln(sprintf('Runtime: <info>PHP %s</info>', PHP_VERSION));
+
+                $stdErr->writeln(sprintf('Using Processes: <info>%d</info>', \function_exists('pcntl_fork') ? $resolver->getParallel() : 1));
             }
 
             $configFile = $resolver->getConfigFile();
@@ -314,7 +318,8 @@ EOF
             $resolver->isDryRun(),
             $resolver->getCacheManager(),
             $resolver->getDirectory(),
-            $resolver->shouldStopOnViolation()
+            $resolver->shouldStopOnViolation(),
+            $resolver->getParallel()
         );
 
         $this->stopwatch->start('fixFiles');

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -131,6 +131,7 @@ final class ConfigurationResolver
         'stop-on-violation' => null,
         'using-cache' => null,
         'verbosity' => null,
+        'parallel' => null,
     ];
 
     private $cacheFile;
@@ -183,6 +184,11 @@ final class ConfigurationResolver
      * @var FixerFactory
      */
     private $fixerFactory;
+
+    /**
+     * @var null|int
+     */
+    private $parallel;
 
     public function __construct(
         ConfigInterface $config,
@@ -357,6 +363,19 @@ final class ConfigurationResolver
         }
 
         return $this->linter;
+    }
+
+    public function getParallel(): int
+    {
+        if (null === $this->parallel) {
+            if (null === $this->options['parallel']) {
+                $this->parallel = $this->getConfig()->getParallel();
+            } else {
+                $this->parallel = (int) $this->options['parallel'];
+            }
+        }
+
+        return $this->parallel;
     }
 
     /**

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -206,6 +206,16 @@ final class CustomConfig implements ConfigInterface
     {
         return $this;
     }
+
+    public function getParallel(): int
+    {
+        return 1;
+    }
+
+    public function setParallel(int $parallel): ConfigInterface
+    {
+        return $this;
+    }
 }
 
 return new CustomConfig();


### PR DESCRIPTION
## Description
This PR adds a new option for the `FixCommand` that allows using multiple processes to analyze the codebase.
Since this feature is possible only when the `pcntl` is loaded, by default and as a fallback it will continue to use a single process.

## Motivation
The current suggested solution to perform parallel checks has some drawbacks:
 - The output can be quite messy
 - If you use a file output you have to merge them in order to be usable (EG: using it in GL pipeline as code quality check)

## Remarks
Please consider this PR as a POC. Before adding tests and documentation I would like to have some feedback on this.