### PR TITLE
Allow composer/xdebug-handler 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "ext-tokenizer": "*",
         "composer/semver": "^3.2",
-        "composer/xdebug-handler": "^3.0",
+        "composer/xdebug-handler": "^2.0.5 || ^3.0",
         "doctrine/annotations": "^1.13",
         "php-cs-fixer/diff": "^2.0",
         "symfony/console": "^5.4 || ^6.0",


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6218 bumped composer/xdebug-handler to v3 but it causes some dependencies to be incompatible with php-cs-fixer.

As said in https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6218#issuecomment-1007224760, I hope this will get merged.