### PR TITLE
PhpdocTypesOrderFixer: handle callable() type

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -211,7 +211,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
     private function sortJoinedTypes(string $types): string
     {
         $types = array_filter(
-            Preg::split('/([^|<{]+(?:[<{].*[>}])?)/', $types, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
+            Preg::split('/([^|<{\(]+(?:[<{].*[>}]|\(.+\)(?::.+)?)?)/', $types, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
             static function (string $value) {
                 return '|' !== $value;
             }

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -156,6 +156,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @return Data<array{enabled: string[], all: array<string, string>}> */',
             ],
+            [
+                '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
+            ],
         ];
     }
 
@@ -271,6 +274,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
                 '<?php /** @var Foo[]|Foo|Foo\Bar|Foo_Bar|null */',
                 '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
             ],
+            [
+                '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
+            ],
         ];
     }
 
@@ -381,6 +387,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var Foo|Foo[]|Foo\Bar|Foo_Bar|null */',
                 '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
+            ],
+            [
+                '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
             ],
         ];
     }
@@ -494,6 +503,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @return array<array<string, int>> */',
             ],
+            [
+                '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
+            ],
         ];
     }
 
@@ -604,6 +616,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @var Foo|Foo[]|Foo\Bar|Foo_Bar|null */',
                 '<?php /** @var Foo[]|null|Foo|Foo\Bar|Foo_Bar */',
+            ],
+            [
+                '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
             ],
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5836

- [x] Do not mangle types
- [ ] ~Handle `callable()` internal types~ too much effort for this bugfix, postponed