### PR TITLE
Bump migration sets used to PHP7.4

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
  */
 
 $header = <<<'EOF'
-This file is part of PHP CS Fixer.
+    This file is part of PHP CS Fixer.
 
-(c) Fabien Potencier <fabien@symfony.com>
-    Dariusz Rumiński <dariusz.ruminski@gmail.com>
+    (c) Fabien Potencier <fabien@symfony.com>
+        Dariusz Rumiński <dariusz.ruminski@gmail.com>
 
-This source file is subject to the MIT license that is bundled
-with this source code in the file LICENSE.
-EOF;
+    This source file is subject to the MIT license that is bundled
+    with this source code in the file LICENSE.
+    EOF;
 
 $finder = PhpCsFixer\Finder::create()
     ->ignoreDotFiles(false)
@@ -37,14 +37,16 @@ $config = new PhpCsFixer\Config();
 $config
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
+        '@PHP74Migration' => true,
+        '@PHP74Migration:risky' => true,
         '@PHPUnit75Migration:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
         'general_phpdoc_annotation_remove' => ['annotations' => ['expectedDeprecation']], // one should use PHPUnit built-in method instead
         'header_comment' => ['header' => $header],
+        'heredoc_indentation' => false, // TODO switch on when # of PR's is lower
         'modernize_strpos' => true, // needs PHP 8+ or polyfill
+        'use_arrow_functions' => false, // TODO switch on when # of PR's is lower
     ])
     ->setFinder($finder)
 ;

--- a/src/AbstractFunctionReferenceFixer.php
+++ b/src/AbstractFunctionReferenceFixer.php
@@ -58,7 +58,7 @@ abstract class AbstractFunctionReferenceFixer extends AbstractFixer
         }
 
         // make interface consistent with findSequence
-        $end = $end ?? $tokens->count();
+        $end ??= $tokens->count();
 
         // find raw sequence which we can analyse for context
         $candidateSequence = [[T_STRING, $functionNameToSearch], '('];

--- a/src/Fixer/Whitespace/HeredocIndentationFixer.php
+++ b/src/Fixer/Whitespace/HeredocIndentationFixer.php
@@ -164,7 +164,7 @@ SAMPLE
 
         $content = $tokens[$index]->getContent();
 
-        if (!\in_array($content[0], ["\r", "\n"], true) && (!$currentIndent || $currentIndent === substr($content, 0, $currentIndentLength))) {
+        if (!\in_array($content[0], ["\r", "\n"], true) && (!$currentIndent || str_starts_with($content, $currentIndent))) {
             $content = $indent.substr($content, $currentIndentLength);
         } elseif ($currentIndent) {
             $content = Preg::replace('/^(?!'.$currentIndent.')\h+/', '', $content);

--- a/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
+++ b/tests/Fixer/StringNotation/SingleQuoteFixerTest.php
@@ -78,10 +78,12 @@ final class SingleQuoteFixerTest extends AbstractFixerTestCase
                 '<?php $a = \'foo "bar"\';',
                 '<?php $a = "foo \"bar\"";',
             ],
-            [<<<'EOF'
+            [
+                <<<'EOF'
 <?php $a = '\\foo\\bar\\\\';
 EOF
-                , <<<'EOF'
+                ,
+                <<<'EOF'
 <?php $a = "\\foo\\bar\\\\";
 EOF
             ],

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -379,7 +379,7 @@ abstract class AbstractFixerTestCase extends TestCase
             throw new \InvalidArgumentException('Input parameter must not be equal to expected parameter.');
         }
 
-        $file = $file ?? $this->getTestFile();
+        $file ??= $this->getTestFile();
         $fileIsSupported = $this->fixer->supports($file);
 
         if (null !== $input) {


### PR DESCRIPTION
First commit updates project config.
Second is the result when running the tool, no additional changes are made.
3rd is to fix SCA checks on PHP8.1 (`highest`) migrations testing