### PR TITLE
minor: Let PhpdocLineSpan fixer detect docblocks when seperator from token with attribute

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,6 @@ parameters:
         -
             message: '#^.+no value type specified in iterable type.+\.$#'
             path: *
-            count: 542
+            count: 540
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -155,10 +155,6 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
         do {
             $index = $tokens->getPrevNonWhitespace($index);
 
-            if (!\defined('T_ATTRIBUTE')) { // @TODO: drop condition when PHP 8.0+ is required
-                continue;
-            }
-
             if ($tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
                 $index = $tokens->getPrevTokenOfKind($index, [[T_ATTRIBUTE]]);
             }

--- a/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php
@@ -144,12 +144,24 @@ final class PhpdocLineSpanFixer extends AbstractFixer implements WhitespacesAwar
             CT::T_NULLABLE_TYPE,
         ];
 
+        if (\defined('T_ATTRIBUTE')) { // @TODO: drop condition when PHP 8.0+ is required
+            $propertyPartKinds[] = T_ATTRIBUTE;
+        }
+
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
             $propertyPartKinds[] = T_READONLY;
         }
 
         do {
             $index = $tokens->getPrevNonWhitespace($index);
+
+            if (!\defined('T_ATTRIBUTE')) { // @TODO: drop condition when PHP 8.0+ is required
+                continue;
+            }
+
+            if ($tokens[$index]->isGivenKind(CT::T_ATTRIBUTE_CLOSE)) {
+                $index = $tokens->getPrevTokenOfKind($index, [[T_ATTRIBUTE]]);
+            }
         } while ($tokens[$index]->isGivenKind($propertyPartKinds));
 
         return $index;

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -576,16 +576,16 @@ class Foo
 {
     /** @var string[] */
     #[Attribute1]
-    private readonly array $foo1;
+    private array $foo1;
 
     /** @var string[] */
     #[Attribute1]
     #[Attribute2]
-    readonly private array $foo2;
+    private array $foo2;
 
     /** @var string[] */
     #[Attribute1, Attribute2]
-    readonly array $foo3;
+    public array $foo3;
 }',
             '<?php
 
@@ -595,27 +595,27 @@ class Foo
      * @var string[]
      */
     #[Attribute1]
-    private readonly array $foo1;
+    private array $foo1;
 
     /**
      * @var string[]
      */
     #[Attribute1]
     #[Attribute2]
-    readonly private array $foo2;
+    private array $foo2;
 
     /**
      * @var string[]
      */
     #[Attribute1, Attribute2]
-    readonly array $foo3;
+    public array $foo3;
 }',
             [
                 'property' => 'single',
             ],
         ];
 
-        yield [
+        yield 'It handles class constants correctly' => [
             '<?php
 class Foo
 {
@@ -630,13 +630,13 @@ class Foo
      */
     #[Attribute1]
     #[Attribute2]
-    final public const B1 = "1";
+    public const B1 = "1";
 
     /**
      * 2
      */
     #[Attribute1, Attribute2]
-    public final const B2 = "2";
+    public const B2 = "2";
 }
 ',
             '<?php
@@ -649,18 +649,18 @@ class Foo
     /** 1 */
     #[Attribute1]
     #[Attribute2]
-    final public const B1 = "1";
+    public const B1 = "1";
 
     /** 2 */
     #[Attribute1, Attribute2]
-    public final const B2 = "2";
+    public const B2 = "2";
 }
 ',
         ];
 
-        yield [
+        yield 'It handles class functions correctly' => [
             '<?php
-                enum Foo
+                class Foo
                 {
                     /**
                      * @return void
@@ -683,7 +683,7 @@ class Foo
                 }
             ',
             '<?php
-                enum Foo
+                class Foo
                 {
                     /** @return void */
                     #[Attribute1]
@@ -714,7 +714,7 @@ class Foo
 
     public function provideFix81Cases(): iterable
     {
-        yield 'readonly' => [
+        yield 'It handles readonly properties correctly' => [
             '<?php
 
 class Foo
@@ -752,7 +752,7 @@ class Foo
             ],
         ];
 
-        yield [
+        yield 'It handles class constant correctly' => [
             '<?php
 class Foo
 {
@@ -795,7 +795,7 @@ class Foo
 ',
         ];
 
-        yield [
+        yield 'It handles enum functions correctly' => [
             '<?php
                 enum Foo
                 {
@@ -810,6 +810,49 @@ class Foo
                 {
                     /** @return void */
                     public function hello() {}
+                }
+            ',
+        ];
+
+        yield 'It handles enum function with attributes correctly' => [
+            '<?php
+                enum Foo
+                {
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1]
+                    public function hello1() {}
+
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1]
+                    #[Attribute2]
+                    public function hello2() {}
+
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1, Attribute2]
+                    public function hello3() {}
+                }
+            ',
+            '<?php
+                enum Foo
+                {
+                    /** @return void */
+                    #[Attribute1]
+                    public function hello1() {}
+
+                    /** @return void */
+                    #[Attribute1]
+                    #[Attribute2]
+                    public function hello2() {}
+
+                    /** @return void */
+                    #[Attribute1, Attribute2]
+                    public function hello3() {}
                 }
             ',
         ];

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -567,7 +567,7 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): \Generator
+    public function provideFix80Cases(): iterable
     {
         yield 'It detects attributes between docblock and token' => [
             '<?php

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -28,7 +28,7 @@ final class PhpdocLineSpanFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      *
-     * @param array<string, string> $config
+     * @param array<string, mixed> $config
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -563,7 +563,7 @@ class Foo
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
      *
-     * @param array<string, string> $config
+     * @param array<string, mixed> $config
      */
     public function testFix80(string $expected, string $input = null, array $config = []): void
     {
@@ -710,7 +710,7 @@ class Foo
      * @dataProvider provideFix81Cases
      * @requires PHP 8.1
      *
-     * @param array<string, string> $config
+     * @param array<string, mixed> $config
      */
     public function testFix81(string $expected, string $input = null, array $config = []): void
     {

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -27,6 +27,8 @@ final class PhpdocLineSpanFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFixCases
+     *
+     * @param array<string, string> $config
      */
     public function testFix(string $expected, ?string $input = null, array $config = []): void
     {
@@ -560,6 +562,8 @@ class Foo
     /**
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
+     *
+     * @param array<string, string> $config
      */
     public function testFix80(string $expected, string $input = null, array $config = []): void
     {
@@ -705,6 +709,8 @@ class Foo
     /**
      * @dataProvider provideFix81Cases
      * @requires PHP 8.1
+     *
+     * @param array<string, string> $config
      */
     public function testFix81(string $expected, string $input = null, array $config = []): void
     {

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -558,6 +558,151 @@ class Foo
     }
 
     /**
+     * @dataProvider provideFix80Cases
+     * @requires PHP 8.0
+     */
+    public function testFix80(string $expected, string $input = null, array $config = []): void
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix80Cases(): \Generator
+    {
+        yield 'It detects attributes between docblock and token' => [
+            '<?php
+
+class Foo
+{
+    /** @var string[] */
+    #[Attribute1]
+    private readonly array $foo1;
+
+    /** @var string[] */
+    #[Attribute1]
+    #[Attribute2]
+    readonly private array $foo2;
+
+    /** @var string[] */
+    #[Attribute1, Attribute2]
+    readonly array $foo3;
+}',
+            '<?php
+
+class Foo
+{
+    /**
+     * @var string[]
+     */
+    #[Attribute1]
+    private readonly array $foo1;
+
+    /**
+     * @var string[]
+     */
+    #[Attribute1]
+    #[Attribute2]
+    readonly private array $foo2;
+
+    /**
+     * @var string[]
+     */
+    #[Attribute1, Attribute2]
+    readonly array $foo3;
+}',
+            [
+                'property' => 'single',
+            ],
+        ];
+
+        yield [
+            '<?php
+class Foo
+{
+    /**
+     * 0
+     */
+    #[Attribute1]
+    const B0 = "0";
+
+    /**
+     * 1
+     */
+    #[Attribute1]
+    #[Attribute2]
+    final public const B1 = "1";
+
+    /**
+     * 2
+     */
+    #[Attribute1, Attribute2]
+    public final const B2 = "2";
+}
+',
+            '<?php
+class Foo
+{
+    /** 0 */
+    #[Attribute1]
+    const B0 = "0";
+
+    /** 1 */
+    #[Attribute1]
+    #[Attribute2]
+    final public const B1 = "1";
+
+    /** 2 */
+    #[Attribute1, Attribute2]
+    public final const B2 = "2";
+}
+',
+        ];
+
+        yield [
+            '<?php
+                enum Foo
+                {
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1]
+                    public function hello1() {}
+
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1]
+                    #[Attribute2]
+                    public function hello2() {}
+
+                    /**
+                     * @return void
+                     */
+                    #[Attribute1, Attribute2]
+                    public function hello3() {}
+                }
+            ',
+            '<?php
+                enum Foo
+                {
+                    /** @return void */
+                    #[Attribute1]
+                    public function hello1() {}
+
+                    /** @return void */
+                    #[Attribute1]
+                    #[Attribute2]
+                    public function hello2() {}
+
+                    /** @return void */
+                    #[Attribute1, Attribute2]
+                    public function hello3() {}
+                }
+            ',
+        ];
+    }
+
+    /**
      * @dataProvider provideFix81Cases
      * @requires PHP 8.1
      */


### PR DESCRIPTION
This fix allows the phpdoc_line_span fixer to detect attributes between a docblock and the token it is working on.

It now updates (depending on the configuration)

```php
/**
 * @return void
 */
#[Attribute1, Attribute2]
public function hello() {}
```

to

```php
/** @return void */
#[Attribute1, Attribute2]
public function hello() {}
```

while it did not touch this structure before.