### PR TITLE
Allow usage with PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
 
           - operating-system: 'ubuntu-20.04'
             php-version: '8.1'
+
+          - operating-system: 'ubuntu-20.04'
+            php-version: '8.2'
             PHP_CS_FIXER_IGNORE_ENV: 1
 
           - operating-system: 'windows-latest'

--- a/php-cs-fixer
+++ b/php-cs-fixer
@@ -40,9 +40,9 @@ set_error_handler(static function ($severity, $message, $file, $line) {
         exit(1);
     } elseif (
         \PHP_VERSION_ID < 70205
-        || \PHP_VERSION_ID >= 80100
+        || \PHP_VERSION_ID >= 80200
     ) {
-        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.2.5 and maximum version of PHP 8.0.*.\n");
+        fwrite(STDERR, "PHP needs to be a minimum version of PHP 7.2.5 and maximum version of PHP 8.1.*.\n");
         fwrite(STDERR, 'Current PHP version: '.PHP_VERSION.".\n");
 
         if (getenv('PHP_CS_FIXER_IGNORE_ENV')) {


### PR DESCRIPTION
As #5891 seems to be resolved it should not longer needed to set `PHP_CS_FIXER_IGNORE_ENV` for php 8.1