### PR TITLE
NullableTypeDeclarationForDefaultNullValueFixer - handle "readonly" a…

### DIFF
--- a/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
+++ b/src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php
@@ -121,6 +121,16 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
      */
     private function fixFunctionParameters(Tokens $tokens, array $arguments): void
     {
+        $constructorPropertyModifiers = [
+            CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
+            CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
+            CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
+        ];
+
+        if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
+            $constructorPropertyModifiers[] = T_READONLY;
+        }
+
         foreach (array_reverse($arguments) as $argumentInfo) {
             if (
                 // Skip, if the parameter
@@ -136,17 +146,10 @@ final class NullableTypeDeclarationForDefaultNullValueFixer extends AbstractFixe
 
             $argumentTypeInfo = $argumentInfo->getTypeAnalysis();
 
-            if (
-                \PHP_VERSION_ID >= 80000
-                && false === $this->configuration['use_nullable_type_declaration']
-            ) {
+            if (\PHP_VERSION_ID >= 80000 && false === $this->configuration['use_nullable_type_declaration']) {
                 $visibility = $tokens[$tokens->getPrevMeaningfulToken($argumentTypeInfo->getStartIndex())];
 
-                if ($visibility->isGivenKind([
-                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
-                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
-                    CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
-                ])) {
+                if ($visibility->isGivenKind($constructorPropertyModifiers)) {
                     continue;
                 }
             }

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -505,8 +505,12 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
      * @dataProvider provideFix81Cases
      * @requires PHP 8.1
      */
-    public function testFix81(string $expected): void
+    public function testFix81(string $expected, ?array $config): void
     {
+        if (null !== $config) {
+            $this->fixer->configure($config);
+        }
+
         $this->doTest($expected);
     }
 
@@ -521,6 +525,19 @@ class Foo
     ) {}
 }
 ',
+            null,
+        ];
+
+        yield [
+            '<?php
+
+            class Foo {
+                public function __construct(
+                   public readonly ?string $readonlyString = null,
+                   readonly public ?int $readonlyInt = null,
+                ) {}
+            }',
+            ['use_nullable_type_declaration' => false],
         ];
     }
 }


### PR DESCRIPTION
…s constructor property modifier

closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6239