### PR TITLE
Removed PHP 5 exception catch

### DIFF
--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -193,10 +193,6 @@ final class Runner
                     $appliedFixers[] = $fixer->getName();
                 }
             }
-        } catch (\Exception $e) {
-            $this->processException($name, $e);
-
-            return null;
         } catch (\ParseError $e) {
             $this->dispatchEvent(
                 FixerFileProcessedEvent::NAME,


### PR DESCRIPTION
Now that we require PHP 7, the `Throwable` catch will suffice.