### PR TITLE
fix: handle unions in phpdoc_types_order

### DIFF
--- a/src/DocBlock/Annotation.php
+++ b/src/DocBlock/Annotation.php
@@ -204,11 +204,11 @@ final class Annotation
      *
      * @param string[] $types
      */
-    public function setTypes(array $types): void
+    public function setTypes(array $types, string $unionType = '|'): void
     {
         $pattern = '/'.preg_quote($this->getTypesContent(), '/').'/';
 
-        $this->lines[0]->setContent(Preg::replace($pattern, implode('|', $types), $this->lines[0]->getContent(), 1));
+        $this->lines[0]->setContent(Preg::replace($pattern, implode($unionType, $types), $this->lines[0]->getContent(), 1));
 
         $this->clearCache();
     }

--- a/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocTypesOrderFixer.php
@@ -142,7 +142,7 @@ final class PhpdocTypesOrderFixer extends AbstractFixer implements ConfigurableF
                 $types = $annotation->getTypes();
 
                 // fix main types
-                $annotation->setTypes($this->sortTypes($types));
+                $annotation->setTypes($this->sortTypes($types), str_contains($annotation->getContent(), '&') ? '&' : '|');
 
                 // fix @method parameters types
                 $line = $doc->getLine($annotation->getStart());

--- a/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocTypesOrderFixerTest.php
@@ -159,6 +159,9 @@ final class PhpdocTypesOrderFixerTest extends AbstractFixerTestCase
             [
                 '<?php /** @return array<int, callable(array<string, null|string> , DateTime): bool> */',
             ],
+            [
+                '<?php /** @return ContainerInterface&SymfonyContainerInterface */',
+            ],
         ];
     }
 


### PR DESCRIPTION
Prevent union types to be replaced.

Not sure it's the optimal way, suggestions welcome!