### PR TITLE
SingleSpaceAfterConstruct - handle before destructuring close brace

### DIFF
--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -219,7 +219,7 @@ yield  from  baz();
 
             $whitespaceTokenIndex = $index + 1;
 
-            if ($tokens[$whitespaceTokenIndex]->equalsAny([',', ';', ')', [CT::T_ARRAY_SQUARE_BRACE_CLOSE]])) {
+            if ($tokens[$whitespaceTokenIndex]->equalsAny([',', ';', ')', [CT::T_ARRAY_SQUARE_BRACE_CLOSE], [CT::T_DESTRUCTURING_SQUARE_BRACE_CLOSE]])) {
                 continue;
             }
 

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -2925,6 +2925,13 @@ foo($a /* d */, $b);
 $arr = [/* empty */];
 ',
         ];
+
+        yield 'before_destructuring_square_brace_close' => [
+            '<?php
+foreach ($fields as [$field/** @var string*/]) {
+}
+',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixer 'single_space_after_construct' should not insert whitespace after those comments that before destructuring square brace close tag

closes #6110 

