### PR TITLE
Fix explicit_string_variable code example

### DIFF
--- a/doc/rules/string_notation/explicit_string_variable.rst
+++ b/doc/rules/string_notation/explicit_string_variable.rst
@@ -34,7 +34,7 @@ Example #1
    -$a = "My name is $name !";
    -$b = "I live in $state->country !";
    -$c = "I have $farm[0] chickens !";
-   +$a = "My name is ${name} !";
+   +$a = "My name is {$name} !";
    +$b = "I live in {$state->country} !";
    +$c = "I have {$farm[0]} chickens !";
 


### PR DESCRIPTION
Fix the code example to use `{$variable}` instead of `${variable}`