### PR TITLE
Remove 2nd parameter to XdebugHandler constructor

### DIFF
--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -107,7 +107,7 @@ use Composer\XdebugHandler\XdebugHandler;
 use PhpCsFixer\Console\Application;
 
 // Restart if xdebug is loaded, unless the environment variable PHP_CS_FIXER_ALLOW_XDEBUG is set.
-$xdebug = new XdebugHandler('PHP_CS_FIXER', '--ansi');
+$xdebug = new XdebugHandler('PHP_CS_FIXER');
 $xdebug->check();
 unset($xdebug);
 


### PR DESCRIPTION
It was removed in https://github.com/composer/xdebug-handler/pull/123  `composer/XdebugHandler` v2.
Issue https://github.com/composer/xdebug-handler/issues/131 has some discussion.
