### PR TITLE
Change: Remove __constructor() from RuleSetDescriptionInterface

### DIFF
--- a/src/RuleSet/RuleSetDescriptionInterface.php
+++ b/src/RuleSet/RuleSetDescriptionInterface.php
@@ -19,8 +19,6 @@ namespace PhpCsFixer\RuleSet;
  */
 interface RuleSetDescriptionInterface
 {
-    public function __construct();
-
     public function getDescription(): string;
 
     public function getName(): string;


### PR DESCRIPTION
Constructor should be defined by the implementation, not by the interface.

With this change one could do, which is not possible at the moment due to the interface defining constructor with no parameters.

```php
class MyDynamicRules implements RuleSetDescriptionInterface {
    protected bool $risky;

    public function __constructor(bool $risky = false) {
        $this->risky = $risky;
    }
    ...
    public function getRules(): array {
        // return rules based on $this->risky     
    }
}
```

This would allow doing something like 

```php
$myRules = new MyDynamicRules(true);
$config->setRules(array_merge(
    $myRules->getRules(),
    [ /* more rules, override previously set rules */ ]
);
```