### PR TITLE
TypeAlternationTransformer - fix for promoted properties

### DIFF
--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -64,6 +64,7 @@ final class TypeAlternationTransformer extends AbstractTransformer
             CT::T_TYPE_COLON, // `:` is part of a function return type `foo(): X|Y`
             CT::T_TYPE_ALTERNATION, // `|` is part of a union (chain) `X|Y`
             T_STATIC, T_VAR, T_PUBLIC, T_PROTECTED, T_PRIVATE, // `var X|Y $a;`, `private X|Y $a` or `public static X|Y $a`
+            CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, // promoted properties
         ])) {
             $this->replaceToken($tokens, $index);
 

--- a/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
@@ -25,7 +25,6 @@ final class TypesSpacesFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
-     * @requires PHP 7.1
      */
     public function testFix(string $expected, ?string $input = null, array $configuration = []): void
     {
@@ -127,6 +126,23 @@ TypeB $x) {}',
 |//not a space
 TypeB $x) {}',
             ['space' => 'single'],
+        ];
+
+        yield [
+            '<?php class Foo {
+                public function __construct(
+                    public int|string $a,
+                    protected int|string $b,
+                    private int|string $c
+                ) {}
+            }',
+            '<?php class Foo {
+                public function __construct(
+                    public int    |    string $a,
+                    protected int | string $b,
+                    private int   |   string $c
+                ) {}
+            }',
         ];
     }
 }

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -28,7 +28,6 @@ final class TypeAlternationTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
-     * @requires PHP 7.1
      */
     public function testProcess(string $source, array $expectedTokens = []): void
     {
@@ -295,6 +294,21 @@ class Number
                 22 => CT::T_TYPE_ALTERNATION,
                 37 => CT::T_TYPE_ALTERNATION,
                 52 => CT::T_TYPE_ALTERNATION,
+            ],
+        ];
+
+        yield 'promoted properties' => [
+            '<?php class Foo {
+                public function __construct(
+                    public int|string $a,
+                    protected int|string $b,
+                    private int|string $c
+                ) {}
+            }',
+            [
+                17 => CT::T_TYPE_ALTERNATION,
+                26 => CT::T_TYPE_ALTERNATION,
+                35 => CT::T_TYPE_ALTERNATION,
             ],
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5922

Pinging @keradus (as the author of TypeAlternationTransformer) and @vudaltsov (as the reporter of the bug ☝🏼) for a review.