### PR TITLE
Deprecate ClassKeywordRemoveFixer

### DIFF
--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -277,7 +277,7 @@ Import
 Language Construct
 ------------------
 
-- `class_keyword_remove <./language_construct/class_keyword_remove.rst>`_
+- `class_keyword_remove <./language_construct/class_keyword_remove.rst>`_ *(deprecated)*
     Converts ``::class`` keywords to FQCN strings.
 - `combine_consecutive_issets <./language_construct/combine_consecutive_issets.rst>`_
     Using ``isset($var) &&`` multiple times should be done in one call.

--- a/doc/rules/language_construct/class_keyword_remove.rst
+++ b/doc/rules/language_construct/class_keyword_remove.rst
@@ -2,6 +2,8 @@
 Rule ``class_keyword_remove``
 =============================
 
+.. warning:: This rule is deprecated and will be removed on next major version.
+
 Converts ``::class`` keywords to FQCN strings.
 
 Examples

--- a/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
+++ b/src/Fixer/LanguageConstruct/ClassKeywordRemoveFixer.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\LanguageConstruct;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\DeprecatedFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -25,9 +26,11 @@ use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
 /**
+ * @deprecated
+ *
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-final class ClassKeywordRemoveFixer extends AbstractFixer
+final class ClassKeywordRemoveFixer extends AbstractFixer implements DeprecatedFixerInterface
 {
     /**
      * @var string[]
@@ -52,6 +55,14 @@ $className = Baz::class;
                 ),
             ]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSuccessorsNames(): array
+    {
+        return [];
     }
 
     /**


### PR DESCRIPTION
As requested in https://gitter.im/PHP-CS-Fixer/Lobby?at=612a3c675b92082de16f62b3

Even when the fixer was [introduced](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/1985) it was considered "harmful and encouraging bad habits".