### PR TITLE
DX: add method Token::isAmpersand

### DIFF
--- a/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
+++ b/src/Fixer/FunctionNotation/LambdaNotUsedImportFixer.php
@@ -291,7 +291,7 @@ final class LambdaNotUsedImportFixer extends AbstractFixer
             $info = $this->argumentsAnalyzer->getArgumentInfo($tokens, $start, $end);
             $argument = $info->getNameIndex();
 
-            if ($tokens[$tokens->getPrevMeaningfulToken($argument)]->equals('&')) {
+            if ($tokens[$tokens->getPrevMeaningfulToken($argument)]->isAmpersand()) {
                 continue;
             }
 

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -153,7 +153,7 @@ function bar($foo) {}
                 }
 
                 $byRefIndex = $tokens->getPrevMeaningfulToken($variableIndex);
-                if ($tokens[$byRefIndex]->equals('&')) {
+                if ($tokens[$byRefIndex]->isAmpersand()) {
                     $variableIndex = $byRefIndex;
                 }
 

--- a/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
+++ b/src/Fixer/FunctionNotation/UseArrowFunctionsFixer.php
@@ -115,7 +115,7 @@ SAMPLE
                 $next = $tokens->getNextMeaningfulToken($next);
 
                 while (!$tokens[$next]->equals(')')) {
-                    if ($tokens[$next]->equals('&')) {
+                    if ($tokens[$next]->isAmpersand()) {
                         // variables used by reference are not supported by arrow functions
                         continue 2;
                     }

--- a/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
+++ b/src/Fixer/ReturnNotation/ReturnAssignmentFixer.php
@@ -129,7 +129,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
         // go through the function declaration and check if references are passed
         // - check if it will be risky to fix return statements of this function
         for ($index = $functionIndex + 1; $index < $functionOpenIndex; ++$index) {
-            if ($tokens[$index]->equals('&')) {
+            if ($tokens[$index]->isAmpersand()) {
                 $isRisky = true;
 
                 break;
@@ -168,7 +168,7 @@ final class ReturnAssignmentFixer extends AbstractFixer
                 continue; // don't bother to look into anything else than nested functions as the current is risky already
             }
 
-            if ($tokens[$index]->equals('&')) {
+            if ($tokens[$index]->isAmpersand()) {
                 $isRisky = true;
 
                 continue;

--- a/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
@@ -105,7 +105,7 @@ final class ArgumentsAnalyzer
                 $token->isComment()
                 || $token->isWhitespace()
                 || $token->isGivenKind([T_ELLIPSIS, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE])
-                || $token->equals('&')
+                || $token->isAmpersand()
             ) {
                 continue;
             }

--- a/src/Tokenizer/Analyzer/ClassyAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ClassyAnalyzer.php
@@ -60,7 +60,7 @@ final class ClassyAnalyzer
         // `Foo & $bar` could be:
         //   - function reference parameter: function baz(Foo & $bar) {}
         //   - bit operator: $x = Foo & $bar;
-        if ($nextToken->equals('&') && $tokens[$tokens->getNextMeaningfulToken($next)]->isGivenKind(T_VARIABLE)) {
+        if ($nextToken->isAmpersand() && $tokens[$tokens->getNextMeaningfulToken($next)]->isGivenKind(T_VARIABLE)) {
             $checkIndex = $tokens->getPrevTokenOfKind($prev + 1, [';', '{', '}', [T_FUNCTION], [T_OPEN_TAG], [T_OPEN_TAG_WITH_ECHO]]);
 
             return $tokens[$checkIndex]->isGivenKind(T_FUNCTION);

--- a/src/Tokenizer/Analyzer/ReferenceAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ReferenceAnalyzer.php
@@ -30,7 +30,7 @@ final class ReferenceAnalyzer
             return true;
         }
 
-        if (!$tokens[$index]->equals('&')) {
+        if (!$tokens[$index]->isAmpersand()) {
             return false;
         }
 

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -429,6 +429,14 @@ final class Token
     }
 
     /**
+     * Check if token is an ampersand.
+     */
+    public function isAmpersand(): bool
+    {
+        return $this->equals('&');
+    }
+
+    /**
      * Check if token is whitespace.
      *
      * @param null|string $whitespaces whitespace characters, default is " \t\n\r\0\x0B"

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -327,7 +327,7 @@ final class TokensAnalyzer
         // `FOO & $bar` could be:
         //   - function reference parameter: function baz(Foo & $bar) {}
         //   - bit operator: $x = FOO & $bar;
-        if ($this->tokens[$nextIndex]->equals('&') && $this->tokens[$this->tokens->getNextMeaningfulToken($nextIndex)]->isGivenKind(T_VARIABLE)) {
+        if ($this->tokens[$nextIndex]->isAmpersand() && $this->tokens[$this->tokens->getNextMeaningfulToken($nextIndex)]->isGivenKind(T_VARIABLE)) {
             $checkIndex = $this->tokens->getPrevTokenOfKind($prevIndex, [';', '{', '}', [T_FUNCTION], [T_OPEN_TAG], [T_OPEN_TAG_WITH_ECHO]]);
 
             if ($this->tokens[$checkIndex]->isGivenKind(T_FUNCTION)) {
@@ -481,7 +481,7 @@ final class TokensAnalyzer
             return true;
         }
 
-        if (!$token->equals('&') || !$prevToken->isGivenKind(T_STRING)) {
+        if (!$token->isAmpersand() || !$prevToken->isGivenKind(T_STRING)) {
             return false;
         }
 

--- a/src/Tokenizer/Transformer/ReturnRefTransformer.php
+++ b/src/Tokenizer/Transformer/ReturnRefTransformer.php
@@ -47,7 +47,7 @@ final class ReturnRefTransformer extends AbstractTransformer
         }
 
         if (
-            $token->equals('&')
+            $token->isAmpersand()
             && $tokens[$tokens->getPrevMeaningfulToken($index)]->isGivenKind($prevKinds)
         ) {
             $tokens[$index] = new Token([CT::T_RETURN_REF, '&']);

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -227,6 +227,21 @@ final class TokenTest extends TestCase
     }
 
     /**
+     * @dataProvider provideIsAmpersandCases
+     */
+    public function testIsAmpersand(bool $isAmpersand, Token $token): void
+    {
+        static::assertSame($isAmpersand, $token->isAmpersand());
+    }
+
+    public function provideIsAmpersandCases(): iterable
+    {
+        yield [false, $this->getBraceToken()];
+        yield [false, $this->getForeachToken()];
+        yield [true, new Token('&')];
+    }
+
+    /**
      * @dataProvider provideIsNativeConstantCases
      */
     public function testIsNativeConstant(Token $token, bool $isNativeConstant): void


### PR DESCRIPTION
Extracted from https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5776 as piece that can be already merged.

In PHP 8.1 there will be 2 new tokens `T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG` and `T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG` which previously were string tokens, so in PHP 8.1 the method will look like this:
```
public function isAmpersand(): bool
    {
        return $this->equals('&')
            || \defined('T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG') && $this->isGivenKind([T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG]);
    }
```

or version with `CT::T_AMPERSAND` if we go this: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5862 way.