### PR TITLE
PSR12Set - set "types_spaces" => ["space_multiple_catch" => "single"]

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2894,7 +2894,7 @@ List of Available Rules
      | Default value: ``null``
 
 
-   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\TypesSpacesFixer <./../src/Fixer/Whitespace/TypesSpacesFixer.php>`_
 -  `unary_operator_spaces <./rules/operator/unary_operator_spaces.rst>`_

--- a/doc/ruleSets/PSR12.rst
+++ b/doc/ruleSets/PSR12.rst
@@ -34,4 +34,7 @@ Rules
 - `single_blank_line_before_namespace <./../rules/namespace_notation/single_blank_line_before_namespace.rst>`_
 - `single_trait_insert_per_statement <./../rules/class_notation/single_trait_insert_per_statement.rst>`_
 - `ternary_operator_spaces <./../rules/operator/ternary_operator_spaces.rst>`_
+- `types_spaces <./../rules/whitespace/types_spaces.rst>`_
+  config:
+  ``['space_multiple_catch' => 'single']``
 - `visibility_required <./../rules/class_notation/visibility_required.rst>`_

--- a/doc/rules/whitespace/types_spaces.rst
+++ b/doc/rules/whitespace/types_spaces.rst
@@ -83,6 +83,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PSR12
+  Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``types_spaces`` rule with the config below:
+
+  ``['space_multiple_catch' => 'single']``
+
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``types_spaces`` rule with the default config.
 

--- a/src/RuleSet/Sets/PSR12Set.php
+++ b/src/RuleSet/Sets/PSR12Set.php
@@ -59,6 +59,9 @@ final class PSR12Set extends AbstractRuleSetDescription
             'single_blank_line_before_namespace' => true,
             'single_trait_insert_per_statement' => true,
             'ternary_operator_spaces' => true,
+            'types_spaces' => [
+                'space_multiple_catch' => 'single',
+            ],
             'visibility_required' => true,
         ];
     }


### PR DESCRIPTION
In `v3.8.0`, we introduced [TypesSpacesFixer - add option for CS of catching multiple types of exceptions](https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6312). And it should be set to `'single'` for PSR12.

- https://www.php-fig.org/psr/psr-12/#56-try-catch-finally