### PR TITLE
NoSuperfluousPhpdocTagsFixer - Remove superfluous annotation `@abstract` and `@final`

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -23,8 +23,6 @@ use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
- *
- * @final
  */
 final class Annotation
 {

--- a/src/DocBlock/DocBlock.php
+++ b/src/DocBlock/DocBlock.php
@@ -24,8 +24,6 @@ use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
  * It internally splits it up into "lines" that we can manipulate.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
- *
- * @final
  */
 final class DocBlock
 {

--- a/src/DocBlock/Line.php
+++ b/src/DocBlock/Line.php
@@ -20,8 +20,6 @@ use PhpCsFixer\Preg;
  * This represents a line of a docblock.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
- *
- * @final
  */
 final class Line
 {

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -20,8 +20,6 @@ use PhpCsFixer\Preg;
  * This represents a tag, as defined by the proposed PSR PHPDoc standard.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
- *
- * @final
  */
 final class Tag
 {

--- a/src/DocBlock/TagComparator.php
+++ b/src/DocBlock/TagComparator.php
@@ -19,8 +19,6 @@ namespace PhpCsFixer\DocBlock;
  * together, or kept apart.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
- *
- * @final
  */
 final class TagComparator
 {

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -66,14 +66,14 @@ class Foo {
 class Foo {
     /**
      */
-    public function doFoo(Bar $bar = null) {}
+    public function doFoo(Bar $bar = NULL) {}
 }',
                 '<?php
 class Foo {
     /**
      * @param Bar|null $bar
      */
-    public function doFoo(Bar $bar = null) {}
+    public function doFoo(Bar $bar = NULL) {}
 }',
             ],
             'same typehint with description' => [
@@ -1041,13 +1041,17 @@ class Foo {
 }',
                 ['remove_inheritdoc' => true],
             ],
-            'dont_remove_inheritdoc_non_structural_element' => [
+            'remove_inheritdoc_non_structural_element_it_does_not_inherit' => [
+                '<?php
+/**
+ *
+ */
+$foo = 1;',
                 '<?php
 /**
  * @inheritDoc
  */
 $foo = 1;',
-                null,
                 ['remove_inheritdoc' => true],
             ],
             'property with unsupported type' => [

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -1406,6 +1406,92 @@ class Foo {
     public function doFoo(iterable $bar, ?int $baz): ?array {}
 }',
             ],
+            'remove abstract annotation in function' => [
+                '<?php
+abstract class Foo {
+    /**
+     */
+    public abstract function doFoo();
+}',
+                '<?php
+abstract class Foo {
+    /**
+     * @abstract
+     */
+    public abstract function doFoo();
+}', ],
+            'dont remove abstract annotation in function' => [
+                '<?php
+class Foo {
+    /**
+     * @abstract
+     */
+    public function doFoo() {}
+}', ],
+            'remove final annotation in function' => [
+                '<?php
+class Foo {
+    /**
+     */
+    public final function doFoo() {}
+}',
+                '<?php
+class Foo {
+    /**
+     * @final
+     */
+    public final function doFoo() {}
+}', ],
+            'dont remove final annotation in function' => [
+                '<?php
+class Foo {
+    /**
+     * @final
+     */
+    public function doFoo() {}
+}', ],
+            'remove abstract annotation in class' => [
+                '<?php
+/**
+ */
+abstract class Foo {
+}',
+                '<?php
+/**
+ * @abstract
+ */
+abstract class Foo {
+}', ],
+            'dont remove abstract annotation in class' => [
+                '<?php
+abstract class Bar{}
+
+/**
+ * @abstract
+ */
+class Foo {
+}', ],
+            'remove final annotation in class' => [
+                '<?php
+/**
+ */
+final class Foo {
+}',
+                '<?php
+/**
+ * @final
+ */
+final class Foo {
+}', ],
+            'dont remove final annotation in class' => [
+                '<?php
+final class Bar{}
+
+/**
+ * @final
+ */
+class Foo {
+}', ],
         ];
     }
 


### PR DESCRIPTION
Closes #5985 