### PR TITLE
Make PhpdocLineSpanFixer don't change doc blocks in trait import statement

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -97,7 +97,7 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
         $analyzer = new TokensAnalyzer($tokens);
 
         foreach ($analyzer->getClassyElements() as $index => $element) {
-            if (!$this->hasDocBlock($tokens, $index)) {
+            if (!$this->hasDocBlock($tokens, $index) || 'trait_import' === $element['type']) {
                 continue;
             }
 

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -502,6 +502,17 @@ class Foo
                     'property' => 'single',
                 ],
             ],
+            'It does not change doc blocks in trait import' => [
+                '<?php
+trait Bar {}
+
+class Foo
+{
+  /** whatever */
+  use Bar;
+}
+            ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Closes #6037 