### PR TITLE
Add AmpersandTransformer

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -7,6 +7,8 @@
         "null", "true", "false",
         "static", "self", "parent",
         "array", "string", "int", "float", "bool", "iterable", "callable", "void",
+        "T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG",
+        "T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG",
         "T_ATTRIBUTE",
         "T_COALESCE_EQUAL",
         "T_FN",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,14 @@ jobs:
             php-version: '8.0'
             job-description: 'with calculating code coverage'
             calculate-code-coverage: 'yes'
-            phpunit-flags: '--testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml'
+            phpunit-options: '--testsuite coverage --exclude-group covers-nothing --coverage-clover build/logs/clover.xml'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.1'
+            job-description: 'with calculating code coverage'
+            composer-flags: '--ignore-platform-req=php' #needed for phpspec/prophecy
+            phpunit-options: 'tests/Tokenizer/Transformer/AmpersandTransformerTest.php'
+            PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'windows-latest'
             php-version: '7.4'
@@ -121,7 +128,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-options }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'
@@ -134,6 +141,7 @@ jobs:
         run: php php-cs-fixer fix --diff --dry-run -v --config .php-cs-fixer.php70types.php
 
       - name: Run PHP CS Fixer
+        if: matrix.php-version != '8.1' # not there yet
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           PHP_CS_FIXER_FUTURE_MODE: 1

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/console": "^4.4.20 || ^5.1.3",
         "symfony/event-dispatcher": "^4.4.20 || ^5.0",
         "symfony/filesystem": "^4.4.20 || ^5.0",
-        "symfony/finder": "^4.4.20 || ^5.0",
+        "symfony/finder": "^4.4.20 || ^5.0 || 5.4.x-dev",
         "symfony/options-resolver": "^4.4.20 || ^5.0",
         "symfony/polyfill-php72": "^1.22",
         "symfony/process": "^4.4.20 || ^5.0",

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -52,6 +52,7 @@ final class CT
     public const T_ATTRIBUTE_CLOSE = 10031;
     public const T_NAMED_ARGUMENT_NAME = 10032;
     public const T_NAMED_ARGUMENT_COLON = 10033;
+    public const T_AMPERSAND = 10034;
 
     private function __construct()
     {

--- a/src/Tokenizer/Transformer/AmpersandTransformer.php
+++ b/src/Tokenizer/Transformer/AmpersandTransformer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Transformer;
+
+use PhpCsFixer\Tokenizer\AbstractTransformer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Transforms ampersand T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG and T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG into single CT::T_AMPERSAND.
+ *
+ * @internal
+ */
+final class AmpersandTransformer extends AbstractTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredPhpVersionId(): int
+    {
+        return 80100;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens, Token $token, int $index): void
+    {
+        if (!$tokens[$index]->isGivenKind([T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG])) {
+            return;
+        }
+
+        $tokens[$index] = new Token([CT::T_AMPERSAND, '&']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokens(): array
+    {
+        return [
+            CT::T_AMPERSAND,
+        ];
+    }
+}

--- a/tests/Tokenizer/Transformer/AmpersandTransformerTest.php
+++ b/tests/Tokenizer/Transformer/AmpersandTransformerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Transformer;
+
+use PhpCsFixer\Tests\Test\AbstractTransformerTestCase;
+use PhpCsFixer\Tokenizer\CT;
+
+    /**
+     * @internal
+     *
+     * @covers \PhpCsFixer\Tokenizer\Transformer\AmpersandTransformer
+     */
+    final class AmpersandTransformerTest extends AbstractTransformerTestCase
+    {
+        /**
+         * @dataProvider provideProcessCases
+         * @requires PHP 8.1
+         */
+        public function testProcess(string $source, array $expectedTokens): void
+        {
+            $this->doTest($source, $expectedTokens);
+        }
+
+        public function provideProcessCases()
+        {
+            yield [
+                '<?php $foo & $bar;',
+                [
+                    3 => CT::T_AMPERSAND,
+                ],
+            ];
+
+            yield [
+                '<?php FOO & BAR;',
+                [
+                    3 => CT::T_AMPERSAND,
+                ],
+            ];
+
+            yield [
+                '<?php $foo &
+                $bar;',
+                [
+                    3 => CT::T_AMPERSAND,
+                ],
+            ];
+
+            yield [
+                '<?php $foo
+                & $bar;',
+                [
+                    3 => CT::T_AMPERSAND,
+                ],
+            ];
+        }
+    }


### PR DESCRIPTION
As PHP CS Fixer do not support PHP 8.1 yet, adding transformer for PHP 8.1 only tokens is not BC break, right?

Must be run after transformer added in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5863