### PR TITLE
Fix STDIN test when path is one level deep

### DIFF
--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace PhpCsFixer\Tests\Smoke;
 
 use Keradus\CliExecutor\CommandExecutor;
+use PhpCsFixer\Preg;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -45,6 +46,7 @@ final class StdinTest extends AbstractSmokeTest
             '',
             $fileResult->getError()
         );
+
         static::assertSame($expectedError, $stdinResult->getError());
 
         $fileResult = $this->unifyFooter($fileResult->getOutput());
@@ -55,7 +57,11 @@ final class StdinTest extends AbstractSmokeTest
         $fileResult = str_replace("\n+++ ".$path."\n", "\n+++ php://stdin\n", $fileResult);
 
         $path = str_replace('/', \DIRECTORY_SEPARATOR, basename(realpath($cwd)).'/'.$inputFile);
-        $fileResult = str_replace($path, 'php://stdin', $fileResult);
+        $fileResult = Preg::replace(
+            '#/?'.preg_quote($path, '#').'#',
+            'php://stdin',
+            $fileResult
+        );
 
         static::assertSame(
             $fileResult,


### PR DESCRIPTION
I already fixed this issue but I think the changes got lost in a merge conflict.

```console
❯ docker-compose run php-7.4 vendor/bin/phpunit tests/Smoke/StdinTest.php
Creating php-cs-fixer_php-7.4_run ... done
PHPUnit 9.5.8 by Sebastian Bergmann and contributors.

Testing PhpCsFixer\Tests\Smoke\StdinTest
F                                                                                                                                                                                                                                                             1 / 1 (100%)

Time: 00:00.442, Memory: 18.50 MB

There was 1 failure:

1) PhpCsFixer\Tests\Smoke\StdinTest::testFixingStdin
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'   1) /php://stdin
+'   1) php://stdin
       ---------- begin diff ----------
 --- php://stdin
 +++ php://stdin

/app/tests/Smoke/StdinTest.php:62

FAILURES!
Tests: 1, Assertions: 3, Failures: 1.
```