### PR TITLE
OrderedClassElementsFixer - PHPUnit assert(Pre|Post)Conditions methods support

### DIFF
--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -402,6 +402,8 @@ class Example
                 [T_STRING, 'doTearDownAfterClass'],
                 [T_STRING, 'setUp'],
                 [T_STRING, 'doSetUp'],
+                [T_STRING, 'assertPreConditions'],
+                [T_STRING, 'assertPostConditions'],
                 [T_STRING, 'tearDown'],
                 [T_STRING, 'doTearDown'],
             ], false)
@@ -444,8 +446,10 @@ class Example
             'doteardownafterclass' => 4,
             'setup' => 5,
             'dosetup' => 6,
-            'teardown' => 7,
-            'doteardown' => 8,
+            'assertpreconditions' => 7,
+            'assertpostconditions' => 8,
+            'teardown' => 9,
+            'doteardown' => 10,
         ];
 
         foreach ($elements as &$element) {

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -148,6 +148,10 @@ abstract class Foo extends FooParent implements FooInterface1, FooInterface2
 
     protected function setUp() {}
 
+    protected function assertPreConditions() {}
+
+    protected function assertPostConditions() {}
+
     protected function tearDown() {}
 
     abstract public function foo1($a, $b = 1);
@@ -233,9 +237,13 @@ abstract class Foo extends FooParent implements FooInterface1, FooInterface2
     } /* multiline
     comment */
 
+    protected function assertPostConditions() {}
+
     use Baz {
         abc as private;
     }
+
+    protected function assertPreConditions() {}
 
     private function foo5()
     {


### PR DESCRIPTION
Add support for PHPUnit `TestCase::assertPreConditions()` and `TestCase::assertPostConditions()` methods.

`TestCase::assertPreConditions()` is called between `TestCase::setUp()` and test.
`TestCase::assertPostConditions()` is called between test and `TestCase::tearDown()`.