### PR TITLE
ClassAttributesSeparationFixer - fixes & enhancements

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -36,6 +36,7 @@ $config = new PhpCsFixer\Config();
 $config
     ->setRiskyAllowed(true)
     ->setRules([
+        '@PHP71Migration' => true,
         '@PHP71Migration:risky' => true,
         '@PHPUnit75Migration:risky' => true,
         '@PhpCsFixer' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,11 @@ Changelog for v3.0.0
 * minor #5657 DX: convert some properties to constants (keradus)
 * minor #5669 Remove TrailingCommaInMultilineArrayFixer (kubawerlos, keradus)
 
+Changelog for v2.19.2
+---------------------
+
+* bug #5881 SelfUpdateCommand - fix link to UPGRADE docs (keradus)
+
 Changelog for v2.19.1
 ---------------------
 

--- a/UPGRADE-v3.md
+++ b/UPGRADE-v3.md
@@ -157,8 +157,8 @@ Code BC changes
 
 - class `Token` is now `final`
 - class `Tokens` is now `final`
-- method `create` of class `Config` has been removed, use the constructor
-- method `create` of class `RuleSet` has been removed, use the constructor
+- method `create` of class `Config` has been removed, [use the constructor](./doc/config.rst)
+- method `create` of class `RuleSet` has been removed, [use the constructor](./doc/custom_rules.rst)
 
 ### BC breaks; common internal classes
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/filesystem": "^4.4.20 || ^5.0",
         "symfony/finder": "^4.4.20 || ^5.0",
         "symfony/options-resolver": "^4.4.20 || ^5.0",
-        "symfony/polyfill-php72": "^1.22",
+        "symfony/polyfill-php72": "^1.23",
+        "symfony/polyfill-php81": "^1.23",
         "symfony/process": "^4.4.20 || ^5.0",
         "symfony/stopwatch": "^4.4.20 || ^5.0"
     },

--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -1,16 +1,16 @@
 {
     "require": {
-        "php": "^7.1"
+        "php": "^7.4"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.13",
+        "ergebnis/composer-normalize": "^2.15.0",
         "humbug/box": "^3.8",
-        "jangregor/phpstan-prophecy": "^0.6",
+        "jangregor/phpstan-prophecy": "^0.8.1",
         "maglnet/composer-require-checker": "2.0.0",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.10.2",
         "phpstan/phpstan": "0.12.92",
-        "phpstan/phpstan-phpunit": "0.12.20"
+        "phpstan/phpstan-phpunit": "0.12.21"
     },
     "config": {
         "optimize-autoloader": true,

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -29,7 +29,7 @@ or with specified version:
 
 .. code-block:: console
 
-    $ wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.15.8/php-cs-fixer.phar -O php-cs-fixer
+    $ wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.0.1/php-cs-fixer.phar -O php-cs-fixer
 
 or with curl:
 

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -29,7 +29,7 @@ Rules
   ``['strategy' => 'new_line_for_chained_calls']``
 - `no_extra_blank_lines <./../rules/whitespace/no_extra_blank_lines.rst>`_
   config:
-  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']]``
+  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
 - `no_null_property_initialization <./../rules/class_notation/no_null_property_initialization.rst>`_
 - `no_superfluous_elseif <./../rules/control_structure/no_superfluous_elseif.rst>`_
 - `no_useless_else <./../rules/control_structure/no_useless_else.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -52,7 +52,7 @@ Rules
 - `no_empty_statement <./../rules/semicolon/no_empty_statement.rst>`_
 - `no_extra_blank_lines <./../rules/whitespace/no_extra_blank_lines.rst>`_
   config:
-  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']]``
+  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``
 - `no_leading_namespace_whitespace <./../rules/namespace_notation/no_leading_namespace_whitespace.rst>`_
 - `no_mixed_echo_print <./../rules/alias/no_mixed_echo_print.rst>`_
 - `no_multiline_whitespace_around_double_arrow <./../rules/array_notation/no_multiline_whitespace_around_double_arrow.rst>`_

--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -15,7 +15,7 @@ Dictionary of ``const|method|property|trait_import`` => ``none|one`` values.
 
 Allowed types: ``array``
 
-Default value: ``['const' => 'one', 'method' => 'one', 'property' => 'one', 'trait_import' => 'one']``
+Default value: ``['const' => 'one', 'method' => 'one', 'property' => 'one', 'trait_import' => 'none']``
 
 Examples
 --------

--- a/doc/rules/whitespace/no_extra_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_blank_lines.rst
@@ -198,24 +198,6 @@ With configuration: ``['tokens' => ['use']]``.
 Example #11
 ~~~~~~~~~~~
 
-With configuration: ``['tokens' => ['use_trait']]``.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-
-    class Foo
-    {
-        use Bar;
-   -
-        use Baz;
-    }
-
-Example #12
-~~~~~~~~~~~
-
 With configuration: ``['tokens' => ['switch', 'case', 'default']]``.
 
 .. code-block:: diff
@@ -240,9 +222,9 @@ The rule is part of the following rule sets:
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_extra_blank_lines`` rule with the config below:
 
-  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']]``
+  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
 
 @Symfony
   Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_extra_blank_lines`` rule with the config below:
 
-  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']]``
+  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -133,7 +133,7 @@ The ``--config`` option can be used, like in the ``fix`` command, to tell from w
 
     $ php php-cs-fixer.phar list-files --config=.php-cs-fixer.dist.php
 
-The output is build in a form that its easy to use in combination with ``xargs`` command in a linux pipe.
+The output is built in a form that its easy to use in combination with ``xargs`` command in a linux pipe.
 This can be useful e.g. in situations where the caching mechanism might not be available (CI, Docker) and distribute
 fixing across several processes might speedup the process.
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - dev-tools/vendor/jangregor/phpstan-prophecy/src/extension.neon
+    - dev-tools/vendor/jangregor/phpstan-prophecy/extension.neon
     - dev-tools/vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - dev-tools/vendor/phpstan/phpstan-phpunit/extension.neon
 

--- a/src/AbstractFunctionReferenceFixer.php
+++ b/src/AbstractFunctionReferenceFixer.php
@@ -52,7 +52,7 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
         }
 
         // translate results for humans
-        list($functionName, $openParenthesis) = array_keys($matches);
+        [$functionName, $openParenthesis] = array_keys($matches);
 
         $functionsAnalyzer = new FunctionsAnalyzer();
 

--- a/src/AbstractNoUselessElseFixer.php
+++ b/src/AbstractNoUselessElseFixer.php
@@ -37,7 +37,7 @@ abstract class AbstractNoUselessElseFixer extends AbstractFixer
         do {
             // Check if all 'if', 'else if ' and 'elseif' blocks above this 'else' always end,
             // if so this 'else' is overcomplete.
-            list($previousBlockStart, $previousBlockEnd) = $this->getPreviousBlock($tokens, $previousBlockStart);
+            [$previousBlockStart, $previousBlockEnd] = $this->getPreviousBlock($tokens, $previousBlockStart);
 
             // short 'if' detection
             $previous = $previousBlockEnd;

--- a/src/Cache/FileHandler.php
+++ b/src/Cache/FileHandler.php
@@ -99,7 +99,7 @@ final class FileHandler implements FileHandlerInterface
             $error = error_get_last();
 
             throw new IOException(
-                sprintf('Failed to write file "%s", "%s".', $this->file, isset($error['message']) ? $error['message'] : 'no reason available'),
+                sprintf('Failed to write file "%s", "%s".', $this->file, $error['message'] ?? 'no reason available'),
                 0,
                 null,
                 $this->file

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -106,7 +106,7 @@ final class HelpCommand extends BaseHelpCommand
             return '[]';
         }
 
-        $isHash = static::isHash($value);
+        $isHash = !array_is_list($value);
         $str = '[';
 
         foreach ($value as $k => $v) {
@@ -121,20 +121,5 @@ final class HelpCommand extends BaseHelpCommand
         }
 
         return substr($str, 0, -2).']';
-    }
-
-    private static function isHash(array $array): bool
-    {
-        $i = 0;
-
-        foreach ($array as $k => $v) {
-            if ($k !== $i) {
-                return true;
-            }
-
-            ++$i;
-        }
-
-        return false;
     }
 }

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -139,7 +139,7 @@ EOT
             && true !== $input->getOption('force')
         ) {
             $output->writeln(sprintf('<info>A new major version of PHP CS Fixer is available</info> (<comment>%s</comment>)', $latestVersion));
-            $output->writeln(sprintf('<info>Before upgrading please read</info> https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/%s/UPGRADE.md', $latestVersion));
+            $output->writeln(sprintf('<info>Before upgrading please read</info> https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/%s/UPGRADE-v%s.md', $latestVersion, $currentMajor + 1));
             $output->writeln('<info>If you are ready to upgrade run this command with</info> <comment>-f</comment>');
             $output->writeln('<info>Checking for new minor/patch version...</info>');
 

--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -86,7 +86,7 @@ final class DocBlock
      */
     public function getLine(int $pos): ?Line
     {
-        return isset($this->lines[$pos]) ? $this->lines[$pos] : null;
+        return $this->lines[$pos] ?? null;
     }
 
     /**
@@ -182,7 +182,7 @@ final class DocBlock
     {
         $annotations = $this->getAnnotations();
 
-        return isset($annotations[$pos]) ? $annotations[$pos] : null;
+        return $annotations[$pos] ?? null;
     }
 
     /**

--- a/src/Doctrine/Annotation/Tokens.php
+++ b/src/Doctrine/Annotation/Tokens.php
@@ -248,7 +248,7 @@ final class Tokens extends \SplFixedArray
         $this->setSize($this->getSize() + 1);
 
         for ($i = $this->getSize() - 1; $i > $index; --$i) {
-            $this[$i] = isset($this[$i - 1]) ? $this[$i - 1] : new Token();
+            $this[$i] = $this[$i - 1] ?? new Token();
         }
 
         $this[$index] = $token;

--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -117,7 +117,7 @@ $a = substr_count($a, $b);
                     continue 2;
                 }
 
-                list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
+                [$functionName, $openParenthesis, $closeParenthesis] = $boundaries;
                 $count = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
                 if (!\in_array($count, $functionReplacement['argumentCount'], true)) {
                     continue 2;

--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -229,7 +229,7 @@ mbereg_search_getregs();
             }
 
             if (\is_array($this->aliases[$tokenContent])) {
-                list($alias, $numberOfArguments) = $this->aliases[$tokenContent];
+                [$alias, $numberOfArguments] = $this->aliases[$tokenContent];
 
                 $count = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesis));
 

--- a/src/Fixer/Alias/RandomApiMigrationFixer.php
+++ b/src/Fixer/Alias/RandomApiMigrationFixer.php
@@ -112,7 +112,7 @@ final class RandomApiMigrationFixer extends AbstractFunctionReferenceFixer imple
                     continue 2;
                 }
 
-                list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
+                [$functionName, $openParenthesis, $closeParenthesis] = $boundaries;
                 $count = $argumentsAnalyzer->countArguments($tokens, $openParenthesis, $closeParenthesis);
 
                 if (!\in_array($count, $functionReplacement['argumentCount'], true)) {

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -659,9 +659,9 @@ class Foo
                 continue;
             }
 
-            // do not add for short 'if' followed by alternative loop,
-            // for example: if ($a) while ($b): ? > X < ?php endwhile; ? >
-            if ($tokenAfterParenthesis->isGivenKind([T_FOR, T_FOREACH, T_SWITCH, T_WHILE])) {
+            // do not add for 'short if' followed by alternative loop, for example: if ($a) while ($b): ? > X < ?php endwhile; ? >
+            // or 'short if' after an alternative loop, for example:  foreach ($arr as $index => $item) if ($item):
+            if ($tokenAfterParenthesis->isGivenKind([T_FOR, T_FOREACH, T_SWITCH, T_WHILE, T_IF])) {
                 $tokenAfterParenthesisBlockEnd = $tokens->findBlockEnd( // go to ')'
                     Tokens::BLOCK_TYPE_PARENTHESIS_BRACE,
                     $tokens->getNextMeaningfulToken($nextAfterParenthesisEndIndex)

--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -128,7 +128,7 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
         $replacements = [];
         $escapeSequences = [];
 
-        foreach ($this->symbolsReplace as $character => list($replacement, $codepoint)) {
+        foreach ($this->symbolsReplace as $character => [$replacement, $codepoint]) {
             $replacements[$character] = $replacement;
             $escapeSequences[$character] = '\u{'.$codepoint.'}';
         }

--- a/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
+++ b/src/Fixer/CastNotation/ModernizeTypesCastingFixer.php
@@ -84,7 +84,7 @@ final class ModernizeTypesCastingFixer extends AbstractFunctionReferenceFixer
                     continue 2;
                 }
 
-                list($functionName, $openParenthesis, $closeParenthesis) = $boundaries;
+                [$functionName, $openParenthesis, $closeParenthesis] = $boundaries;
 
                 // analysing cursor shift
                 $currIndex = $openParenthesis;

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -49,9 +49,6 @@ final class ClassAttributesSeparationFixer extends AbstractFixer implements Conf
      */
     public const SPACING_ONE = 'one';
 
-    private const SUPPORTED_SPACINGS = [self::SPACING_NONE, self::SPACING_ONE];
-    private const SUPPORTED_TYPES = ['const', 'method', 'property', 'trait_import'];
-
     /**
      * @var array<string, string>
      */
@@ -122,7 +119,7 @@ class Sample
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, IndentationTypeFixer.
+     * Must run before BracesFixer, IndentationTypeFixer, NoExtraBlankLinesFixer.
      * Must run after OrderedClassElementsFixer, SingleClassElementPerStatementFixer.
      */
     public function getPriority(): int
@@ -143,40 +140,24 @@ class Sample
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
-        $class = $classStart = $classEnd = false;
+        foreach ($this->getElementsByClass($tokens) as $class) {
+            $elements = $class['elements'];
+            $elementCount = \count($elements);
 
-        foreach (array_reverse($tokensAnalyzer->getClassyElements(), true) as $index => $element) {
-            if (!isset($this->classElementTypes[$element['type']])) {
-                continue; // not configured to be fixed
-            }
-
-            $spacing = $this->classElementTypes[$element['type']];
-
-            if ($element['classIndex'] !== $class) {
-                $class = $element['classIndex'];
-                $classStart = $tokens->getNextTokenOfKind($class, ['{']);
-                $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classStart);
-            }
-
-            if ('method' === $element['type'] && !$tokens[$class]->isGivenKind(T_INTERFACE)) {
-                // method of class or trait
-                $attributes = $tokensAnalyzer->getMethodAttributes($index);
-
-                $methodEnd = true === $attributes['abstract']
-                    ? $tokens->getNextTokenOfKind($index, [';'])
-                    : $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($index, ['{']))
-                ;
-
-                $this->fixSpaceBelowClassMethod($tokens, $classEnd, $methodEnd, $spacing);
-                $this->fixSpaceAboveClassElement($tokens, $classStart, $index, $spacing);
-
+            if (0 === $elementCount) {
                 continue;
             }
 
-            // `const`, `property` or `method` of an `interface`
-            $this->fixSpaceBelowClassElement($tokens, $classEnd, $tokens->getNextTokenOfKind($index, [';']), $spacing);
-            $this->fixSpaceAboveClassElement($tokens, $classStart, $index, $spacing);
+            if (isset($this->classElementTypes[$elements[0]['type']])) {
+                $this->fixSpaceBelowClassElement($tokens, $class, 0);
+                $this->fixSpaceAboveClassElement($tokens, $class, 0);
+            }
+
+            for ($index = 1; $index < $elementCount; ++$index) {
+                if (isset($this->classElementTypes[$elements[$index]['type']])) {
+                    $this->fixSpaceAboveClassElement($tokens, $class, $index);
+                }
+            }
         }
     }
 
@@ -190,22 +171,26 @@ class Sample
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $option) {
                     foreach ($option as $type => $spacing) {
-                        if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
+                        $supportedTypes = ['const', 'method', 'property', 'trait_import'];
+
+                        if (!\in_array($type, $supportedTypes, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
                                     'Unexpected element type, expected any of "%s", got "%s".',
-                                    implode('", "', self::SUPPORTED_TYPES),
+                                    implode('", "', $supportedTypes),
                                     \gettype($type).'#'.$type
                                 )
                             );
                         }
 
-                        if (!\in_array($spacing, self::SUPPORTED_SPACINGS, true)) {
+                        $supportedSpacings = [self::SPACING_NONE, self::SPACING_ONE];
+
+                        if (!\in_array($spacing, $supportedSpacings, true)) {
                             throw new InvalidOptionsException(
                                 sprintf(
                                     'Unexpected spacing for element type "%s", expected any of "%s", got "%s".',
                                     $spacing,
-                                    implode('", "', self::SUPPORTED_SPACINGS),
+                                    implode('", "', $supportedSpacings),
                                     \is_object($spacing) ? \get_class($spacing) : (null === $spacing ? 'null' : \gettype($spacing).'#'.$spacing)
                                 )
                             );
@@ -218,54 +203,10 @@ class Sample
                     'const' => self::SPACING_ONE,
                     'method' => self::SPACING_ONE,
                     'property' => self::SPACING_ONE,
-                    'trait_import' => self::SPACING_ONE,
+                    'trait_import' => self::SPACING_NONE,
                 ])
                 ->getOption(),
         ]);
-    }
-
-    /**
-     * Fix spacing below an element of a class, interface or trait.
-     *
-     * Deals with comments, PHPDocs and spaces above the element with respect to the position of the
-     * element within the class, interface or trait.
-     */
-    private function fixSpaceBelowClassElement(Tokens $tokens, int $classEndIndex, int $elementEndIndex, string $spacing): void
-    {
-        for ($nextNotWhite = $elementEndIndex + 1;; ++$nextNotWhite) {
-            if (($tokens[$nextNotWhite]->isComment() || $tokens[$nextNotWhite]->isWhitespace()) && false === strpos($tokens[$nextNotWhite]->getContent(), "\n")) {
-                continue;
-            }
-
-            break;
-        }
-
-        if ($tokens[$nextNotWhite]->isWhitespace()) {
-            $nextNotWhite = $tokens->getNextNonWhitespace($nextNotWhite);
-        }
-
-        $functionIndex = $tokens->getTokenNotOfKindsSibling($nextNotWhite - 1, 1, [T_ABSTRACT, T_FINAL, T_PUBLIC, T_PROTECTED, T_PRIVATE, T_STATIC, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]);
-
-        if ($tokens[$functionIndex]->isGivenKind(T_FUNCTION)) {
-            $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, 2);
-
-            return;
-        }
-
-        $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, $nextNotWhite === $classEndIndex || self::SPACING_NONE === $spacing ? 1 : 2);
-    }
-
-    /**
-     * Fix spacing below a method of a class or trait.
-     *
-     * Deals with comments, PHPDocs and spaces above the method with respect to the position of the
-     * method within the class or trait.
-     */
-    private function fixSpaceBelowClassMethod(Tokens $tokens, int $classEndIndex, int $elementEndIndex, string $spacing): void
-    {
-        $nextNotWhite = $tokens->getNextNonWhitespace($elementEndIndex);
-
-        $this->correctLineBreaks($tokens, $elementEndIndex, $nextNotWhite, $nextNotWhite === $classEndIndex || self::SPACING_NONE === $spacing ? 1 : 2);
     }
 
     /**
@@ -273,60 +214,53 @@ class Sample
      *
      * Deals with comments, PHPDocs and spaces above the element with respect to the position of the
      * element within the class, interface or trait.
-     *
-     * @param int $classStartIndex index of the class Token the element is in
-     * @param int $elementIndex    index of the element to fix
      */
-    private function fixSpaceAboveClassElement(Tokens $tokens, int $classStartIndex, int $elementIndex, string $spacing): void
+    private function fixSpaceAboveClassElement(Tokens $tokens, array $class, int $elementIndex): void
     {
-        static $methodAttr = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION];
+        $element = $class['elements'][$elementIndex];
+        $nonWhiteAbove = $tokens->getPrevNonWhitespace($element['start']);
 
-        $nonWhiteAbove = null;
+        // element is directly after class open brace
+        if ($nonWhiteAbove === $class['open']) {
+            $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 1);
 
-        // find out where the element definition starts
-        $firstElementAttributeIndex = $elementIndex;
-
-        for ($i = $elementIndex; $i > $classStartIndex; --$i) {
-            $nonWhiteAbove = $tokens->getPrevNonWhitespace($i);
-
-            if (null !== $nonWhiteAbove && $tokens[$nonWhiteAbove]->isGivenKind($methodAttr)) {
-                $firstElementAttributeIndex = $nonWhiteAbove;
-            } else {
-                break;
-            }
+            return;
         }
 
         // deal with comments above an element
         if ($tokens[$nonWhiteAbove]->isGivenKind(T_COMMENT)) {
-            if (1 === $firstElementAttributeIndex - $nonWhiteAbove) {
-                // no white space found between comment and element start
-                $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 1);
+            // check if the comment belongs to the previous element
+            if (isset($class['elements'][$elementIndex + 1]) && $class['elements'][$elementIndex + 1]['end'] === $nonWhiteAbove) {
+                $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], $this->determineRequiredLineCount($tokens, $class, $elementIndex));
 
                 return;
             }
 
-            // $tokens[$nonWhiteAbove+1] is always a white space token here
-            if (substr_count($tokens[$nonWhiteAbove + 1]->getContent(), "\n") > 1) {
-                // more than one line break, always bring it back to 2 line breaks between the element start and what is above it
-                $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 2);
+            // more than one line break, always bring it back to 2 line breaks between the element start and what is above it
+            if ($tokens[$nonWhiteAbove + 1]->isWhitespace() && substr_count($tokens[$nonWhiteAbove + 1]->getContent(), "\n") > 1) {
+                $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 2);
 
                 return;
             }
 
             // there are 2 cases:
-            if ($tokens[$nonWhiteAbove - 1]->isWhitespace() && substr_count($tokens[$nonWhiteAbove - 1]->getContent(), "\n") > 0) {
+            if (
+                1 === $element['start'] - $nonWhiteAbove
+                || $tokens[$nonWhiteAbove - 1]->isWhitespace() && substr_count($tokens[$nonWhiteAbove - 1]->getContent(), "\n") > 0
+                || $tokens[$nonWhiteAbove + 1]->isWhitespace() && substr_count($tokens[$nonWhiteAbove + 1]->getContent(), "\n") > 0
+            ) {
                 // 1. The comment is meant for the element (although not a PHPDoc),
                 //    make sure there is one line break between the element and the comment...
-                $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 1);
+                $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 1);
                 //    ... and make sure there is blank line above the comment (with the exception when it is directly after a class opening)
                 $nonWhiteAbove = $this->findCommentBlockStart($tokens, $nonWhiteAbove);
                 $nonWhiteAboveComment = $tokens->getPrevNonWhitespace($nonWhiteAbove);
 
-                $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $classStartIndex ? 1 : 2);
+                $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $class['open'] ? 1 : 2);
             } else {
                 // 2. The comment belongs to the code above the element,
                 //    make sure there is a blank line above the element (i.e. 2 line breaks)
-                $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 2);
+                $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 2);
             }
 
             return;
@@ -335,11 +269,11 @@ class Sample
         // deal with element with a PHPDoc above it
         if ($tokens[$nonWhiteAbove]->isGivenKind(T_DOC_COMMENT)) {
             // there should be one linebreak between the element and the PHPDoc above it
-            $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 1);
+            $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 1);
 
             // there should be one blank line between the PHPDoc and whatever is above (with the exception when it is directly after a class opening)
             $nonWhiteAbovePHPDoc = $tokens->getPrevNonWhitespace($nonWhiteAbove);
-            $this->correctLineBreaks($tokens, $nonWhiteAbovePHPDoc, $nonWhiteAbove, $nonWhiteAbovePHPDoc === $classStartIndex ? 1 : 2);
+            $this->correctLineBreaks($tokens, $nonWhiteAbovePHPDoc, $nonWhiteAbove, $nonWhiteAbovePHPDoc === $class['open'] ? 1 : 2);
 
             return;
         }
@@ -347,18 +281,56 @@ class Sample
         // deal with element with an attribute above it
         if ($tokens[$nonWhiteAbove]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
             // there should be one linebreak between the element and the attribute above it
-            $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, 1);
+            $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], 1);
 
             // make sure there is blank line above the comment (with the exception when it is directly after a class opening)
             $nonWhiteAbove = $this->findAttributeBlockStart($tokens, $nonWhiteAbove);
             $nonWhiteAboveComment = $tokens->getPrevNonWhitespace($nonWhiteAbove);
 
-            $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $classStartIndex ? 1 : 2);
+            $this->correctLineBreaks($tokens, $nonWhiteAboveComment, $nonWhiteAbove, $nonWhiteAboveComment === $class['open'] ? 1 : 2);
 
             return;
         }
 
-        $this->correctLineBreaks($tokens, $nonWhiteAbove, $firstElementAttributeIndex, $nonWhiteAbove === $classStartIndex || self::SPACING_NONE === $spacing ? 1 : 2);
+        $this->correctLineBreaks($tokens, $nonWhiteAbove, $element['start'], $this->determineRequiredLineCount($tokens, $class, $elementIndex));
+    }
+
+    private function determineRequiredLineCount(Tokens $tokens, array $class, int $elementIndex): int
+    {
+        $type = $class['elements'][$elementIndex]['type'];
+        $spacing = $this->classElementTypes[$type];
+
+        if (self::SPACING_ONE === $spacing) {
+            return 2;
+        }
+
+        if (self::SPACING_NONE === $spacing) {
+            if (!isset($class['elements'][$elementIndex + 1])) {
+                return 1;
+            }
+
+            $aboveElement = $class['elements'][$elementIndex + 1];
+
+            if ($aboveElement['type'] !== $type) {
+                return 2;
+            }
+
+            $aboveElementDocCandidateIndex = $tokens->getPrevNonWhitespace($aboveElement['start']);
+
+            return $tokens[$aboveElementDocCandidateIndex]->isGivenKind([T_DOC_COMMENT, CT::T_ATTRIBUTE_CLOSE]) ? 2 : 1;
+        }
+
+        throw new \RuntimeException(sprintf('Unknown spacing "%s".', $spacing));
+    }
+
+    private function fixSpaceBelowClassElement(Tokens $tokens, array $class, int $elementIndex): void
+    {
+        $element = $class['elements'][$elementIndex];
+
+        // if this is last element fix; fix to the class end `}` here if appropriate
+        if ($class['close'] === $tokens->getNextNonWhitespace($element['end'])) {
+            $this->correctLineBreaks($tokens, $element['end'], $class['close'], 1);
+        }
     }
 
     private function correctLineBreaks(Tokens $tokens, int $startIndex, int $endIndex, int $reqLineCount = 2): void
@@ -415,11 +387,11 @@ class Sample
         }
     }
 
-    private function getLineBreakCount(Tokens $tokens, int $whiteSpaceStartIndex, int $whiteSpaceEndIndex): int
+    private function getLineBreakCount(Tokens $tokens, int $startIndex, int $endIndex): int
     {
         $lineCount = 0;
 
-        for ($i = $whiteSpaceStartIndex; $i < $whiteSpaceEndIndex; ++$i) {
+        for ($i = $startIndex; $i < $endIndex; ++$i) {
             $lineCount += substr_count($tokens[$i]->getContent(), "\n");
         }
 
@@ -465,5 +437,129 @@ class Sample
         }
 
         return $start;
+    }
+
+    private function getElementsByClass(Tokens $tokens): \Generator
+    {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        $class = $classIndex = false;
+        $elements = $tokensAnalyzer->getClassyElements();
+
+        for (end($elements);; prev($elements)) {
+            $index = key($elements);
+
+            if (null === $index) {
+                break;
+            }
+
+            $element = current($elements);
+            $element['index'] = $index;
+
+            if ($element['classIndex'] !== $classIndex) {
+                if (false !== $class) {
+                    yield $class;
+                }
+
+                $classIndex = $element['classIndex'];
+                $classOpen = $tokens->getNextTokenOfKind($classIndex, ['{']);
+                $classEnd = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $classOpen);
+                $class = [
+                    'index' => $classIndex,
+                    'open' => $classOpen,
+                    'close' => $classEnd,
+                    'elements' => [],
+                ];
+            }
+
+            unset($element['classIndex']);
+            $element['start'] = $this->getFirstTokenIndexOfClassElement($tokens, $class, $element);
+            $element['end'] = $this->getLastTokenIndexOfClassElement($tokens, $class, $element, $tokensAnalyzer);
+
+            $class['elements'][] = $element; // reset the key by design
+        }
+
+        if (false !== $class) {
+            yield $class;
+        }
+    }
+
+    private function getFirstTokenIndexOfClassElement(Tokens $tokens, array $class, array $element): int
+    {
+        static $methodAttr = [T_PRIVATE, T_PROTECTED, T_PUBLIC, T_ABSTRACT, T_FINAL, T_STATIC, T_STRING, T_NS_SEPARATOR, T_VAR, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, CT::T_TYPE_ALTERNATION];
+
+        $firstElementAttributeIndex = $element['index'];
+
+        while ($firstElementAttributeIndex > $class['open']) {
+            $nonWhiteAbove = $tokens->getPrevMeaningfulToken($firstElementAttributeIndex);
+
+            if (null !== $nonWhiteAbove && $tokens[$nonWhiteAbove]->isGivenKind($methodAttr)) {
+                $firstElementAttributeIndex = $nonWhiteAbove;
+            } else {
+                break;
+            }
+        }
+
+        return $firstElementAttributeIndex;
+    }
+
+    // including trailing single line comments if belonging to the class element
+    private function getLastTokenIndexOfClassElement(Tokens $tokens, array $class, array $element, TokensAnalyzer $tokensAnalyzer): int
+    {
+        // find last token of the element
+        if ('method' === $element['type'] && !$tokens[$class['index']]->isGivenKind(T_INTERFACE)) {
+            $attributes = $tokensAnalyzer->getMethodAttributes($element['index']);
+
+            if (true === $attributes['abstract']) {
+                $elementEndIndex = $tokens->getNextTokenOfKind($element['index'], [';']);
+                $singleLineElement = true;
+            } else {
+                $elementEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($element['index'], ['{']));
+                $singleLineElement = false;
+            }
+        } elseif ('trait_import' === $element['type']) {
+            $elementEndIndex = $element['index'];
+
+            do {
+                $elementEndIndex = $tokens->getNextMeaningfulToken($elementEndIndex);
+            } while ($tokens[$elementEndIndex]->isGivenKind([T_STRING, T_NS_SEPARATOR]));
+
+            if ($tokens[$elementEndIndex]->equals(';')) {
+                $singleLineElement = true;
+            } else {
+                $singleLineElement = false;
+                $elementEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($element['index'], ['{']));
+            }
+        } else { // const or property
+            $elementEndIndex = $tokens->getNextTokenOfKind($element['index'], [';']);
+            $singleLineElement = true;
+        }
+
+        $singleLineElement = true;
+
+        for ($i = $element['index'] + 1; $i < $elementEndIndex; ++$i) {
+            if (false !== strpos($tokens[$i]->getContent(), "\n")) {
+                $singleLineElement = false;
+
+                break;
+            }
+        }
+
+        if ($singleLineElement) {
+            do {
+                $nextToken = $tokens[$elementEndIndex + 1];
+
+                if (($nextToken->isComment() || $nextToken->isWhitespace()) && false === strpos($nextToken->getContent(), "\n")) {
+                    ++$elementEndIndex;
+                } else {
+                    break;
+                }
+            } while (true);
+
+            if ($tokens[$elementEndIndex]->isWhitespace()) {
+                $elementEndIndex = $tokens->getPrevNonWhitespace($elementEndIndex);
+            }
+        }
+
+        return $elementEndIndex;
     }
 }

--- a/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
+++ b/src/Fixer/ClassNotation/NoPhp4ConstructorFixer.php
@@ -167,7 +167,7 @@ class Foo
         }
 
         // does the PHP4-constructor only call $this->__construct($args, ...)?
-        list($sequences, $case) = $this->getWrapperMethodSequence($tokens, '__construct', $php4['startIndex'], $php4['bodyIndex']);
+        [$sequences, $case] = $this->getWrapperMethodSequence($tokens, '__construct', $php4['startIndex'], $php4['bodyIndex']);
         foreach ($sequences as $seq) {
             if (null !== $tokens->findSequence($seq, $php4['bodyIndex'] - 1, $php4['endIndex'], $case)) {
                 // good, delete it!
@@ -180,7 +180,7 @@ class Foo
         }
 
         // does __construct only call the PHP4-constructor (with the same args)?
-        list($sequences, $case) = $this->getWrapperMethodSequence($tokens, $className, $php4['startIndex'], $php4['bodyIndex']);
+        [$sequences, $case] = $this->getWrapperMethodSequence($tokens, $className, $php4['startIndex'], $php4['bodyIndex']);
         foreach ($sequences as $seq) {
             if (null !== $tokens->findSequence($seq, $php5['bodyIndex'] - 1, $php5['endIndex'], $case)) {
                 // that was a weird choice, but we can safely delete it and...

--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -436,7 +436,7 @@ echo 1;
         }
 
         $nextIndex = $index + 1;
-        $nextToken = isset($tokens[$nextIndex]) ? $tokens[$nextIndex] : null;
+        $nextToken = $tokens[$nextIndex] ?? null;
 
         if (!$newlineRemoved && null !== $nextToken && $nextToken->isWhitespace()) {
             $content = Preg::replace('/^\R/', '', $nextToken->getContent());

--- a/src/Fixer/Comment/NoEmptyCommentFixer.php
+++ b/src/Fixer/Comment/NoEmptyCommentFixer.php
@@ -72,7 +72,7 @@ final class NoEmptyCommentFixer extends AbstractFixer
                 continue;
             }
 
-            list($blockStart, $index, $isEmpty) = $this->getCommentBlock($tokens, $index);
+            [$blockStart, $index, $isEmpty] = $this->getCommentBlock($tokens, $index);
             if (false === $isEmpty) {
                 continue;
             }

--- a/src/Fixer/FunctionNotation/ImplodeCallFixer.php
+++ b/src/Fixer/FunctionNotation/ImplodeCallFixer.php
@@ -101,7 +101,7 @@ final class ImplodeCallFixer extends AbstractFixer
             }
 
             if (2 === \count($argumentsIndices)) {
-                list($firstArgumentIndex, $secondArgumentIndex) = array_keys($argumentsIndices);
+                [$firstArgumentIndex, $secondArgumentIndex] = array_keys($argumentsIndices);
 
                 // If the first argument is string we have nothing to do
                 if ($tokens[$firstArgumentIndex]->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -143,7 +143,7 @@ function bar($foo) {}
                     continue;
                 }
 
-                list($paramType, $isNullable) = $typeInfo;
+                [$paramType, $isNullable] = $typeInfo;
 
                 $startIndex = $tokens->getNextTokenOfKind($index, ['(']);
                 $variableIndex = $this->findCorrectVariable($tokens, $startIndex, $paramTypeAnnotation);

--- a/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToPropertyTypeFixer.php
@@ -143,7 +143,7 @@ class Foo {
                 continue;
             }
 
-            list($propertyType, $isNullable) = $typeInfo;
+            [$propertyType, $isNullable] = $typeInfo;
 
             if (\in_array($propertyType, ['void', 'callable'], true)) {
                 continue;

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -178,7 +178,7 @@ final class Foo {
                 continue;
             }
 
-            list($returnType, $isNullable) = $typeInfo;
+            [$returnType, $isNullable] = $typeInfo;
 
             $startIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
 

--- a/src/Fixer/Import/GlobalNamespaceImportFixer.php
+++ b/src/Fixer/Import/GlobalNamespaceImportFixer.php
@@ -176,7 +176,7 @@ if (count($x)) {
      */
     private function importConstants(Tokens $tokens, array $useDeclarations): array
     {
-        list($global, $other) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global, $other] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isConstant();
         }, true);
 
@@ -248,7 +248,7 @@ if (count($x)) {
      */
     private function importFunctions(Tokens $tokens, array $useDeclarations): array
     {
-        list($global, $other) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global, $other] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isFunction();
         }, false);
 
@@ -299,7 +299,7 @@ if (count($x)) {
      */
     private function importClasses(Tokens $tokens, array $useDeclarations): array
     {
-        list($global, $other) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global, $other] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isClass();
         }, false);
 
@@ -490,7 +490,7 @@ if (count($x)) {
             return;
         }
 
-        list($global) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isConstant() && !$declaration->isAliased();
         }, true);
 
@@ -532,7 +532,7 @@ if (count($x)) {
             return;
         }
 
-        list($global) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isFunction() && !$declaration->isAliased();
         }, false);
 
@@ -574,7 +574,7 @@ if (count($x)) {
             return;
         }
 
-        list($global) = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
+        [$global] = $this->filterUseDeclarations($useDeclarations, static function (NamespaceUseAnalysis $declaration) {
             return $declaration->isClass() && !$declaration->isAliased();
         }, false);
 
@@ -723,7 +723,7 @@ if (count($x)) {
 
                 Preg::matchAll('/[\\\\\w]+/', $fullType, $matches, PREG_OFFSET_CAPTURE);
 
-                foreach (array_reverse($matches[0]) as list($type, $offset)) {
+                foreach (array_reverse($matches[0]) as [$type, $offset]) {
                     $newType = $callback($type);
 
                     if (null !== $newType && $type !== $newType) {

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -173,7 +173,7 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
 
     private function fixGroupUse(Tokens $tokens, int $index, int $endIndex): void
     {
-        list($groupPrefix, $groupOpenIndex, $groupCloseIndex, $comment) = $this->getGroupDeclaration($tokens, $index);
+        [$groupPrefix, $groupOpenIndex, $groupCloseIndex, $comment] = $this->getGroupDeclaration($tokens, $index);
         $statements = $this->getGroupStatements($tokens, $groupPrefix, $groupOpenIndex, $groupCloseIndex, $comment);
 
         if (\count($statements) < 2) {

--- a/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
+++ b/src/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixer.php
@@ -73,7 +73,7 @@ final class CombineConsecutiveUnsetsFixer extends AbstractFixer
                 continue;
             }
 
-            list($previousUnset, , $previousUnsetBraceEnd) = $previousUnsetCall;
+            [$previousUnset, , $previousUnsetBraceEnd] = $previousUnsetCall;
 
             // Merge the tokens inside the 'unset' call into the previous one 'unset' call.
             $tokensAddCount = $this->moveTokens(

--- a/src/Fixer/LanguageConstruct/DirConstantFixer.php
+++ b/src/Fixer/LanguageConstruct/DirConstantFixer.php
@@ -69,7 +69,7 @@ final class DirConstantFixer extends AbstractFunctionReferenceFixer
                 return;
             }
 
-            list($functionNameIndex, $openParenthesis, $closeParenthesis) = $boundaries;
+            [$functionNameIndex, $openParenthesis, $closeParenthesis] = $boundaries;
 
             // analysing cursor shift, so nested expressions kept processed
             $currIndex = $openParenthesis;

--- a/src/Fixer/LanguageConstruct/IsNullFixer.php
+++ b/src/Fixer/LanguageConstruct/IsNullFixer.php
@@ -89,7 +89,7 @@ final class IsNullFixer extends AbstractFixer
             $matches = array_keys($matches);
 
             // move the cursor just after the sequence
-            list($isNullIndex, $currIndex) = $matches;
+            [$isNullIndex, $currIndex] = $matches;
 
             if (!$functionsAnalyzer->isGlobalFunctionCall($tokens, $matches[0])) {
                 continue;

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -209,7 +209,7 @@ yield  from  baz();
 
             $whitespaceTokenIndex = $index + 1;
 
-            if ($tokens[$whitespaceTokenIndex]->equalsAny([';', ')', [CT::T_ARRAY_SQUARE_BRACE_CLOSE]])) {
+            if ($tokens[$whitespaceTokenIndex]->equalsAny([',', ';', ')', [CT::T_ARRAY_SQUARE_BRACE_CLOSE]])) {
                 continue;
             }
 

--- a/src/Fixer/Naming/NoHomoglyphNamesFixer.php
+++ b/src/Fixer/Naming/NoHomoglyphNamesFixer.php
@@ -233,9 +233,7 @@ final class NoHomoglyphNamesFixer extends AbstractFixer
             }
 
             $replaced = Preg::replaceCallback('/[^[:ascii:]]/u', static function (array $matches) {
-                return isset(self::$replacements[$matches[0]])
-                    ? self::$replacements[$matches[0]]
-                    : $matches[0]
+                return self::$replacements[$matches[0]] ?? $matches[0]
                 ;
             }, $token->getContent(), -1, $count);
 

--- a/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitExpectationFixer.php
@@ -207,7 +207,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
                 return;
             }
 
-            list($thisIndex, , $index) = array_keys($match);
+            [$thisIndex, , $index] = array_keys($match);
 
             if (!isset($this->methodMap[$tokens[$index]->getContent()])) {
                 continue;

--- a/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixer.php
@@ -219,7 +219,7 @@ class Sample
         $newTypes = [];
         foreach ($types as $type) {
             $lower = strtolower($type);
-            $newTypes[] = isset($this->configuration['replacements'][$lower]) ? $this->configuration['replacements'][$lower] : $type;
+            $newTypes[] = $this->configuration['replacements'][$lower] ?? $type;
         }
 
         if ($types === $newTypes) {

--- a/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
@@ -90,21 +90,23 @@ final class PhpdocTagTypeFixer extends AbstractFixer implements ConfigurableFixe
             return;
         }
 
+        $regularExpression = sprintf(
+            '/({?@(?:%s).*?(?:(?=\s\*\/)|(?=\n)}?))/i',
+            implode('|', array_map(
+                function (string $tag) {
+                    return preg_quote($tag, '/');
+                },
+                array_keys($this->configuration['tags'])
+            ))
+        );
+
         foreach ($tokens as $index => $token) {
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
             $parts = Preg::split(
-                sprintf(
-                    '/({?@(?:%s)(?:}|\h.*?(?:}|(?=\R)|(?=\h+\*\/)))?)/i',
-                    implode('|', array_map(
-                        function (string $tag) {
-                            return preg_quote($tag, '/');
-                        },
-                        array_keys($this->configuration['tags'])
-                    ))
-                ),
+                $regularExpression,
                 $token->getContent(),
                 -1,
                 PREG_SPLIT_DELIM_CAPTURE

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -29,6 +29,7 @@ use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use PhpCsFixer\Utils;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -80,6 +81,10 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
      */
     public function configure(array $configuration): void
     {
+        if (isset($configuration['tokens']) && \in_array('use_trait', $configuration['tokens'], true)) {
+            Utils::triggerDeprecation(new \RuntimeException('Option "use_trait" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.'));
+        }
+
         parent::configure($configuration);
 
         static $reprToTokenMap = [
@@ -248,18 +253,6 @@ class Bar
                 ),
                 new CodeSample(
                     '<?php
-
-class Foo
-{
-    use Bar;
-
-    use Baz;
-}
-',
-                    ['tokens' => ['use_trait']]
-                ),
-                new CodeSample(
-                    '<?php
 switch($a) {
 
     case 1:
@@ -279,7 +272,7 @@ switch($a) {
      * {@inheritdoc}
      *
      * Must run before BlankLineBeforeStatementFixer.
-     * Must run after CombineConsecutiveUnsetsFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnusedImportsFixer, NoUselessElseFixer, NoUselessReturnFixer, NoUselessSprintfFixer.
+     * Must run after ClassAttributesSeparationFixer, CombineConsecutiveUnsetsFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnusedImportsFixer, NoUselessElseFixer, NoUselessReturnFixer, NoUselessSprintfFixer.
      */
     public function getPriority(): int
     {

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -74,7 +74,6 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_null_property_initialization' => true,

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -86,7 +86,6 @@ final class SymfonySet extends AbstractRuleSetDescription
                     'switch',
                     'throw',
                     'use',
-                    'use_trait',
                 ],
             ],
             'no_leading_namespace_whitespace' => true,

--- a/src/Tokenizer/Analyzer/AttributeAnalyzer.php
+++ b/src/Tokenizer/Analyzer/AttributeAnalyzer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ */
+final class AttributeAnalyzer
+{
+    private const TOKEN_KINDS_NOT_ALLOWED_IN_ATTRIBUTE = [
+        ';',
+        '{',
+        [T_ATTRIBUTE],
+        [T_FUNCTION],
+        [T_OPEN_TAG],
+        [T_OPEN_TAG_WITH_ECHO],
+        [T_PRIVATE],
+        [T_PROTECTED],
+        [T_PUBLIC],
+        [T_RETURN],
+        [T_VARIABLE],
+        [CT::T_ATTRIBUTE_CLOSE],
+    ];
+
+    /**
+     * Check if given index is an attribute declaration.
+     */
+    public static function isAttribute(Tokens $tokens, int $index): bool
+    {
+        if (
+            !\defined('T_ATTRIBUTE') // attributes not available, PHP version lower than 8.0
+            || !$tokens[$index]->isGivenKind(T_STRING) // checked token is not a string
+            || !$tokens->isAnyTokenKindsFound([T_ATTRIBUTE]) // no attributes in the tokens collection
+        ) {
+            return false;
+        }
+
+        $attributeStartIndex = $tokens->getPrevTokenOfKind($index, self::TOKEN_KINDS_NOT_ALLOWED_IN_ATTRIBUTE);
+        if (!$tokens[$attributeStartIndex]->isGivenKind(T_ATTRIBUTE)) {
+            return false;
+        }
+
+        // now, between attribute start and the attribute candidate index cannot be more "(" than ")"
+        $count = 0;
+        for ($i = $attributeStartIndex + 1; $i < $index; ++$i) {
+            if ($tokens[$i]->equals('(')) {
+                ++$count;
+            } elseif ($tokens[$i]->equals(')')) {
+                --$count;
+            }
+        }
+
+        return 0 === $count;
+    }
+}

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -212,7 +212,7 @@ final class Token
     public static function isKeyCaseSensitive($caseSensitive, int $key): bool
     {
         if (\is_array($caseSensitive)) {
-            return isset($caseSensitive[$key]) ? $caseSensitive[$key] : true;
+            return $caseSensitive[$key] ?? true;
         }
 
         return $caseSensitive;

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -1062,7 +1062,7 @@ class Tokens extends \SplFixedArray
      */
     public function countTokenKind($tokenKind): int
     {
-        return isset($this->foundTokenKinds[$tokenKind]) ? $this->foundTokenKinds[$tokenKind] : 0;
+        return $this->foundTokenKinds[$tokenKind] ?? 0;
     }
 
     /**
@@ -1167,7 +1167,7 @@ class Tokens extends \SplFixedArray
 
             // if the token candidate to remove is preceded by single line comment we do not consider the new line after this comment as part of T_WHITESPACE
             if (isset($this[$whitespaceIndex - 1]) && $this[$whitespaceIndex - 1]->isComment() && '/*' !== substr($this[$whitespaceIndex - 1]->getContent(), 0, 2)) {
-                list($emptyString, $newContent, $whitespacesToCheck) = Preg::split('/^(\R)/', $this[$whitespaceIndex]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
+                [$emptyString, $newContent, $whitespacesToCheck] = Preg::split('/^(\R)/', $this[$whitespaceIndex]->getContent(), -1, PREG_SPLIT_DELIM_CAPTURE);
 
                 if ('' === $whitespacesToCheck) {
                     return;
@@ -1217,7 +1217,7 @@ class Tokens extends \SplFixedArray
         $indexOffset = 1;
 
         if (!$findEnd) {
-            list($startEdge, $endEdge) = [$endEdge, $startEdge];
+            [$startEdge, $endEdge] = [$endEdge, $startEdge];
             $indexOffset = -1;
             $endIndex = 0;
         }
@@ -1243,8 +1243,6 @@ class Tokens extends \SplFixedArray
                 if (0 === $blockLevel) {
                     break;
                 }
-
-                continue;
             }
         }
 

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -57,7 +57,7 @@ final class TokensAnalyzer
 
         for ($index = 1, $count = \count($this->tokens) - 2; $index < $count; ++$index) {
             if ($this->tokens[$index]->isClassy()) {
-                list($index, $newElements) = $this->findClassyElements($index, $index);
+                [$index, $newElements] = $this->findClassyElements($index, $index);
                 $elements += $newElements;
             }
         }
@@ -672,7 +672,7 @@ final class TokensAnalyzer
                             --$nestedBracesLevel;
 
                             if (0 === $nestedBracesLevel) {
-                                list($index, $newElements) = $this->findClassyElements($nestedClassIndex, $index);
+                                [$index, $newElements] = $this->findClassyElements($nestedClassIndex, $index);
                                 $elements += $newElements;
 
                                 break;
@@ -682,12 +682,12 @@ final class TokensAnalyzer
                         }
 
                         if ($token->isClassy()) { // anonymous class in class
-                            list($index, $newElements) = $this->findClassyElements($index, $index);
+                            [$index, $newElements] = $this->findClassyElements($index, $index);
                             $elements += $newElements;
                         }
                     }
                 } else {
-                    list($index, $newElements) = $this->findClassyElements($nestedClassIndex, $nestedClassIndex);
+                    [$index, $newElements] = $this->findClassyElements($nestedClassIndex, $nestedClassIndex);
                     $elements += $newElements;
                 }
 

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -55,7 +55,7 @@ final class TypeAlternationTransformer extends AbstractTransformer
             return;
         }
 
-        $prevIndex = $tokens->getTokenNotOfKindsSibling($index, -1, [T_NS_SEPARATOR, T_STRING, CT::T_ARRAY_TYPEHINT, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]);
+        $prevIndex = $tokens->getTokenNotOfKindsSibling($index, -1, [T_CALLABLE, T_NS_SEPARATOR, T_STRING, CT::T_ARRAY_TYPEHINT, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]);
 
         /** @var Token $prevToken */
         $prevToken = $tokens[$prevIndex];

--- a/src/ToolInfo.php
+++ b/src/ToolInfo.php
@@ -48,7 +48,7 @@ final class ToolInfo implements ToolInfoInterface
         if (null === $this->composerInstallationDetails) {
             $composerInstalled = json_decode(file_get_contents($this->getComposerInstalledFile()), true);
 
-            $packages = isset($composerInstalled['packages']) ? $composerInstalled['packages'] : $composerInstalled;
+            $packages = $composerInstalled['packages'] ?? $composerInstalled;
 
             foreach ($packages as $package) {
                 if (\in_array($package['name'], [self::COMPOSER_PACKAGE_NAME, self::COMPOSER_LEGACY_PACKAGE_NAME], true)) {

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -208,7 +208,7 @@ final class CiConfigurationTest extends TestCase
     {
         $yaml = Yaml::parse(file_get_contents(__DIR__.'/../../.github/workflows/ci.yml'));
 
-        $phpVersions = isset($yaml['jobs']['tests']['strategy']['matrix']['php-version']) ? $yaml['jobs']['tests']['strategy']['matrix']['php-version'] : [];
+        $phpVersions = $yaml['jobs']['tests']['strategy']['matrix']['php-version'] ?? [];
 
         foreach ($yaml['jobs']['tests']['strategy']['matrix']['include'] as $job) {
             $phpVersions[] = $job['php-version'];

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -78,6 +78,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['braces'], $fixers['method_chaining_indentation']],
             [$fixers['class_attributes_separation'], $fixers['braces']],
             [$fixers['class_attributes_separation'], $fixers['indentation_type']],
+            [$fixers['class_attributes_separation'], $fixers['no_extra_blank_lines']],
             [$fixers['class_definition'], $fixers['braces']],
             [$fixers['class_keyword_remove'], $fixers['no_unused_imports']],
             [$fixers['combine_consecutive_issets'], $fixers['multiline_whitespace_before_semicolons']],
@@ -519,7 +520,7 @@ final class FixerFactoryTest extends TestCase
         $map = [];
 
         foreach ($cases as $beforeAfter) {
-            list($before, $after) = $beforeAfter;
+            [$before, $after] = $beforeAfter;
 
             $beforeClass = \get_class($before);
             $afterClass = \get_class($after);

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -167,7 +167,7 @@ final class ProjectCodeTest extends TestCase
         $extraProps = array_diff(
             $definedProps,
             $allowedProps,
-            isset($exceptionPropsPerClass[$className]) ? $exceptionPropsPerClass[$className] : []
+            $exceptionPropsPerClass[$className] ?? []
         );
 
         sort($extraProps);

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -58,7 +58,7 @@ final class TransformerTest extends TestCase
         $name = $transformer->getName();
 
         foreach ($this->provideTransformerPriorityCases() as $pair) {
-            list($first, $second) = $pair;
+            [$first, $second] = $pair;
 
             if ($name === $first->getName() || $name === $second->getName()) {
                 $this->addToAssertionCount(1);
@@ -74,7 +74,7 @@ final class TransformerTest extends TestCase
     {
         $transformers = [];
 
-        foreach ($this->provideTransformerCases() as list($transformer)) {
+        foreach ($this->provideTransformerCases() as [$transformer]) {
             $transformers[$transformer->getName()] = $transformer;
         }
 

--- a/tests/Console/Command/SelfUpdateCommandTest.php
+++ b/tests/Console/Command/SelfUpdateCommandTest.php
@@ -46,8 +46,8 @@ final class SelfUpdateCommandTest extends TestCase
 
         file_put_contents($this->getToolPath(), 'Current PHP CS Fixer.');
 
-        file_put_contents("{$this->root->url()}/{$this->getNewMinorVersion()}.phar", 'New minor version of PHP CS Fixer.');
-        file_put_contents("{$this->root->url()}/{$this->getNewMajorVersion()}.phar", 'New major version of PHP CS Fixer.');
+        file_put_contents("{$this->root->url()}/{$this->getNewMinorReleaseVersion()}.phar", 'New minor version of PHP CS Fixer.');
+        file_put_contents("{$this->root->url()}/{$this->getNewMajorReleaseVersion()}.phar", 'New major version of PHP CS Fixer.');
     }
 
     protected function tearDown(): void
@@ -137,7 +137,8 @@ final class SelfUpdateCommandTest extends TestCase
     public function provideExecuteCases()
     {
         $currentVersion = Application::VERSION;
-        $minor = $this->getNewMinorVersion();
+        $minorRelease = $this->getNewMinorReleaseVersion();
+        $majorRelease = $this->getNewMajorReleaseVersion();
         $major = $this->getNewMajorVersion();
 
         $currentContents = 'Current PHP CS Fixer.';
@@ -145,22 +146,22 @@ final class SelfUpdateCommandTest extends TestCase
         $majorContents = 'New major version of PHP CS Fixer.';
 
         $upToDateDisplay = "\033[32mPHP CS Fixer is already up to date.\033[39m\n";
-        $newMinorDisplay = "\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$minor}\033[39m)\n";
-        $newMajorDisplay = "\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$major}\033[39m)\n";
+        $newMinorDisplay = "\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$minorRelease}\033[39m)\n";
+        $newMajorDisplay = "\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$majorRelease}\033[39m)\n";
         $majorInfoNoMinorDisplay = <<<OUTPUT
-\033[32mA new major version of PHP CS Fixer is available\033[39m (\033[33m{$major}\033[39m)
-\033[32mBefore upgrading please read\033[39m https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/{$major}/UPGRADE.md
+\033[32mA new major version of PHP CS Fixer is available\033[39m (\033[33m{$majorRelease}\033[39m)
+\033[32mBefore upgrading please read\033[39m https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/{$majorRelease}/UPGRADE-v{$major}.md
 \033[32mIf you are ready to upgrade run this command with\033[39m \033[33m-f\033[39m
 \033[32mChecking for new minor/patch version...\033[39m
 \033[32mNo minor update for PHP CS Fixer.\033[39m
 
 OUTPUT;
         $majorInfoNewMinorDisplay = <<<OUTPUT
-\033[32mA new major version of PHP CS Fixer is available\033[39m (\033[33m{$major}\033[39m)
-\033[32mBefore upgrading please read\033[39m https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/{$major}/UPGRADE.md
+\033[32mA new major version of PHP CS Fixer is available\033[39m (\033[33m{$majorRelease}\033[39m)
+\033[32mBefore upgrading please read\033[39m https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/{$majorRelease}/UPGRADE-v{$major}.md
 \033[32mIf you are ready to upgrade run this command with\033[39m \033[33m-f\033[39m
 \033[32mChecking for new minor/patch version...\033[39m
-\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$minor}\033[39m)
+\033[32mPHP CS Fixer updated\033[39m (\033[33m{$currentVersion}\033[39m -> \033[33m{$minorRelease}\033[39m)
 
 OUTPUT;
 
@@ -174,28 +175,28 @@ OUTPUT;
             [Application::VERSION, Application::VERSION, ['-f' => true], false, $currentContents, $upToDateDisplay],
 
             // new minor version available
-            [$minor, $minor, [], true, $minorContents, $newMinorDisplay],
-            [$minor, $minor, ['--force' => true], true, $minorContents, $newMinorDisplay],
-            [$minor, $minor, ['-f' => true], true, $minorContents, $newMinorDisplay],
-            [$minor, $minor, [], false, $minorContents, $newMinorDisplay],
-            [$minor, $minor, ['--force' => true], false, $minorContents, $newMinorDisplay],
-            [$minor, $minor, ['-f' => true], false, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, [], true, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, ['--force' => true], true, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, ['-f' => true], true, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, [], false, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, ['--force' => true], false, $minorContents, $newMinorDisplay],
+            [$minorRelease, $minorRelease, ['-f' => true], false, $minorContents, $newMinorDisplay],
 
             // new major version available
-            [$major, Application::VERSION, [], true, $currentContents, $majorInfoNoMinorDisplay],
-            [$major, Application::VERSION, [], false, $currentContents, $majorInfoNoMinorDisplay],
-            [$major, Application::VERSION, ['--force' => true], true, $majorContents, $newMajorDisplay],
-            [$major, Application::VERSION, ['-f' => true], false, $majorContents, $newMajorDisplay],
-            [$major, Application::VERSION, ['--force' => true], true, $majorContents, $newMajorDisplay],
-            [$major, Application::VERSION, ['-f' => true], false, $majorContents, $newMajorDisplay],
+            [$majorRelease, Application::VERSION, [], true, $currentContents, $majorInfoNoMinorDisplay],
+            [$majorRelease, Application::VERSION, [], false, $currentContents, $majorInfoNoMinorDisplay],
+            [$majorRelease, Application::VERSION, ['--force' => true], true, $majorContents, $newMajorDisplay],
+            [$majorRelease, Application::VERSION, ['-f' => true], false, $majorContents, $newMajorDisplay],
+            [$majorRelease, Application::VERSION, ['--force' => true], true, $majorContents, $newMajorDisplay],
+            [$majorRelease, Application::VERSION, ['-f' => true], false, $majorContents, $newMajorDisplay],
 
             // new minor version and new major version available
-            [$major, $minor, [], true, $minorContents, $majorInfoNewMinorDisplay],
-            [$major, $minor, [], false, $minorContents, $majorInfoNewMinorDisplay],
-            [$major, $minor, ['--force' => true], true, $majorContents, $newMajorDisplay],
-            [$major, $minor, ['-f' => true], false, $majorContents, $newMajorDisplay],
-            [$major, $minor, ['--force' => true], true, $majorContents, $newMajorDisplay],
-            [$major, $minor, ['-f' => true], false, $majorContents, $newMajorDisplay],
+            [$majorRelease, $minorRelease, [], true, $minorContents, $majorInfoNewMinorDisplay],
+            [$majorRelease, $minorRelease, [], false, $minorContents, $majorInfoNewMinorDisplay],
+            [$majorRelease, $minorRelease, ['--force' => true], true, $majorContents, $newMajorDisplay],
+            [$majorRelease, $minorRelease, ['-f' => true], false, $majorContents, $newMajorDisplay],
+            [$majorRelease, $minorRelease, ['--force' => true], true, $majorContents, $newMajorDisplay],
+            [$majorRelease, $minorRelease, ['-f' => true], false, $majorContents, $newMajorDisplay],
 
             // weird/unexpected versions
             ['v0.1.0', 'v0.1.0', [], true, $currentContents, $upToDateDisplay],
@@ -236,7 +237,7 @@ OUTPUT;
     ): void {
         $versionChecker = $this->prophesize(\PhpCsFixer\Console\SelfUpdate\NewVersionCheckerInterface::class);
 
-        $newMajorVersion = $this->getNewMajorVersion();
+        $newMajorVersion = $this->getNewMajorReleaseVersion();
         $versionChecker->getLatestVersion()->will(function () use ($latestVersionSuccess, $newMajorVersion) {
             if ($latestVersionSuccess) {
                 return $newMajorVersion;
@@ -245,7 +246,7 @@ OUTPUT;
             throw new \RuntimeException('Foo.');
         });
 
-        $newMinorVersion = $this->getNewMinorVersion();
+        $newMinorVersion = $this->getNewMinorReleaseVersion();
         $versionChecker
             ->getLatestVersionOfMajor($this->getCurrentMajorVersion())
             ->will(function () use ($latestMinorVersionSuccess, $newMinorVersion) {
@@ -390,13 +391,18 @@ OUTPUT;
         return (int) preg_replace('/^v?(\d+).*$/', '$1', Application::VERSION);
     }
 
-    private function getNewMinorVersion()
+    private function getNewMinorReleaseVersion()
     {
         return "{$this->getCurrentMajorVersion()}.999.0";
     }
 
     private function getNewMajorVersion()
     {
-        return ($this->getCurrentMajorVersion() + 1).'.0.0';
+        return $this->getCurrentMajorVersion() + 1;
+    }
+
+    private function getNewMajorReleaseVersion()
+    {
+        return $this->getNewMajorVersion().'.0.0';
     }
 }

--- a/tests/Console/Output/ErrorOutputTest.php
+++ b/tests/Console/Output/ErrorOutputTest.php
@@ -86,7 +86,7 @@ Files that were not fixed due to errors reported during %s:
     public function provideTestCases()
     {
         $lineNumber = __LINE__;
-        list($exceptionLineNumber, $error) = $this->getErrorAndLineNumber(); // note: keep call and __LINE__ separated with one line break
+        [$exceptionLineNumber, $error] = $this->getErrorAndLineNumber(); // note: keep call and __LINE__ separated with one line break
         ++$lineNumber;
 
         return [

--- a/tests/Console/Output/ProcessOutputTest.php
+++ b/tests/Console/Output/ProcessOutputTest.php
@@ -179,7 +179,7 @@ final class ProcessOutputTest extends TestCase
     private function foreachStatus(array $statuses, \Closure $action): void
     {
         foreach ($statuses as $status) {
-            $multiplier = isset($status[1]) ? $status[1] : 1;
+            $multiplier = $status[1] ?? 1;
             $status = $status[0];
 
             for ($i = 0; $i < $multiplier; ++$i) {

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -27,7 +27,6 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -36,7 +36,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php 1**2;',
                 '<?php pow(1,2);',
@@ -225,10 +225,6 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
                 '<?php pow($b, ...$a);',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -789,6 +789,12 @@ echo 2;
 <?php } ?>
 ',
             ],
+            [
+                '<?php $arr = [true, false]; ?>
+<?php foreach ($arr as $index => $item) if ($item): ?>
+    <?php echo $index; ?>
+<?php endif; ?>',
+            ],
         ];
     }
 
@@ -2960,23 +2966,6 @@ if ($a) { /* */ /* */ /* */ /* */ /* */
 ?><?php ++$a;
 } ?>',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixCommentBeforeBrace70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixCommentBeforeBrace70(string $expected, ?string $input = null, array $configuration = []): void
-    {
-        $this->fixer->configure($configuration);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixCommentBeforeBrace70Cases()
-    {
-        return [
             [
                 '<?php
     $foo = new class ($a) extends Foo implements Bar { // foo

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -109,7 +109,6 @@ echo "Hello'.pack('H*', 'e280af').'World'.pack('H*', 'c2a0').'!";',
 
     /**
      * @dataProvider provideFixWithEscapeSequencesInStringsCases
-     * @requires PHP 7.0
      */
     public function testFixWithEscapeSequencesInStrings(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -142,21 +142,6 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
             [
                 '<?php namespace Parent\Foo;',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFix70Cases
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php class Foo extends Bar { public function baz() : self {} }',
                 '<?php class Foo extends Bar { public function baz() : Self {} }',

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -99,39 +99,6 @@ function Foo(INTEGER $a) {}
                     B\String\C $y
                 ) {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP <7.0
-     *
-     * @dataProvider provideFixPre70Cases
-     */
-    public function testFixPre70(string $expected): void
-    {
-        $this->doTest($expected);
-    }
-
-    public function provideFixPre70Cases()
-    {
-        return [
-            ['<?php function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D, ITERABLE $E, VOID $F, OBJECT $o) {}'],
-            ['<?php class Foo { public function Foo(\INT $a) {}}'],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php final class Foo1 { final public function Foo(bool $A, float $B, int $C, string $D): int {} }',
                 '<?php final class Foo1 { final public function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D): INT {} }',

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -175,7 +175,7 @@ OVERRIDDEN;
 
     public function provideFix70Cases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php $foo = ((string) $x)[0];',
                 '<?php $foo = strval($x)[0];',
@@ -185,10 +185,6 @@ OVERRIDDEN;
                 '<?php $foo = strval($x + $y)[0];',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -50,8 +50,6 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      * @param array<string, bool> $config
      *
      * @dataProvider provideAnonymousClassesCases
-     *
-     * @requires PHP 7.0
      */
     public function testFixingAnonymousClasses(string $expected, string $input, array $config = []): void
     {
@@ -493,7 +491,7 @@ TestInterface3, /**/     TestInterface4   ,
 
     public function provideClassyImplementsInfoCases()
     {
-        $tests = [
+        yield from [
             '1' => [
                 '<?php
 class X11 implements    Z   , T,R
@@ -526,10 +524,6 @@ class X10 implements    Z   , T,R    //
                 ['start' => 5, 'numberOfImplements' => 3, 'multiLine' => false],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             $multiLine = true;

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -72,24 +72,6 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
                 '<?php /** @internal Map my app to an @Entity */ final class MyMapper {}',
                 '<?php /** @internal Map my app to an @Entity */ class MyMapper {}',
             ],
-        ];
-    }
-
-    /**
-     * @param string      $expected PHP source code
-     * @param null|string $input    PHP source code
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php $anonymClass = new class {};'],
         ];
     }

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -276,7 +276,6 @@ class B{}
      * @param string      $expected PHP source code
      * @param null|string $input    PHP source code
      *
-     * @requires PHP 7.0
      * @dataProvider provideAnonymousClassesCases
      */
     public function testAnonymousClassesCases(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
@@ -100,24 +100,6 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
                     abstract public static function bar();
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @param string      $expected PHP source code
-     * @param null|string $input    PHP source code
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'anonymous-class' => [
                 sprintf(
                     '<?php abstract class MyClass { private function test() { $a = new class { %s }; } }',

--- a/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
@@ -243,21 +243,6 @@ null;#13
             [
                 '<?php function foo() { static $foo = null; }',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             [
                 '<?php new class () { public $bar; };',
                 '<?php new class () { public $bar = null; };',

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -225,21 +225,6 @@ class Bar
     }
 }',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             'anonymous-class-inside' => [
                 '<?php
 final class Foo

--- a/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
@@ -84,21 +84,6 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
                 '<?php interface T extends A, B, C {}',
                 '<?php interface T extends C, A, B {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFixAlpha70Cases
-     */
-    public function testFixAlpha70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixAlpha70Cases()
-    {
-        return [
             'nested anonymous classes' => [
                 '<?php
                     class T implements A, B, C

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -87,24 +87,6 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
                 '<?php final class MyClass { private $v1; }',
                 '<?php final class MyClass { protected $v1; }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70Fix(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
-        $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
-
-        return [
             'anonymous-class-inside' => [
                 "<?php
 final class Foo

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -142,21 +142,6 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
                     public function baz31(\Test\Foo\Foo2\Bar $bar);
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php class Foo { function bar() {
                     new class() { function baz() { new Foo(); } };

--- a/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
+++ b/tests/Fixer/Comment/NoEmptyCommentFixerTest.php
@@ -267,7 +267,7 @@ echo 1;
         $method = new \ReflectionMethod($this->fixer, 'getCommentBlock');
         $method->setAccessible(true);
 
-        list($foundStart, $foundEnd, $foundIsEmpty) = $method->invoke($this->fixer, $tokens, $startIndex);
+        [$foundStart, $foundEnd, $foundIsEmpty] = $method->invoke($this->fixer, $tokens, $startIndex);
 
         static::assertSame($startIndex, $foundStart, 'Find start index of block failed.');
         static::assertSame($endIndex, $foundEnd, 'Find end index of block failed.');

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -163,22 +163,6 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
                 '<?php foo(\E_DEPRECATED | \E_USER_DEPRECATED);',
                 '<?php foo(E_DEPRECATED | E_USER_DEPRECATED);',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70WithDefaultConfigurationCases
-     *
-     * @requires PHP 7.0
-     */
-    public function testFix70WithDefaultConfiguration(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70WithDefaultConfigurationCases(): array
-    {
-        return [
             ['<?php function foo(): M_PI {}'],
             ['<?php use X\Y\{FOO, BAR as BAR2, M_PI};'],
         ];

--- a/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
@@ -233,21 +233,6 @@ if ($some) { return 1; } elseif ($a == 6){ $test = false; } //',
                     echo 2;
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, string $input): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -51,15 +51,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->fixerTest($expected, $input, $fixStatement);
     }
 
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null, ?string $fixStatement = null): void
-    {
-        $this->fixerTest($expected, $input, $fixStatement);
-    }
-
     public function provideFixCases()
     {
         return [
@@ -429,12 +420,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
                 function foo() { $a = (yield($x)); }
                 ',
             ],
-        ];
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
                 $var = clone ($obj1->getSubject() ?? $obj2);
@@ -445,7 +430,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixYieldFromCases
-     * @requires PHP 7.0
      */
     public function testFixYieldFrom(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -35,7 +35,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'simple sample, last token candidate' => [
                 '<?php  echo 1;',
                 '<?php { echo 1;}',
@@ -112,10 +112,6 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'no fixes, offset access syntax with curly braces' => [

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -285,11 +285,7 @@ else?><?php echo 5;',
             }
         ';
 
-        $tests = $this->generateCases($expected, $input);
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
+        yield from $this->generateCases($expected, $input);
 
         yield [
             '<?php
@@ -453,7 +449,7 @@ else?><?php echo 5;',
 
     public function provideNegativeCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                     if ($a0) {
@@ -611,10 +607,6 @@ else?><?php echo 5;',
                     };',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             $cases = [

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -35,7 +35,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                 switch (1) {
@@ -209,10 +209,6 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -35,7 +35,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
     switch (1) {
@@ -330,10 +330,6 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
                 }',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -33,7 +33,7 @@ final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
 
     public function provideTestFixCases()
     {
-        $tests = [
+        yield from [
             'alternative syntax |' => [
                 '<?php
                     switch($foo):
@@ -399,10 +399,6 @@ case $b:
 }}}}}}}}}}',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 70000) {
             yield 'simple case' => [

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -53,7 +53,7 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php $a = 1 + ($b + $c) === true ? 1 : 2;',
                 null,
@@ -637,10 +637,6 @@ $a#4
                 '<?php $a = $b = $c === null;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         $template = '<?php $a = ($b + $c) %s 1 === true ? 1 : 2;';
         $operators = ['||', '&&'];

--- a/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
@@ -27,7 +27,6 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -354,23 +354,6 @@ foo#
                 ',
                 self::$configurationClosureSpacingNone,
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70(string $expected, ?string $input = null, array $configuration = []): void
-    {
-        $this->fixer->configure($configuration);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php use function Foo\bar; bar ( 1 );'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c};'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c} ?>'],

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -183,21 +183,6 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
                 '<?php function foo(array & ...$param) {}',
                 '<?php function foo(array& ...$param) {}',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php use function some\test\{fn_a, fn_b, fn_c};'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c} ?>'],
         ];

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -103,21 +103,6 @@ $f = function() use ($b) { return function($b) { return function($b) { return fu
 $f = function() use ($a) { return function() use ($a) { return function() use ($a) { return function() use ($a) { }; }; }; };
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             'anonymous class' => [
                 '<?php
 $a = function() use ($b) { new class($b){}; }; // do not fix
@@ -141,7 +126,7 @@ $a = function() use ($b) { new class(){ public function foo($b){echo $b;}}; }; /
 
     public function provideDoNotFixCases()
     {
-        $tests = [
+        yield from [
             'reference' => [
                 '<?php $fn = function() use(&$b) {} ?>',
             ],
@@ -195,10 +180,6 @@ $foo();
 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 70100) {
             yield 'super global, invalid from PHP7.1' => [

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -473,7 +473,7 @@ namespace {
 
     public function provideFixWithConfiguredIncludeCases()
     {
-        $tests = [
+        yield from [
             'include set + 1, exclude 1' => [
                 '<?php
                     echo \count([1]);
@@ -564,10 +564,6 @@ namespace {
                 ],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'include @compiler_optimized with strict enabled' => [

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -35,7 +35,7 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'test function call' => [
                 '<?php abc($a);',
                 '<?php abc ($a);',
@@ -144,10 +144,6 @@ $$e(2);
  ($a);',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'test dynamic by array, curly mix' => [

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -442,28 +442,6 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
                     private $foo10;
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixPhp70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixPhp70(string $expected, ?string $input = null, array $config = []): void
-    {
-        if (null !== $input && \PHP_VERSION_ID < 70400) {
-            $expected = $input;
-            $input = null;
-        }
-
-        $this->fixer->configure($config);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixPhp70Cases()
-    {
-        return [
             'anonymous class' => [
                 '<?php new class { /** @var int */ private int $foo; };',
                 '<?php new class { /** @var int */ private $foo; };',

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -22,7 +22,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer
- * @requires PHP 7.0
  */
 final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 {
@@ -49,7 +48,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'no phpdoc return' => [
                 '<?php function my_foo() {}',
             ],
@@ -331,10 +330,6 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @return string[]|int[] */ function my_foo() {}',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'report static as self' => [

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -21,7 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @requires PHP 7.0
  * @covers \PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer
  */
 final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -26,8 +26,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @requires PHP 7.0
-     *
      * @dataProvider provideCodeWithReturnTypesCases
      */
     public function testCodeWithReturnTypes(string $expected, ?string $input = null): void

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -411,22 +411,6 @@ class Bar {
 \foo();
 INPUT
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixImportFunctions70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixImportFunctions70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure(['import_functions' => true]);
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixImportFunctions70Cases()
-    {
-        return [
             'name already used' => [
                 <<<'EXPECTED'
 <?php

--- a/tests/Fixer/Import/GroupImportFixerTest.php
+++ b/tests/Fixer/Import/GroupImportFixerTest.php
@@ -44,7 +44,6 @@ use Foo\Test;
 
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -206,21 +206,6 @@ C  ; ',
 use X ?><?php new X(); // run before white space around semicolon',
                 '<?php use Z , X ?><?php new X(); // run before white space around semicolon',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php use FooA#
 ;#
@@ -276,9 +261,6 @@ use A,B;
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testMessyComments(): void
     {
         if (\PHP_VERSION_ID >= 80000) {

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -360,21 +360,6 @@ use Bar;
 class Baz {}
 '),
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 use some\test\{ClassA, ClassB, ClassC as C};

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -236,21 +236,6 @@ final class ClassKeywordRemoveFixerTest extends AbstractFixerTestCase
                 var_dump(Baz::class);
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 "<?php
                 use Foo\\Bar\\{ClassA, ClassB, ClassC as C};

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
@@ -179,9 +179,6 @@ isset
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClass(): void
     {
         $this->doTest(

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -35,7 +35,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php //1
                     unset($foo/*;*/, /*;*/$bar, $c , $foobar  ,  $foobar2);
@@ -130,10 +130,6 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -39,7 +39,7 @@ final class ErrorSuppressionFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php trigger_error("This is not a deprecation warning."); ?>',
             ],
@@ -115,10 +115,6 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
                 [ErrorSuppressionFixer::OPTION_MUTE_DEPRECATION_ERROR => true, ErrorSuppressionFixer::OPTION_NOISE_REMAINING_USAGES => true, ErrorSuppressionFixer::OPTION_NOISE_REMAINING_USAGES_EXCLUDE => ['trigger_error']],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -27,7 +27,6 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideTestFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -35,7 +35,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar);',
@@ -108,28 +108,12 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
             ],
         ];
 
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
-
         if (\PHP_VERSION_ID < 80000) {
             yield 'It does not replace unsets on arrays with special notation' => [
                 '<?php unset($bar->foo{0});',
             ];
         }
-    }
 
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
         yield 'It does not break complex expressions' => [
             '<?php
                 unset(a()[b()["a"]]);
@@ -157,7 +141,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFix73Cases()
     {
-        $tests = [
+        yield from [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar,);',
@@ -237,10 +221,6 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php unset($foo->bar , );',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'It does not replace unsets on arrays with special notation' => [

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -467,24 +467,6 @@ Foo {}',
             [
                 '<?php $foo = stdClass::class;',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithClassPhp70Cases
-     */
-    public function testFixWithClassPhp70(string $expected, ?string $input = null, array $config = []): void
-    {
-        $this->fixer->configure($config);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithClassPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class {};',
                 '<?php $foo = new class  {};',
@@ -914,28 +896,6 @@ Bar6, Baz, Qux {}',
     Qux
 {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithExtendsPhp70Cases
-     */
-    public function testFixWithExtendsPhp70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure([
-            'constructs' => [
-                'extends',
-            ],
-        ]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithExtendsPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class extends \InvalidArgumentException {};',
                 '<?php $foo = new class extends  \InvalidArgumentException {};',
@@ -1469,28 +1429,6 @@ foo; foo: echo "Bar";',
                     Baz
                 {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithImplementsPhp70Cases
-     */
-    public function testFixWithImplementsPhp70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure([
-            'constructs' => [
-                'implements',
-            ],
-        ]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithImplementsPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class implements \Countable {};',
                 '<?php $foo = new class implements  \Countable {};',
@@ -3003,6 +2941,7 @@ echo 1;
 new Dummy(/* a */);
 new Dummy(/** b */);
 foo(/* c */);
+foo($a /* d */, $b);
 $arr = [/* empty */];
 ',
         ];

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -2052,6 +2052,10 @@ $a = $ae?? $b;
                 public function bar(TypeA | TypeB|TypeC $x): TypeA|TypeB | TypeC|TypeD
                 {
                 }
+                public function baz(
+                    callable|array $a,
+                    array|callable $b,
+                ) {}
             }'
         );
     }

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -44,7 +44,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php class A { public function B(){ $static = new static(new \SplFileInfo(__FILE__)); }}',
             ],
@@ -254,10 +254,6 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -36,7 +36,7 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php ++$i;',
                 '<?php $i += 1;',
@@ -553,10 +553,6 @@ $i#3
                 }',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -21,7 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @requires PHP 7.0
  * @covers \PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer
  */
 final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
@@ -36,7 +35,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             // Do not fix cases.
             ['<?php $x = isset($a) ? $a[1] : null;'],
             ['<?php $x = isset($a) and $a ? $a : "";'],
@@ -176,10 +175,6 @@ null
 ;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'];

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
@@ -153,21 +153,6 @@ final class MyTest extends \PhpUnit\FrameWork\TestCase
 }
 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'anonymous class false positive case' => [
                 '<?php
 final class MyTest extends \PhpUnit\FrameWork\TestCase

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -500,9 +500,6 @@ EOF
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClassFixing(): void
     {
         $this->doTest(

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -299,23 +299,6 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         return $string;
     }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null, array $config = []): void
-    {
-        $this->fixer->configure($config ?: ['only_untyped' => false]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
     /**

--- a/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
@@ -283,21 +283,6 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
                 }
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -166,9 +166,6 @@ class F
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClassFixing(): void
     {
         $this->doTest(

--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -350,6 +350,40 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
  * @return array{0: float, 1: int}
  */',
             ],
+            [
+                '<?php
+/** @internal Please use {@see Foo} instead */',
+                '<?php
+/** {@internal Please use {@see Foo} instead} */',
+            ],
+            [
+                '<?php
+/**
+ * @internal Please use {@see Foo} instead
+ */',
+                '<?php
+/**
+ * {@internal Please use {@see Foo} instead}
+ */',
+            ],
+            [
+                '<?php
+/**
+ *
+ * @internal Please use {@see Foo} instead
+ *
+ */',
+                '<?php
+/**
+ *
+ * {@internal Please use {@see Foo} instead}
+ *
+ */',
+            ],
+            [
+                '<?php
+/** @internal Foo Bar {@see JsonSerializable} */',
+            ],
         ];
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -382,21 +382,6 @@ class Foo
 class Foo{}
 /**  */',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFixVar70Cases
-     */
-    public function testFixVar70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixVar70Cases()
-    {
-        return [
             'anonymousClass' => [
                 <<<'EOF'
 <?php

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -446,21 +446,6 @@ var names are case insensitive */ return $a   ;}
                     }',
                 ],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, string $input): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
                     function a($foos) {

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -36,7 +36,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
 
     public function provideNoEmptyStatementsCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                 abstract class TestClass0 extends Test IMPLEMENTS TestInterface, TestInterface2
@@ -388,10 +388,6 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         foreach (['break', 'continue'] as $ops) {
             yield [

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -35,7 +35,7 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'comment' => [
                 '<?php $a++;//a ?>',
                 '<?php $a++//a ?>',
@@ -82,10 +82,6 @@ A is equal to 5
 <?php } ?>',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
@@ -28,7 +28,6 @@ final class DeclareStrictTypesFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {
@@ -142,7 +141,6 @@ $a = 456;
 
     /**
      * @dataProvider provideMessyWhitespacesCases
-     * @requires PHP 7.0
      */
     public function testMessyWhitespaces(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1207,7 +1207,6 @@ function foo() {
 
     /**
      * @dataProvider provideFixWithYieldFromCases
-     * @requires PHP 7.0
      */
     public function testFixWithYieldFrom(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -631,9 +631,11 @@ $a = new Qux();',
 
     /**
      * @dataProvider provideRemoveBetweenUseTraitsCases
+     * @group legacy
      */
     public function testRemoveBetweenUseTraits(string $expected, string $input): void
     {
+        $this->expectDeprecation('Option "use_trait" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.');
         $this->fixer->configure(['tokens' => ['use_trait']]);
 
         $this->doTest($expected, $input);
@@ -756,7 +758,7 @@ class Foo
 
     public function provideOneAndInLineCases()
     {
-        $tests = [
+        yield from [
             [
                 "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
             ],
@@ -771,10 +773,6 @@ class Foo
                 "<?php\n\n\$a->{'Test'};\nfunction test(){}\n",
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -116,7 +116,7 @@ EOF;
 
     public function provideOutsideCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
 $a = $b[0]    ;',
@@ -178,10 +178,6 @@ $baz [0]
      [2] = 3;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -35,7 +35,7 @@ final class NoTrailingWhitespaceFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
 $a = 1;',
@@ -134,10 +134,6 @@ EOT;
                 "<?php      \n   \n    ",
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             yield [

--- a/tests/Fixtures/Integration/priority/class_attributes_separation,no_extra_blank_lines.test
+++ b/tests/Fixtures/Integration/priority/class_attributes_separation,no_extra_blank_lines.test
@@ -1,0 +1,28 @@
+--TEST--
+Integration of fixers: class_attributes_separation,no_extra_blank_lines.
+--RULESET--
+{"class_attributes_separation": {"elements": {"trait_import": "one"}}, "no_extra_blank_lines": {"tokens": ["use_trait"]}}
+--SETTINGS--
+{
+    "deprecations": [
+        "Option \"use_trait\" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead."
+    ]
+}
+--EXPECT--
+<?php
+
+class Foo
+{
+    use A;
+    use B;
+}
+
+--INPUT--
+<?php
+
+class Foo
+{
+    use A;
+
+    use B;
+}

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -148,6 +148,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
     {
         $parsed = $this->parseJson($config, [
             'checkPriority' => true,
+            'deprecations' => [],
         ]);
 
         if (!\is_bool($parsed['checkPriority'])) {
@@ -155,6 +156,23 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
                 'Expected bool value for "checkPriority", got "%s".',
                 \is_object($parsed['checkPriority']) ? \get_class($parsed['checkPriority']) : \gettype($parsed['checkPriority']).'#'.$parsed['checkPriority']
             ));
+        }
+
+        if (!\is_array($parsed['deprecations'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected array value for "deprecations", got "%s".',
+                \is_object($parsed['deprecations']) ? \get_class($parsed['deprecations']) : \gettype($parsed['deprecations']).'#'.$parsed['deprecations']
+            ));
+        }
+
+        foreach ($parsed['deprecations'] as $index => $deprecation) {
+            if (!\is_string($deprecation)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Expected only string value for "deprecations", got "%s" @ index %d.',
+                    \is_object($deprecation) ? \get_class($deprecation) : \gettype($deprecation).'#'.$deprecation,
+                    $index
+                ));
+            }
         }
 
         return $parsed;

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -122,9 +122,14 @@ abstract class AbstractIntegrationTestCase extends TestCase
      *
      * @see doTest()
      * @large
+     * @group legacy
      */
     public function testIntegration(IntegrationCase $case): void
     {
+        foreach ($case->getSettings()['deprecations'] as $deprecation) {
+            $this->expectDeprecation($deprecation);
+        }
+
         $this->doTest($case);
     }
 

--- a/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Analyzer;
+
+use PhpCsFixer\Tests\TestCase;
+use PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\Tokenizer\Analyzer\AttributeAnalyzer
+ */
+final class AttributeAnalyzerTest extends TestCase
+{
+    /**
+     * Check it's not crashing for PHP lower than 8.0 as other tests run for PHP 8.0 only.
+     */
+    public function testNotAnAttribute(): void
+    {
+        $tokens = Tokens::fromCode('<?php class Foo { private $bar; }');
+        foreach ($tokens as $index => $token) {
+            static::assertFalse(AttributeAnalyzer::isAttribute($tokens, $index));
+        }
+    }
+
+    /**
+     * @requires     PHP 8.0
+     * @dataProvider provideIsAttributeCases
+     */
+    public function testIsAttribute(bool $isInAttribute, string $code): void
+    {
+        $tokens = Tokens::fromCode($code);
+
+        foreach ($tokens as $index => $token) {
+            if ($token->equals([T_STRING, 'Foo'])) {
+                if (isset($testedIndex)) {
+                    static::fail('Test is run against index of "Foo", multiple occurrences found.');
+                }
+                $testedIndex = $index;
+            }
+        }
+        if (!isset($testedIndex)) {
+            static::fail('Test is run against index of "Foo", but it was not found in the code.');
+        }
+
+        static::assertSame($isInAttribute, AttributeAnalyzer::isAttribute($tokens, $testedIndex));
+    }
+
+    /**
+     * Test case requires to having "Foo" as it will be searched for to test its index.
+     */
+    public static function provideIsAttributeCases(): iterable
+    {
+        yield [false, '<?php Foo; #[Attr] class Bar {}'];
+        yield [false, '<?php Foo(); #[Attr] class Bar {};'];
+        yield [false, '<?php \Foo(); #[Attr] class Bar {}'];
+        yield [false, '<?php #[Attr] class Foo {};'];
+        yield [false, '<?php #[Attr] class Bar {}; Foo;'];
+        yield [false, '<?php #[Attr] class Bar {}; \Foo();'];
+        yield [false, '<?php #[Attr] class Bar { const Foo = 42; };'];
+        yield [false, '<?php #[Attr] class Bar { function Foo() {} };'];
+        yield [false, '<?php #[Attr(Foo)] class Bar {}'];
+        yield [false, '<?php #[Attr(Foo::Bar)] class Baz {}'];
+        yield [false, '<?php #[Attr(Bar::Foo)] class Baz {}'];
+        yield [false, '<?php #[Attr(1, 2, Foo)] class Bar {}'];
+        yield [false, '<?php #[Attr(Foo, 1, 2)] class Bar {}'];
+        yield [false, '<?php #[Attr(1, 2, Foo, 3, 4)] class Bar {}'];
+        yield [false, '<?php #[Attr(2 * (3 + 7), 2, Foo)] class Bar {}'];
+        yield [false, '<?php #[Attr(2 * (3 + 7), 2, Foo, 5)] class Bar {}'];
+        yield [false, '<?php #[Attr(2 * (3 + 7), 2, Foo, (16 + 4) / 5 )] class Bar {}'];
+        yield [false, '<?php #[Attr] function Foo() {};'];
+        yield [false, '<?php #[Attr("Foo()")] class Foo {}'];
+        yield [true, '<?php #[Foo] class Bar {}'];
+        yield [true, '<?php #[Foo, Bar] class Baz {}'];
+        yield [true, '<?php #[Bar, Foo] class Baz {}'];
+        yield [true, '<?php #[Bar, Foo, Baz] class Qux {}'];
+        yield [true, '<?php #[Foo(), Bar()] class Baz {}'];
+        yield [true, '<?php #[Bar(), Foo()] class Baz {}'];
+        yield [true, '<?php #[Bar(), Foo(), Baz()] class Qux {}'];
+        yield [true, '<?php #[Bar(), Foo, Baz()] class Qux {}'];
+        yield [true, '<?php #[Bar, Foo, Baz] class Qux {}'];
+        yield [true, '<?php #[\Foo] class Bar {}'];
+        yield [true, '<?php #[\Bar, \Foo] class Baz {}'];
+        yield [true, '<?php #[Attr1(2 * (3 + 7)), Foo, Attr2((16 + 4) / 5 )] class Bar {}'];
+        yield [true, '<?php #[Foo("(")] class Bar {}'];
+    }
+}

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -285,22 +285,7 @@ final class FunctionsAnalyzerTest extends TestCase
                 11,
             ];
         }
-    }
 
-    /**
-     * @dataProvider provideIsGlobalFunctionCallPhp70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsGlobalFunctionCallPhp70(bool $isFunctionIndex, string $code, int $index): void
-    {
-        $tokens = Tokens::fromCode($code);
-        $analyzer = new FunctionsAnalyzer();
-
-        static::assertSame($isFunctionIndex, $analyzer->isGlobalFunctionCall($tokens, $index));
-    }
-
-    public function provideIsGlobalFunctionCallPhp70Cases()
-    {
         yield [
             true,
             '<?php
@@ -418,7 +403,7 @@ class Foo {}
 
     public function provideFunctionsWithArgumentsCases()
     {
-        $tests = [
+        yield from [
             ['<?php function(){};', 1, []],
             ['<?php function($a){};', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -500,10 +485,6 @@ class Foo {}
             ]],
         ];
 
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
-
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php function(\Foo/** TODO: change to something else */\Bar $a){};', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -550,7 +531,7 @@ class Foo {}
 
     public function provideFunctionsWithArgumentsPhp74Cases()
     {
-        $tests = [
+        yield from [
             ['<?php fn() => null;', 1, []],
             ['<?php fn($a) => null;', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -631,10 +612,6 @@ class Foo {}
                 ),
             ]],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php fn(\Foo/** TODO: change to something else */\Bar $a) => null;', 1, [

--- a/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
@@ -45,7 +45,7 @@ final class GotoLabelAnalyzerTest extends TestCase
 
     public function provideIsClassyInvocationCases()
     {
-        $tests = [
+        yield from [
             'no candidates' => [
                 '<?php
                     $a = \InvalidArgumentException::class;
@@ -84,10 +84,6 @@ final class GotoLabelAnalyzerTest extends TestCase
                 [10],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             yield [

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -119,16 +119,12 @@ final class TokenTest extends TestCase
 
     public function provideIsCommentCases()
     {
-        $tests = [
+        yield from [
             [$this->getBraceToken(), false],
             [$this->getForeachToken(), false],
             [new Token([T_COMMENT, '/* comment */', 1]), true],
             [new Token([T_DOC_COMMENT, '/** docs */', 1]), true],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_ATTRIBUTE')) {
@@ -146,17 +142,13 @@ final class TokenTest extends TestCase
 
     public function provideIsObjectOperatorCases()
     {
-        $tests = [
+        yield from [
             [$this->getBraceToken(), false],
             [$this->getForeachToken(), false],
             [new Token([T_COMMENT, '/* comment */']), false],
             [new Token([T_DOUBLE_COLON, '::']), false],
             [new Token([T_OBJECT_OPERATOR, '->']), true],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
             yield [new Token([T_NULLSAFE_OBJECT_OPERATOR, '?->']), true];

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -575,25 +575,6 @@ preg_replace_callback(
                 '<?php $foo = function &() {};',
                 [5 => true],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideIsLambda70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsLambda70(string $source, array $expected): void
-    {
-        $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
-
-        foreach ($expected as $index => $expectedValue) {
-            static::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
-        }
-    }
-
-    public function provideIsLambda70Cases()
-    {
-        return [
             [
                 '<?php
                     $a = function (): array {
@@ -913,21 +894,6 @@ $a(1,2);',
                 '<?php use Foo\Bar, Foo\Baz, Foo\Qux;',
                 [3 => false, 5 => false, 8 => false, 10 => false, 13 => false, 15 => false],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideIsConstantInvocation70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsConstantInvocation70(string $source, array $expected): void
-    {
-        $this->doIsConstantInvocationTest($source, $expected);
-    }
-
-    public function provideIsConstantInvocation70Cases()
-    {
-        return [
             [
                 '<?php function x(): FOO {}',
                 [3 => false, 8 => false],
@@ -1540,6 +1506,43 @@ $b;',
     }
 
     /**
+     * @dataProvider provideIsBinaryOperator80Cases
+     * @requires PHP 8.0
+     */
+    public function testIsBinaryOperator80(string $source, array $expected): void
+    {
+        $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
+
+        foreach ($expected as $index => $isBinary) {
+            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+            if ($isBinary) {
+                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+            }
+        }
+    }
+
+    public static function provideIsBinaryOperator80Cases(): iterable
+    {
+        yield [
+            '<?php function foo(array|string $x) {}',
+            [6 => false],
+        ];
+        yield [
+            '<?php function foo(string|array $x) {}',
+            [6 => false],
+        ];
+        yield [
+            '<?php function foo(int|callable $x) {}',
+            [6 => false],
+        ];
+        yield [
+            '<?php function foo(callable|int $x) {}',
+            [6 => false],
+        ];
+    }
+
+    /**
      * @dataProvider provideArrayExceptionsCases
      */
     public function testIsNotArray(string $source, int $tokenIndex): void
@@ -1838,23 +1841,6 @@ class AnnotatedClass
 EOF
                 ,
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideGetImportUseIndexesPHP70Cases
-     * @requires PHP 7.0
-     */
-    public function testGetImportUseIndexesPHP70(array $expected, string $input, bool $perNamespace = false): void
-    {
-        $tokens = Tokens::fromCode($input);
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
-        static::assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
-    }
-
-    public function provideGetImportUseIndexesPHP70Cases()
-    {
-        return [
             [
                 [1, 22, 41],
                 '<?php

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -301,7 +301,7 @@ final class TokensTest extends TestCase
     {
         $emptyToken = new Token('');
 
-        $tests = [
+        return [
             ['Invalid sequence.', []],
             [
                 'Non-meaningful token at position: "0".',
@@ -316,10 +316,6 @@ final class TokensTest extends TestCase
                 ['{', '!', $emptyToken, '}'],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
     }
 
     public function testClearRange(): void
@@ -341,7 +337,7 @@ class FooBar
 PHP;
 
         $tokens = Tokens::fromCode($source);
-        list($fooIndex, $barIndex) = array_keys($tokens->findGivenKind(T_PUBLIC));
+        [$fooIndex, $barIndex] = array_keys($tokens->findGivenKind(T_PUBLIC));
 
         $tokens->clearRange($fooIndex, $barIndex - 1);
 
@@ -697,21 +693,7 @@ PHP;
             [4, '<?php list($a) = $b;', Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 2],
             [6, '<?php if($a){}?>', Tokens::BLOCK_TYPE_CURLY_BRACE, 5],
             [11, '<?php $foo = (new Foo());', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFindBlockEnd70Cases
-     */
-    public function testFindBlockEnd70(int $expectedIndex, string $source, int $type, int $searchIndex): void
-    {
-        static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
-    }
-
-    public function provideFindBlockEnd70Cases()
-    {
-        return [
+            [10, '<?php $object->{"set_{$name}"}(42);', Tokens::BLOCK_TYPE_DYNAMIC_PROP_BRACE, 3],
             [19, '<?php $foo = (new class () implements Foo {});', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5],
         ];
     }

--- a/tests/Tokenizer/Transformer/AttributeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/AttributeTransformerTest.php
@@ -63,6 +63,113 @@ final class AttributeTransformerTest extends AbstractTransformerTestCase
                 16 => CT::T_ATTRIBUTE_CLOSE,
             ],
         ];
+
+        yield [
+            '<?php class Foo {
+                #[ORM\Column("string", ORM\Column::UNIQUE)]
+                #[Assert\Email(["message" => "The email {{ value }} is not a valid email."])]
+                private $email;
+            }',
+            [
+                21 => CT::T_ATTRIBUTE_CLOSE,
+                36 => CT::T_ATTRIBUTE_CLOSE,
+            ],
+        ];
+
+        yield [
+            '<?php
+#[ORM\Id]
+
+#[ConditionalDeclare(PHP_VERSION_ID < 70000+1**2-1>>9+foo(a)+foo((bool)$b))] // gets removed from AST when >= 7.0
+#[IgnoreRedeclaration] // throws no error when already declared, removes the redeclared thing
+function intdiv(int $numerator, int $divisor) {
+}
+
+#[
+Attr1("foo"),Attr2("bar"),
+]
+
+#[PhpAttribute(self::IS_REPEATABLE)]
+class Route
+{
+}
+',
+            [
+                5 => CT::T_ATTRIBUTE_CLOSE,
+                35 => CT::T_ATTRIBUTE_CLOSE,
+                41 => CT::T_ATTRIBUTE_CLOSE,
+                76 => CT::T_ATTRIBUTE_CLOSE,
+                85 => CT::T_ATTRIBUTE_CLOSE,
+            ],
+        ];
+
+        yield [
+            '<?php
+#[Jit]
+function foo() {}
+
+class Foo
+{
+    #[ExampleAttribute]
+    public const FOO = "foo";
+
+    #[ExampleAttribute]
+    public function foo(#[ExampleAttribute] Type $bar) {}
+}
+
+$object = new #[ExampleAttribute] class () {};
+
+$f1 = #[ExampleAttribute] function () {};
+
+$f2 = #[ExampleAttribute] fn() => 1;
+',
+            [
+                3 => CT::T_ATTRIBUTE_CLOSE,
+                22 => CT::T_ATTRIBUTE_CLOSE,
+                37 => CT::T_ATTRIBUTE_CLOSE,
+                47 => CT::T_ATTRIBUTE_CLOSE,
+                67 => CT::T_ATTRIBUTE_CLOSE,
+                84 => CT::T_ATTRIBUTE_CLOSE,
+                101 => CT::T_ATTRIBUTE_CLOSE,
+            ],
+        ];
+
+        yield [
+            '<?php
+#[
+    ORM\Entity,
+    ORM\Table("user")
+]
+class User
+{
+    #[ORM\Id, ORM\Column("integer"), ORM\GeneratedValue]
+    private $id;
+
+    #[ORM\Column("string", ORM\Column::UNIQUE)]
+    #[Assert\Email(["message" => "The email \'{{ value }}\' is not a valid email."])]
+    private $email;
+
+    #[\Doctrine\ORM\ManyToMany(
+        targetEntity: User::class,
+        joinColumn: "group_id",
+        inverseJoinColumn: "user_id",
+        cascade: array("persist", "remove")
+    )]
+    #[Assert\Valid]
+    #[JMSSerializer\XmlList(inline: true, entry: "user")]
+    public $users;
+}
+',
+            [
+                15 => CT::T_ATTRIBUTE_CLOSE,
+                40 => CT::T_ATTRIBUTE_CLOSE,
+                61 => CT::T_ATTRIBUTE_CLOSE,
+                76 => CT::T_ATTRIBUTE_CLOSE,
+                124 => CT::T_ATTRIBUTE_CLOSE,
+                130 => CT::T_ATTRIBUTE_CLOSE,
+                148 => CT::T_ATTRIBUTE_CLOSE,
+            ],
+        ];
     }
 
     /**

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -197,6 +197,15 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
                 ],
             ],
             'do not touch' => ['<?php if (1) {} class Foo{ } function bar(){ }'],
+            'dynamic property with string with variable' => [
+                '<?php $object->{"set_{$name}"}(42);',
+                [
+                    3 => CT::T_DYNAMIC_PROP_BRACE_OPEN,
+                    6 => T_CURLY_OPEN,
+                    8 => CT::T_CURLY_CLOSE,
+                    10 => CT::T_DYNAMIC_PROP_BRACE_CLOSE,
+                ],
+            ],
         ];
     }
 

--- a/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
@@ -133,19 +133,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
                 }
             ',
         ];
-    }
 
-    /**
-     * @dataProvider provideDoNotChange70Cases
-     * @requires PHP 7.0
-     */
-    public function testDoNotChange70(string $source): void
-    {
-        static::assertNotChange($source);
-    }
-
-    public function provideDoNotChange70Cases()
-    {
         yield 'return type' => ['<?php function foo(): array { return []; }'];
     }
 

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -282,5 +282,20 @@ class Number
                 66 => CT::T_TYPE_ALTERNATION,
             ],
         ];
+
+        yield 'callable type' => [
+            '<?php
+                function f1(array|callable $x) {};
+                function f2(callable|array $x) {};
+                function f3(string|callable $x) {};
+                function f4(callable|string $x) {};
+            ',
+            [
+                7 => CT::T_TYPE_ALTERNATION,
+                22 => CT::T_TYPE_ALTERNATION,
+                37 => CT::T_TYPE_ALTERNATION,
+                52 => CT::T_TYPE_ALTERNATION,
+            ],
+        ];
     }
 }

--- a/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
@@ -28,7 +28,6 @@ final class TypeColonTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
-     * @requires PHP 7.0
      */
     public function testProcess(string $source, array $expectedTokens = []): void
     {

--- a/tests/Tokenizer/Transformer/UseTransformerTest.php
+++ b/tests/Tokenizer/Transformer/UseTransformerTest.php
@@ -95,31 +95,6 @@ final class UseTransformerTest extends AbstractTransformerTestCase
                     1 => T_USE,
                 ],
             ],
-        ];
-    }
-
-    /**
-     * @param array<int, int> $expectedTokens index => kind
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $source, array $expectedTokens = []): void
-    {
-        $this->doTest(
-            $source,
-            $expectedTokens,
-            [
-                T_USE,
-                CT::T_USE_LAMBDA,
-                CT::T_USE_TRAIT,
-            ]
-        );
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'nested anonymous classes' => [
                 '<?php
 


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5852
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5854
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5843 (including https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5843#issuecomment-895432985)

fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5704#issuecomment-864200146 (cc @ruudk for option `none`)

replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5869
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5868

I haven't found BC breaks, however there is a minor change in how comments that are not related at all to a class element are handled. This is of no concern as people shouldn't just drop comments all over the place and expect these to end up somewhere.

Additionally fixes a bunch of issues with comments, include cases where the fixer had to be run multiple times before done with fixing.

Have to check how `only_if_meta` comes into play on `master` as I suspect this act near the same as `none` now.
