### PR TITLE
DX: Application - better display version when displaying gitSha

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -119,20 +119,20 @@ final class Application extends BaseApplication
      */
     public function getLongVersion(): string
     {
-        $version = implode('', [
+        $commit = '@git-commit@';
+        $versionCommit = '';
+
+        if ('@'.'git-commit@' !== $commit) { /** @phpstan-ignore-line as `$commit` is replaced during phar building */
+            $versionCommit = substr($commit, 0, 7);
+        }
+
+        return implode('', [
             parent::getLongVersion(),
+            $versionCommit ? sprintf(' <info>(%s)</info>', $versionCommit) : '', // @phpstan-ignore-line to avoid `Ternary operator condition is always true|false.`
             self::VERSION_CODENAME ? sprintf(' <info>%s</info>', self::VERSION_CODENAME) : '', // @phpstan-ignore-line to avoid `Ternary operator condition is always true|false.`
             ' by <comment>Fabien Potencier</comment> and <comment>Dariusz Ruminski</comment>.',
             "\nPHP runtime: <info>".PHP_VERSION.'</info>',
         ]);
-
-        $commit = '@git-commit@';
-
-        if ('@'.'git-commit@' !== $commit) { // @phpstan-ignore-line as `$commit` is replaced during phar building
-            $version .= ' ('.substr($commit, 0, 7).')';
-        }
-
-        return $version;
     }
 
     /**

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -55,8 +55,11 @@ final class PharTest extends AbstractSmokeTest
 
     public function testVersion(): void
     {
+        /** @phpstan-ignore-next-line to avoid `Ternary operator condition is always true|false.` */
+        $shouldExpectCodename = Application::VERSION_CODENAME ? 1 : 0;
+
         static::assertMatchesRegularExpression(
-            sprintf("/^.* %s(?: %s)? by .*\nPHP runtime: \\d\\.\\d+\\..*\$/", Application::VERSION, Application::VERSION_CODENAME),
+            sprintf("/^PHP CS Fixer (?<version>%s)(?<git_sha> \\([a-z0-9]+\\))?(?<codename> %s){%d}(?<by> by .*)\nPHP runtime: (?<php_version>\\d\\.\\d+\\..*)$/", Application::VERSION, Application::VERSION_CODENAME, $shouldExpectCodename),
             self::executePharCommand('--version')->getOutput()
         );
     }


### PR DESCRIPTION
before the change of this PR, but after #6222 :
```
ker@dus:~/github/PHP-CS-Fixer λ ./php-cs-fixer.phar 
PHP CS Fixer 3.5.0 The Creation by Fabien Potencier and Dariusz Ruminski.
PHP runtime: 8.0.13 (333f15e)
```
it's misleading, as 333f15e is gitSha of Fixer, not of PHP runtime