### PR TITLE
Add return type to `DummyTestSplFileInfo::getRealPath()`

### DIFF
--- a/tests/Differ/DummyTestSplFileInfo.php
+++ b/tests/Differ/DummyTestSplFileInfo.php
@@ -16,7 +16,7 @@ namespace PhpCsFixer\Tests\Differ;
 
 final class DummyTestSplFileInfo extends \SplFileInfo
 {
-    public function getRealPath()
+    public function getRealPath(): string
     {
         return $this->getFilename();
     }


### PR DESCRIPTION
PHP 8.1 emits a deprecation warning if that method does not declare a return type. So I've added it.