### PR TITLE
DX: update PHPStan

### DIFF
--- a/dev-tools/composer.json
+++ b/dev-tools/composer.json
@@ -9,7 +9,7 @@
         "maglnet/composer-require-checker": "2.0.0",
         "mi-schi/phpmd-extension": "^4.3",
         "phpmd/phpmd": "^2.10.2",
-        "phpstan/phpstan": "0.12.92",
+        "phpstan/phpstan": "0.12.96",
         "phpstan/phpstan-phpunit": "0.12.21"
     },
     "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,4 +10,8 @@ parameters:
         - tests
     excludePaths:
         - tests/Fixtures
+    ignoreErrors:
+        - '/^Class [a-zA-Z\\]+ extends @final class PhpCsFixer\\(ConfigurationException\\InvalidConfigurationException|ConfigurationException\\InvalidFixerConfigurationException|Tokenizer\\Tokens)\.$/'
+        - '/^Unsafe call to private method [a-zA-Z\\]+::[a-zA-Z]+\(\) through static::\.$/'
+        - '/^\$this\(PhpCsFixer\\Tokenizer\\Tokens\) does not accept PhpCsFixer\\Tokenizer\\Token\|null\.$/'
     tipsOfTheDay: false

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -798,6 +798,7 @@ final class ProjectCodeTest extends TestCase
         );
 
         $classes = array_filter($classes, static function (string $class): bool {
+            // @phpstan-ignore-next-line due to false positive reported in https://github.com/phpstan/phpstan/issues/5369
             return is_subclass_of($class, TestCase::class);
         });
 


### PR DESCRIPTION
Added `ignoreErrors` are new things PHPStan now recognises and there is no obvious (at least for me) fixes, so let's update PHPStan itself to allow strict rules in: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5900 and later try to fix the errors.