### PR TITLE
Do not align equal sign with the body of an elseif statement

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -520,6 +520,7 @@ $array = [
     private function injectAlignmentPlaceholders(Tokens $tokens, int $startAt, int $endAt, string $tokenContent): void
     {
         $functionKind = [T_FUNCTION, T_FN];
+        $blockKind    = [T_FOREACH, T_FOR, T_WHILE, T_IF, T_SWITCH, T_ELSEIF];
 
         for ($index = $startAt; $index < $endAt; ++$index) {
             $token = $tokens[$index];
@@ -543,7 +544,7 @@ $array = [
                 continue;
             }
 
-            if ($token->isGivenKind([T_FOREACH, T_FOR, T_WHILE, T_IF, T_SWITCH])) {
+            if ($token->isGivenKind($blockKind)) {
                 $index = $tokens->getNextMeaningfulToken($index);
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1427,6 +1427,24 @@ fn ($x = 1) => $x + 3;
 $f = 123;
 ',
             ],
+            [
+                '<?php
+if ($statement) {
+    $string = \'Some thing\';
+} elseif (($error = file_get_contents($file)) !== false) {
+    throw Exception();
+}
+'
+            ],
+            [
+                '<?php
+if ($statement) {
+    throw Exception();
+} elseif (($error = file_get_contents($file)) !== false) {
+    $string = \'Some thing\';
+}
+'
+            ]
         ];
     }
 


### PR DESCRIPTION
With #6112 a change was introduced, which caused issues on our code base with assignments within else-statements. This pull request fixes one of these issues.

The binary operator on one line, should not be aligned to the next line if the binary operator is inside an statement. For example:

```php
<?php
if ($statement) {
    $string = 'Some thing'; // This line should not be aligned with the next
} elseif (($error = file_get_contents($file)) !== false) {
    throw Exception();
}
```

Line three has an assignment. Currently, it will be aligned to the assignment on line three, which imo is not correct.

PS: I noticed in the contribution guidelines that fixes should be created on the lowest possible branch. However, I only see the `master` branch, is this a typo perhaps?