### PR TITLE
Add branch alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,5 +67,10 @@
     ],
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
     }
 }


### PR DESCRIPTION
allow usage of `^3.3@dev` to install master branch. Alternative default branch to 3.3 or what current version is.