### PR TITLE
minor: NoBinaryStringFixer - Fix more cases

### DIFF
--- a/src/Fixer/StringNotation/NoBinaryStringFixer.php
+++ b/src/Fixer/StringNotation/NoBinaryStringFixer.php
@@ -35,7 +35,7 @@ final class NoBinaryStringFixer extends AbstractFixer
             [
                 T_CONSTANT_ENCAPSED_STRING,
                 T_START_HEREDOC,
-                '"b',
+                'b"',
             ]
         );
     }

--- a/src/Fixer/StringNotation/NoBinaryStringFixer.php
+++ b/src/Fixer/StringNotation/NoBinaryStringFixer.php
@@ -31,7 +31,13 @@ final class NoBinaryStringFixer extends AbstractFixer
      */
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAnyTokenKindsFound([T_CONSTANT_ENCAPSED_STRING, T_START_HEREDOC]);
+        return $tokens->isAnyTokenKindsFound(
+            [
+                T_CONSTANT_ENCAPSED_STRING,
+                T_START_HEREDOC,
+                '"b',
+            ]
+        );
     }
 
     /**
@@ -54,14 +60,14 @@ final class NoBinaryStringFixer extends AbstractFixer
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         foreach ($tokens as $index => $token) {
-            if (!$token->isGivenKind([T_CONSTANT_ENCAPSED_STRING, T_START_HEREDOC])) {
-                continue;
-            }
+            if ($token->isGivenKind([T_CONSTANT_ENCAPSED_STRING, T_START_HEREDOC])) {
+                $content = $token->getContent();
 
-            $content = $token->getContent();
-
-            if ('b' === strtolower($content[0])) {
-                $tokens[$index] = new Token([$token->getId(), substr($content, 1)]);
+                if ('b' === strtolower($content[0])) {
+                    $tokens[$index] = new Token([$token->getId(), substr($content, 1)]);
+                }
+            } elseif ($token->equals('b"')) {
+                $tokens[$index] = new Token('"');
             }
         }
     }

--- a/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
+++ b/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
@@ -98,12 +98,10 @@ final class NoBinaryStringFixerTest extends AbstractFixerTestCase
             ],
             [
                 '<?php
-                    $fruit = "apple";
                     echo "{$fruit}";
                     echo " {$fruit}";
                 ',
                 '<?php
-                    $fruit = "apple";
                     echo b"{$fruit}";
                     echo b" {$fruit}";
                 ',

--- a/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
+++ b/tests/Fixer/StringNotation/NoBinaryStringFixerTest.php
@@ -96,6 +96,18 @@ final class NoBinaryStringFixerTest extends AbstractFixerTestCase
                 "<?php echo <<<\"EOT\"\nfoo\nEOT;\n",
                 "<?php echo B<<<\"EOT\"\nfoo\nEOT;\n",
             ],
+            [
+                '<?php
+                    $fruit = "apple";
+                    echo "{$fruit}";
+                    echo " {$fruit}";
+                ',
+                '<?php
+                    $fruit = "apple";
+                    echo b"{$fruit}";
+                    echo b" {$fruit}";
+                ',
+            ],
             ['<?php echo Bar::foo();'],
             ['<?php echo bar::foo();'],
             ['<?php echo "b";'],


### PR DESCRIPTION
I mean, I was pretty naive thinking PHP would tokenize all binary strings the same way, like, why would that be the case? :D