### PR TITLE
Remove references to PHP 7.0 in tests (only removing lines)

### DIFF
--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -27,7 +27,6 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -2966,23 +2966,6 @@ if ($a) { /* */ /* */ /* */ /* */ /* */
 ?><?php ++$a;
 } ?>',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixCommentBeforeBrace70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixCommentBeforeBrace70(string $expected, ?string $input = null, array $configuration = []): void
-    {
-        $this->fixer->configure($configuration);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixCommentBeforeBrace70Cases()
-    {
-        return [
             [
                 '<?php
     $foo = new class ($a) extends Foo implements Bar { // foo

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -109,7 +109,6 @@ echo "Hello'.pack('H*', 'e280af').'World'.pack('H*', 'c2a0').'!";',
 
     /**
      * @dataProvider provideFixWithEscapeSequencesInStringsCases
-     * @requires PHP 7.0
      */
     public function testFixWithEscapeSequencesInStrings(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -142,21 +142,6 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
             [
                 '<?php namespace Parent\Foo;',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFix70Cases
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php class Foo extends Bar { public function baz() : self {} }',
                 '<?php class Foo extends Bar { public function baz() : Self {} }',

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -99,39 +99,6 @@ function Foo(INTEGER $a) {}
                     B\String\C $y
                 ) {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP <7.0
-     *
-     * @dataProvider provideFixPre70Cases
-     */
-    public function testFixPre70(string $expected): void
-    {
-        $this->doTest($expected);
-    }
-
-    public function provideFixPre70Cases()
-    {
-        return [
-            ['<?php function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D, ITERABLE $E, VOID $F, OBJECT $o) {}'],
-            ['<?php class Foo { public function Foo(\INT $a) {}}'],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php final class Foo1 { final public function Foo(bool $A, float $B, int $C, string $D): int {} }',
                 '<?php final class Foo1 { final public function Foo(BOOL $A, FLOAT $B, INT $C, STRING $D): INT {} }',

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -50,8 +50,6 @@ final class ClassDefinitionFixerTest extends AbstractFixerTestCase
      * @param array<string, bool> $config
      *
      * @dataProvider provideAnonymousClassesCases
-     *
-     * @requires PHP 7.0
      */
     public function testFixingAnonymousClasses(string $expected, string $input, array $config = []): void
     {

--- a/tests/Fixer/ClassNotation/FinalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalClassFixerTest.php
@@ -72,24 +72,6 @@ final class FinalClassFixerTest extends AbstractFixerTestCase
                 '<?php /** @internal Map my app to an @Entity */ final class MyMapper {}',
                 '<?php /** @internal Map my app to an @Entity */ class MyMapper {}',
             ],
-        ];
-    }
-
-    /**
-     * @param string      $expected PHP source code
-     * @param null|string $input    PHP source code
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php $anonymClass = new class {};'],
         ];
     }

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -276,7 +276,6 @@ class B{}
      * @param string      $expected PHP source code
      * @param null|string $input    PHP source code
      *
-     * @requires PHP 7.0
      * @dataProvider provideAnonymousClassesCases
      */
     public function testAnonymousClassesCases(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalPublicMethodForAbstractClassFixerTest.php
@@ -100,24 +100,6 @@ final class FinalPublicMethodForAbstractClassFixerTest extends AbstractFixerTest
                     abstract public static function bar();
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @param string      $expected PHP source code
-     * @param null|string $input    PHP source code
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'anonymous-class' => [
                 sprintf(
                     '<?php abstract class MyClass { private function test() { $a = new class { %s }; } }',

--- a/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
@@ -243,21 +243,6 @@ null;#13
             [
                 '<?php function foo() { static $foo = null; }',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             [
                 '<?php new class () { public $bar; };',
                 '<?php new class () { public $bar = null; };',

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -225,21 +225,6 @@ class Bar
     }
 }',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             'anonymous-class-inside' => [
                 '<?php
 final class Foo

--- a/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedInterfacesFixerTest.php
@@ -84,21 +84,6 @@ final class OrderedInterfacesFixerTest extends AbstractFixerTestCase
                 '<?php interface T extends A, B, C {}',
                 '<?php interface T extends C, A, B {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFixAlpha70Cases
-     */
-    public function testFixAlpha70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixAlpha70Cases()
-    {
-        return [
             'nested anonymous classes' => [
                 '<?php
                     class T implements A, B, C

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -87,24 +87,6 @@ final class ProtectedToPrivateFixerTest extends AbstractFixerTestCase
                 '<?php final class MyClass { private $v1; }',
                 '<?php final class MyClass { protected $v1; }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70Fix(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        $attributesAndMethodsOriginal = $this->getAttributesAndMethods(true);
-        $attributesAndMethodsFixed = $this->getAttributesAndMethods(false);
-
-        return [
             'anonymous-class-inside' => [
                 "<?php
 final class Foo

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -142,21 +142,6 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
                     public function baz31(\Test\Foo\Foo2\Bar $bar);
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php class Foo { function bar() {
                     new class() { function baz() { new Foo(); } };

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -163,22 +163,6 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
                 '<?php foo(\E_DEPRECATED | \E_USER_DEPRECATED);',
                 '<?php foo(E_DEPRECATED | E_USER_DEPRECATED);',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70WithDefaultConfigurationCases
-     *
-     * @requires PHP 7.0
-     */
-    public function testFix70WithDefaultConfiguration(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70WithDefaultConfigurationCases(): array
-    {
-        return [
             ['<?php function foo(): M_PI {}'],
             ['<?php use X\Y\{FOO, BAR as BAR2, M_PI};'],
         ];

--- a/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
@@ -233,21 +233,6 @@ if ($some) { return 1; } elseif ($a == 6){ $test = false; } //',
                     echo 2;
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, string $input): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -51,15 +51,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
         $this->fixerTest($expected, $input, $fixStatement);
     }
 
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null, ?string $fixStatement = null): void
-    {
-        $this->fixerTest($expected, $input, $fixStatement);
-    }
-
     public function provideFixCases()
     {
         return [
@@ -429,12 +420,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
                 function foo() { $a = (yield($x)); }
                 ',
             ],
-        ];
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
                 $var = clone ($obj1->getSubject() ?? $obj2);
@@ -445,7 +430,6 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixYieldFromCases
-     * @requires PHP 7.0
      */
     public function testFixYieldFrom(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
@@ -27,7 +27,6 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -354,23 +354,6 @@ foo#
                 ',
                 self::$configurationClosureSpacingNone,
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70(string $expected, ?string $input = null, array $configuration = []): void
-    {
-        $this->fixer->configure($configuration);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php use function Foo\bar; bar ( 1 );'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c};'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c} ?>'],

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -183,21 +183,6 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
                 '<?php function foo(array & ...$param) {}',
                 '<?php function foo(array& ...$param) {}',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             ['<?php use function some\test\{fn_a, fn_b, fn_c};'],
             ['<?php use function some\test\{fn_a, fn_b, fn_c} ?>'],
         ];

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -103,21 +103,6 @@ $f = function() use ($b) { return function($b) { return function($b) { return fu
 $f = function() use ($a) { return function() use ($a) { return function() use ($a) { return function() use ($a) { }; }; }; };
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider providePhp70Cases
-     */
-    public function testFixPhp70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function providePhp70Cases()
-    {
-        return [
             'anonymous class' => [
                 '<?php
 $a = function() use ($b) { new class($b){}; }; // do not fix

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -442,28 +442,6 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
                     private $foo10;
                 }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixPhp70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixPhp70(string $expected, ?string $input = null, array $config = []): void
-    {
-        if (null !== $input && \PHP_VERSION_ID < 70400) {
-            $expected = $input;
-            $input = null;
-        }
-
-        $this->fixer->configure($config);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixPhp70Cases()
-    {
-        return [
             'anonymous class' => [
                 '<?php new class { /** @var int */ private int $foo; };',
                 '<?php new class { /** @var int */ private $foo; };',

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -22,7 +22,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\PhpdocToReturnTypeFixer
- * @requires PHP 7.0
  */
 final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 {

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -21,7 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @requires PHP 7.0
  * @covers \PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer
  */
 final class ReturnTypeDeclarationFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -26,8 +26,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 final class FullyQualifiedStrictTypesFixerTest extends AbstractFixerTestCase
 {
     /**
-     * @requires PHP 7.0
-     *
      * @dataProvider provideCodeWithReturnTypesCases
      */
     public function testCodeWithReturnTypes(string $expected, ?string $input = null): void

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -411,22 +411,6 @@ class Bar {
 \foo();
 INPUT
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFixImportFunctions70Cases
-     * @requires PHP 7.0
-     */
-    public function testFixImportFunctions70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure(['import_functions' => true]);
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixImportFunctions70Cases()
-    {
-        return [
             'name already used' => [
                 <<<'EXPECTED'
 <?php

--- a/tests/Fixer/Import/GroupImportFixerTest.php
+++ b/tests/Fixer/Import/GroupImportFixerTest.php
@@ -44,7 +44,6 @@ use Foo\Test;
 
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
+++ b/tests/Fixer/Import/SingleImportPerStatementFixerTest.php
@@ -206,21 +206,6 @@ C  ; ',
 use X ?><?php new X(); // run before white space around semicolon',
                 '<?php use Z , X ?><?php new X(); // run before white space around semicolon',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function test70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php use FooA#
 ;#
@@ -276,9 +261,6 @@ use A,B;
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testMessyComments(): void
     {
         if (\PHP_VERSION_ID >= 80000) {

--- a/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
+++ b/tests/Fixer/Import/SingleLineAfterImportsFixerTest.php
@@ -360,21 +360,6 @@ use Bar;
 class Baz {}
 '),
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 use some\test\{ClassA, ClassB, ClassC as C};

--- a/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ClassKeywordRemoveFixerTest.php
@@ -236,21 +236,6 @@ final class ClassKeywordRemoveFixerTest extends AbstractFixerTestCase
                 var_dump(Baz::class);
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 "<?php
                 use Foo\\Bar\\{ClassA, ClassB, ClassC as C};

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveIssetsFixerTest.php
@@ -179,9 +179,6 @@ isset
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClass(): void
     {
         $this->doTest(

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -27,7 +27,6 @@ final class ExplicitIndirectVariableFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideTestFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -117,19 +117,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php unset($bar->foo{0});',
             ];
         }
-    }
 
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
         yield 'It does not break complex expressions' => [
             '<?php
                 unset(a()[b()["a"]]);

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -467,24 +467,6 @@ Foo {}',
             [
                 '<?php $foo = stdClass::class;',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithClassPhp70Cases
-     */
-    public function testFixWithClassPhp70(string $expected, ?string $input = null, array $config = []): void
-    {
-        $this->fixer->configure($config);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithClassPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class {};',
                 '<?php $foo = new class  {};',
@@ -914,28 +896,6 @@ Bar6, Baz, Qux {}',
     Qux
 {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithExtendsPhp70Cases
-     */
-    public function testFixWithExtendsPhp70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure([
-            'constructs' => [
-                'extends',
-            ],
-        ]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithExtendsPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class extends \InvalidArgumentException {};',
                 '<?php $foo = new class extends  \InvalidArgumentException {};',
@@ -1469,28 +1429,6 @@ foo; foo: echo "Bar";',
                     Baz
                 {}',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     *
-     * @dataProvider provideFixWithImplementsPhp70Cases
-     */
-    public function testFixWithImplementsPhp70(string $expected, ?string $input = null): void
-    {
-        $this->fixer->configure([
-            'constructs' => [
-                'implements',
-            ],
-        ]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixWithImplementsPhp70Cases()
-    {
-        return [
             [
                 '<?php $foo = new class implements \Countable {};',
                 '<?php $foo = new class implements  \Countable {};',

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -21,7 +21,6 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  *
  * @internal
  *
- * @requires PHP 7.0
  * @covers \PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer
  */
 final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixerTest.php
@@ -153,21 +153,6 @@ final class MyTest extends \PhpUnit\FrameWork\TestCase
 }
 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'anonymous class false positive case' => [
                 '<?php
 final class MyTest extends \PhpUnit\FrameWork\TestCase

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -500,9 +500,6 @@ EOF
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClassFixing(): void
     {
         $this->doTest(

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -299,23 +299,6 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
         return $string;
     }',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null, array $config = []): void
-    {
-        $this->fixer->configure($config ?: ['only_untyped' => false]);
-
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
     /**

--- a/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixerTest.php
@@ -283,21 +283,6 @@ final class PhpdocNoUselessInheritdocFixerTest extends AbstractFixerTestCase
                 }
                 ',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
 

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -166,9 +166,6 @@ class F
         ];
     }
 
-    /**
-     * @requires PHP 7.0
-     */
     public function testAnonymousClassFixing(): void
     {
         $this->doTest(

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -382,21 +382,6 @@ class Foo
 class Foo{}
 /**  */',
             ],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFixVar70Cases
-     */
-    public function testFixVar70(string $expected, ?string $input = null): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFixVar70Cases()
-    {
-        return [
             'anonymousClass' => [
                 <<<'EOF'
 <?php

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -446,21 +446,6 @@ var names are case insensitive */ return $a   ;}
                     }',
                 ],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $expected, string $input): void
-    {
-        $this->doTest($expected, $input);
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             [
                 '<?php
                     function a($foos) {

--- a/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
+++ b/tests/Fixer/Strict/DeclareStrictTypesFixerTest.php
@@ -28,7 +28,6 @@ final class DeclareStrictTypesFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.0
      */
     public function testFix(string $expected, ?string $input = null): void
     {
@@ -142,7 +141,6 @@ $a = 456;
 
     /**
      * @dataProvider provideMessyWhitespacesCases
-     * @requires PHP 7.0
      */
     public function testMessyWhitespaces(string $expected, ?string $input = null): void
     {

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1207,7 +1207,6 @@ function foo() {
 
     /**
      * @dataProvider provideFixWithYieldFromCases
-     * @requires PHP 7.0
      */
     public function testFixWithYieldFrom(string $expected, ?string $input = null): void
     {

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -285,22 +285,7 @@ final class FunctionsAnalyzerTest extends TestCase
                 11,
             ];
         }
-    }
 
-    /**
-     * @dataProvider provideIsGlobalFunctionCallPhp70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsGlobalFunctionCallPhp70(bool $isFunctionIndex, string $code, int $index): void
-    {
-        $tokens = Tokens::fromCode($code);
-        $analyzer = new FunctionsAnalyzer();
-
-        static::assertSame($isFunctionIndex, $analyzer->isGlobalFunctionCall($tokens, $index));
-    }
-
-    public function provideIsGlobalFunctionCallPhp70Cases()
-    {
         yield [
             true,
             '<?php

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -575,25 +575,6 @@ preg_replace_callback(
                 '<?php $foo = function &() {};',
                 [5 => true],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideIsLambda70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsLambda70(string $source, array $expected): void
-    {
-        $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
-
-        foreach ($expected as $index => $expectedValue) {
-            static::assertSame($expectedValue, $tokensAnalyzer->isLambda($index));
-        }
-    }
-
-    public function provideIsLambda70Cases()
-    {
-        return [
             [
                 '<?php
                     $a = function (): array {
@@ -913,21 +894,6 @@ $a(1,2);',
                 '<?php use Foo\Bar, Foo\Baz, Foo\Qux;',
                 [3 => false, 5 => false, 8 => false, 10 => false, 13 => false, 15 => false],
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideIsConstantInvocation70Cases
-     * @requires PHP 7.0
-     */
-    public function testIsConstantInvocation70(string $source, array $expected): void
-    {
-        $this->doIsConstantInvocationTest($source, $expected);
-    }
-
-    public function provideIsConstantInvocation70Cases()
-    {
-        return [
             [
                 '<?php function x(): FOO {}',
                 [3 => false, 8 => false],
@@ -1838,23 +1804,6 @@ class AnnotatedClass
 EOF
                 ,
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideGetImportUseIndexesPHP70Cases
-     * @requires PHP 7.0
-     */
-    public function testGetImportUseIndexesPHP70(array $expected, string $input, bool $perNamespace = false): void
-    {
-        $tokens = Tokens::fromCode($input);
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
-        static::assertSame($expected, $tokensAnalyzer->getImportUseIndexes($perNamespace));
-    }
-
-    public function provideGetImportUseIndexesPHP70Cases()
-    {
-        return [
             [
                 [1, 22, 41],
                 '<?php

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -697,21 +697,6 @@ PHP;
             [4, '<?php list($a) = $b;', Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, 2],
             [6, '<?php if($a){}?>', Tokens::BLOCK_TYPE_CURLY_BRACE, 5],
             [11, '<?php $foo = (new Foo());', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5],
-        ];
-    }
-
-    /**
-     * @requires PHP 7.0
-     * @dataProvider provideFindBlockEnd70Cases
-     */
-    public function testFindBlockEnd70(int $expectedIndex, string $source, int $type, int $searchIndex): void
-    {
-        static::assertFindBlockEnd($expectedIndex, $source, $type, $searchIndex);
-    }
-
-    public function provideFindBlockEnd70Cases()
-    {
-        return [
             [19, '<?php $foo = (new class () implements Foo {});', Tokens::BLOCK_TYPE_BRACE_CLASS_INSTANTIATION, 5],
         ];
     }

--- a/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
@@ -133,19 +133,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
                 }
             ',
         ];
-    }
 
-    /**
-     * @dataProvider provideDoNotChange70Cases
-     * @requires PHP 7.0
-     */
-    public function testDoNotChange70(string $source): void
-    {
-        static::assertNotChange($source);
-    }
-
-    public function provideDoNotChange70Cases()
-    {
         yield 'return type' => ['<?php function foo(): array { return []; }'];
     }
 

--- a/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
@@ -28,7 +28,6 @@ final class TypeColonTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
-     * @requires PHP 7.0
      */
     public function testProcess(string $source, array $expectedTokens = []): void
     {

--- a/tests/Tokenizer/Transformer/UseTransformerTest.php
+++ b/tests/Tokenizer/Transformer/UseTransformerTest.php
@@ -95,31 +95,6 @@ final class UseTransformerTest extends AbstractTransformerTestCase
                     1 => T_USE,
                 ],
             ],
-        ];
-    }
-
-    /**
-     * @param array<int, int> $expectedTokens index => kind
-     *
-     * @dataProvider provideFix70Cases
-     * @requires PHP 7.0
-     */
-    public function testFix70(string $source, array $expectedTokens = []): void
-    {
-        $this->doTest(
-            $source,
-            $expectedTokens,
-            [
-                T_USE,
-                CT::T_USE_LAMBDA,
-                CT::T_USE_TRAIT,
-            ]
-        );
-    }
-
-    public function provideFix70Cases()
-    {
-        return [
             'nested anonymous classes' => [
                 '<?php
 


### PR DESCRIPTION
This is first part of removing PHP 7.0 references from code - with only removing obvious stuff, to make easy review.

This touches 50 files, so more interesting changes will be in separate PR.

Most of the fixes are when having:
```
testFix
provideFixCases
testFix70
provideFix70Cases
```

is removing `testFix70` and merging the providers.