### PR TITLE
bug: BinaryOperatorSpacesFixer - Fix align of operator with function declaration

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -536,7 +536,6 @@ $array = [
             }
 
             if ($token->isGivenKind($functionKind)) {
-                ++$this->deepestLevel;
                 $index = $tokens->getNextTokenOfKind($index, ['(']);
                 $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -474,7 +474,7 @@ $a = $ae?? $b;
             ],
             'align array destruction' => [
                 '<?php
-                    $c = [$d] = $e[1];
+                    $c                 = [$d]                 = $e[1];
                     function A(){}[$a] = $a[$c];
                     $b                 = 1;
                 ',
@@ -1483,6 +1483,16 @@ if (($c = count($array)) > 100) {
 } elseif (($c = count($array)) > 0) {
     $closure = fn ($x = 1) => $x ** 3;
 }
+',
+            ],
+            [
+                '<?php
+$suppliersTitles          = $container->getContainerSuppliers()->map(fn (ContainerSupplier $containerSupplier) => $containerSupplier->getSupplier()->getTitle());
+$suppliersClassifications = $container->getContainerSuppliers()->map(fn (ContainerSupplier $containerSupplier) => $containerSupplier->getSupplier()->getClassification());
+',
+                '<?php
+$suppliersTitles = $container->getContainerSuppliers()->map(fn (ContainerSupplier $containerSupplier) => $containerSupplier->getSupplier()->getTitle());
+$suppliersClassifications = $container->getContainerSuppliers()->map(fn (ContainerSupplier $containerSupplier) => $containerSupplier->getSupplier()->getClassification());
 ',
             ],
         ];


### PR DESCRIPTION
Hi @SpacePossum, I found another bug with the `BinaryOperatorSpacesFixer`.
Seems like removing the `++$this->deepestLevel` is solving the issue without any other test failing.

NB: The code 
```
'<?php
                    $c                 = [$d]                 = $e[1];
                    function A(){}[$a] = $a[$c];
                    $b                 = 1;
                ',
                '<?php
                    $c = [$d] = $e[1];
                    function A(){}[$a] = $a[$c];
                    $b = 1;
                ',
```
is not a bug introduce by my PR.

Prior to my fix the `$c =` was ignored and not align with the following lines.
The fact the second `=` has a weird alignment is another bug which exist already and should be fixed in another PR.

```
'<?php
                    $c          = [$d]          = $e[1];
                    $bbbbb = 1;
                ',
                '<?php
                    $c = [$d] = $e[1];
                    $bbbbb = 1;
                ',
```
is a reproducer of the bug, which was already failing without my PR.