### PR TITLE
Fixed `class_attributes_separation` processing class with multiple trait imports

### DIFF
--- a/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
+++ b/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php
@@ -533,7 +533,7 @@ class Sample
 
             do {
                 $elementEndIndex = $tokens->getNextMeaningfulToken($elementEndIndex);
-            } while ($tokens[$elementEndIndex]->isGivenKind([T_STRING, T_NS_SEPARATOR]));
+            } while ($tokens[$elementEndIndex]->isGivenKind([T_STRING, T_NS_SEPARATOR]) || $tokens[$elementEndIndex]->equals(','));
 
             if (!$tokens[$elementEndIndex]->equals(';')) {
                 $elementEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $tokens->getNextTokenOfKind($element['index'], ['{']));

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1161,7 +1161,7 @@ class ezcReflectionMethod extends ReflectionMethod {
     /**
      * @dataProvider provideConfigCases
      */
-    public function testWithConfig(string $expected, string $input, array $config): void
+    public function testWithConfig(string $expected, ?string $input, array $config): void
     {
         $this->fixer->configure($config);
         $this->doTest($expected, $input);
@@ -1280,6 +1280,33 @@ class Foo
     const OTHER2 = 5;
 }',
                 ['elements' => ['const' => 'none']],
+            ],
+            'multiple trait import 5954' => [
+                '<?php
+class Foo
+{
+    use Bar, Baz;
+}',
+                null,
+                ['elements' => ['method' => 'one']],
+            ],
+            'multiple trait import with method 5954' => [
+                '<?php
+class Foo
+{
+    use Bar, Baz;
+
+    public function f() {}
+}',
+                '<?php
+class Foo
+{
+    use Bar, Baz;
+
+
+    public function f() {}
+}',
+                ['elements' => ['method' => 'one']],
             ],
             'trait group import 5843' => [
                 '<?php


### PR DESCRIPTION
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5954.