### PR TITLE
PhpdocTo(Param|Property|Return)TypeFixer - fix for type intersections

### DIFF
--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -29,7 +29,7 @@ final class TypeExpression
      * @internal
      */
     public const REGEX_TYPES = '
-    (?<types> # alternation of several types separated by `|`
+    (?<types> # several types separated by `|` or `&`
         (?<type> # single type
             \?? # optionally nullable
             (?:
@@ -88,13 +88,9 @@ final class TypeExpression
                     [\\\\\w-]++
                 )
             )
-            (?: # intersection
-                \h*&\h*
-                (?&type)
-            )*
         )
         (?:
-            \h*\|\h*
+            \h*[|&]\h*
             (?&type)
         )*
     )
@@ -129,7 +125,7 @@ final class TypeExpression
 
             $this->types[] = $matches['type'];
             $value = Preg::replace(
-                '/^'.preg_quote($matches['type'], '/').'(\h*\|\h*)?/',
+                '/^'.preg_quote($matches['type'], '/').'(\h*[|&]\h*)?/',
                 '',
                 $value
             );

--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -386,7 +386,7 @@ class Foo {
         while (true) {
             $type = '';
 
-            while ($tokens[$index]->isGivenKind([T_NS_SEPARATOR, T_STATIC, T_STRING, CT::T_ARRAY_TYPEHINT, T_CALLABLE, CT::T_TYPE_INTERSECTION])) {
+            while ($tokens[$index]->isGivenKind([T_NS_SEPARATOR, T_STATIC, T_STRING, CT::T_ARRAY_TYPEHINT, T_CALLABLE])) {
                 $type .= $tokens[$index]->getContent();
                 $index = $tokens->getNextMeaningfulToken($index);
             }
@@ -397,7 +397,7 @@ class Foo {
 
             $types[] = $type;
 
-            if (!$tokens[$index]->isGivenKind(CT::T_TYPE_ALTERNATION)) {
+            if (!$tokens[$index]->isGivenKind([CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION])) {
                 break;
             }
 

--- a/tests/DocBlock/AnnotationTest.php
+++ b/tests/DocBlock/AnnotationTest.php
@@ -382,11 +382,11 @@ final class AnnotationTest extends TestCase
                 '/** @var class-string<Foo> */',
             ],
             [
-                ['A&B'],
+                ['A', 'B'],
                 '/** @var A&B */',
             ],
             [
-                ['A & B'],
+                ['A', 'B'],
                 '/** @var A & B */',
             ],
             [

--- a/tests/DocBlock/TypeExpressionTest.php
+++ b/tests/DocBlock/TypeExpressionTest.php
@@ -69,8 +69,8 @@ final class TypeExpressionTest extends TestCase
         yield ['null|true|false|1|1.5|\'a\'|"b"', ['null', 'true', 'false', '1', '1.5', "'a'", '"b"']];
         yield ['int | "a" | A<B<C, D>, E<F::*|G[]>>', ['int', '"a"', 'A<B<C, D>, E<F::*|G[]>>']];
         yield ['class-string<Foo>', ['class-string<Foo>']];
-        yield ['A&B', ['A&B']];
-        yield ['A & B', ['A & B']];
+        yield ['A&B', ['A', 'B']];
+        yield ['A & B', ['A', 'B']];
         yield ['array{1: bool, 2: bool}', ['array{1: bool, 2: bool}']];
         yield ['array{a: int|string, b?: bool}', ['array{a: int|string, b?: bool}']];
         yield ['array{\'a\': "a", "b"?: \'b\'}', ['array{\'a\': "a", "b"?: \'b\'}']];

--- a/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToParamTypeFixerTest.php
@@ -416,6 +416,24 @@ final class PhpdocToParamTypeFixerTest extends AbstractFixerTestCase
                     }
                 ',
             ],
+            'intersection types' => [
+                '<?php
+                    /** @param Bar&Baz $x */
+                    function bar($x) {}
+                ',
+            ],
+            'very long class name before ampersand' => [
+                '<?php
+                    /** @param Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar&Baz $x */
+                    function bar($x) {}
+                ',
+            ],
+            'very long class name after ampersand' => [
+                '<?php
+                    /** @param Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz $x */
+                    function bar($x) {}
+                ',
+            ],
         ];
     }
 }

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -449,6 +449,15 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
                 '<?php new class { /** @var int */ private int $foo; };',
                 '<?php new class { /** @var int */ private $foo; };',
             ],
+            'intersection types' => [
+                '<?php class Foo { /** @var Bar&Baz */ private $x; }',
+            ],
+            'very long class name before ampersand' => [
+                '<?php class Foo { /** @var Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar&Baz */ private $x; }',
+            ],
+            'very long class name after ampersand' => [
+                '<?php class Foo { /** @var Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz */ private $x; }',
+            ],
         ];
     }
 

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -313,6 +313,24 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
                 '<?php /** @return string[]|int[] */ function my_foo(): array {}',
                 '<?php /** @return string[]|int[] */ function my_foo() {}',
             ],
+            'intersection types' => [
+                '<?php
+                    /** @return Bar&Baz */
+                    function bar() {}
+                ',
+            ],
+            'very long class name before ampersand' => [
+                '<?php
+                    /** @return Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar&Baz */
+                    function bar() {}
+                ',
+            ],
+            'very long class name after ampersand' => [
+                '<?php
+                    /** @return Bar&Baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaz */
+                    function bar() {}
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6187