### PR TITLE
Consistency invalid configuration exception for test

### DIFF
--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests;
 
 use PhpCsFixer\Config;
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Console\ConfigurationResolver;
@@ -80,7 +81,7 @@ final class ConfigTest extends TestCase
 
     public function testConfigRulesUsingInvalidJson(): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
 
         $config = new Config();
         $configResolver = new ConfigurationResolver(

--- a/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
+++ b/tests/ConfigurationException/InvalidFixerConfigurationExceptionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\ConfigurationException;
 
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
 use PhpCsFixer\Tests\TestCase;
@@ -31,7 +32,7 @@ final class InvalidFixerConfigurationExceptionTest extends TestCase
     {
         $exception = new InvalidFixerConfigurationException('foo', 'I cannot do that, Dave.');
 
-        static::assertInstanceOf(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class, $exception);
+        static::assertInstanceOf(InvalidConfigurationException::class, $exception);
     }
 
     public function testDefaults(): void

--- a/tests/Console/Command/FixCommandTest.php
+++ b/tests/Console/Command/FixCommandTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Console\Command;
 
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Console\Application;
 use PhpCsFixer\Console\Command\FixCommand;
 use PhpCsFixer\Tests\TestCase;
@@ -31,7 +32,7 @@ final class FixCommandTest extends TestCase
     public function testEmptyRulesValue(): void
     {
         $this->expectException(
-            \PhpCsFixer\ConfigurationException\InvalidConfigurationException::class
+            InvalidConfigurationException::class
         );
         $this->expectExceptionMessageMatches(
             '#^Empty rules value is not allowed\.$#'
@@ -44,7 +45,7 @@ final class FixCommandTest extends TestCase
 
     public function testEmptyFormatValue(): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('Expected "yes" or "no" for option "using-cache", got "not today".');
 
         $cmdTester = $this->doTestExecute(

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\ConstantNotation;
 
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -29,7 +30,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
     {
         $key = 'foo';
 
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf('[native_constant_invocation] Invalid configuration: The option "%s" does not exist.', $key));
 
         $this->fixer->configure([
@@ -44,7 +45,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
      */
     public function testConfigureRejectsInvalidExcludeConfigurationElement($element): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
             'Each element must be a non-empty, trimmed string, got "%s" instead.',
             \is_object($element) ? \get_class($element) : \gettype($element)
@@ -64,7 +65,7 @@ final class NativeConstantInvocationFixerTest extends AbstractFixerTestCase
      */
     public function testConfigureRejectsInvalidIncludeConfigurationElement($element): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
             'Each element must be a non-empty, trimmed string, got "%s" instead.',
             \is_object($element) ? \get_class($element) : \gettype($element)

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\FunctionNotation;
 
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
@@ -32,7 +33,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
     {
         $key = 'foo';
 
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
             '[native_function_invocation] Invalid configuration: The option "%s" does not exist.',
             $key
@@ -50,7 +51,7 @@ final class NativeFunctionInvocationFixerTest extends AbstractFixerTestCase
      */
     public function testConfigureRejectsInvalidConfigurationElement($element): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
             'Each element must be a non-empty, trimmed string, got "%s" instead.',
             \is_object($element) ? \get_class($element) : \gettype($element)

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
+use PhpCsFixer\ConfigurationException\InvalidConfigurationException;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 use PhpCsFixer\WhitespacesFixerConfig;
 
@@ -30,7 +31,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
     {
         $key = 'foo';
 
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage(sprintf(
             '[phpdoc_add_missing_param_annotation] Invalid configuration: The option "%s" does not exist.',
             $key
@@ -48,7 +49,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      */
     public function testConfigureRejectsInvalidConfigurationValue($value, string $expectedMessage): void
     {
-        $this->expectException(\PhpCsFixer\ConfigurationException\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessageMatches($expectedMessage);
 
         $this->fixer->configure([


### PR DESCRIPTION
Since I check that @SpacePossum  [was doing this exact change](https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/98eed9f27b943ac28e811b0ca7b89f89a40d62c4#diff-dbe968ecfaa21d9e35844f2fd63b12bb1fec4265cb453961db3796bb40accf03L1076) in some part of code, I think that it is good for consistency that in other places appears in the same way.

Also we are lacking of the inverse of fixer similar to "[fully_qualified_strict_types](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/import/fully_qualified_strict_types.rst)" that only works in methods declaration and not inside of methods and "[class_keyword_remove](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/doc/rules/language_construct/class_keyword_remove.rst)". Then I had to perform this manually with occurences on:

`grep -rin 'ConfigurationException\\InvalidConfigurationException' | grep -v namespace | grep -v use | grep -v cover`

Would be nice to have fixer to do this over other codebases.