### PR TITLE
DeclareEqualNormalizeFixer - fix for declare having multiple directives

### DIFF
--- a/src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
+++ b/src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php
@@ -88,9 +88,14 @@ final class DeclareEqualNormalizeFixer extends AbstractFixer implements Configur
                 continue;
             }
 
-            while (!$tokens[++$index]->equals('='));
+            $openParenthesisIndex = $tokens->getNextMeaningfulToken($index);
+            $closeParenthesisIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openParenthesisIndex);
 
-            $this->{$callback}($tokens, $index);
+            for ($i = $closeParenthesisIndex; $i > $openParenthesisIndex; --$i) {
+                if ($tokens[$i]->equals('=')) {
+                    $this->{$callback}($tokens, $i);
+                }
+            }
         }
     }
 

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -87,10 +87,15 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
                 null,
                 ['space' => 'none'],
             ],
-            'declare having multiple directives' => [
+            'declare having multiple directives, single' => [
                 '<?php declare(strict_types=1, ticks=1);',
                 '<?php declare(strict_types = 1, ticks = 1);',
                 [],
+            ],
+            'declare having multiple directives, none' => [
+                '<?php declare(strict_types = 1, ticks = 1);',
+                '<?php declare(strict_types=1, ticks=1);',
+                ['space' => 'single'],
             ],
         ];
     }

--- a/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/DeclareEqualNormalizeFixerTest.php
@@ -87,6 +87,11 @@ final class DeclareEqualNormalizeFixerTest extends AbstractFixerTestCase
                 null,
                 ['space' => 'none'],
             ],
+            'declare having multiple directives' => [
+                '<?php declare(strict_types=1, ticks=1);',
+                '<?php declare(strict_types = 1, ticks = 1);',
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
One more edgy edge case found running [regression](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6152#issue-1073467344).