### PR TITLE
Missing import of PhpCsFixer\ConfigInterface

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer;
 
+use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Fixer\FixerInterface;
 
 /**


### PR DESCRIPTION
It seems there's a missing interface that needed to be imported.

I just installed php-cs-fixer to configure with Visual Studio code and it kept repeating the same error when I was trying to format on save :

`Undefined type 'PhpCsFixer\\Fixer\\FixerInterface'`

I went into the file, imported the correct interface and it seems to work now. 

Hope this helps ! ;)