### PR TITLE
Remove PHP 7.2 polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/finder": "^4.4.20 || ^5.0",
         "symfony/options-resolver": "^4.4.20 || ^5.0",
         "symfony/polyfill-mbstring": "^1.23",
-        "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.23",
         "symfony/polyfill-php81": "^1.23",
         "symfony/process": "^4.4.20 || ^5.0",


### PR DESCRIPTION
Because the minimum PHP version has been bumped to 7.2, we don't need to polyfill functions anymore that have been introduced with PHP 7.2.