### PR TITLE
PHP 8.1 support

### DIFF
--- a/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitConstructFixer.php
@@ -173,7 +173,7 @@ final class FooTest extends \PHPUnit_Framework_TestCase {
         $sequence = $tokens->findSequence(
             [
                 [T_STRING, $method],
-                '(',
+                '(', // FIXME
             ],
             $index
         );


### PR DESCRIPTION
- [x] [Never type](https://wiki.php.net/rfc/noreturn_type) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5967
- [x] [Readonly properties](https://wiki.php.net/rfc/readonly_properties_v2) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5968
- [ ] [Enums](https://wiki.php.net/rfc/enumerations) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5978 (first small changes only to prevent conflicts)
- [ ] [Array unpacking with string keys](https://wiki.php.net/rfc/array_unpacking_string_keys)
- [ ] [New in initializers](https://wiki.php.net/rfc/new_in_initializers)
- [x] [First-class callable](https://wiki.php.net/rfc/first_class_callable_syntax) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5972
- [ ] [Pure intersection types](https://wiki.php.net/rfc/pure-intersection-types)
- [x] [Final class constants](https://wiki.php.net/rfc/final_class_const) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5973
- [x] [Explicit octal integer literal notation](https://wiki.php.net/rfc/explicit_octal_notation) https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5971

---

-  `braces` need checking
- `ClassyAnalyzer::isClassyInvocation` needs checking
