### PR TITLE
Update UPGRADE-v3.md with php_unit_test_annotation/case deprecation

### DIFF
--- a/UPGRADE-v3.md
+++ b/UPGRADE-v3.md
@@ -91,6 +91,7 @@ Rule | Option | Change
 `ordered_imports`                        | `importsOrder`                               | option was renamed, use `imports_order`
 `ordered_imports`                        | `sortAlgorithm`                              | option was renamed, use `sort_algorithm`
 `php_unit_dedicate_assert`               | `functions`                                  | option was removed, use `target` instead
+`php_unit_test_annotation`               | `case`                                       | option was removed, use `php_unit_method_casing` rule instead
 
 ### Changed default values of options
 


### PR DESCRIPTION
Deprecation was added [here](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3886/files#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR1330).