### PR TITLE
NonPrintableCharacterFixer - fix for string in single quotes, having non-breaking space, linebreak, and single quote inside

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/Basic/NonPrintableCharacterFixerTest.php ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit tests/Fixer/Basic/NonPrintableCharacterFixerTest.php ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/Basic/NonPrintableCharacterFixer.php
+++ b/src/Fixer/Basic/NonPrintableCharacterFixer.php
@@ -165,7 +165,7 @@ final class NonPrintableCharacterFixer extends AbstractFixer implements Configur
 
                 if ($swapQuotes) {
                     $content = str_replace('"', '\"', $content);
-                    $content = Preg::replace('/^\'(.*)\'$/', '"$1"', $content);
+                    $content = Preg::replace('/^\'(.*)\'$/s', '"$1"', $content);
                 }
 
                 $tokens[$index] = new Token([$token->getId(), strtr($content, $escapeSequences)]);

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -303,6 +303,11 @@ EXPECTED
 INPUT
                  , pack('H*', 'e2808b')),
             ],
+            [
+//                "<?php \"String in single quotes, having non-breaking space: \\u{a0}, linebreak: \n, and single quote inside: ' is a dangerous mix.\";", // <- this is expected result
+                "<?php 'String in single quotes, having non-breaking space: \\u{a0}, linebreak: \n, and single quote inside: ' is a dangerous mix.';", // <- this is current result, which is broken PHP syntax
+                "<?php 'String in single quotes, having non-breaking space: " . pack('H*', 'c2a0') . ", linebreak: \n, and single quote inside: \\' is a dangerous mix.';",
+            ],
         ];
     }
 }

--- a/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
+++ b/tests/Fixer/Basic/NonPrintableCharacterFixerTest.php
@@ -304,9 +304,8 @@ INPUT
                  , pack('H*', 'e2808b')),
             ],
             [
-//                "<?php \"String in single quotes, having non-breaking space: \\u{a0}, linebreak: \n, and single quote inside: ' is a dangerous mix.\";", // <- this is expected result
-                "<?php 'String in single quotes, having non-breaking space: \\u{a0}, linebreak: \n, and single quote inside: ' is a dangerous mix.';", // <- this is current result, which is broken PHP syntax
-                "<?php 'String in single quotes, having non-breaking space: " . pack('H*', 'c2a0') . ", linebreak: \n, and single quote inside: \\' is a dangerous mix.';",
+                "<?php \"String in single quotes, having non-breaking space: \\u{a0}, linebreak: \n, and single quote inside: ' is a dangerous mix.\";",
+                "<?php 'String in single quotes, having non-breaking space: ".pack('H*', 'c2a0').", linebreak: \n, and single quote inside: \\' is a dangerous mix.';",
             ],
         ];
     }


### PR DESCRIPTION
In the topic of edge cases - this one is awesome, the title says it all.

Don't give me any credits for this, I'm not that smart to came with this one - all the glory goes to Google.

see it at your own risk, not the prettiest code you'll ever see: https://github.com/googleapis/google-cloud-php/blob/v0.172.0/Compute/metadata/V1/Compute.php.