### PR TITLE
Detect renamed rules in configuration resolver

### DIFF
--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -954,17 +954,53 @@ final class ConfigurationResolverTest extends TestCase
         );
     }
 
+    /**
+     * @param string[] $rules
+     *
+     * @dataProvider provideRenamedRulesCases
+     */
+    public function testResolveRenamedRulesWithUnknownRules(string $expectedMessage, array $rules): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $resolver = $this->createConfigurationResolver(['rules' => implode(',', $rules)]);
+        $resolver->getRules();
+    }
+
+    public function provideRenamedRulesCases(): \Generator
+    {
+        yield 'with config' => [
+            'The rules contain unknown fixers: "blank_line_before_return" is renamed (did you mean "blank_line_before_statement"? (note: use configuration "[\'statements\' => [\'return\']]")).
+For more info about updating see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+            ['blank_line_before_return'],
+        ];
+
+        yield 'without config' => [
+            'The rules contain unknown fixers: "final_static_access" is renamed (did you mean "self_static_accessor"?).
+For more info about updating see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+            ['final_static_access'],
+        ];
+
+        yield [
+            'The rules contain unknown fixers: "hash_to_slash_comment" is renamed (did you mean "single_line_comment_style"? (note: use configuration "[\'comment_types\' => [\'hash\']]")).
+For more info about updating see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+            ['hash_to_slash_comment'],
+        ];
+
+        yield 'both renamed and unknown' => [
+            'The rules contain unknown fixers: "final_static_access" is renamed (did you mean "self_static_accessor"?), "binary_operator_space" (did you mean "binary_operator_spaces"?).
+For more info about updating see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md#renamed-ruless.',
+            ['final_static_access', 'binary_operator_space'],
+        ];
+    }
+
     public function testResolveRulesWithUnknownRules(): void
     {
-        $this->expectException(
-            \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class
-        );
-        $this->expectExceptionMessage(
-            'The rules contain unknown fixers: "bar", "binary_operator_space" (did you mean "binary_operator_spaces"?).'
-        );
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The rules contain unknown fixers: "bar", "binary_operator_space" (did you mean "binary_operator_spaces"?).');
 
         $resolver = $this->createConfigurationResolver(['rules' => 'braces,-bar,binary_operator_space']);
-
         $resolver->getRules();
     }
 
@@ -1073,7 +1109,7 @@ final class ConfigurationResolverTest extends TestCase
 
     public function testDeprecationOfPassingOtherThanNoOrYes(): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Expected "yes" or "no" for option "allow-risky", got "yes please".');
 
         $resolver = $this->createConfigurationResolver(['allow-risky' => 'yes please']);


### PR DESCRIPTION
Following recomendation of #5880 from @keradus .

I improved the detection rules suggestion with the following table:

https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/UPGRADE-v3.md#renamed-rules

From:

```
In ConfigurationResolver.php line 717:
                                                                                             
  The rules contain unknown fixers: "lowercase_constants" (did you mean "lowercase_cast"?).  
```

To:

```
In ConfigurationResolver.php line 811:
                                                                                                                                                         
  The rules contain unknown fixers: "lowercase_constants" is a renamed rule,  did you mean "constant_case"? note: use configuration ['case' => 'lower']  
                                                                                                                                                         
  For more info see: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/UPGRADE-v3.md#renamed-rules.     
```                                             
                                                                                                                                                         

