### PR TITLE
EmptyLoopConditionFixer - introduction

### DIFF
--- a/doc/rules/control_structure/empty_loop_condition.rst
+++ b/doc/rules/control_structure/empty_loop_condition.rst
@@ -1,0 +1,56 @@
+=============================
+Rule ``empty_loop_condition``
+=============================
+
+Empty loop-condition must be in configured style.
+
+Configuration
+-------------
+
+``style``
+~~~~~~~~~
+
+Style of empty loop-condition.
+
+Allowed values: ``'for'``, ``'while'``
+
+Default value: ``'while'``
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -for(;;) {
+   +while(true) {
+        foo();
+    }
+
+   -do {
+   +while(true) {
+        foo();
+   -} while(true); // do while
+   +}  // do while
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['style' => 'for']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -while(true) {
+   +for(;;) {
+        foo();
+    }

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -165,6 +165,8 @@ Control Structure
     The keyword ``elseif`` should be used instead of ``else if`` so that all control keywords look like single words.
 - `empty_loop_body <./control_structure/empty_loop_body.rst>`_
     Empty loop-body must be in configured style.
+- `empty_loop_condition <./control_structure/empty_loop_condition.rst>`_
+    Empty loop-condition must be in configured style.
 - `include <./control_structure/include.rst>`_
     Include/Require and file path should be divided with a single space. File path should not be placed under brackets.
 - `no_alternative_syntax <./control_structure/no_alternative_syntax.rst>`_

--- a/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\ControlStructure;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @author SpacePossum
+ */
+final class EmptyLoopConditionFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    private const STYLE_FOR = 'for';
+
+    private const STYLE_WHILE = 'while';
+
+    private const TOKEN_LOOP_KINDS = [T_FOR, T_WHILE];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Empty loop-condition must be in configured style.',
+            [
+                new CodeSample("<?php\nfor(;;) {\n    foo();\n}\n\ndo {\n    foo();\n} while(true); // do while\n"),
+                new CodeSample("<?php\nwhile(true) {\n    foo();\n}\n", ['style' => 'for']),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer.
+     */
+    public function getPriority(): int
+    {
+        return 1;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound(self::TOKEN_LOOP_KINDS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        if (self::STYLE_WHILE === $this->configuration['style']) {
+            $candidateLoopKinds = [T_FOR, T_WHILE];
+            $replacement = [new Token([T_WHILE, 'while']), new Token('('), new Token([T_STRING, 'true']), new Token(')')];
+
+            $fixLoop = static function (int $index, int $openIndex, int $endIndex) use ($tokens, $replacement): void {
+                if (self::isForLoopWithEmptyCondition($tokens, $index, $openIndex, $endIndex)) {
+                    self::clearNotCommentsInRange($tokens, $index, $endIndex);
+                    self::cloneAndInsert($tokens, $index, $replacement);
+                } elseif (self::isWhileLoopWithEmptyCondition($tokens, $index, $openIndex, $endIndex)) {
+                    $doIndex = self::getDoIndex($tokens, $index);
+
+                    if (null !== $doIndex) {
+                        self::clearNotCommentsInRange($tokens, $index, $tokens->getNextMeaningfulToken($endIndex)); // clear including `;`
+                        $tokens->clearAt($doIndex);
+                        self::cloneAndInsert($tokens, $doIndex, $replacement);
+                    }
+                }
+            };
+        } else { // self::STYLE_FOR
+            $candidateLoopKinds = [T_WHILE];
+            $replacement = [new Token([T_FOR, 'for']), new Token('('), new Token(';'), new Token(';'), new Token(')')];
+
+            $fixLoop = static function (int $index, int $openIndex, int $endIndex) use ($tokens, $replacement): void {
+                if (!self::isWhileLoopWithEmptyCondition($tokens, $index, $openIndex, $endIndex)) {
+                    return;
+                }
+
+                $doIndex = self::getDoIndex($tokens, $index);
+
+                if (null === $doIndex) {
+                    self::clearNotCommentsInRange($tokens, $index, $endIndex);
+                    self::cloneAndInsert($tokens, $index, $replacement);
+                } else {
+                    self::clearNotCommentsInRange($tokens, $index, $tokens->getNextMeaningfulToken($endIndex)); // clear including `;`
+                    $tokens->clearAt($doIndex);
+                    self::cloneAndInsert($tokens, $doIndex, $replacement);
+                }
+            };
+        }
+
+        for ($index = $tokens->count() - 1; $index > 0; --$index) {
+            if ($tokens[$index]->isGivenKind($candidateLoopKinds)) {
+                $openIndex = $tokens->getNextTokenOfKind($index, ['(']); // proceed to open '('
+                $endIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openIndex); // proceed to close ')'
+                $fixLoop($index, $openIndex, $endIndex); // fix loop if needed
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('style', 'Style of empty loop-condition.'))
+                ->setAllowedTypes(['string'])
+                ->setAllowedValues([self::STYLE_WHILE, self::STYLE_FOR])
+                ->setDefault(self::STYLE_WHILE)
+                ->getOption(),
+        ]);
+    }
+
+    private static function clearNotCommentsInRange(Tokens $tokens, int $indexStart, int $indexEnd): void
+    {
+        for ($i = $indexStart; $i <= $indexEnd; ++$i) {
+            if (!$tokens[$i]->isComment()) {
+                $tokens->clearTokenAndMergeSurroundingWhitespace($i);
+            }
+        }
+    }
+
+    /**
+     * @param Token[] $replacement
+     */
+    private static function cloneAndInsert(Tokens $tokens, int $index, array $replacement): void
+    {
+        $replacementClones = [];
+
+        foreach ($replacement as $token) {
+            $replacementClones[] = clone $token;
+        }
+
+        $tokens->insertAt($index, $replacementClones);
+    }
+
+    private static function getDoIndex(Tokens $tokens, int $index): ?int
+    {
+        $endIndex = $tokens->getPrevMeaningfulToken($index);
+
+        if (!$tokens[$endIndex]->equals('}')) {
+            return null;
+        }
+
+        $startIndex = $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $endIndex);
+        $index = $tokens->getPrevMeaningfulToken($startIndex);
+
+        return null === $index || !$tokens[$index]->isGivenKind(T_DO) ? null : $index;
+    }
+
+    private static function isForLoopWithEmptyCondition(Tokens $tokens, int $index, int $openIndex, int $endIndex): bool
+    {
+        if (!$tokens[$index]->isGivenKind(T_FOR)) {
+            return false;
+        }
+
+        $index = $tokens->getNextMeaningfulToken($openIndex);
+
+        if (null === $index || !$tokens[$index]->equals(';')) {
+            return false;
+        }
+
+        $index = $tokens->getNextMeaningfulToken($index);
+
+        return null !== $index && $tokens[$index]->equals(';') && $endIndex === $tokens->getNextMeaningfulToken($index);
+    }
+
+    private static function isWhileLoopWithEmptyCondition(Tokens $tokens, int $index, int $openIndex, int $endIndex): bool
+    {
+        if (!$tokens[$index]->isGivenKind(T_WHILE)) {
+            return false;
+        }
+
+        $index = $tokens->getNextMeaningfulToken($openIndex);
+
+        return null !== $index && $tokens[$index]->equals([T_STRING, 'true']) && $endIndex === $tokens->getNextMeaningfulToken($index);
+    }
+}

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -272,7 +272,7 @@ switch($a) {
      * {@inheritdoc}
      *
      * Must run before BlankLineBeforeStatementFixer.
-     * Must run after ClassAttributesSeparationFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnusedImportsFixer, NoUselessElseFixer, NoUselessReturnFixer, NoUselessSprintfFixer.
+     * Must run after ClassAttributesSeparationFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, EmptyLoopConditionFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnusedImportsFixer, NoUselessElseFixer, NoUselessReturnFixer, NoUselessSprintfFixer.
      */
     public function getPriority(): int
     {

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -46,7 +46,7 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, TernaryToElvisOperatorFixer.
+     * Must run after CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, EmptyLoopConditionFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, TernaryToElvisOperatorFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -102,6 +102,8 @@ final class FixerFactoryTest extends TestCase
             [$fixers['empty_loop_body'], $fixers['braces']],
             [$fixers['empty_loop_body'], $fixers['no_extra_blank_lines']],
             [$fixers['empty_loop_body'], $fixers['no_trailing_whitespace']],
+            [$fixers['empty_loop_condition'], $fixers['no_extra_blank_lines']],
+            [$fixers['empty_loop_condition'], $fixers['no_trailing_whitespace']],
             [$fixers['escape_implicit_backslashes'], $fixers['heredoc_to_nowdoc']],
             [$fixers['escape_implicit_backslashes'], $fixers['single_quote']],
             [$fixers['explicit_string_variable'], $fixers['simple_to_complex_string_variable']],

--- a/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopBodyFixerTest.php
@@ -28,7 +28,7 @@ final class EmptyLoopBodyFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFixConfig(string $expected, ?string $input = null, ?array $config = null): void
+    public function testFixConfig(string $expected, ?string $input = null, array $config = null): void
     {
         if (null === $config) {
             $this->doTest($expected, $input);

--- a/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
+++ b/tests/Fixer/ControlStructure/EmptyLoopConditionFixerTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\ControlStructure;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\ControlStructure\EmptyLoopConditionFixer
+ */
+final class EmptyLoopConditionFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixConfig(string $expected, ?string $input = null, array $config = null): void
+    {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCases(): \Generator
+    {
+        yield 'from `for` to `while`' => [
+            '<?php
+                while(true){ if(foo()) {break;}}
+                for(;$i < 1;){ if(foo()) {break;}}',
+            '<?php
+                for(;;){ if(foo()) {break;}}
+                for(;$i < 1;){ if(foo()) {break;}}',
+        ];
+
+        yield 'from `do while` to `while`' => [
+            '<?php while(true){ if(foo()) {break;}}',
+            '<?php do{ if(foo()) {break;}}while(true);',
+        ];
+
+        yield 'from `while` to `for`' => [
+            '<?php
+                for(;;){ if(foo()) {break;}}
+                while(false){ echo 1; }
+                while($a()) { echo 2; }
+            ',
+            '<?php
+                while(true){ if(foo()) {break;}}
+                while(false){ echo 1; }
+                while($a()) { echo 2; }
+            ',
+            ['style' => 'for'],
+        ];
+
+        yield 'from `do while` to `for`' => [
+            '<?php for(;;){ if(foo()) {break;}}',
+            '<?php do{ if(foo()) {break;}}while(true);',
+            ['style' => 'for'],
+        ];
+
+        yield 'multiple `do while` to `while`' => [
+            '<?php while(true){}while(true){}while(true){}while(true){}while(true){}while(true){}',
+            '<?php do{}while(true);do{}while(true);do{}while(true);do{}while(true);do{}while(true);do{}while(true);',
+        ];
+
+        yield 'multiple nested `do while` to `while`' => [
+            '<?php while(true){while(true){while(true){while(true){while(true){while(true){while(true){}}}}}}}',
+            '<?php do{do{do{do{do{do{do{}while(true);}while(true);}while(true);}while(true);}while(true);}while(true);}while(true);',
+        ];
+
+        // comment cases
+
+        yield 'comment inside empty `for` condition' => [
+            '<?php while(true)/* 1 *//* 2 */{}',
+            '<?php for(/* 1 */;;/* 2 */){}',
+        ];
+
+        yield 'comment following empty `for` condition' => [
+            '<?php for(;;)/* 3 */{}',
+            '<?php while(true/* 3 */){}',
+            ['style' => 'for'],
+        ];
+
+        // space cases
+        yield 'lot of space' => [
+            '<?php while(true){ foo3(); }              ',
+            '<?php do{ foo3(); } while(true)            ; ',
+        ];
+
+        yield [
+            '<?php
+
+while(true) {
+    foo1();
+}
+
+
+
+',
+            '<?php
+
+do {
+    foo1();
+}
+while(
+true
+)
+;',
+        ];
+
+        // do not fix cases
+
+        yield 'not empty `while` condition' => [
+            '<?php while(true === foo()){ if(foo()) {break;}}',
+            null,
+            ['style' => 'for'],
+        ];
+
+        yield 'not empty `for` condition' => [
+            '<?php for(;foo();){ if(foo()) {break;}}',
+        ];
+
+        yield 'not empty `do while` condition' => [
+            '<?php do{ if(foo()) {break;}}while(foo());',
+        ];
+
+        yield '`while` false' => [
+            '<?php while(false){ if(foo()) {break;}}',
+            null,
+            ['style' => 'for'],
+        ];
+    }
+}

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -28,7 +28,7 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null, ?int $versionSpecificFix = null, ?array $config = null): void
+    public function testFix(string $expected, ?string $input = null, ?int $versionSpecificFix = null, array $config = null): void
     {
         if (
             null !== $input
@@ -40,6 +40,7 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
             $expected = $input;
             $input = null;
         }
+
         if (null !== $config) {
             $this->fixer->configure($config);
         }

--- a/tests/Fixtures/Integration/priority/empty_loop_condition,no_extra_blank_lines.test
+++ b/tests/Fixtures/Integration/priority/empty_loop_condition,no_extra_blank_lines.test
@@ -1,0 +1,25 @@
+--TEST--
+Integration of fixers: empty_loop_condition,no_extra_blank_lines.
+--RULESET--
+{"empty_loop_condition": true, "no_extra_blank_lines": true}
+--EXPECT--
+<?php
+
+while(true) {
+    foo1();
+}
+
+# 1
+
+--INPUT--
+<?php
+
+do {
+    foo1();
+}
+while(
+true
+)
+;
+
+# 1

--- a/tests/Fixtures/Integration/priority/empty_loop_condition,no_trailing_whitespace.test
+++ b/tests/Fixtures/Integration/priority/empty_loop_condition,no_trailing_whitespace.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: empty_loop_condition,no_trailing_whitespace.
+--RULESET--
+{"empty_loop_condition": true, "no_trailing_whitespace": true}
+--EXPECT--
+<?php
+while(true){ foo2(); }
+
+--INPUT--
+<?php
+do{ foo2(); } while(true)            ;


### PR DESCRIPTION
```
Description of empty_loop_condition rule.
Empty loop-condition must be in configured style.

Fixer is configurable using following option:
* style ('for', 'while'): style of empty loop-condition; defaults to 'while'
```

```diff
--- Original
+++ New
@@ -1,8 +1,8 @@
 <?php
-for(;;) {
+while(true) {
     foo();
 }
 
-do {
+while(true) {
     foo();
-} while(true); // do while
+}  // do while
```

Fixing with configuration: ['style' => 'for']

```diff
--- Original
+++ New
@@ -1,4 +1,4 @@
 <?php
-while(true) {
+for(;;) {
      foo();
 }
```