### PR TITLE
Re-add `function_exists` check for cases when mbstring polyfill is removed

### DIFF
--- a/src/Fixer/Alias/MbStrFunctionsFixer.php
+++ b/src/Fixer/Alias/MbStrFunctionsFixer.php
@@ -58,7 +58,7 @@ final class MbStrFunctionsFixer extends AbstractFunctionReferenceFixer
         $this->functions = array_filter(
             self::$functionsMap,
             static function (array $mapping): bool {
-                return (new \ReflectionFunction($mapping['alternativeName']))->isInternal();
+                return \function_exists($mapping['alternativeName']) && (new \ReflectionFunction($mapping['alternativeName']))->isInternal();
             }
         );
     }


### PR DESCRIPTION
Fix for https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6054#discussion_r752157049