### PR TITLE
DX: add phpstan/phpstan-strict-rules

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -10,7 +10,8 @@
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.10.2",
         "phpstan/phpstan": "0.12.96",
-        "phpstan/phpstan-phpunit": "0.12.21"
+        "phpstan/phpstan-phpunit": "0.12.21",
+        "phpstan/phpstan-strict-rules": "0.12.11"
     },
     "config": {
         "optimize-autoloader": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ includes:
     - dev-tools/vendor/jangregor/phpstan-prophecy/extension.neon
     - dev-tools/vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - dev-tools/vendor/phpstan/phpstan-phpunit/extension.neon
+    - dev-tools/vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
     level: 5
@@ -10,8 +11,27 @@ parameters:
         - tests
     excludePaths:
         - tests/Fixtures
+    treatPhpDocTypesAsCertain: false
+    reportMaybesInPropertyPhpDocTypes: false
     ignoreErrors:
+        - '/^Anonymous function should have native return typehint ".+"\.$/'
+        - '/^Call to function array_key_exists\(\) with string and array<string, mixed> will always evaluate to true\.$/'
+        - '/^Call to static method PHPUnit\\Framework\\Assert::[a-zA-Z]+\(\) with .+ will always evaluate to true\.$/'
         - '/^Class [a-zA-Z\\]+ extends @final class PhpCsFixer\\(ConfigurationException\\InvalidConfigurationException|ConfigurationException\\InvalidFixerConfigurationException|Tokenizer\\Tokens)\.$/'
+        - '/^Construct empty\(\) is not allowed\. Use more strict comparison\.$/'
+        - '/^For loop initial assignment overwrites variable \$[a-zA-Z]+\.$/'
+        - '/^Foreach overwrites \$[a-zA-Z]+ with its key variable\.$/'
+        - '/^Foreach overwrites \$[a-zA-Z]+ with its value variable\.$/'
+        - '/^Only booleans are allowed in (&&|\|\|), .+ given on the (left|right) side\.$/'
+        - '/^Only booleans are allowed in a negated boolean, .+ given\.$/'
+        - '/^Only booleans are allowed in a ternary operator condition, .+ given\.$/'
+        - '/^Only booleans are allowed in an if condition, .+ given\.$/'
+        - '/^Parameter #\d \$[a-zA-Z]+ \([a-zA-Z\\<>|,\h]+\) of method [a-zA-Z\\]+::[a-zA-Z]+\(\) should be contravariant with parameter \$[a-zA-Z_]+ \([a-zA-Z\\<>|,\h]+\) of method [a-zA-Z\\<>|,]+::[a-zA-Z]+\(\)$/'
+        - '/^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$/'
+        - '/^Strict comparison using !== between .+ and .+ will always evaluate to true.$/'
+        - '/^Unreachable statement - code above always terminates\.$/'
         - '/^Unsafe call to private method [a-zA-Z\\]+::[a-zA-Z]+\(\) through static::\.$/'
+        - '/^Variable \$[a-zA-Z0-9]+ might not be defined\.$/'
+        - '/^Variable method call on \$this\([a-zA-Z\\]+\)\.$/'
         - '/^\$this\(PhpCsFixer\\Tokenizer\\Tokens\) does not accept PhpCsFixer\\Tokenizer\\Token\|null\.$/'
     tipsOfTheDay: false

--- a/src/StdinFileInfo.php
+++ b/src/StdinFileInfo.php
@@ -23,6 +23,7 @@ final class StdinFileInfo extends \SplFileInfo
 {
     public function __construct()
     {
+        parent::__construct($this->getFilename());
     }
 
     public function __toString(): string

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -83,7 +83,6 @@ final class Token
         } else {
             throw new \InvalidArgumentException(sprintf(
                 'Cannot recognize input value as valid Token prototype, got "%s".',
-                // @phpstan-ignore-next-line due to lack of strong typing of method parameter
                 \is_object($token) ? \get_class($token) : \gettype($token)
             ));
         }

--- a/tests/RuleSet/Sets/AbstractSetTest.php
+++ b/tests/RuleSet/Sets/AbstractSetTest.php
@@ -29,7 +29,6 @@ abstract class AbstractSetTest extends TestCase
     public function testSet(): void
     {
         $set = self::getSet();
-        static::assertTrue($set instanceof RuleSetDescriptionInterface);
 
         $setName = $set->getName();
         $setDescription = $set->getDescription();

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -166,7 +166,7 @@ abstract class AbstractFixerTestCase extends TestCase
             $duplicatedCodeSample = array_search(
                 $sample,
                 \array_slice($samples, 0, $sampleCounter),
-                false
+                true
             );
 
             static::assertFalse(


### PR DESCRIPTION
PHPStan to upgrade before this change as latest `phpstan/phpstan-strict-rules` (`0.12.10`) requires `phpstan/phpstan` at least `0.12.96`.