### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
             execute-flex-with-symfony-version: '^5' # Explicit check for Sf 5.x compatibility
 
           - operating-system: 'ubuntu-20.04'
+            php-version: '8.0'
+            job-description: 'with Sf ^6'
+            execute-flex-with-symfony-version: '^6' # Explicit check for Sf 6.x compatibility
+
+          - operating-system: 'ubuntu-20.04'
             php-version: '7.4'
             job-description: 'with deployment'
             execute-deployment: 'yes'

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,22 @@
         "composer/xdebug-handler": "^2.0",
         "doctrine/annotations": "^1.12",
         "php-cs-fixer/diff": "^2.0",
-        "symfony/console": "^4.4.20 || ^5.1.3",
-        "symfony/event-dispatcher": "^4.4.20 || ^5.0",
-        "symfony/filesystem": "^4.4.20 || ^5.0",
-        "symfony/finder": "^4.4.20 || ^5.0",
-        "symfony/options-resolver": "^4.4.20 || ^5.0",
+        "symfony/console": "^4.4.20 || ^5.1.3 || ^6.0",
+        "symfony/event-dispatcher": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/finder": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/options-resolver": "^4.4.20 || ^5.0 || ^6.0",
         "symfony/polyfill-mbstring": "^1.23",
         "symfony/polyfill-php80": "^1.23",
         "symfony/polyfill-php81": "^1.23",
-        "symfony/process": "^4.4.20 || ^5.0",
-        "symfony/stopwatch": "^4.4.20 || ^5.0"
+        "symfony/process": "^4.4.20 || ^5.0 || ^6.0",
+        "symfony/stopwatch": "^4.4.20 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "justinrainbow/json-schema": "^5.2",
         "keradus/cli-executor": "^1.5",
         "mikey179/vfsstream": "^1.6.8",
-        "php-coveralls/php-coveralls": "^2.4.3",
+        "php-coveralls/php-coveralls": "^2.5.2",
         "php-cs-fixer/accessible-object": "^1.1",
         "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
         "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
@@ -45,8 +45,8 @@
         "phpunit/phpunit": "^8.5.21 || ^9.5",
         "phpunitgoodpractices/polyfill": "^1.5",
         "phpunitgoodpractices/traits": "^1.9.1",
-        "symfony/phpunit-bridge": "^5.2.4",
-        "symfony/yaml": "^4.4.20 || ^5.0"
+        "symfony/phpunit-bridge": "^5.2.4 || ^6.0",
+        "symfony/yaml": "^4.4.20 || ^5.0 || ^6.0"
     },
     "suggest": {
         "ext-dom": "For handling output formats in XML",

--- a/tests/Linter/ProcessLintingResultTest.php
+++ b/tests/Linter/ProcessLintingResultTest.php
@@ -26,6 +26,17 @@ use Symfony\Component\Process\Process;
  */
 final class ProcessLintingResultTest extends TestCase
 {
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        /** @TODO drop me after Prophecy issue is soled: https://github.com/phpspec/prophecy/issues/527 */
+        $type = (new \ReflectionMethod(\Symfony\Component\Process\Process::class, 'mustRun'))->getReturnType();
+        if ($type instanceof \ReflectionNamedType && 'static' === $type->getName()) {
+            static::markTestSkipped('Prophecy cannot handle the static return type.');
+        }
+    }
+
     /**
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
Replaces #5966

This PR allows to install PHP-CS-Fixer in Symfony 6 applications.