### PR TITLE
minor: SymfonySet - Add `nullable_type_declaration_for_default_null_value`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1736,6 +1736,8 @@ List of Available Rules
      | Default value: ``true``
 
 
+   Part of rule set `@Symfony <./ruleSets/Symfony.rst>`_
+
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\NullableTypeDeclarationForDefaultNullValueFixer <./../src/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixer.php>`_
 -  `object_operator_without_whitespace <./rules/operator/object_operator_without_whitespace.rst>`_
 

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -35,6 +35,7 @@ Rules
 - `no_superfluous_elseif <./../rules/control_structure/no_superfluous_elseif.rst>`_
 - `no_useless_else <./../rules/control_structure/no_useless_else.rst>`_
 - `no_useless_return <./../rules/return_notation/no_useless_return.rst>`_
+- `nullable_type_declaration_for_default_null_value <./../rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
 - `operator_linebreak <./../rules/operator/operator_linebreak.rst>`_
   config:
   ``['only_booleans' => true]``

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -82,6 +82,7 @@ Rules
 - `no_unused_imports <./../rules/import/no_unused_imports.rst>`_
 - `no_whitespace_before_comma_in_array <./../rules/array_notation/no_whitespace_before_comma_in_array.rst>`_
 - `normalize_index_brace <./../rules/array_notation/normalize_index_brace.rst>`_
+- `nullable_type_declaration_for_default_null_value <./../rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
 - `object_operator_without_whitespace <./../rules/operator/object_operator_without_whitespace.rst>`_
 - `ordered_imports <./../rules/import/ordered_imports.rst>`_
 - `php_unit_fqcn_annotation <./../rules/php_unit/php_unit_fqcn_annotation.rst>`_

--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -53,3 +53,11 @@ With configuration: ``['use_nullable_type_declaration' => false]``.
    -function sample(?string $str = null)
    +function sample(string $str = null)
     {}
+
+Rule sets
+---------
+
+The rule is part of the following rule set:
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``nullable_type_declaration_for_default_null_value`` rule with the default config.

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -83,6 +83,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             'no_superfluous_elseif' => true,
             'no_useless_else' => true,
             'no_useless_return' => true,
+            'nullable_type_declaration_for_default_null_value' => false,
             'operator_linebreak' => [
                 'only_booleans' => true,
             ],

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -125,6 +125,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_unused_imports' => true,
             'no_whitespace_before_comma_in_array' => true,
             'normalize_index_brace' => true,
+            'nullable_type_declaration_for_default_null_value' => true,
             'object_operator_without_whitespace' => true,
             'ordered_imports' => true,
             'php_unit_fqcn_annotation' => true,


### PR DESCRIPTION
Following preference expressed here https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5785 by two maintainers of the projects.