### PR TITLE
feature: NoExtraBlankLinesFixer - Add `attributes` option - Fix support for `enum` `case`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1390,7 +1390,7 @@ List of Available Rules
 
    - | ``tokens``
      | List of tokens to fix.
-     | Allowed values: a subset of ``['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']``
+     | Allowed values: a subset of ``['attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']``
      | Default value: ``['extra']``
 
 

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -30,7 +30,7 @@ Rules
   ``['strategy' => 'new_line_for_chained_calls']``
 - `no_extra_blank_lines <./../rules/whitespace/no_extra_blank_lines.rst>`_
   config:
-  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
+  ``['tokens' => ['attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
 - `no_null_property_initialization <./../rules/class_notation/no_null_property_initialization.rst>`_
 - `no_superfluous_elseif <./../rules/control_structure/no_superfluous_elseif.rst>`_
 - `no_useless_else <./../rules/control_structure/no_useless_else.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -58,7 +58,7 @@ Rules
 - `no_empty_statement <./../rules/semicolon/no_empty_statement.rst>`_
 - `no_extra_blank_lines <./../rules/whitespace/no_extra_blank_lines.rst>`_
   config:
-  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``
+  ``['tokens' => ['attribute', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``
 - `no_leading_namespace_whitespace <./../rules/namespace_notation/no_leading_namespace_whitespace.rst>`_
 - `no_mixed_echo_print <./../rules/alias/no_mixed_echo_print.rst>`_
 - `no_multiline_whitespace_around_double_arrow <./../rules/array_notation/no_multiline_whitespace_around_double_arrow.rst>`_

--- a/doc/rules/whitespace/no_extra_blank_lines.rst
+++ b/doc/rules/whitespace/no_extra_blank_lines.rst
@@ -12,7 +12,7 @@ Configuration
 
 List of tokens to fix.
 
-Allowed values: a subset of ``['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']``
+Allowed values: a subset of ``['attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use', 'use_trait']``
 
 Default value: ``['extra']``
 
@@ -222,9 +222,9 @@ The rule is part of the following rule sets:
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_extra_blank_lines`` rule with the config below:
 
-  ``['tokens' => ['break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
+  ``['tokens' => ['attribute', 'break', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'switch', 'throw', 'use']]``
 
 @Symfony
   Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_extra_blank_lines`` rule with the config below:
 
-  ``['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``
+  ``['tokens' => ['attribute', 'case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']]``

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -40,6 +40,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
      * @var string[]
      */
     private static array $availableTokens = [
+        'attribute',
         'break',
         'case',
         'continue',
@@ -58,22 +59,16 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
     /**
      * @var array<int, string> key is token id, value is name of callback
      */
-    private $tokenKindCallbackMap;
+    private array $tokenKindCallbackMap;
 
     /**
      * @var array<string, string> token prototype, value is name of callback
      */
-    private $tokenEqualsMap;
+    private array $tokenEqualsMap;
 
-    /**
-     * @var Tokens
-     */
-    private $tokens;
+    private Tokens $tokens;
 
-    /**
-     * @var TokensAnalyzer
-     */
-    private $tokensAnalyzer;
+    private TokensAnalyzer $tokensAnalyzer;
 
     /**
      * {@inheritdoc}
@@ -86,45 +81,40 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
 
         parent::configure($configuration);
 
-        static $reprToTokenMap = [
-            'break' => T_BREAK,
-            'case' => T_CASE,
-            'continue' => T_CONTINUE,
-            'curly_brace_block' => '{',
-            'default' => T_DEFAULT,
-            'extra' => T_WHITESPACE,
-            'parenthesis_brace_block' => '(',
-            'return' => T_RETURN,
-            'square_brace_block' => CT::T_ARRAY_SQUARE_BRACE_OPEN,
-            'switch' => T_SWITCH,
-            'throw' => T_THROW,
-            'use' => T_USE,
-            'use_trait' => CT::T_USE_TRAIT,
+        $tokensConfiguration = $this->configuration['tokens'];
+
+        $this->tokenEqualsMap = [];
+
+        if (\in_array('curly_brace_block', $tokensConfiguration, true)) {
+            $this->tokenEqualsMap['{'] = 'fixStructureOpenCloseIfMultiLine'; // i.e. not: CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN
+        }
+
+        if (\in_array('parenthesis_brace_block', $tokensConfiguration, true)) {
+            $this->tokenEqualsMap['('] = 'fixStructureOpenCloseIfMultiLine'; // i.e. not: CT::T_BRACE_CLASS_INSTANTIATION_OPEN
+        }
+
+        static $configMap = [
+            'attribute' => [CT::T_ATTRIBUTE_CLOSE, 'fixAfterToken'],
+            'break' => [T_BREAK, 'fixAfterToken'],
+            'case' => [T_CASE, 'fixAfterCaseToken'],
+            'continue' => [T_CONTINUE, 'fixAfterToken'],
+            'default' => [T_DEFAULT, 'fixAfterToken'],
+            'extra' => [T_WHITESPACE, 'removeMultipleBlankLines'],
+            'return' => [T_RETURN, 'fixAfterToken'],
+            'square_brace_block' => [CT::T_ARRAY_SQUARE_BRACE_OPEN, 'fixStructureOpenCloseIfMultiLine'],
+            'switch' => [T_SWITCH, 'fixAfterToken'],
+            'throw' => [T_THROW, 'fixAfterThrowToken'],
+            'use' => [T_USE, 'removeBetweenUse'],
+            'use_trait' => [CT::T_USE_TRAIT, 'removeBetweenUse'],
         ];
 
-        static $tokenKindCallbackMap = [
-            T_BREAK => 'fixAfterToken',
-            T_CASE => 'fixAfterToken',
-            T_CONTINUE => 'fixAfterToken',
-            T_DEFAULT => 'fixAfterToken',
-            T_RETURN => 'fixAfterToken',
-            T_SWITCH => 'fixAfterToken',
-            T_THROW => 'fixAfterThrowToken',
-            T_USE => 'removeBetweenUse',
-            T_WHITESPACE => 'removeMultipleBlankLines',
-            CT::T_USE_TRAIT => 'removeBetweenUse',
-            CT::T_ARRAY_SQUARE_BRACE_OPEN => 'fixStructureOpenCloseIfMultiLine', // typeless '[' tokens should not be fixed (too rare)
-        ];
+        $this->tokenKindCallbackMap = [];
 
-        static $tokenEqualsMap = [
-            '{' => 'fixStructureOpenCloseIfMultiLine', // i.e. not: CT::T_ARRAY_INDEX_CURLY_BRACE_OPEN
-            '(' => 'fixStructureOpenCloseIfMultiLine', // i.e. not: CT::T_BRACE_CLASS_INSTANTIATION_OPEN
-        ];
-
-        $tokensAssoc = array_flip(array_intersect_key($reprToTokenMap, array_flip($this->configuration['tokens'])));
-
-        $this->tokenKindCallbackMap = array_intersect_key($tokenKindCallbackMap, $tokensAssoc);
-        $this->tokenEqualsMap = array_intersect_key($tokenEqualsMap, $tokensAssoc);
+        foreach ($tokensConfiguration as $config) {
+            if (isset($configMap[$config])) {
+                $this->tokenKindCallbackMap[$configMap[$config][0]] = $configMap[$config][1];
+            }
+        }
     }
 
     /**
@@ -293,6 +283,7 @@ switch($a) {
     {
         $this->tokens = $tokens;
         $this->tokensAnalyzer = new TokensAnalyzer($this->tokens);
+
         for ($index = $tokens->getSize() - 1; $index > 0; --$index) {
             $this->fixByToken($tokens[$index], $index);
         }
@@ -338,11 +329,13 @@ switch($a) {
     private function removeBetweenUse(int $index): void
     {
         $next = $this->tokens->getNextTokenOfKind($index, [';', [T_CLOSE_TAG]]);
+
         if (null === $next || $this->tokens[$next]->isGivenKind(T_CLOSE_TAG)) {
             return;
         }
 
         $nextUseCandidate = $this->tokens->getNextMeaningfulToken($next);
+
         if (null === $nextUseCandidate || !$this->tokens[$nextUseCandidate]->isGivenKind($this->tokens[$index]->getId()) || !$this->containsLinebreak($index, $nextUseCandidate)) {
             return;
         }
@@ -375,6 +368,19 @@ switch($a) {
 
             if ($this->tokens[$i]->isWhitespace() && str_contains($this->tokens[$i]->getContent(), "\n")) {
                 break;
+            }
+        }
+
+        $this->removeEmptyLinesAfterLineWithTokenAt($index);
+    }
+
+    private function fixAfterCaseToken(int $index): void
+    {
+        if (\defined('T_ENUM')) { // @TODO: drop condition when PHP 8.1+ is required
+            $enumSwitchIndex = $this->tokens->getPrevTokenOfKind($index, [[T_SWITCH], [T_ENUM]]);
+
+            if (!$this->tokens[$enumSwitchIndex]->isGivenKind(T_SWITCH)) {
+                return;
             }
         }
 
@@ -430,11 +436,13 @@ switch($a) {
 
         for ($i = $end; $i < $tokenCount && $this->tokens[$i]->isWhitespace(); ++$i) {
             $content = $this->tokens[$i]->getContent();
+
             if (substr_count($content, "\n") < 1) {
                 continue;
             }
 
             $pos = strrpos($content, "\n");
+
             if ($pos + 2 <= \strlen($content)) { // preserve indenting where possible
                 $newContent = $ending.substr($content, $pos + 1);
             } else {

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -65,6 +65,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
             ],
             'no_extra_blank_lines' => [
                 'tokens' => [
+                    'attribute',
                     'break',
                     'case',
                     'continue',

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -80,6 +80,7 @@ final class SymfonySet extends AbstractRuleSetDescription
             'no_empty_statement' => true,
             'no_extra_blank_lines' => [
                 'tokens' => [
+                    'attribute',
                     'case',
                     'continue',
                     'curly_brace_block',

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -25,10 +25,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
  */
 final class NoExtraBlankLinesFixerTest extends AbstractFixerTestCase
 {
-    /**
-     * @var string
-     */
-    private $template = <<<'EOF'
+    private string $template = <<<'EOF'
 <?php
 use \DateTime;
 
@@ -103,10 +100,11 @@ EOF;
     public function testWithConfig(array $lineNumberRemoved, array $config): void
     {
         $this->fixer->configure(['tokens' => $config]);
+
         $this->doTest($this->removeLinesFromString($this->template, $lineNumberRemoved), $this->template);
     }
 
-    public function provideWithConfigCases(): array
+    public function provideWithConfigCases(): iterable
     {
         $tests = [
             [
@@ -139,14 +137,16 @@ EOF;
             ],
         ];
 
+        yield from $tests;
+
         $all = [[], []];
+
         foreach ($tests as $test) {
             $all[0] = array_merge($test[0], $all[0]);
             $all[1] = array_merge($test[1], $all[1]);
         }
-        $tests[] = $all;
 
-        return $tests;
+        yield $all;
     }
 
     public function testFix(): void
@@ -419,7 +419,7 @@ EOF
         $this->doTest($expected, $input);
     }
 
-    public function provideLineBreakCases(): array
+    public function provideLineBreakCases(): iterable
     {
         $input = '<?php //
 
@@ -436,25 +436,27 @@ $a = 1;
 $b = 1;
 ';
 
-        return [
-            [
-                "<?php\r\n//a\r\n\r\n\$a =1;",
-                "<?php\r\n//a\r\n\r\n\r\n\r\n\$a =1;",
-            ],
-            [
-                $expected,
-                $input,
-            ],
-            [
-                str_replace("\n", "\r\n", $expected),
-                str_replace("\n", "\r\n", $input),
-            ],
-            [
-                str_replace("\n", "\r", $input),
-            ],
-            [
-                str_replace("\n", "\r", $expected),
-            ],
+        yield [
+            "<?php\r\n//a\r\n\r\n\$a =1;",
+            "<?php\r\n//a\r\n\r\n\r\n\r\n\$a =1;",
+        ];
+
+        yield [
+            $expected,
+            $input,
+        ];
+
+        yield [
+            str_replace("\n", "\r\n", $expected),
+            str_replace("\n", "\r\n", $input),
+        ];
+
+        yield [
+            str_replace("\n", "\r", $input),
+        ];
+
+        yield [
+            str_replace("\n", "\r", $expected),
         ];
     }
 
@@ -472,10 +474,11 @@ $b = 1;
     public function testBetweenUse(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['tokens' => ['use']]);
+
         $this->doTest($expected, $input);
     }
 
-    public function provideBetweenUseCases(): \Generator
+    public function provideBetweenUseCases(): iterable
     {
         yield from [
             ['<?php use A\B;'],
@@ -557,6 +560,7 @@ use const some\Z\{ConstX,ConstY,ConstZ,};
     public function testRemoveLinesBetweenUseStatements(string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['tokens' => ['use']]);
+
         $this->doTest($expected, $input);
     }
 
@@ -630,29 +634,31 @@ use const some\a\{ConstA, ConstB, ConstC};
     public function testWithoutUses(string $expected): void
     {
         $this->fixer->configure(['tokens' => ['use']]);
+
         $this->doTest($expected);
     }
 
-    public function provideWithoutUsesCases(): array
+    public function provideWithoutUsesCases(): iterable
     {
-        return [
-            [
-                '<?php
+        yield [
+            '<?php
 
 $c = 1;
 
 $a = new Baz();
 $a = new Qux();',
-            ],
-            [
-                '<?php use A\B;',
-            ],
-            [
-                '<?php use A\B?>',
-            ],
-            [
-                '<?php use A\B;?>',
-            ],
+        ];
+
+        yield [
+            '<?php use A\B;',
+        ];
+
+        yield [
+            '<?php use A\B?>',
+        ];
+
+        yield [
+            '<?php use A\B;?>',
         ];
     }
 
@@ -663,11 +669,13 @@ $a = new Qux();',
     public function testRemoveBetweenUseTraits(string $expected, string $input): void
     {
         $this->expectDeprecation('Option "tokens: use_trait" used in `no_extra_blank_lines` rule is deprecated, use the rule `class_attributes_separation` with `elements: trait_import` instead.');
+
         $this->fixer->configure(['tokens' => ['use_trait']]);
+
         $this->doTest($expected, $input);
     }
 
-    public function provideRemoveBetweenUseTraitsCases(): \Generator
+    public function provideRemoveBetweenUseTraitsCases(): iterable
     {
         yield [
             '<?php
@@ -782,22 +790,27 @@ class Foo
         $this->doTest($expected, $input);
     }
 
-    public function provideOneAndInLineCases(): \Generator
+    public function provideOneAndInLineCases(): iterable
     {
-        yield from [
-            [
-                "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
-            ],
-            [
-                "<?php throw new \\Exception('do not import.');\n",
-                "<?php throw new \\Exception('do not import.');\n\n",
-            ],
-            [
-                "<?php\n\n\$a = \$b[0];\n\n",
-            ],
-            [
-                "<?php\n\n\$a->{'Test'};\nfunction test(){}\n",
-            ],
+        yield [
+            "<?php\n\n\$a = function() use (\$b) { while(3<1)break; \$c = \$b[1]; while(\$b<1)continue; if (true) throw \$e; return 1; };\n\n",
+        ];
+
+        yield [
+            "<?php throw new \\Exception('do not import.');\n",
+            "<?php throw new \\Exception('do not import.');\n\n",
+        ];
+
+        yield [
+            "<?php\n\n\$a = \$b[0];\n\n",
+        ];
+
+        yield [
+            "<?php\n\n\$a->{'Test'};\nfunction test(){}\n",
+        ];
+
+        yield [
+            "<?php\n\n\$a = new class { public function a () { while(4<1)break; while(3<1)continue; if (true) throw \$e; return 1; }};\n\n",
         ];
 
         if (\PHP_VERSION_ID < 80000) {
@@ -805,10 +818,6 @@ class Foo
                 "<?php\n\n\$a = \$b{0};\n\n",
             ];
         }
-
-        yield [
-            "<?php\n\n\$a = new class { public function a () { while(4<1)break; while(3<1)continue; if (true) throw \$e; return 1; }};\n\n",
-        ];
     }
 
     /**
@@ -817,6 +826,7 @@ class Foo
     public function testBraces(array $config, string $expected, ?string $input = null): void
     {
         $this->fixer->configure($config);
+
         $this->doTest($expected, $input);
     }
 
@@ -915,32 +925,34 @@ class Foo
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\r\n"));
         $this->fixer->configure($config);
+
         $this->doTest($expected, $input);
     }
 
-    public function provideMessyWhitespacesCases(): array
+    public function provideMessyWhitespacesCases(): iterable
     {
-        return [
-            [
-                [],
-                "<?php\r\nuse AAA;\r\n\r\nuse BBB;\r\n\r\n",
-                "<?php\r\nuse AAA;\r\n\r\n\r\n\r\nuse BBB;\r\n\r\n",
-            ],
-            [
-                ['tokens' => ['parenthesis_brace_block']],
-                "<?php is_int(\r\n1);",
-                "<?php is_int(\r\n\r\n\r\n\r\n1);",
-            ],
-            [
-                ['tokens' => ['square_brace_block']],
-                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
-                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
-            ],
-            [
-                ['tokens' => ['square_brace_block']],
-                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\t1,\r\n2];",
-                "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n\t1,\r\n2];",
-            ],
+        yield [
+            [],
+            "<?php\r\nuse AAA;\r\n\r\nuse BBB;\r\n\r\n",
+            "<?php\r\nuse AAA;\r\n\r\n\r\n\r\nuse BBB;\r\n\r\n",
+        ];
+
+        yield [
+            ['tokens' => ['parenthesis_brace_block']],
+            "<?php is_int(\r\n1);",
+            "<?php is_int(\r\n\r\n\r\n\r\n1);",
+        ];
+
+        yield [
+            ['tokens' => ['square_brace_block']],
+            "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
+            "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n   1,\r\n2];\r\necho 1;\r\n\$b = [];\r\n\r\n\r\n//a\r\n",
+        ];
+
+        yield [
+            ['tokens' => ['square_brace_block']],
+            "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\t1,\r\n2];",
+            "<?php \$c = \$b[0];\r\n\r\n\r\n\$a = [\r\n\r\n\t1,\r\n2];",
         ];
     }
 
@@ -950,6 +962,7 @@ class Foo
     public function testInSwitchStatement(array $config, string $expected, ?string $input = null): void
     {
         $this->fixer->configure(['tokens' => $config]);
+
         $this->doTest($expected, $input);
     }
 
@@ -1086,15 +1099,17 @@ class Foo {}'
      * @dataProvider provideFix80Cases
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected): void
+    public function testFix80(array $config, string $expected, string $input = null): void
     {
-        $this->fixer->configure(['tokens' => ['throw']]);
-        $this->doTest($expected);
+        $this->fixer->configure($config);
+
+        $this->doTest($expected, $input);
     }
 
-    public function provideFix80Cases(): \Generator
+    public function provideFix80Cases(): iterable
     {
         yield [
+            ['tokens' => ['throw']],
             '<?php
                 $a = $bar ?? throw new \Exception();
 
@@ -1105,6 +1120,7 @@ class Foo {}'
         ];
 
         yield [
+            ['tokens' => ['throw']],
             '<?php
                 $a = $bar ?? throw new \Exception();
 
@@ -1112,12 +1128,110 @@ class Foo {}'
                 var_dump($a);
             ',
         ];
+
+        yield [
+            ['tokens' => ['attribute']],
+            '<?php
+#[Attr]
+#[AttrFoo1]
+#[AttrFoo2]
+function foo(){}
+            ',
+            '<?php
+#[Attr]
+
+
+
+#[AttrFoo1]
+
+
+#[AttrFoo2]
+
+function foo(){}
+            ',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix81Cases
+     * @requires PHP 8.1
+     */
+    public function testFix81(string $expected, string $input = null): void
+    {
+        $this->fixer->configure(['tokens' => ['case']]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix81Cases(): iterable
+    {
+        yield [
+            '<?php
+enum test
+{
+    case Baz;
+
+    public function foo() {
+        switch (bar()) {
+            case 1: echo 1; break;
+            case 2: echo 2; break;
+        }
+    }
+
+    case Bad;
+}
+',
+            '<?php
+enum test
+{
+    case Baz;
+
+    public function foo() {
+        switch (bar()) {
+            case 1: echo 1; break;
+
+
+            case 2: echo 2; break;
+        }
+    }
+
+    case Bad;
+}
+',
+        ];
+
+        $expectedTemplate = '<?php
+enum Foo
+{
+    case CASE_1;
+
+    %s
+}'
+        ;
+
+        $enumAttributes = [
+            'case CASE_2;',
+            'const CONST_1 = self::CASE_1;',
+            'private const CONST_1 = self::CASE_1;',
+            'public function bar(): void {}',
+            'protected function bar(): void {}',
+            'private function bar(): void {}',
+            'static function bar(): void {}',
+            'final function bar(): void {}',
+        ];
+
+        foreach ($enumAttributes as $enumAttribute) {
+            yield [
+                sprintf($expectedTemplate, $enumAttribute),
+            ];
+        }
     }
 
     private function removeLinesFromString(string $input, array $lineNumbers): string
     {
         sort($lineNumbers);
         $lines = explode("\n", $input);
+
         foreach ($lineNumbers as $lineNumber) {
             --$lineNumber;
 


### PR DESCRIPTION
closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6214

opt-in option for `attributes`, fixes:

```php
<?php
#[Attr]



#[AttrFoo1]


#[AttrFoo2]

function foo(){}
```

into:
```php
<?php
#[Attr]
#[AttrFoo1]
#[AttrFoo2]
function foo(){}
```