### PR TITLE
Simplify DiffConsoleFormatter

### DIFF
--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -58,11 +58,7 @@ final class DiffConsoleFormatter
                         if ($isDecorated) {
                             $count = 0;
                             $line = Preg::replaceCallback(
-                                [
-                                    '/^(\+.*)/',
-                                    '/^(\-.*)/',
-                                    '/^(@.*)/',
-                                ],
+                                '/^([+-@].*)/',
                                 static function (array $matches): string {
                                     if ('+' === $matches[0][0]) {
                                         $colour = 'green';


### PR DESCRIPTION
This is actually only place where any `Preg` method is called with an array (of patterns), not a string.

To be continued: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6184.