### PR TITLE
EmptyLoopBodyFixer - NoTrailingWhitespaceFixer - priority test

### DIFF
--- a/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopBodyFixer.php
@@ -59,7 +59,7 @@ final class EmptyLoopBodyFixer extends AbstractFixer implements ConfigurableFixe
     /**
      * {@inheritdoc}
      *
-     * Must run before BracesFixer, NoExtraBlankLinesFixer.
+     * Must run before BracesFixer, NoExtraBlankLinesFixer, NoTrailingWhitespaceFixer.
      * Must run after NoEmptyStatementFixer.
      */
     public function getPriority(): int

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -46,7 +46,7 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
     /**
      * {@inheritdoc}
      *
-     * Must run after CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, TernaryToElvisOperatorFixer.
+     * Must run after CombineConsecutiveIssetsFixer, CombineConsecutiveUnsetsFixer, EmptyLoopBodyFixer, FunctionToConstantFixer, NoEmptyCommentFixer, NoEmptyPhpdocFixer, NoEmptyStatementFixer, NoUnneededControlParenthesesFixer, NoUselessElseFixer, TernaryToElvisOperatorFixer.
      */
     public function getPriority(): int
     {

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -100,6 +100,7 @@ final class FixerFactoryTest extends TestCase
             [$fixers['elseif'], $fixers['braces']],
             [$fixers['empty_loop_body'], $fixers['braces']],
             [$fixers['empty_loop_body'], $fixers['no_extra_blank_lines']],
+            [$fixers['empty_loop_body'], $fixers['no_trailing_whitespace']],
             [$fixers['escape_implicit_backslashes'], $fixers['heredoc_to_nowdoc']],
             [$fixers['escape_implicit_backslashes'], $fixers['single_quote']],
             [$fixers['explicit_string_variable'], $fixers['simple_to_complex_string_variable']],

--- a/tests/Fixtures/Integration/priority/empty_loop_body,no_trailing_whitespace.test
+++ b/tests/Fixtures/Integration/priority/empty_loop_body,no_trailing_whitespace.test
@@ -1,0 +1,11 @@
+--TEST--
+Integration of fixers: empty_loop_body,no_trailing_whitespace.
+--RULESET--
+{"empty_loop_body": true, "no_trailing_whitespace": true}
+--EXPECT--
+<?php
+while(foo());
+
+--INPUT--
+<?php
+while(foo()){      }


### PR DESCRIPTION
add missing test, fixer doesn't exists on 3.0 so target set to `master`