### PR TITLE
PHP 8.1 - handle enums in class fixers

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -176,7 +176,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ClassNotation\\ClassAttributesSeparationFixer <./../src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php>`_
 -  `class_definition <./rules/class_notation/class_definition.rst>`_
 
-   Whitespace around the keywords of a class, trait or interfaces definition should be one space.
+   Whitespace around the keywords of a class, trait, enum or interfaces definition should be one space.
 
    Configuration options:
 
@@ -1719,14 +1719,14 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Operator\\OperatorLinebreakFixer <./../src/Fixer/Operator/OperatorLinebreakFixer.php>`_
 -  `ordered_class_elements <./rules/class_notation/ordered_class_elements.rst>`_
 
-   Orders the elements of classes/interfaces/traits.
+   Orders the elements of classes/interfaces/traits/enums.
 
    Configuration options:
 
    - | ``order``
      | List of strings defining order of elements.
-     | Allowed values: a subset of ``['use_trait', 'public', 'protected', 'private', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_readonly', 'property_protected_readonly', 'property_private_readonly', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_abstract', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_abstract', 'method_protected_abstract', 'method_private_abstract', 'method_public_abstract_static', 'method_protected_abstract_static', 'method_private_abstract_static', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']``
-     | Default value: ``['use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
+     | Allowed values: a subset of ``['use_trait', 'public', 'protected', 'private', 'case', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_readonly', 'property_protected_readonly', 'property_private_readonly', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_abstract', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_abstract', 'method_protected_abstract', 'method_private_abstract', 'method_public_abstract_static', 'method_protected_abstract_static', 'method_private_abstract_static', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']``
+     | Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
    - | ``sort_algorithm``
      | How multiple occurrences of same type statements should be sorted
      | Allowed values: ``'alpha'``, ``'none'``

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -2,8 +2,8 @@
 Rule ``class_definition``
 =========================
 
-Whitespace around the keywords of a class, trait or interfaces definition should
-be one space.
+Whitespace around the keywords of a class, trait, enum or interfaces definition
+should be one space.
 
 Configuration
 -------------

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -2,7 +2,7 @@
 Rule ``ordered_class_elements``
 ===============================
 
-Orders the elements of classes/interfaces/traits.
+Orders the elements of classes/interfaces/traits/enums.
 
 Configuration
 -------------
@@ -12,9 +12,9 @@ Configuration
 
 List of strings defining order of elements.
 
-Allowed values: a subset of ``['use_trait', 'public', 'protected', 'private', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_readonly', 'property_protected_readonly', 'property_private_readonly', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_abstract', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_abstract', 'method_protected_abstract', 'method_private_abstract', 'method_public_abstract_static', 'method_protected_abstract_static', 'method_private_abstract_static', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']``
+Allowed values: a subset of ``['use_trait', 'public', 'protected', 'private', 'case', 'constant', 'constant_public', 'constant_protected', 'constant_private', 'property', 'property_static', 'property_public', 'property_protected', 'property_private', 'property_public_readonly', 'property_protected_readonly', 'property_private_readonly', 'property_public_static', 'property_protected_static', 'property_private_static', 'method', 'method_abstract', 'method_static', 'method_public', 'method_protected', 'method_private', 'method_public_abstract', 'method_protected_abstract', 'method_private_abstract', 'method_public_abstract_static', 'method_protected_abstract_static', 'method_private_abstract_static', 'method_public_static', 'method_protected_static', 'method_private_static', 'construct', 'destruct', 'magic', 'phpunit']``
 
-Default value: ``['use_trait', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
+Default value: ``['use_trait', 'case', 'constant_public', 'constant_protected', 'constant_private', 'property_public', 'property_protected', 'property_private', 'construct', 'destruct', 'magic', 'phpunit', 'method_public', 'method_protected', 'method_private']``
 
 ``sort_algorithm``
 ~~~~~~~~~~~~~~~~~~

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -141,7 +141,7 @@ Class Notation
   Class, trait and interface elements must be separated with one or none blank line.
 - `class_definition <./class_notation/class_definition.rst>`_
 
-  Whitespace around the keywords of a class, trait or interfaces definition should be one space.
+  Whitespace around the keywords of a class, trait, enum or interfaces definition should be one space.
 - `final_class <./class_notation/final_class.rst>`_ *(risky)*
 
   All classes must be final, except abstract ones and Doctrine entities.
@@ -165,7 +165,7 @@ Class Notation
   A ``final`` class must not have ``final`` methods and ``private`` methods must not be ``final``.
 - `ordered_class_elements <./class_notation/ordered_class_elements.rst>`_
 
-  Orders the elements of classes/interfaces/traits.
+  Orders the elements of classes/interfaces/traits/enums.
 - `ordered_interfaces <./class_notation/ordered_interfaces.rst>`_ *(risky)*
 
   Orders the interfaces in an ``implements`` or ``interface extends`` clause.

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -38,7 +38,7 @@ final class ClassDefinitionFixer extends AbstractFixer implements ConfigurableFi
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Whitespace around the keywords of a class, trait or interfaces definition should be one space.',
+            'Whitespace around the keywords of a class, trait, enum or interfaces definition should be one space.',
             [
                 new CodeSample(
                     '<?php

--- a/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
+++ b/src/Fixer/ClassNotation/OrderedClassElementsFixer.php
@@ -51,6 +51,7 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
         'public' => null,
         'protected' => null,
         'private' => null,
+        'case' => ['public'],
         'constant' => null,
         'constant_public' => ['constant', 'public'],
         'constant_protected' => ['constant', 'protected'],
@@ -159,7 +160,7 @@ final class OrderedClassElementsFixer extends AbstractFixer implements Configura
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Orders the elements of classes/interfaces/traits.',
+            'Orders the elements of classes/interfaces/traits/enums.',
             [
                 new CodeSample(
                     '<?php
@@ -270,6 +271,7 @@ class Example
                 ->setAllowedValues([new AllowedValueSubset(array_keys(array_merge(self::$typeHierarchy, self::$specialTypes)))])
                 ->setDefault([
                     'use_trait',
+                    'case',
                     'constant_public',
                     'constant_protected',
                     'constant_private',
@@ -297,7 +299,7 @@ class Example
      */
     private function getElements(Tokens $tokens, int $startIndex): array
     {
-        static $elementTokenKinds = [CT::T_USE_TRAIT, T_CONST, T_VARIABLE, T_FUNCTION];
+        static $elementTokenKinds = [CT::T_USE_TRAIT, T_CASE, T_CONST, T_VARIABLE, T_FUNCTION];
 
         ++$startIndex;
         $elements = [];
@@ -356,7 +358,7 @@ class Example
 
                 if ('property' === $element['type']) {
                     $element['name'] = $tokens[$i]->getContent();
-                } elseif (\in_array($element['type'], ['use_trait', 'constant', 'method', 'magic', 'construct', 'destruct'], true)) {
+                } elseif (\in_array($element['type'], ['use_trait', 'case', 'constant', 'method', 'magic', 'construct', 'destruct'], true)) {
                     $element['name'] = $tokens[$tokens->getNextMeaningfulToken($i)]->getContent();
                 }
 
@@ -379,6 +381,10 @@ class Example
 
         if ($token->isGivenKind(CT::T_USE_TRAIT)) {
             return 'use_trait';
+        }
+
+        if ($token->isGivenKind(T_CASE)) {
+            return 'case';
         }
 
         if ($token->isGivenKind(T_CONST)) {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -106,7 +106,15 @@ final class Token
      */
     public static function getClassyTokenKinds(): array
     {
-        static $classTokens = [T_CLASS, T_TRAIT, T_INTERFACE];
+        static $classTokens;
+
+        if (null === $classTokens) {
+            $classTokens = [T_CLASS, T_TRAIT, T_INTERFACE];
+
+            if (\defined('T_ENUM')) { // @TODO: drop condition when PHP 8.1+ is required
+                $classTokens[] = T_ENUM;
+            }
+        }
 
         return $classTokens;
     }

--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -763,6 +763,12 @@ final class TokensAnalyzer
                     'token' => $token,
                     'type' => 'trait_import',
                 ];
+            } elseif ($token->isGivenKind(T_CASE)) {
+                $elements[$index] = [
+                    'classIndex' => $classIndex,
+                    'token' => $token,
+                    'type' => 'case',
+                ];
             }
         }
 

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5428,4 +5428,46 @@ if ($a) foreach ($b as $c): ?>
 };',
         ];
     }
+
+    /**
+     * @requires PHP 8.1
+     *
+     * @dataProvider provideFix81Cases
+     */
+    public function testFix81(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix81Cases()
+    {
+        yield 'enum' => [
+            '<?php
+enum Foo
+{
+    case Bar;
+
+    public function abc()
+    {
+    }
+}',
+            '<?php
+enum Foo {
+    case Bar;
+
+    public function abc() {
+    }
+}',
+        ];
+        yield 'backed-enum' => [
+            '<?php
+enum Foo: string
+{
+    case Bar = "bar";
+}',
+            '<?php
+enum Foo: string {
+case Bar = "bar";}',
+        ];
+    }
 }

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -656,6 +656,33 @@ $a = new class implements
     }
 
     /**
+     * @dataProvider providePHP81Cases
+     * @requires PHP 8.1
+     */
+    public function testFixPHP81(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure([]);
+        $this->doTest($expected, $input);
+    }
+
+    public function providePHP81Cases(): array
+    {
+        return [
+            [
+                "<?php enum Foo\n{}",
+                '<?php enum   Foo   {}',
+            ],
+            [
+                "<?php enum Foo : int\n{}",
+                '<?php enum   Foo  :  int   {}',
+            ],
+            [
+                "<?php enum Foo: string\n{}",
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideMessyWhitespacesCases
      */
     public function testMessyWhitespaces(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1440,5 +1440,36 @@ class A
 ',
             ['order' => ['property_public_readonly', 'property_public', 'property_protected_readonly', 'property_private_readonly'], 'sort_algorithm' => 'alpha'],
         ];
+
+        yield [
+            '<?php
+
+enum A: int
+{
+    case Foo = 1;
+    case Bar = 2;
+    private const C1 = 1;
+    function qux() {
+        switch (true) {
+            case 1: break;
+        }
+    }
+}
+',
+            '<?php
+
+enum A: int
+{
+    private const C1 = 1;
+    case Foo = 1;
+    function qux() {
+        switch (true) {
+            case 1: break;
+        }
+    }
+    case Bar = 2;
+}
+',
+        ];
     }
 }

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -553,6 +553,36 @@ class Foo
 }
             ',
         ];
+
+        yield 'enum' => [
+            [
+                10 => [
+                    'classIndex' => 1,
+                    'type' => 'case',
+                ],
+                19 => [
+                    'classIndex' => 1,
+                    'type' => 'case',
+                ],
+                28 => [
+                    'classIndex' => 1,
+                    'type' => 'method',
+                ],
+            ],
+            '<?php
+enum Foo: string
+{
+    case Bar = "bar";
+    case Baz = "baz";
+
+    function qux() {
+        switch (true) {
+            case "x": break;
+        }
+    }
+}
+            ',
+        ];
     }
 
     /**


### PR DESCRIPTION
This pull request…
* adds `T_ENUM` to `Token::getClassyTokenKinds()` (`$token->isClassy()` returns `true` for enums)
* adds enum cases to `TokenAnalyzer::findClassyElements()`
* adds test cases and some fixes for enums for `ClassDefinitionFixer`, `BracesFixer`, `OrderedClassElementsFixer`