### PR TITLE
feature: FullyQualifiedStrictTypesFixer - Support `implements`, `extends` and `catch`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -780,7 +780,15 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\FopenFlagOrderFixer <./../src/Fixer/FunctionNotation/FopenFlagOrderFixer.php>`_
 -  `fully_qualified_strict_types <./rules/import/fully_qualified_strict_types.rst>`_
 
-   Transforms imported FQCN parameters and return types in function arguments to short version.
+   Removes the leading part of fully qualified symbol references if a given symbol is imported or belongs to the current namespace. Fixes function arguments, caught exception ``classes``, ``extend`` and ``implements`` of ``classes`` and ``interfaces`` to short version.
+
+   Configuration options:
+
+   - | ``shorten_globals_in_global_ns``
+     | remove leading `\` when in global namespace.
+     | Allowed types: ``bool``
+     | Default value: ``false``
+
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -784,7 +784,7 @@ List of Available Rules
 
    Configuration options:
 
-   - | ``shorten_globals_in_global_ns``
+   - | ``shorten_globals_in_global_namespace``
      | remove leading `\` when in global namespace.
      | Allowed types: ``bool``
      | Default value: ``false``

--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -2,8 +2,22 @@
 Rule ``fully_qualified_strict_types``
 =====================================
 
-Transforms imported FQCN parameters and return types in function arguments to
-short version.
+Removes the leading part of fully qualified symbol references if a given symbol
+is imported or belongs to the current namespace. Fixes function arguments,
+caught exception ``classes``, ``extend`` and ``implements`` of ``classes`` and
+``interfaces`` to short version.
+
+Configuration
+-------------
+
+``shorten_globals_in_global_ns``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+remove leading ``\`` when in global namespace.
+
+Allowed types: ``bool``
+
+Default value: ``false``
 
 Examples
 --------
@@ -11,18 +25,20 @@ Examples
 Example #1
 ~~~~~~~~~~
 
+*Default* configuration.
+
 .. code-block:: diff
 
    --- Original
    +++ New
     <?php
-
     use Foo\Bar;
+    use Foo\Bar\Baz;
 
     class SomeClass
     {
-   -    public function doSomething(\Foo\Bar $foo)
-   +    public function doSomething(Bar $foo)
+   -    public function doSomething(\Foo\Bar $foo, \Exception $e): \Foo\Bar\Baz
+   +    public function doSomething(Bar $foo, \Exception $e): Baz
         {
         }
     }
@@ -30,19 +46,27 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
+With configuration: ``['shorten_globals_in_global_ns' => true]``.
+
 .. code-block:: diff
 
    --- Original
    +++ New
     <?php
+    namespace {
+        use Foo\A;
 
-    use Foo\Bar;
-    use Foo\Bar\Baz;
+        try {
+            foo();
+   -    } catch (\Exception|\Foo\A $e) {
+   +    } catch (Exception|A $e) {
 
-    class SomeClass
-    {
-   -    public function doSomething(\Foo\Bar $foo): \Foo\Bar\Baz
-   +    public function doSomething(Bar $foo): Baz
+        }
+    }
+
+    namespace Foo\Bar {
+   -    class SomeClass implements \Foo\Bar\Baz
+   +    class SomeClass implements Baz
         {
         }
     }
@@ -53,7 +77,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``fully_qualified_strict_types`` rule.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``fully_qualified_strict_types`` rule with the default config.
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``fully_qualified_strict_types`` rule.
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``fully_qualified_strict_types`` rule with the default config.

--- a/doc/rules/import/fully_qualified_strict_types.rst
+++ b/doc/rules/import/fully_qualified_strict_types.rst
@@ -10,7 +10,7 @@ caught exception ``classes``, ``extend`` and ``implements`` of ``classes`` and
 Configuration
 -------------
 
-``shorten_globals_in_global_ns``
+``shorten_globals_in_global_namespace``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 remove leading ``\`` when in global namespace.
@@ -46,7 +46,7 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-With configuration: ``['shorten_globals_in_global_ns' => true]``.
+With configuration: ``['shorten_globals_in_global_namespace' => true]``.
 
 .. code-block:: diff
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -397,7 +397,7 @@ Import
 
 - `fully_qualified_strict_types <./import/fully_qualified_strict_types.rst>`_
 
-  Transforms imported FQCN parameters and return types in function arguments to short version.
+  Removes the leading part of fully qualified symbol references if a given symbol is imported or belongs to the current namespace. Fixes function arguments, caught exception ``classes``, ``extend`` and ``implements`` of ``classes`` and ``interfaces`` to short version.
 - `global_namespace_import <./import/global_namespace_import.rst>`_
 
   Imports or fully qualifies global classes/functions/constants.

--- a/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
+++ b/src/Fixer/Import/FullyQualifiedStrictTypesFixer.php
@@ -74,7 +74,7 @@ namespace Foo\Bar {
     }
 }
 ',
-                    ['shorten_globals_in_global_ns' => true],
+                    ['shorten_globals_in_global_namespace' => true],
                 ),
             ]
         );
@@ -136,7 +136,7 @@ namespace Foo\Bar {
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('shorten_globals_in_global_ns', 'remove leading `\` when in global namespace.'))
+            (new FixerOptionBuilder('shorten_globals_in_global_namespace', 'remove leading `\` when in global namespace.'))
                 ->setAllowedTypes(['bool'])
                 ->setDefault(false)
                 ->getOption(),
@@ -255,7 +255,7 @@ namespace Foo\Bar {
                 // if the type without leading "\" equals any of the full "uses" long names, it can be replaced with the short one
                 $this->replaceClassWithShort($tokens, $class, $uses[$typeNameLower]);
             } elseif ('' === $namespaceName) {
-                if (true === $this->configuration['shorten_globals_in_global_ns']) {
+                if (true === $this->configuration['shorten_globals_in_global_namespace']) {
                     // if we are in the global namespace and the type is not imported the leading '\' can be removed
                     $inUses = false;
 
@@ -313,7 +313,7 @@ namespace Foo\Bar {
                 // if the type without leading "\" equals any of the full "uses" long names, it can be replaced with the short one
                 $tokens->overrideRange($startIndex, $endIndex, $this->namespacedStringToTokens($uses[$typeNameLower]));
             } elseif ('' === $namespaceName) {
-                if (true === $this->configuration['shorten_globals_in_global_ns']) {
+                if (true === $this->configuration['shorten_globals_in_global_namespace']) {
                     foreach ($uses as $useShortName) {
                         if (strtolower($useShortName) === $typeNameLower) {
                             continue 2;

--- a/tests/Cache/NullCacheManagerTest.php
+++ b/tests/Cache/NullCacheManagerTest.php
@@ -28,14 +28,14 @@ final class NullCacheManagerTest extends TestCase
 {
     public function testIsFinal(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\NullCacheManager::class);
+        $reflection = new \ReflectionClass(NullCacheManager::class);
 
         static::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsCacheManagerInterface(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\NullCacheManager::class);
+        $reflection = new \ReflectionClass(NullCacheManager::class);
 
         static::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\CacheManagerInterface::class));
     }

--- a/tests/Cache/SignatureTest.php
+++ b/tests/Cache/SignatureTest.php
@@ -28,14 +28,14 @@ final class SignatureTest extends TestCase
 {
     public function testIsFinal(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
+        $reflection = new \ReflectionClass(Signature::class);
 
         static::assertTrue($reflection->isFinal());
     }
 
     public function testImplementsSignatureInterface(): void
     {
-        $reflection = new \ReflectionClass(\PhpCsFixer\Cache\Signature::class);
+        $reflection = new \ReflectionClass(Signature::class);
 
         static::assertTrue($reflection->implementsInterface(\PhpCsFixer\Cache\SignatureInterface::class));
     }

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -277,7 +277,7 @@ final class ConfigurationResolverTest extends TestCase
             'path' => [$dirBase.'case_1/.php-cs-fixer.dist.php', $dirBase.'case_1/foo.php'],
         ]);
 
-        static::assertInstanceOf(\PhpCsFixer\Console\ConfigurationResolver::class, $resolver);
+        static::assertInstanceOf(ConfigurationResolver::class, $resolver);
     }
 
     /**

--- a/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
+++ b/tests/Fixer/Import/FullyQualifiedStrictTypesFixerTest.php
@@ -91,7 +91,7 @@ namespace A\B\C\D
         yield 'simple use with global' => [
             '<?php use B\Exception; function foo(Exception $e, \Exception $e2, A\B $f) {}',
             '<?php use B\Exception; function foo(\B\Exception $e, \Exception $e2, \A\B $f) {}',
-            ['shorten_globals_in_global_ns' => true],
+            ['shorten_globals_in_global_namespace' => true],
         ];
 
         yield 'simple use as' => [
@@ -131,13 +131,13 @@ interface NakanoInterface extends \Foo\Bar\IzumiInterface, \Foo\Bar\A, \D\E, \C,
         yield 'interface in global namespace with global extend' => [
             '<?php interface Foo1 extends ArrayAccess2{}',
             '<?php interface Foo1 extends \ArrayAccess2{}',
-            ['shorten_globals_in_global_ns' => true],
+            ['shorten_globals_in_global_namespace' => true],
         ];
 
         yield 'interface in global namespace with multiple extend' => [
             '<?php use B\Exception; interface Foo extends ArrayAccess, \Exception, Exception {}',
             '<?php use B\Exception; interface Foo extends \ArrayAccess, \Exception, \B\Exception {}',
-            ['shorten_globals_in_global_ns' => true],
+            ['shorten_globals_in_global_namespace' => true],
         ];
 
         yield 'class implements' => [
@@ -233,7 +233,7 @@ namespace B {
     try{ foo(); } catch (\B\Z $z) {}
 }
 ',
-            ['shorten_globals_in_global_ns' => true],
+            ['shorten_globals_in_global_namespace' => true],
         ];
 
         yield 'starts with but not full name arg' => [
@@ -763,7 +763,7 @@ class SomeClass
 function withReference(Exception &$e) {}',
             '<?php
 function withReference(\Exception &$e) {}',
-            ['shorten_globals_in_global_ns' => true],
+            ['shorten_globals_in_global_namespace' => true],
         ];
 
         yield 'Test reference with use' => [
@@ -842,7 +842,7 @@ class Two
      */
     public function testFix80(string $expected, string $input): void
     {
-        $this->fixer->configure(['shorten_globals_in_global_ns' => true]);
+        $this->fixer->configure(['shorten_globals_in_global_namespace' => true]);
         $this->doTest($expected, $input);
     }
 
@@ -881,7 +881,7 @@ class Two
      */
     public function testFix81(string $expected, string $input): void
     {
-        $this->fixer->configure(['shorten_globals_in_global_ns' => true]);
+        $this->fixer->configure(['shorten_globals_in_global_namespace' => true]);
         $this->doTest($expected, $input);
     }
 

--- a/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
+++ b/tests/FixerDefinition/VersionSpecificCodeSampleTest.php
@@ -88,6 +88,6 @@ final class VersionSpecificCodeSampleTest extends TestCase
      */
     private function createVersionSpecificationMock()
     {
-        return $this->prophesize(\PhpCsFixer\FixerDefinition\VersionSpecificationInterface::class);
+        return $this->prophesize(VersionSpecificationInterface::class);
     }
 }

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -396,7 +396,7 @@ final class FixerFactoryTest extends TestCase
 
     private function createFixerDouble(string $name, int $priority = 0): FixerInterface
     {
-        $fixer = $this->prophesize(\PhpCsFixer\Fixer\FixerInterface::class);
+        $fixer = $this->prophesize(FixerInterface::class);
         $fixer->getName()->willReturn($name);
         $fixer->getPriority()->willReturn($priority);
 

--- a/tests/Fixtures/Integration/priority/fully_qualified_strict_types,no_superfluous_phpdoc_tags.test
+++ b/tests/Fixtures/Integration/priority/fully_qualified_strict_types,no_superfluous_phpdoc_tags.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: fully_qualified_strict_types,no_superfluous_phpdoc_tags.
 --RULESET--
-{"fully_qualified_strict_types": {"shorten_globals_in_global_ns": true}, "no_superfluous_phpdoc_tags": true}
+{"fully_qualified_strict_types": {"shorten_globals_in_global_namespace": true}, "no_superfluous_phpdoc_tags": true}
 --EXPECT--
 <?php
 // No namespace

--- a/tests/Fixtures/Integration/priority/fully_qualified_strict_types,no_superfluous_phpdoc_tags.test
+++ b/tests/Fixtures/Integration/priority/fully_qualified_strict_types,no_superfluous_phpdoc_tags.test
@@ -1,7 +1,7 @@
 --TEST--
 Integration of fixers: fully_qualified_strict_types,no_superfluous_phpdoc_tags.
 --RULESET--
-{"fully_qualified_strict_types": true, "no_superfluous_phpdoc_tags": true}
+{"fully_qualified_strict_types": {"shorten_globals_in_global_ns": true}, "no_superfluous_phpdoc_tags": true}
 --EXPECT--
 <?php
 // No namespace

--- a/tests/Runner/FileFilterIteratorTest.php
+++ b/tests/Runner/FileFilterIteratorTest.php
@@ -93,7 +93,7 @@ final class FileFilterIteratorTest extends TestCase
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        static::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
+        static::assertInstanceOf(FixerFileProcessedEvent::class, $event);
         static::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 
@@ -126,7 +126,7 @@ final class FileFilterIteratorTest extends TestCase
         /** @var FixerFileProcessedEvent $event */
         $event = reset($events);
 
-        static::assertInstanceOf(\PhpCsFixer\FixerFileProcessedEvent::class, $event);
+        static::assertInstanceOf(FixerFileProcessedEvent::class, $event);
         static::assertSame(FixerFileProcessedEvent::STATUS_SKIPPED, $event->getStatus());
     }
 

--- a/tests/Runner/RunnerTest.php
+++ b/tests/Runner/RunnerTest.php
@@ -137,7 +137,7 @@ final class RunnerTest extends TestCase
 
         $error = $errors[0];
 
-        static::assertInstanceOf(\PhpCsFixer\Error\Error::class, $error);
+        static::assertInstanceOf(Error::class, $error);
 
         static::assertSame(Error::TYPE_INVALID, $error->getType());
         static::assertSame($pathToInvalidFile, $error->getFilePath());

--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -85,7 +85,7 @@ final class CTTest extends TestCase
         static $constants;
 
         if (null === $constants) {
-            $reflection = new \ReflectionClass(\PhpCsFixer\Tokenizer\CT::class);
+            $reflection = new \ReflectionClass(CT::class);
             $constants = $reflection->getConstants();
         }
 


### PR DESCRIPTION
replaces https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4310
fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4309