### PR TITLE
Use Tokens::ensureWhitespaceAtIndex to simplify code

### DIFF
--- a/src/Fixer/Comment/HeaderCommentFixer.php
+++ b/src/Fixer/Comment/HeaderCommentFixer.php
@@ -427,11 +427,7 @@ echo 1;
 
             $content = Preg::replace('/\R?\h*$/', '', $content);
 
-            if ('' === $content) {
-                $tokens->clearAt($prevIndex);
-            } else {
-                $tokens[$prevIndex] = new Token([T_WHITESPACE, $content]);
-            }
+            $tokens->ensureWhitespaceAtIndex($prevIndex, 0, $content);
         }
 
         $nextIndex = $index + 1;
@@ -440,11 +436,7 @@ echo 1;
         if (!$newlineRemoved && null !== $nextToken && $nextToken->isWhitespace()) {
             $content = Preg::replace('/^\R/', '', $nextToken->getContent());
 
-            if ('' === $content) {
-                $tokens->clearAt($nextIndex);
-            } else {
-                $tokens[$nextIndex] = new Token([T_WHITESPACE, $content]);
-            }
+            $tokens->ensureWhitespaceAtIndex($nextIndex, 0, $content);
         }
 
         $tokens->clearTokenAndMergeSurroundingWhitespace($index);

--- a/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
+++ b/src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php
@@ -76,11 +76,7 @@ final class NoTrailingWhitespaceInCommentFixer extends AbstractFixer
                     $tokens[$index] = new Token([T_COMMENT, Preg::replace('/(*ANY)[\h]+$/m', '', $token->getContent())]);
                 } elseif (isset($tokens[$index + 1]) && $tokens[$index + 1]->isWhitespace()) {
                     $trimmedContent = ltrim($tokens[$index + 1]->getContent(), " \t");
-                    if ('' !== $trimmedContent) {
-                        $tokens[$index + 1] = new Token([T_WHITESPACE, $trimmedContent]);
-                    } else {
-                        $tokens->clearAt($index + 1);
-                    }
+                    $tokens->ensureWhitespaceAtIndex($index + 1, 0, $trimmedContent);
                 }
             }
         }

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -302,11 +302,7 @@ switch ($foo) {
         if ($whitespaceToken->isGivenKind(T_WHITESPACE)) {
             $content = Preg::replace($regex, '', $whitespaceToken->getContent());
 
-            if ('' !== $content) {
-                $tokens[$whitespacePosition] = new Token([T_WHITESPACE, $content]);
-            } else {
-                $tokens->clearAt($whitespacePosition);
-            }
+            $tokens->ensureWhitespaceAtIndex($whitespacePosition, 0, $content);
         }
 
         $tokens->clearTokenAndMergeSurroundingWhitespace($commentPosition);

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -303,11 +303,7 @@ SAMPLE
 
         $content = Preg::replace('/\R\h*/', '', $tokens[$index]->getContent());
 
-        if ('' !== $content) {
-            $tokens[$index] = new Token([T_WHITESPACE, $content]);
-        } else {
-            $tokens->clearAt($index);
-        }
+        $tokens->ensureWhitespaceAtIndex($index, 0, $content);
 
         return true;
     }

--- a/src/Fixer/Import/NoUnusedImportsFixer.php
+++ b/src/Fixer/Import/NoUnusedImportsFixer.php
@@ -232,11 +232,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         if ($prevToken->isWhitespace()) {
             $content = rtrim($prevToken->getContent(), " \t");
 
-            if ('' === $content) {
-                $tokens->clearAt($prevIndex);
-            } else {
-                $tokens[$prevIndex] = new Token([T_WHITESPACE, $content]);
-            }
+            $tokens->ensureWhitespaceAtIndex($prevIndex, 0, $content);
 
             $prevToken = $tokens[$prevIndex];
         }
@@ -261,11 +257,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
                 1
             );
 
-            if ('' !== $content) {
-                $tokens[$nextIndex] = new Token([T_WHITESPACE, $content]);
-            } else {
-                $tokens->clearAt($nextIndex);
-            }
+            $tokens->ensureWhitespaceAtIndex($nextIndex, 0, $content);
 
             $nextToken = $tokens[$nextIndex];
         }
@@ -273,11 +265,7 @@ final class NoUnusedImportsFixer extends AbstractFixer
         if ($prevToken->isWhitespace() && $nextToken->isWhitespace()) {
             $content = $prevToken->getContent().$nextToken->getContent();
 
-            if ('' !== $content) {
-                $tokens[$nextIndex] = new Token([T_WHITESPACE, $content]);
-            } else {
-                $tokens->clearAt($nextIndex);
-            }
+            $tokens->ensureWhitespaceAtIndex($nextIndex, 0, $content);
 
             $tokens->clearAt($prevIndex);
         }

--- a/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
+++ b/src/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixer.php
@@ -256,11 +256,7 @@ yield  from  baz();
                 }
             }
 
-            if ($tokens[$whitespaceTokenIndex]->equals([T_WHITESPACE])) {
-                $tokens[$whitespaceTokenIndex] = new Token([T_WHITESPACE, ' ']);
-            } else {
-                $tokens->insertAt($whitespaceTokenIndex, new Token([T_WHITESPACE, ' ']));
-            }
+            $tokens->ensureWhitespaceAtIndex($whitespaceTokenIndex, 0, ' ');
 
             if (
                 $token->isGivenKind(T_YIELD_FROM)

--- a/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
+++ b/src/Fixer/Operator/NotOperatorWithSuccessorSpaceFixer.php
@@ -18,7 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -71,11 +70,7 @@ if (!$bar) {
             $token = $tokens[$index];
 
             if ($token->equals('!')) {
-                if (!$tokens[$index + 1]->isWhitespace()) {
-                    $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
-                } else {
-                    $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
-                }
+                $tokens->ensureWhitespaceAtIndex($index + 1, 0, ' ');
             }
         }
     }

--- a/src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
+++ b/src/Fixer/Semicolon/NoSinglelineWhitespaceBeforeSemicolonsFixer.php
@@ -18,7 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
 /**
@@ -67,9 +66,7 @@ final class NoSinglelineWhitespaceBeforeSemicolonsFixer extends AbstractFixer
 
             if ($tokens[$index - 2]->equals(';')) {
                 // do not remove all whitespace before the semicolon because it is also whitespace after another semicolon
-                if (!$tokens[$index - 1]->equals(' ')) {
-                    $tokens[$index - 1] = new Token([T_WHITESPACE, ' ']);
-                }
+                $tokens->ensureWhitespaceAtIndex($index - 1, 0, ' ');
             } elseif (!$tokens[$index - 2]->isComment()) {
                 $tokens->clearAt($index - 1);
             }

--- a/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
+++ b/src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php
@@ -76,11 +76,7 @@ final class NoTrailingWhitespaceFixer extends AbstractFixer
                 && 1 === Preg::match('/^(\R)(.*)$/s', $tokens[$index + 1]->getContent(), $whitespaceMatches)
             ) {
                 $tokens[$index] = new Token([T_OPEN_TAG, $openTagMatches[1].$whitespaceMatches[1]]);
-                if ('' === $whitespaceMatches[2]) {
-                    $tokens->clearAt($index + 1);
-                } else {
-                    $tokens[$index + 1] = new Token([T_WHITESPACE, $whitespaceMatches[2]]);
-                }
+                $tokens->ensureWhitespaceAtIndex($index + 1, 0, $whitespaceMatches[2]);
 
                 continue;
             }

--- a/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
+++ b/src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php
@@ -93,11 +93,7 @@ final class NoWhitespaceInBlankLineFixer extends AbstractFixer implements Whites
                 $lines[$l] = Preg::replace('/^\h+$/', '', $lines[$l]);
             }
             $content = implode($this->whitespacesConfig->getLineEnding(), $lines);
-            if ('' !== $content) {
-                $tokens[$index] = new Token([T_WHITESPACE, $content]);
-            } else {
-                $tokens->clearAt($index);
-            }
+            $tokens->ensureWhitespaceAtIndex($index, 0, $content);
         }
     }
 }


### PR DESCRIPTION
It lowers cyclomatic complexity.

Before:
```console
$ phploc src/Fixer | grep 'Average Complexity per Class'
  Average Complexity per Class                   17.27
```

After:
```console
$ phploc src/Fixer | grep 'Average Complexity per Class'
  Average Complexity per Class                   17.22
```