### PR TITLE
DX: DiffConsoleFormatter - escape -

### DIFF
--- a/src/Differ/DiffConsoleFormatter.php
+++ b/src/Differ/DiffConsoleFormatter.php
@@ -58,7 +58,7 @@ final class DiffConsoleFormatter
                         if ($isDecorated) {
                             $count = 0;
                             $line = Preg::replaceCallback(
-                                '/^([+-@].*)/',
+                                '/^([+\-@].*)/',
                                 static function (array $matches): string {
                                     if ('+' === $matches[0][0]) {
                                         $colour = 'green';


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6183/files#r770714802

Original form, depending on language or analyser, may trigger a warning.

> https://www.regular-expressions.info/charclass.html
> In most regex flavors, the only special characters or metacharacters inside a character class are the closing bracket ], the backslash \, the caret ^, and the hyphen -. The usual metacharacters are normal characters inside a character class, and do not need to be escaped by a backslash