### PR TITLE
feature: PhpdocOrderByValueFixer - Allow sorting of mixin annotations by value

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1987,7 +1987,7 @@ List of Available Rules
 
    - | ``annotations``
      | List of annotations to order, e.g. `["covers"]`.
-     | Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'method', 'property', 'property-read', 'property-write', 'requires', 'throws', 'uses']``
+     | Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'method', 'mixin', 'property', 'property-read', 'property-write', 'requires', 'throws', 'uses']``
      | Default value: ``['covers']``
 
 

--- a/doc/rules/phpdoc/phpdoc_order_by_value.rst
+++ b/doc/rules/phpdoc/phpdoc_order_by_value.rst
@@ -12,7 +12,7 @@ Configuration
 
 List of annotations to order, e.g. ``["covers"]``.
 
-Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'method', 'property', 'property-read', 'property-write', 'requires', 'throws', 'uses']``
+Allowed values: a subset of ``['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'method', 'mixin', 'property', 'property-read', 'property-write', 'requires', 'throws', 'uses']``
 
 Default value: ``['covers']``
 

--- a/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderByValueFixer.php
@@ -186,6 +186,7 @@ final class MyTest extends \PHPUnit_Framework_TestCase
             'group',
             'internal',
             'method',
+            'mixin',
             'property',
             'property-read',
             'property-write',

--- a/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderByValueFixerTest.php
@@ -1030,6 +1030,128 @@ final class PhpdocOrderByValueFixerTest extends AbstractFixerTestCase
     }
 
     /**
+     * @dataProvider provideFixWithMixinCases
+     */
+    public function testFixWithMixin(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure([
+            'annotations' => [
+                'mixin',
+            ],
+        ]);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixWithMixinCases(): array
+    {
+        return [
+            'skip on 1 or 0 occurrences' => [
+                '<?php
+                    /**
+                     * @package SomePackage
+                     * @mixin Bar
+                     * @license MIT
+                     */
+                    class Foo {
+                    }
+
+                    /**
+                     * @package SomePackage
+                     * @license MIT
+                     */
+                    class Foo2 {
+                    }
+                ',
+            ],
+            'base case' => [
+                '<?php
+                    /**
+                     * @mixin Bar1
+                     * @mixin Bar2
+                     * @mixin Bar3
+                     */
+                    class Foo {
+                    }
+                ',
+                '<?php
+                    /**
+                     * @mixin Bar2
+                     * @mixin Bar3
+                     * @mixin Bar1
+                     */
+                    class Foo {
+                    }
+                ',
+            ],
+            'preserve positions if other docblock parts are present' => [
+                '<?php
+                    /**
+                     * Comment 1
+                     * @mixin Bar1
+                     * Comment 3
+                     * @mixin Bar2
+                     * Comment 2
+                     */
+                    class Foo {
+                    }
+                ',
+                '<?php
+                    /**
+                     * Comment 1
+                     * @mixin Bar2
+                     * Comment 2
+                     * @mixin Bar1
+                     * Comment 3
+                     */
+                    class Foo {
+                    }
+                ',
+            ],
+            'case-insensitive' => [
+                '<?php
+                    /**
+                     * @mixin A
+                     * @mixin b
+                     * @mixin C
+                     */
+                    class Foo {
+                    }
+                ',
+                '<?php
+                    /**
+                     * @mixin b
+                     * @mixin A
+                     * @mixin C
+                     */
+                    class Foo {
+                    }
+                ',
+            ],
+            'fully-qualified' => [
+                '<?php
+                    /**
+                     * @mixin \A\B\Bar2
+                     * @mixin Bar1
+                     * @mixin Bar3
+                     */
+                    class Foo {
+                    }
+                ',
+                '<?php
+                    /**
+                     * @mixin Bar3
+                     * @mixin Bar1
+                     * @mixin \A\B\Bar2
+                     */
+                    class Foo {
+                    }
+                ',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider provideFixWithPropertyCases
      */
     public function testFixWithProperty(string $expected, ?string $input = null): void


### PR DESCRIPTION
This PR adjusts the PhpdocOrderByValueFixer to allow sorting of `@mixin` annotations by value