### PR TITLE
Do not support array of patterns in Preg methods

### DIFF
--- a/src/Preg.php
+++ b/src/Preg.php
@@ -65,15 +65,11 @@ final class Preg
     }
 
     /**
-     * @param string|string[] $pattern
-     * @param string|string[] $replacement
      * @param string|string[] $subject
      *
      * @throws PregException
-     *
-     * @return string|string[]
      */
-    public static function replace($pattern, $replacement, $subject, int $limit = -1, ?int &$count = null)
+    public static function replace(string $pattern, string $replacement, $subject, int $limit = -1, ?int &$count = null): string
     {
         $result = @preg_replace(self::addUtf8Modifier($pattern), $replacement, $subject, $limit, $count);
         if (null !== $result && PREG_NO_ERROR === preg_last_error()) {
@@ -89,14 +85,9 @@ final class Preg
     }
 
     /**
-     * @param string|string[] $pattern
-     * @param string|string[] $subject
-     *
      * @throws PregException
-     *
-     * @return string|string[]
      */
-    public static function replaceCallback($pattern, callable $callback, $subject, int $limit = -1, ?int &$count = null)
+    public static function replaceCallback(string $pattern, callable $callback, string $subject, int $limit = -1, ?int &$count = null): string
     {
         $result = @preg_replace_callback(self::addUtf8Modifier($pattern), $callback, $subject, $limit, $count);
         if (null !== $result && PREG_NO_ERROR === preg_last_error()) {

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -125,7 +125,7 @@ final class PregTest extends TestCase
 
         try {
             $buffer = "The quick brown \xFF\x00\\xXX jumps over the lazy dog\n";
-            $actual = $buffer !== Preg::replace((array) $pattern, 'abc', $buffer);
+            $actual = $buffer !== Preg::replace($pattern, 'abc', $buffer);
         } catch (\Exception $ex) {
             $setup();
 
@@ -176,7 +176,6 @@ final class PregTest extends TestCase
      * @param string|string[] $subject
      *
      * @dataProvider provideCommonCases
-     * @dataProvider provideArrayOfPatternsCases
      */
     public function testReplace($pattern, $subject): void
     {
@@ -199,7 +198,6 @@ final class PregTest extends TestCase
      * @param string|string[] $subject
      *
      * @dataProvider provideCommonCases
-     * @dataProvider provideArrayOfPatternsCases
      */
     public function testReplaceCallback($pattern, $subject): void
     {
@@ -219,14 +217,6 @@ final class PregTest extends TestCase
             ['/./', \chr(224).'bc'],
             ['/à/', 'àbc'],
             ['/'.\chr(224).'|í/', 'àbc'],
-        ];
-    }
-
-    public function provideArrayOfPatternsCases(): array
-    {
-        return [
-            [['/à/', '/í/'], 'Tàíl'],
-            [['/'.\chr(174).'/', '/'.\chr(224).'/'], 'foo'],
         ];
     }
 


### PR DESCRIPTION
Requires https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6183 to be merged.

`Preg` is an internal class, so BC break is fine.

To be continued: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6185.