### PR TITLE
Failing test for #5798

### DIFF
--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -144,6 +144,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var array<array<int, int>, OutputInterface> */',
             ],
+            [
+                '<?php /** @var array<string, array{event: string, subscribers: array<int, string>}> */',
+            ],
         ];
     }
 


### PR DESCRIPTION
See https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5798

The problem is here:
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/7c1dff08d39d342b73f475952632ee1f7a445022/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php#L211-L221

<img width="1430" alt="Screenshot 2021-08-03 at 10 09 52@2x" src="https://user-images.githubusercontent.com/104180/127981262-d3b9e5fc-10e2-4daf-b4a4-be26ace795f2.png">

<img width="1496" alt="Screenshot 2021-08-03 at 10 10 09@2x" src="https://user-images.githubusercontent.com/104180/127981242-645a15e1-7722-4111-82fe-f76b27c49b9c.png">

/cc @julienfalque 
