### PR TITLE
ClassAttributesSeparationFixer - Re-add omitted `only_if_meta` option

### DIFF
--- a/doc/rules/class_notation/class_attributes_separation.rst
+++ b/doc/rules/class_notation/class_attributes_separation.rst
@@ -11,7 +11,8 @@ Configuration
 ``elements``
 ~~~~~~~~~~~~
 
-Dictionary of ``const|method|property|trait_import`` => ``none|one`` values.
+Dictionary of ``const|method|property|trait_import`` =>
+``none|one|only_if_meta`` values.
 
 Allowed types: ``array``
 

--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -204,7 +204,7 @@ class Sample
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property|trait_import` => `none|one` values.'))
+            (new FixerOptionBuilder('elements', 'Dictionary of `const|method|property|trait_import` => `none|one|only_if_meta` values.'))
                 ->setAllowedTypes(['array'])
                 ->setAllowedValues([static function (array $option): bool {
                     foreach ($option as $type => $spacing) {


### PR DESCRIPTION
Since #5920, the `only_if_meta` option was inadvertently removed from fixer description. This PR simply re-adds it.