### PR TITLE
Show runtime on version command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,7 @@ labels: kind/bug
   Before reporting a bug, make sure PHP CS Fixer is up-to-date.
 
   Please describe the problem and provide technical details such as:
-   * PHP version: php -v
-   * PHP CS Fixer version: php-cs-fixer -V
+   * PHP CS Fixer version and PHP runtime: php-cs-fixer -V
    * the command used to run PHP CS Fixer (run with `-vvv`)
    * the configuration (file) you used
 -->

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -122,7 +122,8 @@ final class Application extends BaseApplication
         $version = implode('', [
             parent::getLongVersion(),
             self::VERSION_CODENAME ? sprintf(' <info>%s</info>', self::VERSION_CODENAME) : '', // @phpstan-ignore-line to avoid `Ternary operator condition is always true|false.`
-            ' by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>',
+            ' by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>.',
+            "\nPHP runtime: <info>".PHP_VERSION.'</info>',
         ]);
 
         $commit = '@git-commit@';

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -101,7 +101,6 @@ final class DescribeCommand extends Command
         if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity() && $output instanceof ConsoleOutputInterface) {
             $stdErr = $output->getErrorOutput();
             $stdErr->writeln($this->getApplication()->getLongVersion());
-            $stdErr->writeln(sprintf('Runtime: <info>PHP %s</info>', PHP_VERSION));
         }
 
         $name = $input->getArgument('name');

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -268,7 +268,6 @@ EOF
         if (null !== $stdErr) {
             if (OutputInterface::VERBOSITY_VERBOSE <= $verbosity) {
                 $stdErr->writeln($this->getApplication()->getLongVersion());
-                $stdErr->writeln(sprintf('Runtime: <info>PHP %s</info>', PHP_VERSION));
             }
 
             $configFile = $resolver->getConfigFile();

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -100,7 +100,6 @@ EOT
         if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity() && $output instanceof ConsoleOutputInterface) {
             $stdErr = $output->getErrorOutput();
             $stdErr->writeln($this->getApplication()->getLongVersion());
-            $stdErr->writeln(sprintf('Runtime: <info>PHP %s</info>', PHP_VERSION));
         }
 
         if (!$this->toolInfo->isInstalledAsPhar()) {

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -27,7 +27,7 @@ final class ApplicationTest extends TestCase
     public function testApplication(): void
     {
         $app = new Application();
-        static::assertStringMatchesFormat('%s by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>', $app->getLongVersion());
+        static::assertStringMatchesFormat("%s by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>.\nPHP runtime: <info>%d.%d.%d</info>", $app->getLongVersion());
     }
 
     public function testGetMajorVersion(): void

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -166,17 +166,16 @@ Ignoring environment requirements because `PHP_CS_FIXER_IGNORE_ENV` is set. Exec
 
         /** @phpstan-ignore-next-line to avoid `Ternary operator condition is always true|false.` */
         $aboutSubpattern = Application::VERSION_CODENAME
-            ? 'PHP CS Fixer '.preg_quote(Application::VERSION, '/').' '.preg_quote(Application::VERSION_CODENAME, '/').' by Fabien Potencier and Dariusz Ruminski'
-            : 'PHP CS Fixer '.preg_quote(Application::VERSION, '/').' by Fabien Potencier and Dariusz Ruminski';
+            ? 'PHP CS Fixer '.preg_quote(Application::VERSION, '/').' '.preg_quote(Application::VERSION_CODENAME, '/')." by Fabien Potencier and Dariusz Ruminski.\nPHP runtime: ".PHP_VERSION
+            : 'PHP CS Fixer '.preg_quote(Application::VERSION, '/')." by Fabien Potencier and Dariusz Ruminski.\nPHP runtime: ".PHP_VERSION;
 
         $pattern = sprintf(
-            '/^(?:%s)?(?:%s)?(?:%s)?(?:%s)?%s\n%s\n%s\n([\.S]{%d})%s\n%s$/',
+            '/^(?:%s)?(?:%s)?(?:%s)?(?:%s)?%s\n%s\n([\.S]{%d})%s\n%s$/',
             preg_quote($optionalDeprecatedVersionWarning, '/'),
             preg_quote($optionalIncompatibilityWarning, '/'),
             preg_quote($optionalXdebugWarning, '/'),
             preg_quote($optionalWarningsHelp, '/'),
             $aboutSubpattern,
-            preg_quote(sprintf('Runtime: PHP %s', PHP_VERSION), '/'),
             preg_quote('Loaded config default from ".php-cs-fixer.dist.php".', '/'),
             \strlen($expectedResult3FilesDots),
             preg_quote($expectedResult3FilesPercentage, '/'),

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -56,7 +56,7 @@ final class PharTest extends AbstractSmokeTest
     public function testVersion(): void
     {
         static::assertMatchesRegularExpression(
-            '/^.* '.Application::VERSION.'(?: '.Application::VERSION_CODENAME.')? by .*$/',
+            sprintf("/^.* %s(?: %s)? by .*\nPHP runtime: \\d\\.\\d+\\..*\$/", Application::VERSION, Application::VERSION_CODENAME),
             self::executePharCommand('--version')->getOutput()
         );
     }


### PR DESCRIPTION
Show the PHP runtime on version command (php-cs-fixer -V), simplify code.