### PR TITLE
minor: TrailingCommaInMultilineFixer - Add comma to multiline `new static`

### DIFF
--- a/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
+++ b/src/Fixer/ControlStructure/TrailingCommaInMultilineFixer.php
@@ -165,7 +165,7 @@ SAMPLE
             $prevPrevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
 
             if ($fixArguments
-                && $tokens[$prevIndex]->equalsAny([']', [T_CLASS], [T_STRING], [T_VARIABLE]])
+                && $tokens[$prevIndex]->equalsAny([']', [T_CLASS], [T_STRING], [T_VARIABLE], [T_STATIC]])
                 && !$tokens[$prevPrevIndex]->isGivenKind(T_FUNCTION)
             ) {
                 $this->fixBlock($tokens, $index);

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -539,16 +539,16 @@ INPUT
                 ['after_heredoc' => true],
             ],
             [
-                "<?php \$a = new class() {function A() { return new static(
+                '<?php $a = new class() {function A() { return new static(
 1,
 2,
-); }};",
-                "<?php \$a = new class() {function A() { return new static(
+); }};',
+                '<?php $a = new class() {function A() { return new static(
 1,
 2
-); }};",
+); }};',
                 ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARGUMENTS]],
-            ]
+            ],
         ];
     }
 

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -538,6 +538,17 @@ INPUT
                 ,
                 ['after_heredoc' => true],
             ],
+            [
+                "<?php \$a = new class() {function A() { return new static(
+1,
+2,
+); }};",
+                "<?php \$a = new class() {function A() { return new static(
+1,
+2
+); }};",
+                ['elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARGUMENTS]],
+            ]
         ];
     }
 


### PR DESCRIPTION
Trailing comma is not added to multi-line function invocations In code such as.

```
class Foo {

  public static function create(): static {
    return new static(
      'foo',
      'bar'
    );
  }

}
```

I expect a comma to be added directly after 'bar', such that code becomes:

```
class Foo {

  public static function create(): static {
    return new static(
      'foo',
      'bar',
    );
  }

}
```

