### PR TITLE
NoSuperfluousPhpdocTagsFixer - fix for reference and splat operator

### DIFF
--- a/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
+++ b/src/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixer.php
@@ -416,7 +416,7 @@ class Foo {
     private function annotationIsSuperfluous(Annotation $annotation, array $info, array $symbolShortNames): bool
     {
         if ('param' === $annotation->getTag()->getName()) {
-            $regex = '/@param\s+(?:\S|\s(?!\$))++\s\$\S+\s+\S/';
+            $regex = '/@param\s+[^\$]+\s(?:\&\s*)?(?:\.{3}\s*)?\$\S+\s+\S/';
         } elseif ('var' === $annotation->getTag()->getName()) {
             $regex = '/@var\s+\S+(\s+\$\S+)?(\s+)(?!\*+\/)([^$\s]+)/';
         } else {

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -1496,6 +1496,104 @@ final class Bar{}
  */
 class Foo {
 }', ],
+            'remove when used with reference' => [
+                '<?php class Foo {
+                    /**
+                     */
+                     function f1(string &$x) {}
+                    /**
+                     */
+                     function f2(string &$x) {}
+                    /**
+                     */
+                     function f3(string &$x) {}
+                }',
+                '<?php class Foo {
+                    /**
+                     * @param string $x
+                     */
+                     function f1(string &$x) {}
+                    /**
+                     * @param string &$x
+                     */
+                     function f2(string &$x) {}
+                    /**
+                     * @param string $y Description
+                     */
+                     function f3(string &$x) {}
+                }',
+            ],
+            'dont remove when used with reference' => [
+                '<?php class Foo {
+                    /**
+                     * @param string ...$x Description
+                     */
+                     function f(string ...$x) {}
+                }',
+            ],
+            'remove when used with splat operator' => [
+                '<?php class Foo {
+                    /**
+                     */
+                     function f1(string ...$x) {}
+                    /**
+                     */
+                     function f2(string ...$x) {}
+                }',
+                '<?php class Foo {
+                    /**
+                     * @param string ...$x
+                     */
+                     function f1(string ...$x) {}
+                    /**
+                     * @param string ...$y Description
+                     */
+                     function f2(string ...$x) {}
+                }',
+            ],
+            'dont remove when used with splat operator' => [
+                '<?php class Foo {
+                    /**
+                     * @param string ...$x Description
+                     */
+                     function f(string ...$x) {}
+                }',
+            ],
+            'remove when used with reference and splat operator' => [
+                '<?php class Foo {
+                    /**
+                     */
+                     function f1(string &...$x) {}
+                    /**
+                     */
+                     function f2(string &...$x) {}
+                    /**
+                     */
+                     function f3(string &...$x) {}
+                }',
+                '<?php class Foo {
+                    /**
+                     * @param string ...$x
+                     */
+                     function f1(string &...$x) {}
+                    /**
+                     * @param string &...$x
+                     */
+                     function f2(string &...$x) {}
+                    /**
+                     * @param string ...$y Description
+                     */
+                     function f3(string &...$x) {}
+                }',
+            ],
+            'dont remove when used with reference and splat operator' => [
+                '<?php class Foo {
+                    /**
+                     * @param string &...$x Description
+                     */
+                     function f(string &...$x) {}
+                }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6240