### PR TITLE
PhpdocLineSpan - Allow certain types to be ignored

### DIFF
--- a/doc/rules/phpdoc/phpdoc_line_span.rst
+++ b/doc/rules/phpdoc/phpdoc_line_span.rst
@@ -13,7 +13,7 @@ Configuration
 
 Whether const blocks should be single or multi line
 
-Allowed values: ``'multi'``, ``'single'``
+Allowed values: ``'multi'``, ``'single'``, ``null``
 
 Default value: ``'multi'``
 
@@ -22,7 +22,7 @@ Default value: ``'multi'``
 
 Whether property doc blocks should be single or multi line
 
-Allowed values: ``'multi'``, ``'single'``
+Allowed values: ``'multi'``, ``'single'``, ``null``
 
 Default value: ``'multi'``
 
@@ -31,7 +31,7 @@ Default value: ``'multi'``
 
 Whether method doc blocks should be single or multi line
 
-Allowed values: ``'multi'``, ``'single'``
+Allowed values: ``'multi'``, ``'single'``, ``null``
 
 Default value: ``'multi'``
 

--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -78,15 +78,15 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('const', 'Whether const blocks should be single or multi line'))
-                ->setAllowedValues(['single', 'multi'])
+                ->setAllowedValues(['single', 'multi', null])
                 ->setDefault('multi')
                 ->getOption(),
             (new FixerOptionBuilder('property', 'Whether property doc blocks should be single or multi line'))
-                ->setAllowedValues(['single', 'multi'])
+                ->setAllowedValues(['single', 'multi', null])
                 ->setDefault('multi')
                 ->getOption(),
             (new FixerOptionBuilder('method', 'Whether method doc blocks should be single or multi line'))
-                ->setAllowedValues(['single', 'multi'])
+                ->setAllowedValues(['single', 'multi', null])
                 ->setDefault('multi')
                 ->getOption(),
         ]);
@@ -101,12 +101,13 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
                 continue;
             }
 
+            $type = $element['type'];
             $docIndex = $this->getDocBlockIndex($tokens, $index);
             $doc = new DocBlock($tokens[$docIndex]->getContent());
 
-            if ('multi' === $this->configuration[$element['type']]) {
+            if ('multi' === $this->configuration[$type]) {
                 $doc->makeMultiLine(WhitespacesAnalyzer::detectIndent($tokens, $docIndex), $this->whitespacesConfig->getLineEnding());
-            } else {
+            } elseif ('single' === $this->configuration[$type]) {
                 $doc->makeSingleLine();
             }
 

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -419,6 +419,60 @@ class Bar
 }
 ',
             ],
+            'It does not change method doc blocks if configured to do so' => [
+                '<?php
+
+class Foo
+{
+    /** @return mixed */
+    public function bar() {}
+
+    /**
+     * @return void
+     */
+    public function baz() {}
+}',
+                null,
+                [
+                    'method' => null,
+                ],
+            ],
+            'It does not change property doc blocks if configured to do so' => [
+                '<?php
+
+class Foo
+{
+    /**
+     * @var int
+     */
+    public $foo;
+
+    /** @var mixed */
+    public $bar;
+}',
+                null,
+                [
+                    'property' => null,
+                ],
+            ],
+            'It does not change const doc blocks if configured to do so' => [
+                '<?php
+
+class Foo
+{
+    /**
+     * @var int
+     */
+    public const FOO = 1;
+
+    /** @var mixed */
+    public const BAR = null;
+}',
+                null,
+                [
+                    'const' => null,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This feature was requested here: #5886

Basically the new `null` option values allow you to enforce one or more styles for some types, but not all. You can now have single line PHPDocs enforced for properties and constants, but allow both single and multiline PHPDocs for methods. Without this change you'd be forced to pick a style for every type (or it would default to `multi`).

It's a non-breaking change, by the way.