### PR TITLE
PhpdocTagTypeFixer - must not remove inlined tags within other tags

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
@@ -90,21 +90,23 @@ final class PhpdocTagTypeFixer extends AbstractFixer implements ConfigurableFixe
             return;
         }
 
+        $regularExpression = sprintf(
+            '/({?@(?:%s).*?(?:(?=\s\*\/)|(?=\n)}?))/i',
+            implode('|', array_map(
+                function (string $tag) {
+                    return preg_quote($tag, '/');
+                },
+                array_keys($this->configuration['tags'])
+            ))
+        );
+
         foreach ($tokens as $index => $token) {
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
             $parts = Preg::split(
-                sprintf(
-                    '/({?@(?:%s)(?:}|\h.*?(?:}|(?=\R)|(?=\h+\*\/)))?)/i',
-                    implode('|', array_map(
-                        function (string $tag) {
-                            return preg_quote($tag, '/');
-                        },
-                        array_keys($this->configuration['tags'])
-                    ))
-                ),
+                $regularExpression,
                 $token->getContent(),
                 -1,
                 PREG_SPLIT_DELIM_CAPTURE

--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -350,6 +350,40 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
  * @return array{0: float, 1: int}
  */',
             ],
+            [
+                '<?php
+/** @internal Please use {@see Foo} instead */',
+                '<?php
+/** {@internal Please use {@see Foo} instead} */',
+            ],
+            [
+                '<?php
+/**
+ * @internal Please use {@see Foo} instead
+ */',
+                '<?php
+/**
+ * {@internal Please use {@see Foo} instead}
+ */',
+            ],
+            [
+                '<?php
+/**
+ *
+ * @internal Please use {@see Foo} instead
+ *
+ */',
+                '<?php
+/**
+ *
+ * {@internal Please use {@see Foo} instead}
+ *
+ */',
+            ],
+            [
+                '<?php
+/** @internal Foo Bar {@see JsonSerializable} */',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #5815 