### PR TITLE
bug: MethodArgumentSpaceFixer - first element in same line, space before comma and inconsistent indent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         env:
           PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}
           FAST_LINT_TEST_CASES: ${{ matrix.FAST_LINT_TEST_CASES }}
-        run: vendor/bin/phpunit tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php ${{ matrix.phpunit-flags }}
+        run: vendor/bin/phpunit ${{ matrix.phpunit-flags }}
 
       - name: Upload coverage results to Coveralls
         if: matrix.calculate-code-coverage == 'yes'

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -251,8 +251,6 @@ SAMPLE
                 $this->fixSpace($tokens, $index);
                 if (!$isMultiline && $this->isNewline($tokens[$index + 1])) {
                     $isMultiline = true;
-
-                    break;
                 }
             }
         }

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -922,6 +922,23 @@ $example = function () use ($message1,$message2) {
         $f);
 ',
             ],
+            'test first element in same line, space before comma and inconsistent indent with comments' => [
+                '<?php foo(
+    "aaa
+    bbb", // comment1
+    $c, /** comment2 */
+    $d,
+    $e/* comment3 */,
+    $f
+);# comment4
+',
+                '<?php foo("aaa
+    bbb", // comment1
+    $c, /** comment2 */$d ,
+        $e/* comment3 */,
+        $f);# comment4
+',
+            ],
         ];
     }
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -910,7 +910,7 @@ $example = function () use ($message1,$message2) {
     "aaa
     bbb",
     $c,
-    $d ,
+    $d,
     $e,
     $f
 );

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -905,6 +905,23 @@ $example = function () use ($message1, $message2) {
 $example = function () use ($message1,$message2) {
 };',
             ],
+            'test first element in same line, space before comma and inconsistent indent' => [
+                '<?php foo(
+    "aaa
+    bbb",
+    $c,
+    $d ,
+    $e,
+    $f
+);
+',
+                '<?php foo("aaa
+    bbb",
+    $c, $d ,
+        $e,
+        $f);
+',
+            ],
         ];
     }
 


### PR DESCRIPTION
See that 1st commit is failing not because the test case's pair is changing incorrectly, but because "Code build on expected code must not change."