### PR TITLE
PhpdocTypesOrderFixer: fix for array shapes

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -211,7 +211,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
     private function sortJoinedTypes(string $types): string
     {
         $types = array_filter(
-            Preg::split('/([^|<]+(?:<.*>)?)/', $types, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
+            Preg::split('/([^|<{]+(?:[<{].*[>}])?)/', $types, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
             static function (string $value) {
                 return '|' !== $value;
             }

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -144,6 +144,18 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var array<array<int, int>, OutputInterface> */',
             ],
+            [
+                '<?php /** @var iterable<array{names:array<string>, surname:string}> */',
+            ],
+            [
+                '<?php /** @var iterable<array{surname:string, names:array<string>}> */',
+            ],
+            [
+                '<?php /** @return array<array{level:string, message:string, context:array<mixed>}> */',
+            ],
+            [
+                '<?php /** @return Data<array{enabled: string[], all: array<string, string>}> */',
+            ],
         ];
     }
 


### PR DESCRIPTION
fixes #5798 
closes #5833

As an extra it will "work" for broken types such as  `array<string}` or `array{string>`.