### PR TITLE
Linter/*Exception - Tag as final

### DIFF
--- a/src/Linter/LintingException.php
+++ b/src/Linter/LintingException.php
@@ -16,6 +16,9 @@ namespace PhpCsFixer\Linter;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @final
+ * @TODO 4.0 make class "final"
  */
 class LintingException extends \RuntimeException
 {

--- a/src/Linter/UnavailableLinterException.php
+++ b/src/Linter/UnavailableLinterException.php
@@ -18,6 +18,9 @@ namespace PhpCsFixer\Linter;
  * Exception that is thrown when the chosen linter is not available on the environment.
  *
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * @final
+ * @TODO 4.0 make class "final"
  */
 class UnavailableLinterException extends \RuntimeException
 {


### PR DESCRIPTION
Extracted from #6019 https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6019#discussion_r712397505

I see no value in these as possible extend point, declaring as `final` will make it more easy to refactor etc.
