### PR TITLE
NonPrintableCharacterFixer - fix for when removing non-printable character break PHP syntax

### DIFF
--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -174,7 +174,19 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
             }
 
             if ($token->isGivenKind(self::$tokens)) {
-                $tokens[$index] = new Token([$token->getId(), strtr($content, $replacements)]);
+                $newContent = strtr($content, $replacements);
+
+                // variable name cannot contain space
+                if ($token->isGivenKind([T_STRING_VARNAME, T_VARIABLE]) && str_contains($newContent, ' ')) {
+                    continue;
+                }
+
+                // multiline comment must have "*/" only at the end
+                if ($token->isGivenKind([T_COMMENT, T_DOC_COMMENT]) && str_starts_with($newContent, '/*') && strpos($newContent, '*/') !== \strlen($newContent) - 2) {
+                    continue;
+                }
+
+                $tokens[$index] = new Token([$token->getId(), $newContent]);
             }
         }
     }

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -103,6 +103,18 @@ echo "Hello'.pack('H*', 'e280af').'World'.pack('H*', 'c2a0').'!";',
                 '<?php echo \'12345\';?>abc<?php ?>',
                 '<?php echo \'123'.pack('H*', 'e2808b').'45\';?>a'.pack('H*', 'e2808b').'bc<?php ?>',
             ],
+            [
+                '<?php echo "${foo'.pack('H*', 'c2a0').'bar} is great!";',
+            ],
+            [
+                '<?php echo $foo'.pack('H*', 'c2a0').'bar;',
+            ],
+            [
+                '<?php /* foo *'.pack('H*', 'e2808b').'/ bar */',
+            ],
+            [
+                '<?php /** foo *'.pack('H*', 'e2808b').'/ bar */',
+            ],
         ];
     }
 


### PR DESCRIPTION
Apparently it is possible to use [zero-width space](https://github.com/colinodell/json5/blob/v2.2.1/src/Json5Decoder.php#L375) and [non-breaking space](https://github.com/markrogoyski/math-php/blob/v2.5.0/src/Statistics/Distance.php#L241) in such way that removing them (`NonPrintableCharacterFixer` replaces non-breaking space with normal space) breaks PHP syntax:
```php
<?php
/* Hello *<zero-width space here>/ World! */
$foo<non-breaking space here>bar = true;
```

Should we use ultimate solution here and check if removing non-printable character breaks PHP syntax or have fun with tokens and comment's content (if that's even possible, I've found these 2 cases, could be more)?