### PR TITLE
DX: Fix SCA with PHPMD

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -86,22 +86,29 @@ jobs:
       - name: Find changed files (for pull request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          git diff origin/$GITHUB_BASE_REF --name-only --diff-filter=ACMRTUXB | grep -E "\.php$" || true
-          echo 'CHANGED_PHP_FILES<<EOF' >> $GITHUB_ENV
-          git diff origin/$GITHUB_BASE_REF --name-only --diff-filter=ACMRTUXB | grep -E "\.php$" || true >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          if git diff origin/$GITHUB_BASE_REF --name-only --diff-filter=ACMRTUXB | grep -E "\.php$"; then
+            echo 'CHANGED_PHP_FILES<<EOF' >> $GITHUB_ENV
+            git diff origin/$GITHUB_BASE_REF --name-only --diff-filter=ACMRTUXB | grep -E "\.php$" >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+          fi
 
       - name: Find changed files (for push)
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          git diff --name-only --diff-filter=ACMRTUXB HEAD~..HEAD | grep -E "\.php$" || true
-          echo 'CHANGED_PHP_FILES<<EOF' >> $GITHUB_ENV
-          git diff --name-only --diff-filter=ACMRTUXB HEAD~..HEAD | grep -E "\.php$" || true >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          if git diff --name-only --diff-filter=ACMRTUXB HEAD~..HEAD | grep -E "\.php$"; then
+            echo 'CHANGED_PHP_FILES<<EOF' >> $GITHUB_ENV
+            git diff --name-only --diff-filter=ACMRTUXB HEAD~..HEAD | grep -E "\.php$" >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+          fi
 
       - name: Check - phpmd
-        if: ${{ github.env.CHANGED_PHP_FILES }}
-        run: ./dev-tools/vendor/bin/phpmd `echo "$CHANGED_PHP_FILES" | xargs | sed 's/ /,/g'` text phpmd.xml
+        if: ${{ env.CHANGED_PHP_FILES }}
+        run: |
+          if [ '${{ github.event_name }}' == 'pull_request' ]; then
+            ./dev-tools/vendor/bin/phpmd `echo "$CHANGED_PHP_FILES" | xargs | sed 's/ /,/g'` github phpmd.xml
+          else
+            ./dev-tools/vendor/bin/phpmd `echo "$CHANGED_PHP_FILES" | xargs | sed 's/ /,/g'` ansi phpmd.xml
+          fi
 
       - name: Check - ensure test files are not present in the archive
         run: |


### PR DESCRIPTION
I found the SCA workflow here using PHPMD very useful and applied it in one of my projects. However, I noted that the actual fixing part with PHPMD is never run. I checked with the actions runs here and it seems the same is true. So after a lot of trial and error fixing the syntax, I found a solution at least working for me and wished to share here.

The problems are:
- The results of `git diff` with `grep` is never saved to `$GITHUB_ENV`, even though there are changed PHP files. This is maybe because of the `|| true` part.
- `Check - phpmd` step has a condition to run `if: ${{ github.env.CHANGED_PHP_FILES }}`. The problem here is that the `github` context does not have the `env` property. Rather, the `env` is a context of its own. See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#env-context