### PR TITLE
Provide test case for issue #5950

### DIFF
--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -143,6 +143,10 @@ $$e(2);
                 '<?php abc#
  ($a);',
             ],
+            'whitespace between echo and IIFE\'s parenthesis Issue #5950' => [
+                '<?php echo (function () {})();',
+                '<?php echo (function  () {})();'
+            ]
         ];
 
         yield [


### PR DESCRIPTION
The test will fail since there is a bug in #5950. After bug would be fixed, should be valid:

```diff
--- Expected
+++ Actual
@@ @@
-'<?php echo (function () {})();'
+'<?php echo(function  () {})();'

```