### PR TITLE
fix parsing of argument types in PHP 8.1 and later

### DIFF
--- a/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
+++ b/src/Tokenizer/Analyzer/ArgumentsAnalyzer.php
@@ -95,6 +95,12 @@ final class ArgumentsAnalyzer
             'type_index_start' => null,
             'type_index_end' => null,
         ];
+        $skip_tokens = [T_ELLIPSIS, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE];
+
+        // @TODO: drop condition when PHP 8.1+ is required
+        if (\defined('T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG')) {
+            $skip_tokens = array_merge($skip_tokens, [T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG, T_COALESCE]);
+        }
 
         $sawName = false;
 
@@ -104,7 +110,7 @@ final class ArgumentsAnalyzer
             if (
                 $token->isComment()
                 || $token->isWhitespace()
-                || $token->isGivenKind([T_ELLIPSIS, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE])
+                || $token->isGivenKind($skip_tokens)
                 || $token->equals('&')
             ) {
                 continue;


### PR DESCRIPTION
when running cs-fixer with 8.1 beta 2 against our codebase, I noticed an incorrect or at least changed fix in relation to how reference parameters are handled.

expected (and as handled in 8.0):

```php
function foo(string &$bar): void {}
```

actually happening in 8.1:

```php
function foo(string & $bar): void {}
```

It turns out that in order to handle either union types or first class callables, a few changes to the tokenizer were needed which means that the `&` token now got an actual type constant rather than just being as string.

After fixing this, there was one more failing unit test in `FunctionTypehintSpaceFixerTest` when running in 8.1 around the fact that the `...` token has changed from `T_ELLIPSIS` to `T_COALESCE` which this patch also takes care of.

With this PR, all tests in `FunctionTypehintSpaceFixerTest` pass in PHP 8.1 beta 2
