### PR TITLE
PHP8.1 - Explicit octal integer literal notation

### DIFF
--- a/doc/ruleSets/PHP81Migration.rst
+++ b/doc/ruleSets/PHP81Migration.rst
@@ -1,0 +1,11 @@
+============================
+Rule set ``@PHP81Migration``
+============================
+
+Rules to improve code for PHP 8.1 compatibility.
+
+Rules
+-----
+
+- `@PHP80Migration <./PHP80Migration.rst>`_
+- `octal_notation <./../rules/basic/octal_notation.rst>`_

--- a/doc/ruleSets/index.rst
+++ b/doc/ruleSets/index.rst
@@ -13,6 +13,7 @@ List of Available Rule sets
 - `@PHP74Migration:risky <./PHP74MigrationRisky.rst>`_
 - `@PHP80Migration <./PHP80Migration.rst>`_
 - `@PHP80Migration:risky <./PHP80MigrationRisky.rst>`_
+- `@PHP81Migration <./PHP81Migration.rst>`_
 - `@PHPUnit30Migration:risky <./PHPUnit30MigrationRisky.rst>`_
 - `@PHPUnit32Migration:risky <./PHPUnit32MigrationRisky.rst>`_
 - `@PHPUnit35Migration:risky <./PHPUnit35MigrationRisky.rst>`_

--- a/doc/rules/array_notation/array_syntax.rst
+++ b/doc/rules/array_notation/array_syntax.rst
@@ -68,6 +68,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``array_syntax`` rule with the default config.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``array_syntax`` rule with the default config.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``array_syntax`` rule with the default config.
 

--- a/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
+++ b/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst
@@ -68,6 +68,11 @@ The rule is part of the following rule sets:
 
   ``['after_heredoc' => true]``
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``no_whitespace_before_comma_in_array`` rule with the config below:
+
+  ``['after_heredoc' => true]``
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_whitespace_before_comma_in_array`` rule with the default config.
 

--- a/doc/rules/array_notation/normalize_index_brace.rst
+++ b/doc/rules/array_notation/normalize_index_brace.rst
@@ -29,6 +29,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``normalize_index_brace`` rule.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``normalize_index_brace`` rule.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``normalize_index_brace`` rule.
 

--- a/doc/rules/basic/octal_notation.rst
+++ b/doc/rules/basic/octal_notation.rst
@@ -1,0 +1,26 @@
+=======================
+Rule ``octal_notation``
+=======================
+
+Literal octal must be in ``0o`` notation.
+
+Examples
+--------
+
+Example #1
+~~~~~~~~~~
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+   -<?php $foo = 0123;
+   +<?php $foo = 0o123;
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``octal_notation`` rule.

--- a/doc/rules/cast_notation/no_unset_cast.rst
+++ b/doc/rules/cast_notation/no_unset_cast.rst
@@ -26,6 +26,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``no_unset_cast`` rule.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``no_unset_cast`` rule.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_unset_cast`` rule.
 

--- a/doc/rules/cast_notation/short_scalar_cast.rst
+++ b/doc/rules/cast_notation/short_scalar_cast.rst
@@ -58,6 +58,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``short_scalar_cast`` rule.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``short_scalar_cast`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``short_scalar_cast`` rule.
 

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -77,6 +77,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
 

--- a/doc/rules/control_structure/trailing_comma_in_multiline.rst
+++ b/doc/rules/control_structure/trailing_comma_in_multiline.rst
@@ -118,6 +118,11 @@ The rule is part of the following rule sets:
 
   ``['after_heredoc' => true]``
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``trailing_comma_in_multiline`` rule with the config below:
+
+  ``['after_heredoc' => true]``
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``trailing_comma_in_multiline`` rule with the default config.
 

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -224,6 +224,11 @@ The rule is part of the following rule sets:
 
   ``['after_heredoc' => true]``
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``method_argument_space`` rule with the config below:
+
+  ``['after_heredoc' => true]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``method_argument_space`` rule with the config below:
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -55,6 +55,8 @@ Basic
     PHP code MUST use only UTF-8 without BOM (remove BOM).
 - `non_printable_character <./basic/non_printable_character.rst>`_ *(risky)*
     Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.
+- `octal_notation <./basic/octal_notation.rst>`_
+    Literal octal must be in ``0o`` notation.
 - `psr_autoloading <./basic/psr_autoloading.rst>`_ *(risky)*
     Classes must be in a path that matches their namespace, be at least one namespace deep and the class name should match the file name.
 

--- a/doc/rules/list_notation/list_syntax.rst
+++ b/doc/rules/list_notation/list_syntax.rst
@@ -62,3 +62,6 @@ The rule is part of the following rule sets:
 
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``list_syntax`` rule with the default config.
+
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``list_syntax`` rule with the default config.

--- a/doc/rules/namespace_notation/clean_namespace.rst
+++ b/doc/rules/namespace_notation/clean_namespace.rst
@@ -37,6 +37,9 @@ The rule is part of the following rule sets:
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``clean_namespace`` rule.
 
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``clean_namespace`` rule.
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``clean_namespace`` rule.
 

--- a/doc/rules/operator/ternary_to_null_coalescing.rst
+++ b/doc/rules/operator/ternary_to_null_coalescing.rst
@@ -37,3 +37,6 @@ The rule is part of the following rule sets:
 
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``ternary_to_null_coalescing`` rule.
+
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``ternary_to_null_coalescing`` rule.

--- a/doc/rules/whitespace/heredoc_indentation.rst
+++ b/doc/rules/whitespace/heredoc_indentation.rst
@@ -87,3 +87,6 @@ The rule is part of the following rule sets:
 
 @PHP80Migration
   Using the `@PHP80Migration <./../../ruleSets/PHP80Migration.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.
+
+@PHP81Migration
+  Using the `@PHP81Migration <./../../ruleSets/PHP81Migration.rst>`_ rule set will enable the ``heredoc_indentation`` rule with the default config.

--- a/src/Fixer/Basic/OctalNotationFixer.php
+++ b/src/Fixer/Basic/OctalNotationFixer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Fixer\Basic;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\FixerDefinition\VersionSpecification;
+use PhpCsFixer\FixerDefinition\VersionSpecificCodeSample;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class OctalNotationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Literal octal must be in `0o` notation.',
+            [
+                new VersionSpecificCodeSample(
+                    "<?php \$foo = 0123;\n",
+                    new VersionSpecification(80100)
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return \PHP_VERSION_ID >= 80100 && $tokens->isTokenKindFound(T_LNUMBER);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_LNUMBER)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+
+            if (1 !== Preg::match('#^0\d+$#', $content)) {
+                continue;
+            }
+
+            $tokens[$index] = 1 === Preg::match('#^0+$#', $content)
+                ? new Token([T_LNUMBER, '0'])
+                : new Token([T_LNUMBER, '0o'.substr($content, 1)])
+            ;
+        }
+    }
+}

--- a/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
+++ b/src/Fixer/ControlStructure/EmptyLoopConditionFixer.php
@@ -25,9 +25,6 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-/**
- * @author SpacePossum
- */
 final class EmptyLoopConditionFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
     private const STYLE_FOR = 'for';

--- a/src/RuleSet/Sets/PHP81MigrationSet.php
+++ b/src/RuleSet/Sets/PHP81MigrationSet.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\RuleSet\Sets;
+
+use PhpCsFixer\RuleSet\AbstractMigrationSetDescription;
+
+/**
+ * @internal
+ */
+final class PHP81MigrationSet extends AbstractMigrationSetDescription
+{
+    public function getRules(): array
+    {
+        return [
+            '@PHP80Migration' => true,
+            'octal_notation' => true,
+        ];
+    }
+}

--- a/tests/Fixer/Basic/OctalNotationFixerTest.php
+++ b/tests/Fixer/Basic/OctalNotationFixerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Fixer\Basic;
+
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ *
+ * @covers \PhpCsFixer\Fixer\Basic\OctalNotationFixer
+ */
+final class OctalNotationFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFix81Cases
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, ?string $input = null): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public static function provideFix81Cases(): \Generator
+    {
+        yield [
+            '<?php
+                $a = 0;
+                $b = \'0\';
+                $foo = 0b01;
+                $foo = 0x01;
+                $foo = 0B01;
+                $foo = 0X01;
+                $foo = 0b0;
+                $foo = 0x0;
+                $foo = 0B0;
+                $foo = 0X0;
+                $foo = 1;
+                $foo = 10;
+            ',
+        ];
+
+        yield [
+            '<?php $foo = 0;',
+            '<?php $foo = 00000;',
+        ];
+
+        yield [
+            '<?php
+                $foo = 0o123;
+                $foo = 0o1;
+            ',
+            '<?php
+                $foo = 0123;
+                $foo = 01;
+            ',
+        ];
+    }
+}

--- a/tests/Fixtures/Integration/misc/PHP8_1.test
+++ b/tests/Fixtures/Integration/misc/PHP8_1.test
@@ -18,6 +18,10 @@ function endProgram(): never
 // https://wiki.php.net/rfc/fsync_function
 fsync($fp);
 
+// https://wiki.php.net/rfc/explicit_octal_notation
+$a = 0o16 === 14;
+$b = 0o744;
+
 --INPUT--
 <?php
 
@@ -29,3 +33,7 @@ function endProgram(): NEVER
 
 // https://wiki.php.net/rfc/fsync_function
 FSYNC($fp);
+
+// https://wiki.php.net/rfc/explicit_octal_notation
+$a = 0O16 === 14;
+$b = 0744;

--- a/tests/Fixtures/Integration/set/@PHP81Migration.test
+++ b/tests/Fixtures/Integration/set/@PHP81Migration.test
@@ -1,0 +1,6 @@
+--TEST--
+Integration of @PHP81Migration.
+--RULESET--
+{"@PHP81Migration": true}
+--REQUIREMENTS--
+{"php": 80100}

--- a/tests/Fixtures/Integration/set/@PHP81Migration.test-in.php
+++ b/tests/Fixtures/Integration/set/@PHP81Migration.test-in.php
@@ -1,0 +1,4 @@
+<?php
+
+// https://wiki.php.net/rfc/explicit_octal_notation
+$a = 016 === 14;

--- a/tests/Fixtures/Integration/set/@PHP81Migration.test-out.php
+++ b/tests/Fixtures/Integration/set/@PHP81Migration.test-out.php
@@ -1,0 +1,4 @@
+<?php
+
+// https://wiki.php.net/rfc/explicit_octal_notation
+$a = 0o16 === 14;

--- a/tests/RuleSet/Sets/PHP81MigrationSetTest.php
+++ b/tests/RuleSet/Sets/PHP81MigrationSetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\RuleSet\Sets;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\RuleSet\Sets\PHP81MigrationSet
+ */
+final class PHP81MigrationSetTest extends AbstractSetTest
+{
+}


### PR DESCRIPTION
PHP8.1 - Add support for explicit octal integer literal notation

(reworded)