### PR TITLE
NoAliasFunctionsFixer - remove dir -> getdir mapping

### DIFF
--- a/src/Fixer/Alias/NoAliasFunctionsFixer.php
+++ b/src/Fixer/Alias/NoAliasFunctionsFixer.php
@@ -36,7 +36,6 @@ final class NoAliasFunctionsFixer extends AbstractFixer implements ConfigurableF
 {
     private const SETS = [
         '@internal' => [
-            'dir' => 'getdir',
             'diskfreespace' => 'disk_free_space',
 
             'checkdnsrr' => 'dns_check_record',


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5936