### PR TITLE
bug: PhpdocAddMissingParamAnnotationFixer nullable types

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixer.php
@@ -191,7 +191,11 @@ function f9(string $foo, $bar, $baz) {}
             foreach ($arguments as $argument) {
                 $type = $argument['type'] ?: 'mixed';
 
-                if (!str_starts_with($type, '?') && 'null' === strtolower($argument['default'])) {
+                if (true === ($nullableType = str_starts_with($type, '?')) || 'null' === strtolower($argument['default'])) {
+                    if ($nullableType) {
+                        $type = substr($type, 1);
+                    }
+
                     $type = 'null|'.$type;
                 }
 

--- a/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocAddMissingParamAnnotationFixerTest.php
@@ -330,7 +330,7 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
                 '<?php
     /**
      * @param int $bar
-     * @param ?array $foo
+     * @param null|array $foo
      */
     function p1(?array $foo = null, $bar) {}',
                 '<?php
@@ -339,6 +339,20 @@ final class PhpdocAddMissingParamAnnotationFixerTest extends AbstractFixerTestCa
      */
     function p1(?array $foo = null, $bar) {}',
                 ['only_untyped' => false],
+            ],
+            [
+                '<?php
+    /**
+     * Foo
+     * @param null|int $foo
+     * @param null|string $bar
+     */
+     function p1(?int $foo, ?string $bar = null) {}',
+                '<?php
+    /**
+     * Foo
+     */
+     function p1(?int $foo, ?string $bar = null) {}',
             ],
             [
                 '<?php


### PR DESCRIPTION
`PhpdocAddMissingParamAnnotationFixer` would handle nullable types
incorrectly. The resulting `@param` would look like `?<type>`. After the fix
the resulting `@param` looks like `null|<type>` instead.

I could not find any reference where the `@param ?array $foo` for example would be a valid PHPDoc, but I could be wrong on this. I'd be happy to work on an alternative fix if deemed necessary also.