### PR TITLE
NoExtraBlankLinesFixer - Improve deprecation message

### DIFF
--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -81,7 +81,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
     public function configure(array $configuration): void
     {
         if (isset($configuration['tokens']) && \in_array('use_trait', $configuration['tokens'], true)) {
-            Utils::triggerDeprecation(new \RuntimeException('Option "use_trait" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.'));
+            Utils::triggerDeprecation(new \RuntimeException('Option "tokens: use_trait" used in `no_extra_blank_lines` rule is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.'));
         }
 
         parent::configure($configuration);

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -633,7 +633,7 @@ $a = new Qux();',
      */
     public function testRemoveBetweenUseTraits(string $expected, string $input): void
     {
-        $this->expectDeprecation('Option "use_trait" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.');
+        $this->expectDeprecation('Option "tokens: use_trait" used in `no_extra_blank_lines` rule is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.');
         $this->fixer->configure(['tokens' => ['use_trait']]);
 
         $this->doTest($expected, $input);

--- a/tests/Fixtures/Integration/priority/class_attributes_separation,no_extra_blank_lines.test
+++ b/tests/Fixtures/Integration/priority/class_attributes_separation,no_extra_blank_lines.test
@@ -5,7 +5,7 @@ Integration of fixers: class_attributes_separation,no_extra_blank_lines.
 --SETTINGS--
 {
     "deprecations": [
-        "Option \"use_trait\" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead."
+        "Option \"tokens: use_trait\" used in `no_extra_blank_lines` rule is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead."
     ]
 }
 --EXPECT--


### PR DESCRIPTION
Running the new version would give the deprecation message:
```
Option "use_trait" is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.
```

but it is not quite evident where that option _was_ used. This proposes to include as well the fixer where the option was used.