### PR TITLE
bug: BinaryOperatorSpacesFixer - Allow to align `=` inside array definitions

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -555,12 +555,6 @@ $array = [
 
                 continue;
             }
-
-            if ($token->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
-
-                continue;
-            }
         }
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1463,6 +1463,60 @@ m(
             ],
             [
                 '<?php
+
+class TaskObjectType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                "choices" => function (Options $options) {
+                    $choices   = TaskService::getFormMapperObjectList();
+                    $element   = null;
+                    $elementId = null;
+
+                    if (isset($options["task"]) && $options["task"]->getElement() === 42) {
+                        $element   = $options["task"]->getElement();
+                        $elementId = $options["task"]->getElementId();
+                    } elseif (isset($options["elementId"], $options["element"]) && $options["element"] === 42) {
+                        $element   = $options["element"];
+                        $elementId = $options["elementId"];
+                    };
+                },
+            ]
+        );
+    }
+}
+',
+                '<?php
+
+class TaskObjectType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                "choices" => function (Options $options) {
+                    $choices = TaskService::getFormMapperObjectList();
+                    $element = null;
+                    $elementId = null;
+
+                    if (isset($options["task"]) && $options["task"]->getElement() === 42) {
+                        $element = $options["task"]->getElement();
+                        $elementId = $options["task"]->getElementId();
+                    } elseif (isset($options["elementId"], $options["element"]) && $options["element"] === 42) {
+                        $element = $options["element"];
+                        $elementId = $options["elementId"];
+                    };
+                },
+            ]
+        );
+    }
+}
+',
+            ],
+            [
+                '<?php
 fn ($x = 1) => $x + 3;
 $f = 123;
 ',


### PR DESCRIPTION
Hi @SpacePossum, seems like you worked on the BinaryOperatorSpacesFixer.
I recently found a use-case where this is not working as expected.

Seems like removing a check you made fix my issue.
I added a test, and it seems it doesn't break any of the other tests.
Do you know why the check was here ?