### PR TITLE
PhpdocAlignFixer: fix property-read/property-write descriptions not getting aligned

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAlignFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAlignFixer.php
@@ -64,6 +64,8 @@ final class PhpdocAlignFixer extends AbstractFixer implements ConfigurableFixerI
     private const TAGS_WITH_NAME = [
         'param',
         'property',
+        'property-read',
+        'property-write',
     ];
 
     private const TAGS_WITH_METHOD_SIGNATURE = [

--- a/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAlignFixerTest.php
@@ -1227,17 +1227,17 @@ final class Sample
                 ['tags' => ['property', 'property-read', 'property-write']],
                 '<?php
 /**
- * @property       string $myMagicProperty
- * @property-read  string $myMagicReadyProperty
- * @property-write string $myMagicWriteProperty
+ * @property       string $myMagicProperty      magic property
+ * @property-read  string $myMagicReadProperty  magic read-only property
+ * @property-write string $myMagicWriteProperty magic write-only property
  */
 class Foo {}
 ',
                 '<?php
 /**
- * @property string $myMagicProperty
- * @property-read string $myMagicReadyProperty
- * @property-write string $myMagicWriteProperty
+ * @property string $myMagicProperty magic property
+ * @property-read string $myMagicReadProperty magic read-only property
+ * @property-write string $myMagicWriteProperty magic write-only property
  */
 class Foo {}
 ',


### PR DESCRIPTION
Although the PHPDoc descriptions of `@property` tags did get aligned vertically, the `@property-read` and `@property-write` ones didn't. Now they do.

This is done by adding `@property-read` and `@property-write` to the `TAGS_WITH_NAME` const array.

The `PhpdocAlignFixerTest::testVariadicParams()` case for magic `@property(...)` tags also now has the PHPDoc descriptions that were missing.

Feedback is very welcome, as always.