### PR TITLE
ModernizeStrposFixer - fix leading backslash with yoda

### DIFF
--- a/src/Fixer/Alias/ModernizeStrposFixer.php
+++ b/src/Fixer/Alias/ModernizeStrposFixer.php
@@ -164,7 +164,11 @@ if (strpos($haystack, $needle) === false) {}
     {
         $operatorIndex = $tokens->getMeaningfulTokenSibling($offsetIndex, $direction);
 
-        if (null === $operatorIndex) {
+        if (null !== $operatorIndex && $tokens[$operatorIndex]->isGivenKind(T_NS_SEPARATOR)) {
+            $operatorIndex = $tokens->getMeaningfulTokenSibling($operatorIndex, $direction);
+        }
+
+        if (null === $operatorIndex || !$tokens[$operatorIndex]->isGivenKind([T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
             return null;
         }
 
@@ -177,10 +181,6 @@ if (strpos($haystack, $needle) === false) {}
         $operand = $tokens[$operandIndex];
 
         if (!$operand->equals([T_LNUMBER, '0']) && !$operand->equals([T_STRING, 'false'], false)) {
-            return null;
-        }
-
-        if (!$tokens[$operatorIndex]->isGivenKind([T_IS_IDENTICAL, T_IS_NOT_IDENTICAL])) {
             return null;
         }
 

--- a/tests/Fixer/Alias/ModernizeStrposFixerTest.php
+++ b/tests/Fixer/Alias/ModernizeStrposFixerTest.php
@@ -65,6 +65,11 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
             '<?php if (\strpos($haystack5, $needle) === 0) {}',
         ];
 
+        yield 'leading namespace with yoda' => [
+            '<?php if (  \str_starts_with($haystack5, $needle)) {}',
+            '<?php if (0 === \strpos($haystack5, $needle)) {}',
+        ];
+
         yield [
             '<?php if (!str_starts_with($haystack6, $needle)  ) {}',
             '<?php if (strpos($haystack6, $needle) !== 0) {}',
@@ -73,6 +78,11 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
         yield [
             '<?php if (!\str_starts_with($haystack6, $needle)  ) {}',
             '<?php if (\strpos($haystack6, $needle) !== 0) {}',
+        ];
+
+        yield [
+            '<?php if (  !\str_starts_with($haystack6, $needle)) {}',
+            '<?php if (0 !== \strpos($haystack6, $needle)) {}',
         ];
 
         yield 'casing operand' => [
@@ -123,6 +133,10 @@ final class ModernizeStrposFixerTest extends AbstractFixerTestCase
 
         yield 'different namespace' => [
             '<?php if (a\strpos($haystack14, $needle) === 0) {}',
+        ];
+
+        yield 'different namespace with yoda' => [
+            '<?php if (0 === a\strpos($haystack14, $needle)) {}',
         ];
 
         yield 'non condition (hardcoded)' => [


### PR DESCRIPTION
Currently the `modernize_strpos` rule doesn't work when yoda coding is used in combination with a leading backslash:

```php
if (0 === \strpos($haystack5, $needle)) {}
```