### PR TITLE
Remove PHP version specific code sample constraint when not needed

### DIFF
--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -64,21 +64,10 @@ Example #1
     {
     }
 
-Example #2
-~~~~~~~~~~
-
-*Default* configuration.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-
    -$foo = new  class  extends  Bar  implements  Baz,  BarBaz {};
    +$foo = new class extends Bar implements Baz, BarBaz {};
 
-Example #3
+Example #2
 ~~~~~~~~~~
 
 With configuration: ``['single_line' => true]``.
@@ -95,7 +84,7 @@ With configuration: ``['single_line' => true]``.
    +class Foo extends Bar implements Baz, BarBaz
     {}
 
-Example #4
+Example #3
 ~~~~~~~~~~
 
 With configuration: ``['single_item_single_line' => true]``.
@@ -112,7 +101,7 @@ With configuration: ``['single_item_single_line' => true]``.
    +class Foo extends Bar implements Baz
     {}
 
-Example #5
+Example #4
 ~~~~~~~~~~
 
 With configuration: ``['multi_line_extends_each_single_line' => true]``.

--- a/doc/rules/function_notation/phpdoc_to_param_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_param_type.rst
@@ -40,28 +40,15 @@ Example #1
    +++ New
     <?php
 
-    /** @param string $bar */
-   -function my_foo($bar)
-   +function my_foo(string $bar)
+    /**
+     * @param string $foo
+     * @param string|null $bar
+     */
+   -function f($foo, $bar)
+   +function f(string $foo, ?string $bar)
     {}
 
 Example #2
-~~~~~~~~~~
-
-*Default* configuration.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-
-    /** @param string|null $bar */
-   -function my_foo($bar)
-   +function my_foo(?string $bar)
-    {}
-
-Example #3
 ~~~~~~~~~~
 
 With configuration: ``['scalar_types' => false]``.

--- a/doc/rules/function_notation/phpdoc_to_return_type.rst
+++ b/doc/rules/function_notation/phpdoc_to_return_type.rst
@@ -41,27 +41,16 @@ Example #1
     <?php
 
     /** @return \My\Bar */
-   -function my_foo()
-   +function my_foo(): \My\Bar
+   -function f1()
+   +function f1(): \My\Bar
+    {}
+
+    /** @return void */
+   -function f2()
+   +function f2(): void
     {}
 
 Example #2
-~~~~~~~~~~
-
-*Default* configuration.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-
-    /** @return void */
-   -function my_foo()
-   +function my_foo(): void
-    {}
-
-Example #3
 ~~~~~~~~~~
 
 *Default* configuration.
@@ -77,7 +66,7 @@ Example #3
    +function my_foo(): object
     {}
 
-Example #4
+Example #3
 ~~~~~~~~~~
 
 With configuration: ``['scalar_types' => false]``.
@@ -94,7 +83,7 @@ With configuration: ``['scalar_types' => false]``.
     /** @return string */
     function bar() {}
 
-Example #5
+Example #4
 ~~~~~~~~~~
 
 *Default* configuration.

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -39,8 +39,11 @@ Example #1
    --- Original
    +++ New
     <?php
-   -use Z; use A;
-   +use A; use Z;
+   +use AAA;
+   +use const AAB;
+    use function AAC;
+   -use const AAB;
+   -use AAA;
 
 Example #2
 ~~~~~~~~~~
@@ -63,22 +66,6 @@ With configuration: ``['sort_algorithm' => 'length']``.
 Example #3
 ~~~~~~~~~~
 
-*Default* configuration.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-   +use AAA;
-   +use const AAB;
-    use function AAC;
-   -use const AAB;
-   -use AAA;
-
-Example #4
-~~~~~~~~~~
-
 With configuration: ``['sort_algorithm' => 'length', 'imports_order' => ['const', 'class', 'function']]``.
 
 .. code-block:: diff
@@ -99,7 +86,7 @@ With configuration: ``['sort_algorithm' => 'length', 'imports_order' => ['const'
     use function CCC\AA;
    -use function DDD;
 
-Example #5
+Example #4
 ~~~~~~~~~~
 
 With configuration: ``['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']]``.
@@ -122,7 +109,7 @@ With configuration: ``['sort_algorithm' => 'alpha', 'imports_order' => ['const',
     use function DDD;
    -use function CCC\AA;
 
-Example #6
+Example #5
 ~~~~~~~~~~
 
 With configuration: ``['sort_algorithm' => 'none', 'imports_order' => ['const', 'class', 'function']]``.

--- a/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
+++ b/doc/rules/phpdoc/no_superfluous_phpdoc_tags.rst
@@ -54,8 +54,10 @@ Example #1
         /**
    -     * @param Bar $bar
    -     * @param mixed $baz
+         *
+   -     * @return Baz
          */
-        public function doFoo(Bar $bar, $baz) {}
+        public function doFoo(Bar $bar, $baz): Baz {}
     }
 
 Example #2
@@ -79,26 +81,6 @@ With configuration: ``['allow_mixed' => true]``.
 Example #3
 ~~~~~~~~~~
 
-*Default* configuration.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-    class Foo {
-        /**
-   -     * @param Bar $bar
-   -     * @param mixed $baz
-         *
-   -     * @return Baz
-         */
-        public function doFoo(Bar $bar, $baz): Baz {}
-    }
-
-Example #4
-~~~~~~~~~~
-
 With configuration: ``['remove_inheritdoc' => true]``.
 
 .. code-block:: diff
@@ -114,7 +96,7 @@ With configuration: ``['remove_inheritdoc' => true]``.
         public function doFoo(Bar $bar, $baz) {}
     }
 
-Example #5
+Example #4
 ~~~~~~~~~~
 
 With configuration: ``['allow_unused_params' => true]``.

--- a/src/Fixer/Alias/ArrayPushFixer.php
+++ b/src/Fixer/Alias/ArrayPushFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Alias;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
@@ -36,7 +35,7 @@ final class ArrayPushFixer extends AbstractFixer
     {
         return new FixerDefinition(
             'Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`.',
-            [new VersionSpecificCodeSample("<?php\narray_push(\$x, \$y);\n", new VersionSpecification(70000))],
+            [new CodeSample("<?php\narray_push(\$x, \$y);\n")],
             null,
             'Risky when the function `array_push` is overridden.'
         );

--- a/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
+++ b/src/Fixer/ArrayNotation/ArraySyntaxFixer.php
@@ -22,8 +22,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -65,9 +63,8 @@ final class ArraySyntaxFixer extends AbstractFixer implements ConfigurableFixerI
         return new FixerDefinition(
             'PHP arrays should be declared using the configured syntax.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\narray(1,2);\n",
-                    new VersionSpecification(50400)
+                new CodeSample(
+                    "<?php\narray(1,2);\n"
                 ),
                 new CodeSample(
                     "<?php\n[1,2];\n",

--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -23,8 +23,6 @@ use PhpCsFixer\FixerConfiguration\InvalidOptionsForEnvException;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -73,9 +71,8 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
                 new CodeSample(
                     '<?php echo "'.pack('H*', 'e2808b').'Hello'.pack('H*', 'e28087').'World'.pack('H*', 'c2a0')."!\";\n"
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php echo "'.pack('H*', 'e2808b').'Hello'.pack('H*', 'e28087').'World'.pack('H*', 'c2a0')."!\";\n",
-                    new VersionSpecification(70000),
                     ['use_escape_sequences_in_strings' => false]
                 ),
             ],

--- a/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
+++ b/src/Fixer/Casing/LowercaseStaticReferenceFixer.php
@@ -18,8 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -55,7 +53,7 @@ class Foo extends Bar
     }
 }
 '),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 class Foo extends Bar
 {
@@ -64,8 +62,7 @@ class Foo extends Bar
         return false;
     }
 }
-',
-                    new VersionSpecification(70100)
+'
                 ),
             ]
         );

--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -108,13 +108,11 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
             'Native type hints for functions should use the correct case.',
             [
                 new CodeSample("<?php\nclass Bar {\n    public function Foo(CALLABLE \$bar)\n    {\n        return 1;\n    }\n}\n"),
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction Foo(INT \$a): Bool\n{\n    return true;\n}\n",
-                    new VersionSpecification(70000)
+                new CodeSample(
+                    "<?php\nfunction Foo(INT \$a): Bool\n{\n    return true;\n}\n"
                 ),
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction Foo(Iterable \$a): VOID\n{\n    echo 'Hello world';\n}\n",
-                    new VersionSpecification(70100)
+                new CodeSample(
+                    "<?php\nfunction Foo(Iterable \$a): VOID\n{\n    echo 'Hello world';\n}\n"
                 ),
                 new VersionSpecificCodeSample(
                     "<?php\nfunction Foo(Object \$a)\n{\n    return 'hi!';\n}\n",

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -23,8 +23,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -58,14 +56,9 @@ final  class  Foo  extends  Bar  implements  Baz,  BarBaz
 trait  Foo
 {
 }
-'
-                ),
-                new VersionSpecificCodeSample(
-                    '<?php
 
 $foo = new  class  extends  Bar  implements  Baz,  BarBaz {};
-',
-                    new VersionSpecification(70100)
+'
                 ),
                 new CodeSample(
                     '<?php

--- a/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
@@ -18,8 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
@@ -79,7 +77,7 @@ final class Foo
 }
 '
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 $a = new class() {
     public function getBar()
@@ -87,8 +85,7 @@ $a = new class() {
         return static::class;
     }
 };
-',
-                    new VersionSpecification(70000)
+'
                 ),
             ]
         );

--- a/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
+++ b/src/Fixer/ClassNotation/VisibilityRequiredFixer.php
@@ -23,8 +23,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -59,14 +57,13 @@ class Sample
 }
 '
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 class Sample
 {
     const SAMPLE = 1;
 }
 ',
-                    new VersionSpecification(70100),
                     ['elements' => ['const']]
                 ),
             ]

--- a/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
+++ b/src/Fixer/FunctionNotation/CombineNestedDirnameFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -36,9 +35,8 @@ final class CombineNestedDirnameFixer extends AbstractFixer
         return new FixerDefinition(
             'Replace multiple nested calls of `dirname` by only one call with second `$level` parameter. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\ndirname(dirname(dirname(\$path)));\n",
-                    new VersionSpecification(70000)
+                new CodeSample(
+                    "<?php\ndirname(dirname(dirname(\$path)));\n"
                 ),
             ],
             null,

--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -19,10 +19,9 @@ use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\ArgumentAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
@@ -42,13 +41,11 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
         return new FixerDefinition(
             'Adds or removes `?` before type declarations for parameters with a default `null` value.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction sample(string \$str = null)\n{}\n",
-                    new VersionSpecification(70100)
+                new CodeSample(
+                    "<?php\nfunction sample(string \$str = null)\n{}\n"
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     "<?php\nfunction sample(?string \$str = null)\n{}\n",
-                    new VersionSpecification(70100),
                     ['use_nullable_type_declaration' => false]
                 ),
             ],

--- a/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToParamTypeFixer.php
@@ -16,10 +16,9 @@ namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
 use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -56,25 +55,18 @@ final class PhpdocToParamTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
         return new FixerDefinition(
             'EXPERIMENTAL: Takes `@param` annotations of non-mixed types and adjusts accordingly the function signature. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
-/** @param string $bar */
-function my_foo($bar)
+/**
+ * @param string $foo
+ * @param string|null $bar
+ */
+function f($foo, $bar)
 {}
-',
-                    new VersionSpecification(70000)
+'
                 ),
-                new VersionSpecificCodeSample(
-                    '<?php
-
-/** @param string|null $bar */
-function my_foo($bar)
-{}
-',
-                    new VersionSpecification(70100)
-                ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
 /** @param Foo $foo */
@@ -82,7 +74,6 @@ function foo($foo) {}
 /** @param string $foo */
 function bar($foo) {}
 ',
-                    new VersionSpecification(70100),
                     ['scalar_types' => false]
                 ),
             ],
@@ -143,7 +134,7 @@ function bar($foo) {}
                     continue;
                 }
 
-                list($paramType, $isNullable) = $typeInfo;
+                [$paramType, $isNullable] = $typeInfo;
 
                 $startIndex = $tokens->getNextTokenOfKind($index, ['(']);
                 $variableIndex = $this->findCorrectVariable($tokens, $startIndex, $paramTypeAnnotation);

--- a/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
+++ b/src/Fixer/FunctionNotation/PhpdocToReturnTypeFixer.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\FunctionNotation;
 
 use PhpCsFixer\AbstractPhpdocToTypeDeclarationFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
@@ -54,23 +55,17 @@ final class PhpdocToReturnTypeFixer extends AbstractPhpdocToTypeDeclarationFixer
         return new FixerDefinition(
             'EXPERIMENTAL: Takes `@return` annotation of non-mixed types and adjusts accordingly the function signature. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
 /** @return \My\Bar */
-function my_foo()
+function f1()
 {}
-',
-                    new VersionSpecification(70000)
-                ),
-                new VersionSpecificCodeSample(
-                    '<?php
 
 /** @return void */
-function my_foo()
+function f2()
 {}
-',
-                    new VersionSpecification(70100)
+'
                 ),
                 new VersionSpecificCodeSample(
                     '<?php
@@ -81,7 +76,7 @@ function my_foo()
 ',
                     new VersionSpecification(70200)
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
 /** @return Foo */
@@ -89,7 +84,6 @@ function foo() {}
 /** @return string */
 function bar() {}
 ',
-                    new VersionSpecification(70100),
                     ['scalar_types' => false]
                 ),
                 new VersionSpecificCodeSample(
@@ -178,7 +172,7 @@ final class Foo {
                 continue;
             }
 
-            list($returnType, $isNullable) = $typeInfo;
+            [$returnType, $isNullable] = $typeInfo;
 
             $startIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
 

--- a/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
+++ b/src/Fixer/FunctionNotation/RegularCallableCallFixer.php
@@ -18,8 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\ArgumentsAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Token;
@@ -47,13 +45,12 @@ final class RegularCallableCallFixer extends AbstractFixer
     call_user_func_array($callback, [1, 2]);
 '
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 call_user_func(function ($a, $b) { var_dump($a, $b); }, 1, 2);
 
 call_user_func(static function ($a, $b) { var_dump($a, $b); }, 1, 2);
-',
-                    new VersionSpecification(70000)
+'
                 ),
             ],
             null,

--- a/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php
@@ -19,10 +19,9 @@ use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -37,23 +36,18 @@ final class ReturnTypeDeclarationFixer extends AbstractFixer implements Configur
      */
     public function getDefinition(): FixerDefinitionInterface
     {
-        $versionSpecification = new VersionSpecification(70000);
-
         return new FixerDefinition(
             'There should be one or no space before colon, and one space after it in return type declarations, according to configuration.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction foo(int \$a):string {};\n",
-                    $versionSpecification
+                new CodeSample(
+                    "<?php\nfunction foo(int \$a):string {};\n"
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     "<?php\nfunction foo(int \$a):string {};\n",
-                    $versionSpecification,
                     ['space_before' => 'none']
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     "<?php\nfunction foo(int \$a):string {};\n",
-                    $versionSpecification,
                     ['space_before' => 'one']
                 ),
             ],

--- a/src/Fixer/FunctionNotation/VoidReturnFixer.php
+++ b/src/Fixer/FunctionNotation/VoidReturnFixer.php
@@ -17,10 +17,9 @@ namespace PhpCsFixer\Fixer\FunctionNotation;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -39,9 +38,8 @@ final class VoidReturnFixer extends AbstractFixer
         return new FixerDefinition(
             'Add `void` return type to functions with missing or empty return statements, but priority is given to `@return` annotations. Requires PHP >= 7.1.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction foo(\$a) {};\n",
-                    new VersionSpecification(70100)
+                new CodeSample(
+                    "<?php\nfunction foo(\$a) {};\n"
                 ),
             ],
             null,

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -18,8 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
 use PhpCsFixer\Tokenizer\Analyzer\NamespacesAnalyzer;
@@ -55,7 +53,7 @@ class SomeClass
 }
 '
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
 use Foo\Bar;
@@ -67,8 +65,7 @@ class SomeClass
     {
     }
 }
-',
-                    new VersionSpecification(70000)
+'
                 ),
             ]
         );

--- a/src/Fixer/Import/GroupImportFixer.php
+++ b/src/Fixer/Import/GroupImportFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Import;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
 use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
@@ -38,9 +37,8 @@ final class GroupImportFixer extends AbstractFixer
         return new FixerDefinition(
             'There MUST be group use for the same namespaces.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nuse Foo\\Bar;\nuse Foo\\Baz;\n",
-                    new VersionSpecification(70000)
+                new CodeSample(
+                    "<?php\nuse Foo\\Bar;\nuse Foo\\Baz;\n"
                 ),
             ]
         );

--- a/src/Fixer/Import/OrderedImportsFixer.php
+++ b/src/Fixer/Import/OrderedImportsFixer.php
@@ -23,8 +23,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
@@ -93,7 +91,9 @@ final class OrderedImportsFixer extends AbstractFixer implements ConfigurableFix
         return new FixerDefinition(
             'Ordering `use` statements.',
             [
-                new CodeSample("<?php\nuse Z; use A;\n"),
+                new CodeSample(
+                    "<?php\nuse function AAC;\nuse const AAB;\nuse AAA;\n"
+                ),
                 new CodeSample(
                     '<?php
 use Acme\Bar;
@@ -103,11 +103,7 @@ use Bar;
 ',
                     ['sort_algorithm' => self::SORT_LENGTH]
                 ),
-                new VersionSpecificCodeSample(
-                    "<?php\nuse function AAC;\nuse const AAB;\nuse AAA;\n",
-                    new VersionSpecification(70000)
-                ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 use const AAAA;
 use const BBB;
@@ -119,7 +115,6 @@ use Acme;
 use function CCC\AA;
 use function DDD;
 ',
-                    new VersionSpecification(70000),
                     [
                         'sort_algorithm' => self::SORT_LENGTH,
                         'imports_order' => [
@@ -129,7 +124,7 @@ use function DDD;
                         ],
                     ]
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 use const BBB;
 use const AAAA;
@@ -141,7 +136,6 @@ use Bar;
 use function DDD;
 use function CCC\AA;
 ',
-                    new VersionSpecification(70000),
                     [
                         'sort_algorithm' => self::SORT_ALPHA,
                         'imports_order' => [
@@ -151,7 +145,7 @@ use function CCC\AA;
                         ],
                     ]
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 use const BBB;
 use const AAAA;
@@ -163,7 +157,6 @@ use Acme;
 use AAC;
 use Bar;
 ',
-                    new VersionSpecification(70000),
                     [
                         'sort_algorithm' => self::SORT_NONE,
                         'imports_order' => [

--- a/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
+++ b/src/Fixer/LanguageConstruct/ExplicitIndirectVariableFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\LanguageConstruct;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -36,7 +35,7 @@ final class ExplicitIndirectVariableFixer extends AbstractFixer
         return new FixerDefinition(
             'Add curly braces to indirect variables to make them clear to understand. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     <<<'EOT'
 <?php
 echo $$foo;
@@ -45,8 +44,6 @@ echo $foo->$bar['baz'];
 echo $foo->$callback($baz);
 
 EOT
-,
-                    new VersionSpecification(70000)
                 ),
             ]
         );

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -23,8 +23,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
@@ -159,12 +157,11 @@ echo  "Hello!";
                         ],
                     ]
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     '<?php
 
 yield  from  baz();
 ',
-                    new VersionSpecification(70000),
                     [
                         'constructs' => [
                             'yield_from',

--- a/src/Fixer/ListNotation/ListSyntaxFixer.php
+++ b/src/Fixer/ListNotation/ListSyntaxFixer.php
@@ -20,10 +20,9 @@ use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -60,13 +59,11 @@ final class ListSyntaxFixer extends AbstractFixer implements ConfigurableFixerIn
         return new FixerDefinition(
             'List (`array` destructuring) assignment should be declared using the configured syntax. Requires PHP >= 7.1.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nlist(\$sample) = \$array;\n",
-                    new VersionSpecification(70100)
+                new CodeSample(
+                    "<?php\nlist(\$sample) = \$array;\n"
                 ),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     "<?php\n[\$sample] = \$array;\n",
-                    new VersionSpecification(70100),
                     ['syntax' => 'long']
                 ),
             ]

--- a/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
+++ b/src/Fixer/Operator/TernaryToNullCoalescingFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Operator;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -35,9 +34,8 @@ final class TernaryToNullCoalescingFixer extends AbstractFixer
         return new FixerDefinition(
             'Use `null` coalescing operator `??` where possible. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\n\$sample = isset(\$a) ? \$a : \$b;\n",
-                    new VersionSpecification(70000)
+                new CodeSample(
+                    "<?php\n\$sample = isset(\$a) ? \$a : \$b;\n"
                 ),
             ]
         );

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -24,8 +24,6 @@ use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use PhpCsFixer\Tokenizer\CT;
@@ -47,8 +45,10 @@ class Foo {
     /**
      * @param Bar $bar
      * @param mixed $baz
+     *
+     * @return Baz
      */
-    public function doFoo(Bar $bar, $baz) {}
+    public function doFoo(Bar $bar, $baz): Baz {}
 }
 '),
                 new CodeSample('<?php
@@ -60,17 +60,6 @@ class Foo {
     public function doFoo(Bar $bar, $baz) {}
 }
 ', ['allow_mixed' => true]),
-                new VersionSpecificCodeSample('<?php
-class Foo {
-    /**
-     * @param Bar $bar
-     * @param mixed $baz
-     *
-     * @return Baz
-     */
-    public function doFoo(Bar $bar, $baz): Baz {}
-}
-', new VersionSpecification(70000)),
                 new CodeSample('<?php
 class Foo {
     /**

--- a/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
+++ b/src/Fixer/ReturnNotation/SimplifiedNullReturnFixer.php
@@ -18,8 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -37,7 +35,7 @@ final class SimplifiedNullReturnFixer extends AbstractFixer
             'A return statement wishing to return `void` should not return `null`.',
             [
                 new CodeSample("<?php return null;\n"),
-                new VersionSpecificCodeSample(
+                new CodeSample(
                     <<<'EOT'
 <?php
 function foo() { return null; }
@@ -46,8 +44,6 @@ function baz(): ?int { return null; }
 function xyz(): void { return null; }
 
 EOT
-                    ,
-                    new VersionSpecification(70100)
                 ),
             ]
         );

--- a/src/Fixer/Strict/DeclareStrictTypesFixer.php
+++ b/src/Fixer/Strict/DeclareStrictTypesFixer.php
@@ -16,10 +16,9 @@ namespace PhpCsFixer\Fixer\Strict;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -37,9 +36,8 @@ final class DeclareStrictTypesFixer extends AbstractFixer implements Whitespaces
         return new FixerDefinition(
             'Force strict types declaration in all files. Requires PHP >= 7.0.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\n",
-                    new VersionSpecification(70000)
+                new CodeSample(
+                    "<?php\n"
                 ),
             ],
             null,

--- a/src/Fixer/Whitespace/CompactNullableTypehintFixer.php
+++ b/src/Fixer/Whitespace/CompactNullableTypehintFixer.php
@@ -15,10 +15,9 @@ declare(strict_types=1);
 namespace PhpCsFixer\Fixer\Whitespace;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\FixerDefinition\VersionSpecification;
-use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -35,9 +34,8 @@ final class CompactNullableTypehintFixer extends AbstractFixer
         return new FixerDefinition(
             'Remove extra spaces in a nullable typehint.',
             [
-                new VersionSpecificCodeSample(
-                    "<?php\nfunction sample(? string \$str): ? string\n{}\n",
-                    new VersionSpecification(70100)
+                new CodeSample(
+                    "<?php\nfunction sample(? string \$str): ? string\n{}\n"
                 ),
             ],
             'Rule is applied only in a PHP 7.1+ environment.'


### PR DESCRIPTION
PHP version constraint is not needed for versions up to 7.1 as it's the lowest version currently supported.