### PR TITLE
ClassReferenceNameCasingFixer - Fix for double arrow

### DIFF
--- a/src/AbstractNoUselessElseFixer.php
+++ b/src/AbstractNoUselessElseFixer.php
@@ -68,7 +68,7 @@ abstract class AbstractNoUselessElseFixer extends AbstractFixer
                 return false;
             }
 
-            if ($tokens[$candidateIndex]->equals([T_THROW])) {
+            if ($tokens[$candidateIndex]->isGivenKind(T_THROW)) {
                 $previousIndex = $tokens->getPrevMeaningfulToken($candidateIndex);
 
                 if (!$tokens[$previousIndex]->equalsAny([';', '{'])) {

--- a/src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
+++ b/src/Fixer/ArrayNotation/NoWhitespaceBeforeCommaInArrayFixer.php
@@ -121,7 +121,7 @@ SAMPLE
 
             if (
                 $currentToken->equals(',') && !$tokens[$prevIndex]->isComment()
-                && (true === $this->configuration['after_heredoc'] || !$tokens[$prevIndex]->equals([T_END_HEREDOC]))
+                && (true === $this->configuration['after_heredoc'] || !$tokens[$prevIndex]->isGivenKind(T_END_HEREDOC))
             ) {
                 $tokens->removeLeadingWhitespace($i);
             }

--- a/src/Fixer/Casing/ClassReferenceNameCasingFixer.php
+++ b/src/Fixer/Casing/ClassReferenceNameCasingFixer.php
@@ -78,6 +78,7 @@ final class ClassReferenceNameCasingFixer extends AbstractFixer
                 T_CASE, // PHP 8.1 trait enum-case
                 T_CLASS,
                 T_CONST,
+                T_DOUBLE_ARROW,
                 T_DOUBLE_COLON,
                 T_FUNCTION,
                 T_INTERFACE,
@@ -120,7 +121,7 @@ final class ClassReferenceNameCasingFixer extends AbstractFixer
                 continue;
             }
 
-            if (!$tokens[$prevIndex]->isGivenKind([T_NEW]) && $tokens[$nextIndex]->equals('(')) {
+            if (!$tokens[$prevIndex]->isGivenKind(T_NEW) && $tokens[$nextIndex]->equals('(')) {
                 continue;
             }
 

--- a/src/Fixer/ControlStructure/NoBreakCommentFixer.php
+++ b/src/Fixer/ControlStructure/NoBreakCommentFixer.php
@@ -154,7 +154,7 @@ switch ($foo) {
                 continue;
             }
 
-            if ($tokens[$i]->isGivenKind([T_THROW])) {
+            if ($tokens[$i]->isGivenKind(T_THROW)) {
                 $previousIndex = $tokens->getPrevMeaningfulToken($i);
 
                 if ($previousIndex === $casePosition || $tokens[$previousIndex]->equalsAny(['{', ';', '}', [T_OPEN_TAG]])) {

--- a/src/Fixer/Import/SingleImportPerStatementFixer.php
+++ b/src/Fixer/Import/SingleImportPerStatementFixer.php
@@ -130,7 +130,7 @@ final class SingleImportPerStatementFixer extends AbstractFixer implements White
         for ($i = $groupOpenIndex + 1; $i <= $groupCloseIndex; ++$i) {
             $token = $tokens[$i];
 
-            if ($token->equals(',') && $tokens[$tokens->getNextMeaningfulToken($i)]->equals([CT::T_GROUP_IMPORT_BRACE_CLOSE])) {
+            if ($token->equals(',') && $tokens[$tokens->getNextMeaningfulToken($i)]->isGivenKind(CT::T_GROUP_IMPORT_BRACE_CLOSE)) {
                 continue;
             }
 

--- a/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitDedicateAssertInternalTypeFixer.php
@@ -169,7 +169,7 @@ final class MyTest extends \PHPUnit\Framework\TestCase
             $expectedTypeTokenIndex = $tokens->getNextMeaningfulToken($bracketTokenIndex);
             $expectedTypeToken = $tokens[$expectedTypeTokenIndex];
 
-            if (!$expectedTypeToken->equals([T_CONSTANT_ENCAPSED_STRING])) {
+            if (!$expectedTypeToken->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
                 continue;
             }
 

--- a/src/Tokenizer/AbstractTypeTransformer.php
+++ b/src/Tokenizer/AbstractTypeTransformer.php
@@ -56,7 +56,7 @@ abstract class AbstractTypeTransformer extends AbstractTransformer
 
         $prevPrevTokenIndex = $tokens->getPrevMeaningfulToken($prevIndex);
 
-        if ($tokens[$prevPrevTokenIndex]->isGivenKind([T_CATCH])) {
+        if ($tokens[$prevPrevTokenIndex]->isGivenKind(T_CATCH)) {
             $this->replaceToken($tokens, $index);
 
             return;

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -51,7 +51,7 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
      */
     public function process(Tokens $tokens, Token $token, int $index): void
     {
-        if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->equals([T_NEW])) {
+        if (!$tokens[$index]->equals('(') || !$tokens[$tokens->getNextMeaningfulToken($index)]->isGivenKind(T_NEW)) {
             return;
         }
 

--- a/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
+++ b/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
@@ -138,6 +138,10 @@ final class ClassReferenceNameCasingFixerTest extends AbstractFixerTestCase
         ];
 
         yield [
+            '<?php $foo = ["const" => exception];',
+        ];
+
+        yield [
             '<?php
 namespace {
     $a = new Exception;
@@ -180,6 +184,23 @@ namespace Foo {
         yield [
             '<?php try { foo(); } catch(\LogicException $e) {}',
             '<?php try { foo(); } catch(\logicexception $e) {}',
+        ];
+
+        yield [
+            '<?php
+                Closure::bind(fn () => null, null, new class {});
+                \Closure::bind(fn () => null, null, new class {});
+
+                Foo\Bar::bind(fn () => null, null, new class {});
+                \A\B\\Bar::bind(fn () => null, null, new class {});
+            ',
+            '<?php
+                CLOSURE::bind(fn () => null, null, new class {});
+                \CLOSURE::bind(fn () => null, null, new class {});
+
+                Foo\Bar::bind(fn () => null, null, new class {});
+                \A\B\\Bar::bind(fn () => null, null, new class {});
+            ',
         ];
     }
 


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6278