### PR TITLE
DX: Fix CI/CD issues

### DIFF
--- a/docker/php-7.4/Dockerfile
+++ b/docker/php-7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-cli-alpine3.15
+FROM php:7.4-cli-alpine3.16
 
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID

--- a/docker/php-8.0/Dockerfile
+++ b/docker/php-8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-cli-alpine3.15
+FROM php:8.0-cli-alpine3.16
 
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID

--- a/docker/php-8.1/Dockerfile
+++ b/docker/php-8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli-alpine3.15
+FROM php:8.1-cli-alpine3.16
 
 ARG DOCKER_USER_ID
 ARG DOCKER_GROUP_ID

--- a/src/Console/Command/DescribeCommand.php
+++ b/src/Console/Command/DescribeCommand.php
@@ -32,6 +32,7 @@ use PhpCsFixer\StdinFileInfo;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Utils;
 use PhpCsFixer\WordMatcher;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
@@ -44,6 +45,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
+#[AsCommand(name: 'describe')]
 final class DescribeCommand extends Command
 {
     /**

--- a/src/Console/Command/DocumentationCommand.php
+++ b/src/Console/Command/DocumentationCommand.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Documentation\ListDocumentGenerator;
 use PhpCsFixer\Documentation\RuleSetDocumentationGenerator;
 use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet\RuleSets;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,6 +31,7 @@ use Symfony\Component\Finder\SplFileInfo;
 /**
  * @internal
  */
+#[AsCommand(name: 'documentation')]
 final class DocumentationCommand extends Command
 {
     /**

--- a/src/Console/Command/FixCommand.php
+++ b/src/Console/Command/FixCommand.php
@@ -25,6 +25,7 @@ use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Error\ErrorsManager;
 use PhpCsFixer\Runner\Runner;
 use PhpCsFixer\ToolInfoInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -42,6 +43,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  *
  * @internal
  */
+#[AsCommand(name: 'fix')]
 final class FixCommand extends Command
 {
     /**

--- a/src/Console/Command/HelpCommand.php
+++ b/src/Console/Command/HelpCommand.php
@@ -17,6 +17,7 @@ namespace PhpCsFixer\Console\Command;
 use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerOptionInterface;
 use PhpCsFixer\Preg;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\HelpCommand as BaseHelpCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,6 +29,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
+#[AsCommand(name: 'help')]
 final class HelpCommand extends BaseHelpCommand
 {
     /**

--- a/src/Console/Command/ListFilesCommand.php
+++ b/src/Console/Command/ListFilesCommand.php
@@ -19,6 +19,7 @@ use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\ToolInfoInterface;
 use SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -29,6 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
+#[AsCommand(name: 'list-files')]
 final class ListFilesCommand extends Command
 {
     /**

--- a/src/Console/Command/ListSetsCommand.php
+++ b/src/Console/Command/ListSetsCommand.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Console\Report\ListSetsReport\ReporterInterface;
 use PhpCsFixer\Console\Report\ListSetsReport\ReportSummary;
 use PhpCsFixer\Console\Report\ListSetsReport\TextReporter;
 use PhpCsFixer\RuleSet\RuleSets;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,6 +32,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
+#[AsCommand(name: 'list-sets')]
 final class ListSetsCommand extends Command
 {
     /**

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Console\SelfUpdate\NewVersionCheckerInterface;
 use PhpCsFixer\PharCheckerInterface;
 use PhpCsFixer\Preg;
 use PhpCsFixer\ToolInfoInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,6 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @internal
  */
+#[AsCommand(name: 'self-update')]
 final class SelfUpdateCommand extends Command
 {
     /**

--- a/src/Fixer/Basic/PsrAutoloadingFixer.php
+++ b/src/Fixer/Basic/PsrAutoloadingFixer.php
@@ -74,7 +74,13 @@ class InvalidName {}
         parent::configure($configuration);
 
         if (null !== $this->configuration['dir']) {
-            $this->configuration['dir'] = realpath($this->configuration['dir']);
+            $realpath = realpath($this->configuration['dir']);
+
+            if (false === $realpath) {
+                throw new \InvalidArgumentException(sprintf('Failed to resolve configured directory "%s".', $this->configuration['dir']));
+            }
+
+            $this->configuration['dir'] = $realpath;
         }
     }
 

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -459,15 +459,23 @@ final class ProjectCodeTest extends TestCase
 
         static::assertTrue($tokens->isAnyTokenKindsFound(Token::getClassyTokenKinds()), sprintf('File "%s" should contains a classy.', $file));
 
-        foreach ($tokens as $index => $token) {
-            if ($token->isClassy()) {
+        $count = \count($tokens);
+
+        for ($index = 1; $index < $count; ++$index) {
+            if ($tokens[$index]->isClassy()) {
                 $classyIndex = $index;
 
                 break;
             }
 
-            if (!$token->isGivenKind($headerTypes) && !$token->equalsAny([';', '=', '(', ')'])) {
-                static::fail(sprintf('File "%s" should only contains single classy, found "%s" @ %d.', $file, $token->toJson(), $index));
+            if (\defined('T_ATTRIBUTE') && $tokens[$index]->isGivenKind(T_ATTRIBUTE)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ATTRIBUTE, $index);
+
+                continue;
+            }
+
+            if (!$tokens[$index]->isGivenKind($headerTypes) && !$tokens[$index]->equalsAny([';', '=', '(', ')'])) {
+                static::fail(sprintf('File "%s" should only contains single classy, found "%s" @ %d.', $file, $tokens[$index]->toJson(), $index));
             }
         }
 


### PR DESCRIPTION
Currently PR's are failing because of:

```
 Time: 17:43.384, Memory: 553.38 MB
OK, but incomplete, skipped, or risky tests!
Tests: 28703, Assertions: 512446, Skipped: 125, Incomplete: 50.
Remaining direct deprecation notices (2372)
  593x: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "PhpCsFixer\Console\Command\DescribeCommand" class instead.
    592x in Invoker::invoke from SebastianBergmann\Invoker
    1x in CommandTest::provideCommandHasNameConstCases from PhpCsFixer\Tests\AutoReview
```

and bunch more, this PR aim to fix that.

Additional fix:

```
$ docker-compose run php app/vendor/bin/phpunit app/tests/AutoReview/DescribeCommandTest.php -vvv
PHPUnit 9.5.20 #StandWithUkraine

Runtime:       PHP 8.1.6

...............................................................  63 / 247 ( 25%)
............................................................... 126 / 247 ( 51%)
............................................................... 189 / 247 ( 76%)
...............................E..........................      247 / 247 (100%)

Time: 00:02.098, Memory: 22.00 MB

There was 1 error:

1) PhpCsFixer\Tests\AutoReview\DescribeCommandTest::testDescribeCommand with data set #220 (PhpCsFixer\FixerFactory Object (...), 'psr_autoloading')
TypeError: str_starts_with(): Argument #2 ($needle) must be of type string, bool given

/app/src/Fixer/Basic/PsrAutoloadingFixer.php:165
/app/src/AbstractFixer.php:75
/app/src/Console/Command/DescribeCommand.php:285
/app/src/Console/Command/DescribeCommand.php:112
/app/vendor/symfony/console/Command/Command.php:298
/app/vendor/symfony/console/Tester/CommandTester.php:74
/app/tests/AutoReview/DescribeCommandTest.php:45
```

rest is bumping the alpine image, because why not