### PR TITLE
DX: remove not needed requirements from fixtures

### DIFF
--- a/tests/Fixtures/Integration/misc/PHP7_0.test
+++ b/tests/Fixtures/Integration/misc/PHP7_0.test
@@ -7,8 +7,6 @@ PHP 7.0 test.
     "random_api_migration": true,
     "visibility_required": {"elements": ["property", "method"]}
 }
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/misc/PHP7_1.test
+++ b/tests/Fixtures/Integration/misc/PHP7_1.test
@@ -4,8 +4,6 @@ PHP 7.1 test.
 {
     "@Symfony": true
 }
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/misc/combine_nested_dirname,no_trailing_whitespace.test
+++ b/tests/Fixtures/Integration/misc/combine_nested_dirname,no_trailing_whitespace.test
@@ -2,8 +2,6 @@
 Integration of fixers: combine_nested_dirname,no_trailing_whitespace.
 --RULESET--
 {"combine_nested_dirname": true, "no_trailing_whitespace": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 dirname($path

--- a/tests/Fixtures/Integration/misc/combine_nested_dirname,no_whitespace_in_blank_line.test
+++ b/tests/Fixtures/Integration/misc/combine_nested_dirname,no_whitespace_in_blank_line.test
@@ -2,8 +2,6 @@
 Integration of fixers: combine_nested_dirname,no_whitespace_in_blank_line.
 --RULESET--
 {"combine_nested_dirname": true, "no_whitespace_in_blank_line": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 dirname(

--- a/tests/Fixtures/Integration/misc/declare_strict_types,single_blank_line_before_namespace.test
+++ b/tests/Fixtures/Integration/misc/declare_strict_types,single_blank_line_before_namespace.test
@@ -2,8 +2,6 @@
 Integration of fixers: declare_strict_types,single_blank_line_before_namespace.
 --RULESET--
 {"declare_strict_types": true, "single_blank_line_before_namespace" : true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php declare(strict_types=1);
 

--- a/tests/Fixtures/Integration/misc/header_comment,declare_strict_types.test
+++ b/tests/Fixtures/Integration/misc/header_comment,declare_strict_types.test
@@ -8,8 +8,6 @@ Integration of fixers: header_comment, declare_strict_types
     },
     "declare_strict_types": true
 }
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/misc/huge_array.test
+++ b/tests/Fixtures/Integration/misc/huge_array.test
@@ -4,5 +4,3 @@ Test if array_indentation can handle huge arrays.
 {
     "array_indentation": true
 }
---REQUIREMENTS--
-{"php": 70000}

--- a/tests/Fixtures/Integration/misc/single_import_per_statement,ordered_imports.test
+++ b/tests/Fixtures/Integration/misc/single_import_per_statement,ordered_imports.test
@@ -2,8 +2,6 @@
 Integration of fixers: single_import_per_statement,ordered_imports.
 --RULESET--
 {"single_import_per_statement": true, "ordered_imports": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 use some\A;

--- a/tests/Fixtures/Integration/misc/void_return,phpdoc_to_return_type.test
+++ b/tests/Fixtures/Integration/misc/void_return,phpdoc_to_return_type.test
@@ -2,8 +2,6 @@
 Integration of fixers: void_return,phpdoc_to_return_type.
 --RULESET--
 {"void_return": true, "phpdoc_to_return_type": true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 /** @return void */

--- a/tests/Fixtures/Integration/priority/combine_nested_dirname,method_argument_space.test
+++ b/tests/Fixtures/Integration/priority/combine_nested_dirname,method_argument_space.test
@@ -2,8 +2,6 @@
 Integration of fixers: combine_nested_dirname,method_argument_space.
 --RULESET--
 {"combine_nested_dirname": true, "method_argument_space": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 dirname( $path, 2);

--- a/tests/Fixtures/Integration/priority/combine_nested_dirname,no_spaces_inside_parenthesis.test
+++ b/tests/Fixtures/Integration/priority/combine_nested_dirname,no_spaces_inside_parenthesis.test
@@ -2,8 +2,6 @@
 Integration of fixers: combine_nested_dirname,no_spaces_inside_parenthesis.
 --RULESET--
 {"combine_nested_dirname": true, "no_spaces_inside_parenthesis": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 dirname ($path , 2);

--- a/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
+++ b/tests/Fixtures/Integration/priority/declare_strict_types,blank_line_after_opening_tag.test
@@ -2,8 +2,6 @@
 Integration of fixers: declare_strict_types,blank_line_after_opening_tag.
 --RULESET--
 {"declare_strict_types" : true, "blank_line_after_opening_tag": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/declare_strict_types,declare_equal_normalize.test
+++ b/tests/Fixtures/Integration/priority/declare_strict_types,declare_equal_normalize.test
@@ -2,8 +2,6 @@
 Integration of fixers: declare_strict_types,declare_equal_normalize.
 --RULESET--
 {"declare_strict_types": true, "declare_equal_normalize": {"space":"single"}}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php declare(strict_types = 1);
 

--- a/tests/Fixtures/Integration/priority/declare_strict_types,header_comment.test
+++ b/tests/Fixtures/Integration/priority/declare_strict_types,header_comment.test
@@ -8,8 +8,6 @@ Integration of fixers: declare_strict_types,header_comment.
     },
     "declare_strict_types": true
 }
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/priority/dir_constant,combine_nested_dirname.test
+++ b/tests/Fixtures/Integration/priority/dir_constant,combine_nested_dirname.test
@@ -2,8 +2,6 @@
 Integration of fixers: dir_constant,combine_nested_dirname.
 --RULESET--
 {"dir_constant": true, "combine_nested_dirname": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 dirname(__DIR__, 2);

--- a/tests/Fixtures/Integration/priority/list_syntax,binary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/list_syntax,binary_operator_spaces.test
@@ -2,8 +2,6 @@
 Integration of fixers: list_syntax,binary_operator_spaces.
 --RULESET--
 {"list_syntax": {"syntax":"short"}, "binary_operator_spaces": {"operators":{"=":"single_space"}}}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 $a = [$a] = $b;

--- a/tests/Fixtures/Integration/priority/list_syntax,ternary_operator_spaces.test
+++ b/tests/Fixtures/Integration/priority/list_syntax,ternary_operator_spaces.test
@@ -2,8 +2,6 @@
 Integration of fixers: list_syntax,ternary_operator_spaces.
 --RULESET--
 {"list_syntax": {"syntax":"short"}, "ternary_operator_spaces":true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 $a = $z ? [$c,$d] = $a : 1;

--- a/tests/Fixtures/Integration/priority/no_superfluous_phpdoc_tags,void_return.test
+++ b/tests/Fixtures/Integration/priority/no_superfluous_phpdoc_tags,void_return.test
@@ -2,8 +2,6 @@
 Integration of fixers: no_superfluous_phpdoc_tags,void_return.
 --RULESET--
 {"no_superfluous_phpdoc_tags": true, "void_return": true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/priority/nullable_type_declaration_for_default_null_value,no_unreachable_default_argument_value.test
+++ b/tests/Fixtures/Integration/priority/nullable_type_declaration_for_default_null_value,no_unreachable_default_argument_value.test
@@ -2,8 +2,6 @@
 Integration of fixers: nullable_type_declaration_for_default_null_value,no_unreachable_default_argument_value.
 --RULESET--
 {"nullable_type_declaration_for_default_null_value": true, "no_unreachable_default_argument_value": true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 function foo(?int $a, int $b) {}

--- a/tests/Fixtures/Integration/priority/phpdoc_return_self_reference,no_superfluous_phpdoc_tags.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_return_self_reference,no_superfluous_phpdoc_tags.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_return_self_reference,no_superfluous_phpdoc_tags.
 --RULESET--
 {"no_superfluous_phpdoc_tags": true, "phpdoc_return_self_reference": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/phpdoc_scalar,phpdoc_to_return_type.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_scalar,phpdoc_to_return_type.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_scalar,phpdoc_to_return_type.
 --RULESET--
 {"phpdoc_to_return_type": {"scalar_types": true}, "phpdoc_scalar": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 /** @return string */

--- a/tests/Fixtures/Integration/priority/phpdoc_to_param_type,no_superfluous_phpdoc_tags.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_param_type,no_superfluous_phpdoc_tags.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_to_param_type,no_superfluous_phpdoc_tags.
 --RULESET--
 {"phpdoc_to_param_type": true, "no_superfluous_phpdoc_tags": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,fully_qualified_strict_types.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_to_return_type,fully_qualified_strict_types.
 --RULESET--
 {"fully_qualified_strict_types": true, "phpdoc_to_return_type": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 use \Foo\Bar\Baz;

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,no_superfluous_phpdoc_tags.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,no_superfluous_phpdoc_tags.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_to_return_type,no_superfluous_phpdoc_tags.
 --RULESET--
 {"phpdoc_to_return_type": true, "no_superfluous_phpdoc_tags": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 

--- a/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_to_return_type,return_type_declaration.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_to_return_type,return_type_declaration.
 --RULESET--
 {"return_type_declaration": {"space_before": "one"}, "phpdoc_to_return_type": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 /** @return Bar */

--- a/tests/Fixtures/Integration/priority/phpdoc_types,phpdoc_to_return_type.test
+++ b/tests/Fixtures/Integration/priority/phpdoc_types,phpdoc_to_return_type.test
@@ -2,8 +2,6 @@
 Integration of fixers: phpdoc_types,phpdoc_to_return_type.
 --RULESET--
 {"phpdoc_types": true, "phpdoc_to_return_type": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 /**

--- a/tests/Fixtures/Integration/priority/simplified_null_return,void_return.test
+++ b/tests/Fixtures/Integration/priority/simplified_null_return,void_return.test
@@ -2,8 +2,6 @@
 Integration of fixers: simplified_null_return,void_return.
 --RULESET--
 {"simplified_null_return": true, "void_return": true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 class Foo {

--- a/tests/Fixtures/Integration/priority/single_line_throw,braces.test
+++ b/tests/Fixtures/Integration/priority/single_line_throw,braces.test
@@ -2,8 +2,6 @@
 Integration of fixers: single_line_throw,braces.
 --RULESET--
 {"braces": true, "single_line_throw": true}
---REQUIREMENTS--
-{"php": 70000}
 --EXPECT--
 <?php
 throw new class() extends Exception {

--- a/tests/Fixtures/Integration/priority/void_return,phpdoc_no_empty_return.test
+++ b/tests/Fixtures/Integration/priority/void_return,phpdoc_no_empty_return.test
@@ -2,8 +2,6 @@
 Integration of fixers: void_return,phpdoc_no_empty_return.
 --RULESET--
 {"void_return": true, "phpdoc_no_empty_return": true}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 interface Test {

--- a/tests/Fixtures/Integration/priority/void_return,return_type_declaration.test
+++ b/tests/Fixtures/Integration/priority/void_return,return_type_declaration.test
@@ -2,8 +2,6 @@
 Integration of fixers: void_return,return_type_declaration.
 --RULESET--
 {"void_return": true, "return_type_declaration": {"space_before":"one"}}
---REQUIREMENTS--
-{"php": 70100}
 --EXPECT--
 <?php
 function test() : void {}

--- a/tests/Fixtures/Integration/set/@PHP54Migration.test
+++ b/tests/Fixtures/Integration/set/@PHP54Migration.test
@@ -2,5 +2,3 @@
 Integration of @PHP54Migration.
 --RULESET--
 {"@PHP54Migration": true}
---REQUIREMENTS--
-{"php": 50400}

--- a/tests/Fixtures/Integration/set/@PSR12_php70.test
+++ b/tests/Fixtures/Integration/set/@PSR12_php70.test
@@ -2,5 +2,3 @@
 Integration of @PSR12 [PHP 7.0 version].
 --RULESET--
 {"@PSR12": true}
---REQUIREMENTS--
-{"php": 70000}

--- a/tests/Fixtures/Integration/set/@PSR12_php71.test
+++ b/tests/Fixtures/Integration/set/@PSR12_php71.test
@@ -2,5 +2,3 @@
 Integration of @PSR12 [PHP 7.1 version].
 --RULESET--
 {"@PSR12": true}
---REQUIREMENTS--
-{"php": 70100}


### PR DESCRIPTION
As minimum supported PHP version is 7.1.