### PR TITLE
DX: Use "yield from" in tests

### DIFF
--- a/UPGRADE-v3.md
+++ b/UPGRADE-v3.md
@@ -157,8 +157,8 @@ Code BC changes
 
 - class `Token` is now `final`
 - class `Tokens` is now `final`
-- method `create` of class `Config` has been removed, use the constructor
-- method `create` of class `RuleSet` has been removed, use the constructor
+- method `create` of class `Config` has been removed, [use the constructor](./doc/config.rst)
+- method `create` of class `RuleSet` has been removed, [use the constructor](./doc/custom_rules.rst)
 
 ### BC breaks; common internal classes
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/filesystem": "^4.4.20 || ^5.0",
         "symfony/finder": "^4.4.20 || ^5.0",
         "symfony/options-resolver": "^4.4.20 || ^5.0",
-        "symfony/polyfill-php72": "^1.22",
+        "symfony/polyfill-php72": "^1.23",
+        "symfony/polyfill-php81": "^1.23",
         "symfony/process": "^4.4.20 || ^5.0",
         "symfony/stopwatch": "^4.4.20 || ^5.0"
     },

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -133,7 +133,7 @@ The ``--config`` option can be used, like in the ``fix`` command, to tell from w
 
     $ php php-cs-fixer.phar list-files --config=.php-cs-fixer.dist.php
 
-The output is build in a form that its easy to use in combination with ``xargs`` command in a linux pipe.
+The output is built in a form that its easy to use in combination with ``xargs`` command in a linux pipe.
 This can be useful e.g. in situations where the caching mechanism might not be available (CI, Docker) and distribute
 fixing across several processes might speedup the process.
 

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -106,7 +106,7 @@ final class HelpCommand extends BaseHelpCommand
             return '[]';
         }
 
-        $isHash = static::isHash($value);
+        $isHash = !array_is_list($value);
         $str = '[';
 
         foreach ($value as $k => $v) {
@@ -121,20 +121,5 @@ final class HelpCommand extends BaseHelpCommand
         }
 
         return substr($str, 0, -2).']';
-    }
-
-    private static function isHash(array $array): bool
-    {
-        $i = 0;
-
-        foreach ($array as $k => $v) {
-            if ($k !== $i) {
-                return true;
-            }
-
-            ++$i;
-        }
-
-        return false;
     }
 }

--- a/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTagTypeFixer.php
@@ -90,21 +90,23 @@ final class PhpdocTagTypeFixer extends AbstractFixer implements ConfigurableFixe
             return;
         }
 
+        $regularExpression = sprintf(
+            '/({?@(?:%s).*?(?:(?=\s\*\/)|(?=\n)}?))/i',
+            implode('|', array_map(
+                function (string $tag) {
+                    return preg_quote($tag, '/');
+                },
+                array_keys($this->configuration['tags'])
+            ))
+        );
+
         foreach ($tokens as $index => $token) {
             if (!$token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
             $parts = Preg::split(
-                sprintf(
-                    '/({?@(?:%s)(?:}|\h.*?(?:}|(?=\R)|(?=\h+\*\/)))?)/i',
-                    implode('|', array_map(
-                        function (string $tag) {
-                            return preg_quote($tag, '/');
-                        },
-                        array_keys($this->configuration['tags'])
-                    ))
-                ),
+                $regularExpression,
                 $token->getContent(),
                 -1,
                 PREG_SPLIT_DELIM_CAPTURE

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -36,7 +36,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php 1**2;',
                 '<?php pow(1,2);',
@@ -225,10 +225,6 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
                 '<?php pow($b, ...$a);',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -175,7 +175,7 @@ OVERRIDDEN;
 
     public function provideFix70Cases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php $foo = ((string) $x)[0];',
                 '<?php $foo = strval($x)[0];',
@@ -185,10 +185,6 @@ OVERRIDDEN;
                 '<?php $foo = strval($x + $y)[0];',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -491,7 +491,7 @@ TestInterface3, /**/     TestInterface4   ,
 
     public function provideClassyImplementsInfoCases()
     {
-        $tests = [
+        yield from [
             '1' => [
                 '<?php
 class X11 implements    Z   , T,R
@@ -524,10 +524,6 @@ class X10 implements    Z   , T,R    //
                 ['start' => 5, 'numberOfImplements' => 3, 'multiLine' => false],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             $multiLine = true;

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -35,7 +35,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'simple sample, last token candidate' => [
                 '<?php  echo 1;',
                 '<?php { echo 1;}',
@@ -112,10 +112,6 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'no fixes, offset access syntax with curly braces' => [

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -285,11 +285,7 @@ else?><?php echo 5;',
             }
         ';
 
-        $tests = $this->generateCases($expected, $input);
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
+        yield from $this->generateCases($expected, $input);
 
         yield [
             '<?php
@@ -453,7 +449,7 @@ else?><?php echo 5;',
 
     public function provideNegativeCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                     if ($a0) {
@@ -611,10 +607,6 @@ else?><?php echo 5;',
                     };',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             $cases = [

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -35,7 +35,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                 switch (1) {
@@ -209,10 +209,6 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -35,7 +35,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
     switch (1) {
@@ -330,10 +330,6 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
                 }',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchContinueToBreakFixerTest.php
@@ -33,7 +33,7 @@ final class SwitchContinueToBreakFixerTest extends AbstractFixerTestCase
 
     public function provideTestFixCases()
     {
-        $tests = [
+        yield from [
             'alternative syntax |' => [
                 '<?php
                     switch($foo):
@@ -399,10 +399,6 @@ case $b:
 }}}}}}}}}}',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 70000) {
             yield 'simple case' => [

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -53,7 +53,7 @@ final class YodaStyleFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php $a = 1 + ($b + $c) === true ? 1 : 2;',
                 null,
@@ -637,10 +637,6 @@ $a#4
                 '<?php $a = $b = $c === null;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         $template = '<?php $a = ($b + $c) %s 1 === true ? 1 : 2;';
         $operators = ['||', '&&'];

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -126,7 +126,7 @@ $a = function() use ($b) { new class(){ public function foo($b){echo $b;}}; }; /
 
     public function provideDoNotFixCases()
     {
-        $tests = [
+        yield from [
             'reference' => [
                 '<?php $fn = function() use(&$b) {} ?>',
             ],
@@ -180,10 +180,6 @@ $foo();
 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 70100) {
             yield 'super global, invalid from PHP7.1' => [

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -473,7 +473,7 @@ namespace {
 
     public function provideFixWithConfiguredIncludeCases()
     {
-        $tests = [
+        yield from [
             'include set + 1, exclude 1' => [
                 '<?php
                     echo \count([1]);
@@ -564,10 +564,6 @@ namespace {
                 ],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'include @compiler_optimized with strict enabled' => [

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -35,7 +35,7 @@ final class NoSpacesAfterFunctionNameFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'test function call' => [
                 '<?php abc($a);',
                 '<?php abc ($a);',
@@ -144,10 +144,6 @@ $$e(2);
  ($a);',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'test dynamic by array, curly mix' => [

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -48,7 +48,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'no phpdoc return' => [
                 '<?php function my_foo() {}',
             ],
@@ -330,10 +330,6 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @return string[]|int[] */ function my_foo() {}',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'report static as self' => [

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -35,7 +35,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php //1
                     unset($foo/*;*/, /*;*/$bar, $c , $foobar  ,  $foobar2);
@@ -130,10 +130,6 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -39,7 +39,7 @@ final class ErrorSuppressionFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php trigger_error("This is not a deprecation warning."); ?>',
             ],
@@ -115,10 +115,6 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
                 [ErrorSuppressionFixer::OPTION_MUTE_DEPRECATION_ERROR => true, ErrorSuppressionFixer::OPTION_NOISE_REMAINING_USAGES => true, ErrorSuppressionFixer::OPTION_NOISE_REMAINING_USAGES_EXCLUDE => ['trigger_error']],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -35,7 +35,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar);',
@@ -108,10 +108,6 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
             ],
         ];
 
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
-
         if (\PHP_VERSION_ID < 80000) {
             yield 'It does not replace unsets on arrays with special notation' => [
                 '<?php unset($bar->foo{0});',
@@ -145,7 +141,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     public function provideFix73Cases()
     {
-        $tests = [
+        yield from [
             'It replaces an unset on a property with  = null' => [
                 '<?php $foo->bar = null;',
                 '<?php unset($foo->bar,);',
@@ -225,10 +221,6 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
                 '<?php unset($foo->bar , );',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield 'It does not replace unsets on arrays with special notation' => [

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -44,7 +44,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php class A { public function B(){ $static = new static(new \SplFileInfo(__FILE__)); }}',
             ],
@@ -254,10 +254,6 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -36,7 +36,7 @@ final class StandardizeIncrementFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php ++$i;',
                 '<?php $i += 1;',
@@ -553,10 +553,6 @@ $i#3
                 }',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -35,7 +35,7 @@ final class TernaryToNullCoalescingFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             // Do not fix cases.
             ['<?php $x = isset($a) ? $a[1] : null;'],
             ['<?php $x = isset($a) and $a ? $a : "";'],
@@ -175,10 +175,6 @@ null
 ;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php $x = $a ? $a : isset($b) ? $b : isset($c) ? $c : "";'];

--- a/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTagTypeFixerTest.php
@@ -350,6 +350,40 @@ final class PhpdocTagTypeFixerTest extends AbstractFixerTestCase
  * @return array{0: float, 1: int}
  */',
             ],
+            [
+                '<?php
+/** @internal Please use {@see Foo} instead */',
+                '<?php
+/** {@internal Please use {@see Foo} instead} */',
+            ],
+            [
+                '<?php
+/**
+ * @internal Please use {@see Foo} instead
+ */',
+                '<?php
+/**
+ * {@internal Please use {@see Foo} instead}
+ */',
+            ],
+            [
+                '<?php
+/**
+ *
+ * @internal Please use {@see Foo} instead
+ *
+ */',
+                '<?php
+/**
+ *
+ * {@internal Please use {@see Foo} instead}
+ *
+ */',
+            ],
+            [
+                '<?php
+/** @internal Foo Bar {@see JsonSerializable} */',
+            ],
         ];
     }
 

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -36,7 +36,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
 
     public function provideNoEmptyStatementsCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
                 abstract class TestClass0 extends Test IMPLEMENTS TestInterface, TestInterface2
@@ -388,10 +388,6 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
                 ',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         foreach (['break', 'continue'] as $ops) {
             yield [

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -35,7 +35,7 @@ final class SemicolonAfterInstructionFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             'comment' => [
                 '<?php $a++;//a ?>',
                 '<?php $a++//a ?>',
@@ -82,10 +82,6 @@ A is equal to 5
 <?php } ?>',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -756,7 +756,7 @@ class Foo
 
     public function provideOneAndInLineCases()
     {
-        $tests = [
+        yield from [
             [
                 "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
             ],
@@ -771,10 +771,6 @@ class Foo
                 "<?php\n\n\$a->{'Test'};\nfunction test(){}\n",
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesAroundOffsetFixerTest.php
@@ -116,7 +116,7 @@ EOF;
 
     public function provideOutsideCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
 $a = $b[0]    ;',
@@ -178,10 +178,6 @@ $baz [0]
      [2] = 3;',
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield [

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -35,7 +35,7 @@ final class NoTrailingWhitespaceFixerTest extends AbstractFixerTestCase
 
     public function provideFixCases()
     {
-        $tests = [
+        yield from [
             [
                 '<?php
 $a = 1;',
@@ -134,10 +134,6 @@ EOT;
                 "<?php      \n   \n    ",
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             yield [

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -403,7 +403,7 @@ class Foo {}
 
     public function provideFunctionsWithArgumentsCases()
     {
-        $tests = [
+        yield from [
             ['<?php function(){};', 1, []],
             ['<?php function($a){};', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -485,10 +485,6 @@ class Foo {}
             ]],
         ];
 
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
-
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php function(\Foo/** TODO: change to something else */\Bar $a){};', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -535,7 +531,7 @@ class Foo {}
 
     public function provideFunctionsWithArgumentsPhp74Cases()
     {
-        $tests = [
+        yield from [
             ['<?php fn() => null;', 1, []],
             ['<?php fn($a) => null;', 1, [
                 '$a' => new ArgumentAnalysis(
@@ -616,10 +612,6 @@ class Foo {}
                 ),
             ]],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID < 80000) {
             yield ['<?php fn(\Foo/** TODO: change to something else */\Bar $a) => null;', 1, [

--- a/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/GotoLabelAnalyzerTest.php
@@ -45,7 +45,7 @@ final class GotoLabelAnalyzerTest extends TestCase
 
     public function provideIsClassyInvocationCases()
     {
-        $tests = [
+        yield from [
             'no candidates' => [
                 '<?php
                     $a = \InvalidArgumentException::class;
@@ -84,10 +84,6 @@ final class GotoLabelAnalyzerTest extends TestCase
                 [10],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\PHP_VERSION_ID >= 80000) {
             yield [

--- a/tests/Tokenizer/TokenTest.php
+++ b/tests/Tokenizer/TokenTest.php
@@ -119,16 +119,12 @@ final class TokenTest extends TestCase
 
     public function provideIsCommentCases()
     {
-        $tests = [
+        yield from [
             [$this->getBraceToken(), false],
             [$this->getForeachToken(), false],
             [new Token([T_COMMENT, '/* comment */', 1]), true],
             [new Token([T_DOC_COMMENT, '/** docs */', 1]), true],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         // @TODO: drop condition when PHP 8.0+ is required
         if (\defined('T_ATTRIBUTE')) {
@@ -146,17 +142,13 @@ final class TokenTest extends TestCase
 
     public function provideIsObjectOperatorCases()
     {
-        $tests = [
+        yield from [
             [$this->getBraceToken(), false],
             [$this->getForeachToken(), false],
             [new Token([T_COMMENT, '/* comment */']), false],
             [new Token([T_DOUBLE_COLON, '::']), false],
             [new Token([T_OBJECT_OPERATOR, '->']), true],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
 
         if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
             yield [new Token([T_NULLSAFE_OBJECT_OPERATOR, '?->']), true];

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -301,7 +301,7 @@ final class TokensTest extends TestCase
     {
         $emptyToken = new Token('');
 
-        $tests = [
+        return [
             ['Invalid sequence.', []],
             [
                 'Non-meaningful token at position: "0".',
@@ -316,10 +316,6 @@ final class TokensTest extends TestCase
                 ['{', '!', $emptyToken, '}'],
             ],
         ];
-
-        foreach ($tests as $index => $test) {
-            yield $index => $test;
-        }
     }
 
     public function testClearRange(): void


### PR DESCRIPTION
The scenario is almost always the same, huge array `$tests` and the `foreach` with `yield` and some `if` after:
```php
        $tests = [/** ... */];

        foreach ($tests as $index => $test) {
            yield $index => $test;
        }

        if (\PHP_VERSION_ID < 80000) {
```