### PR TITLE
feature: Introduce configurability to PhpdocOrderFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2038,7 +2038,7 @@ List of Available Rules
      | Default value: ``['param', 'throws', 'return']``
 
 
-   Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
+   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Phpdoc\\PhpdocOrderFixer <./../src/Fixer/Phpdoc/PhpdocOrderFixer.php>`_
 -  `phpdoc_order_by_value <./rules/phpdoc/phpdoc_order_by_value.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2028,7 +2028,22 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Phpdoc\\PhpdocNoUselessInheritdocFixer <./../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php>`_
 -  `phpdoc_order <./rules/phpdoc/phpdoc_order.rst>`_
 
-   Annotations in PHPDoc should be ordered so that ``@param`` annotations come first, then ``@throws`` annotations, then ``@return`` annotations.
+   Annotations in PHPDoc should be ordered in specific style.
+
+   Annotations in PHPDoc should be ordered in one of the styles below:
+
+   - ``'phpcs'`` style annotations order is ``@param``, ``@throws``,
+   ``@return``,
+   - ``'symfony'`` style annotations order is ``@param``, ``@return``,
+   ``@throws``.
+
+   Configuration options:
+
+   - | ``style``
+     | Style in which annotations in PHPDoc should be ordered.
+     | Allowed values: ``'phpcs'``, ``'symfony'``
+     | Default value: ``'phpcs'``
+
 
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_
 

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2028,21 +2028,14 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Phpdoc\\PhpdocNoUselessInheritdocFixer <./../src/Fixer/Phpdoc/PhpdocNoUselessInheritdocFixer.php>`_
 -  `phpdoc_order <./rules/phpdoc/phpdoc_order.rst>`_
 
-   Annotations in PHPDoc should be ordered in specific style.
-
-   Annotations in PHPDoc should be ordered in one of the styles below:
-
-   - ``'phpcs'`` style annotations order is ``@param``, ``@throws``,
-   ``@return``,
-   - ``'symfony'`` style annotations order is ``@param``, ``@return``,
-   ``@throws``.
+   Annotations in PHPDoc should be ordered in defined sequence.
 
    Configuration options:
 
-   - | ``style``
-     | Style in which annotations in PHPDoc should be ordered.
-     | Allowed values: ``'phpcs'``, ``'symfony'``
-     | Default value: ``'phpcs'``
+   - | ``order``
+     | Sequence in which annotations in PHPDoc should be ordered.
+     | Allowed types: ``string[]``
+     | Default value: ``['param', 'throws', 'return']``
 
 
    Part of rule set `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -95,6 +95,9 @@ Rules
 - `phpdoc_no_alias_tag <./../rules/phpdoc/phpdoc_no_alias_tag.rst>`_
 - `phpdoc_no_package <./../rules/phpdoc/phpdoc_no_package.rst>`_
 - `phpdoc_no_useless_inheritdoc <./../rules/phpdoc/phpdoc_no_useless_inheritdoc.rst>`_
+- `phpdoc_order <./../rules/phpdoc/phpdoc_order.rst>`_
+  config:
+  ``['order' => ['param', 'return', 'throws']]``
 - `phpdoc_return_self_reference <./../rules/phpdoc/phpdoc_return_self_reference.rst>`_
 - `phpdoc_scalar <./../rules/phpdoc/phpdoc_scalar.rst>`_
 - `phpdoc_separation <./../rules/phpdoc/phpdoc_separation.rst>`_

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -690,7 +690,7 @@ PHPDoc
   Order phpdoc tags by value.
 - `phpdoc_order <./phpdoc/phpdoc_order.rst>`_
 
-  Annotations in PHPDoc should be ordered in specific style.
+  Annotations in PHPDoc should be ordered in defined sequence.
 - `phpdoc_return_self_reference <./phpdoc/phpdoc_return_self_reference.rst>`_
 
   The type of ``@return`` annotations of methods returning a reference to itself must the configured one.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -690,7 +690,7 @@ PHPDoc
   Order phpdoc tags by value.
 - `phpdoc_order <./phpdoc/phpdoc_order.rst>`_
 
-  Annotations in PHPDoc should be ordered so that ``@param`` annotations come first, then ``@throws`` annotations, then ``@return`` annotations.
+  Annotations in PHPDoc should be ordered in specific style.
 - `phpdoc_return_self_reference <./phpdoc/phpdoc_return_self_reference.rst>`_
 
   The type of ``@return`` annotations of methods returning a reference to itself must the configured one.

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -111,7 +111,12 @@ With configuration: ``['order' => ['param', 'custom', 'throws', 'return']]``.
 Rule sets
 ---------
 
-The rule is part of the following rule set:
+The rule is part of the following rule sets:
 
 @PhpCsFixer
   Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_order`` rule with the default config.
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``phpdoc_order`` rule with the config below:
+
+  ``['order' => ['param', 'return', 'throws']]``

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -2,27 +2,19 @@
 Rule ``phpdoc_order``
 =====================
 
-Annotations in PHPDoc should be ordered in specific style.
-
-Description
------------
-
-Annotations in PHPDoc should be ordered in one of the styles below:
-
-- ``'phpcs'`` style annotations order is ``@param``, ``@throws``, ``@return``,
-- ``'symfony'`` style annotations order is ``@param``, ``@return``, ``@throws``.
+Annotations in PHPDoc should be ordered in defined sequence.
 
 Configuration
 -------------
 
-``style``
+``order``
 ~~~~~~~~~
 
-Style in which annotations in PHPDoc should be ordered.
+Sequence in which annotations in PHPDoc should be ordered.
 
-Allowed values: ``'phpcs'``, ``'symfony'``
+Allowed types: ``string[]``
 
-Default value: ``'phpcs'``
+Default value: ``['param', 'throws', 'return']``
 
 Examples
 --------
@@ -52,7 +44,29 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-With configuration: ``['style' => 'symfony']``.
+With configuration: ``['order' => ['param', 'throws', 'return']]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+   - * @throws Exception|RuntimeException foo
+     * @custom Test!
+   - * @return int  Return the number of changes.
+     * @param string $foo
+     * @param bool   $bar Bar
+   + * @throws Exception|RuntimeException foo
+   + * @return int  Return the number of changes.
+     */
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['order' => ['param', 'return', 'throws']]``.
 
 .. code-block:: diff
 
@@ -71,10 +85,10 @@ With configuration: ``['style' => 'symfony']``.
    + * @throws Exception|RuntimeException foo
      */
 
-Example #3
+Example #4
 ~~~~~~~~~~
 
-With configuration: ``['style' => 'phpcs']``.
+With configuration: ``['order' => ['param', 'custom', 'throws', 'return']]``.
 
 .. code-block:: diff
 
@@ -84,13 +98,14 @@ With configuration: ``['style' => 'phpcs']``.
     /**
      * Hello there!
      *
-   - * @throws Exception|RuntimeException foo
-     * @custom Test!
-   - * @return int  Return the number of changes.
-     * @param string $foo
-     * @param bool   $bar Bar
-   + * @throws Exception|RuntimeException foo
-   + * @return int  Return the number of changes.
+   + * @param string $foo
+   + * @param bool   $bar Bar
+   + * @custom Test!
+     * @throws Exception|RuntimeException foo
+   - * @custom Test!
+     * @return int  Return the number of changes.
+   - * @param string $foo
+   - * @param bool   $bar Bar
      */
 
 Rule sets

--- a/doc/rules/phpdoc/phpdoc_order.rst
+++ b/doc/rules/phpdoc/phpdoc_order.rst
@@ -2,14 +2,79 @@
 Rule ``phpdoc_order``
 =====================
 
-Annotations in PHPDoc should be ordered so that ``@param`` annotations come
-first, then ``@throws`` annotations, then ``@return`` annotations.
+Annotations in PHPDoc should be ordered in specific style.
+
+Description
+-----------
+
+Annotations in PHPDoc should be ordered in one of the styles below:
+
+- ``'phpcs'`` style annotations order is ``@param``, ``@throws``, ``@return``,
+- ``'symfony'`` style annotations order is ``@param``, ``@return``, ``@throws``.
+
+Configuration
+-------------
+
+``style``
+~~~~~~~~~
+
+Style in which annotations in PHPDoc should be ordered.
+
+Allowed values: ``'phpcs'``, ``'symfony'``
+
+Default value: ``'phpcs'``
 
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+   - * @throws Exception|RuntimeException foo
+     * @custom Test!
+   - * @return int  Return the number of changes.
+     * @param string $foo
+     * @param bool   $bar Bar
+   + * @throws Exception|RuntimeException foo
+   + * @return int  Return the number of changes.
+     */
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['style' => 'symfony']``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+   - * @throws Exception|RuntimeException foo
+     * @custom Test!
+   - * @return int  Return the number of changes.
+     * @param string $foo
+     * @param bool   $bar Bar
+   + * @return int  Return the number of changes.
+   + * @throws Exception|RuntimeException foo
+     */
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['style' => 'phpcs']``.
 
 .. code-block:: diff
 
@@ -34,4 +99,4 @@ Rule sets
 The rule is part of the following rule set:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_order`` rule.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_order`` rule with the default config.

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -66,8 +66,6 @@ final class PhpdocOrderFixer extends AbstractFixer implements ConfigurableFixerI
 
 EOF;
 
-        $description = null;
-
         return new FixerDefinition(
             'Annotations in PHPDoc should be ordered in defined sequence.',
             [
@@ -76,7 +74,6 @@ EOF;
                 new CodeSample($code, ['order' => self::ORDER_LARAVEL]),
                 new CodeSample($code, ['order' => ['param', 'custom', 'throws', 'return']]),
             ],
-            $description
         );
     }
 

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -32,6 +32,9 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class PhpdocOrderFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    /**
+     * @const string[]
+     */
     private const ORDER_DEFAULT = ['param', 'throws', 'return'];
 
     /**
@@ -71,6 +74,8 @@ EOF;
 
     /**
      * {@inheritdoc}
+     *
+     * @param array<string, mixed> $configuration
      */
     public function configure(array $configuration): void
     {
@@ -103,13 +108,12 @@ EOF;
      */
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
-        $order = new FixerOptionBuilder('order', 'Sequence in which annotations in PHPDoc should be ordered.');
-        $order
-            ->setAllowedTypes(['string[]'])
-            ->setDefault(self::ORDER_DEFAULT)
-        ;
-
-        return new FixerConfigurationResolver([$order->getOption()]);
+        return new FixerConfigurationResolver([
+            ( new FixerOptionBuilder('order', 'Sequence in which annotations in PHPDoc should be ordered.') )
+                ->setAllowedTypes(['string[]'])
+                ->setDefault(self::ORDER_DEFAULT)
+                ->getOption(),
+        ]);
     }
 
     /**

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -165,10 +165,10 @@ EOF;
     private function moveAnnotationsBefore(string $move, array $before, string $content): string
     {
         $doc = new DocBlock($content);
-        $to_be_moved = $doc->getAnnotationsOfType($move);
+        $toBeMoved = $doc->getAnnotationsOfType($move);
 
         // nothing to do if there are no annotations to be moved
-        if (0 === \count($to_be_moved)) {
+        if (0 === \count($toBeMoved)) {
             return $content;
         }
 
@@ -178,8 +178,8 @@ EOF;
             return $content;
         }
 
-        // get the index of the final line of the final to_be_moved annotation
-        $end = end($to_be_moved)->getEnd();
+        // get the index of the final line of the final toBoMoved annotation
+        $end = end($toBeMoved)->getEnd();
 
         $line = $doc->getLine($end);
 
@@ -204,10 +204,10 @@ EOF;
     private function moveAnnotationsAfter(string $move, array $after, string $content): string
     {
         $doc = new DocBlock($content);
-        $to_be_moved = $doc->getAnnotationsOfType($move);
+        $toBeMoved = $doc->getAnnotationsOfType($move);
 
         // nothing to do if there are no annotations to be moved
-        if (0 === \count($to_be_moved)) {
+        if (0 === \count($toBeMoved)) {
             return $content;
         }
 
@@ -218,8 +218,8 @@ EOF;
             return $content;
         }
 
-        // get the index of the first line of the first to_be_moved annotation
-        $start = $to_be_moved[0]->getStart();
+        // get the index of the first line of the first toBeMoved annotation
+        $start = $toBeMoved[0]->getStart();
         $line = $doc->getLine($start);
 
         // move stuff about if required

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -17,7 +17,6 @@ namespace PhpCsFixer\Fixer\Phpdoc;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
-use PhpCsFixer\FixerConfiguration\AllowedValueSubset;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
@@ -118,9 +117,6 @@ EOF;
         $order = new FixerOptionBuilder('order', 'Sequence in which annotations in PHPDoc should be ordered.');
         $order
             ->setAllowedTypes(['string[]'])
-//            ->setAllowedValues([
-//                   new AllowedValueSubset(self::ORDERABLE_TAGS),
-//            ])
             ->setDefault(self::ORDER_DEFAULT)
         ;
 

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -32,15 +32,7 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class PhpdocOrderFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
-    /**
-     * @internal
-     */
-    public const ORDER_DEFAULT = ['param', 'throws', 'return'];
-
-    /**
-     * @internal
-     */
-    public const ORDER_LARAVEL = ['param', 'return', 'throws'];
+    private const ORDER_DEFAULT = ['param', 'throws', 'return'];
 
     /**
      * @var string[]
@@ -71,7 +63,7 @@ EOF;
             [
                 new CodeSample($code),
                 new CodeSample($code, ['order' => self::ORDER_DEFAULT]),
-                new CodeSample($code, ['order' => self::ORDER_LARAVEL]),
+                new CodeSample($code, ['order' => ['param', 'return', 'throws']]),
                 new CodeSample($code, ['order' => ['param', 'custom', 'throws', 'return']]),
             ],
         );

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Fixer\Phpdoc;
 
+use ArrayIterator;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
@@ -25,6 +26,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\OptionsResolver\Options;
 
 /**
  * @author Graham Campbell <hello@gjcampbell.co.uk>
@@ -81,7 +83,7 @@ EOF;
     {
         parent::configure($configuration);
 
-        $this->order = $this->configuration['order'];
+        $this->order = (array) $this->configuration['order'];
     }
 
     /**
@@ -112,6 +114,7 @@ EOF;
             ( new FixerOptionBuilder('order', 'Sequence in which annotations in PHPDoc should be ordered.') )
                 ->setAllowedTypes(['string[]'])
                 ->setDefault(self::ORDER_DEFAULT)
+                ->setNormalizer(static function (Options $options, $value) { return new ArrayIterator($value); })
                 ->getOption(),
         ]);
     }

--- a/src/Fixer/Phpdoc/PhpdocOrderFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocOrderFixer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Fixer\Phpdoc;
 
-use ArrayIterator;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
@@ -26,7 +25,6 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use Symfony\Component\OptionsResolver\Options;
 
 /**
  * @author Graham Campbell <hello@gjcampbell.co.uk>
@@ -114,7 +112,6 @@ EOF;
             ( new FixerOptionBuilder('order', 'Sequence in which annotations in PHPDoc should be ordered.') )
                 ->setAllowedTypes(['string[]'])
                 ->setDefault(self::ORDER_DEFAULT)
-                ->setNormalizer(static function (Options $options, $value) { return new ArrayIterator($value); })
                 ->getOption(),
         ]);
     }

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -140,6 +140,13 @@ final class SymfonySet extends AbstractRuleSetDescription
             'phpdoc_no_alias_tag' => true,
             'phpdoc_no_package' => true,
             'phpdoc_no_useless_inheritdoc' => true,
+            'phpdoc_order' => [
+                'order' => [
+                    'param',
+                    'return',
+                    'throws',
+                ],
+            ],
             'phpdoc_return_self_reference' => true,
             'phpdoc_scalar' => true,
             'phpdoc_separation' => true,

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -143,7 +143,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function testFixCompeteCase(): void
+    public function testFixCompleteCase(): void
     {
         $expected = <<<'EOF'
 <?php
@@ -285,7 +285,7 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function testFixCompeteCaseWithLaravelStyle(): void
+    public function testFixCompleteCaseWithLaravelStyle(): void
     {
         $this->fixer->configure(['order' => ['param', 'return', 'throws']]);
 
@@ -436,7 +436,7 @@ EOF,
         ];
     }
 
-    public function testFixCompeteCaseWithCustomOrder(): void
+    public function testFixCompleteCaseWithCustomOrder(): void
     {
         $this->fixer->configure(['order' => [
             'throws',
@@ -502,11 +502,11 @@ EOF;
     }
 
     /**
-     * @dataProvider provideCompeteCasesWithCustomOrdersCases
+     * @dataProvider provideCompleteCasesWithCustomOrdersCases
      *
      * @param array<string, mixed> $config
      */
-    public function testFixCompeteCasesWithCustomOrders(array $config, string $expected, string $input): void
+    public function testFixCompleteCasesWithCustomOrders(array $config, string $expected, string $input): void
     {
         $this->fixer->configure($config);
 
@@ -514,122 +514,293 @@ EOF;
     }
 
     /**
-     * @return array<int, array<int, string|string[][]>>
+     * @return array<string, array<int, string|string[][]>>
      */
-    public function provideCompeteCasesWithCustomOrdersCases(): array
+    public function provideCompleteCasesWithCustomOrdersCases(): array
     {
-        $docBlockBricks = [
-            'title' => "Hello there\n",
-            'description' => "Long description\ngoes here.\n",
-            '@internal' => '',
-            '@throws' => "Exception|RuntimeException dfsdf\njkaskdnaksdnkasndansdnansdajsdnkasd",
-            '@custom' => "Test!\nasldnaksdkjasdasd",
-            '@return' => [
-                'bool Return false on failure',
-                'int  Return the number of changes.',
-            ],
-            '@param' => [
-                'string $foo',
-                'bool   $bar Bar',
-                'class-string<T> $id',
-            ],
-            '@template' => 'T of Extension\Extension',
-        ];
-
         return [
-            [
+            'intepacuthre' => [
                 ['order' => ['internal', 'template', 'param', 'custom', 'throws', 'return']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'template', 'param', 'custom', 'throws', 'return']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'param', 'custom', 'template', 'return', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
-            [
+            'pare' => [
                 ['order' => ['param', 'return']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'param', 'return', 'custom', 'template', 'throws']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'return', 'custom', 'template', 'param', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
-            [
+            'pareth' => [
                 ['order' => ['param', 'return', 'throws']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'custom', 'template', 'param', 'return', 'throws']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'return', 'custom', 'template', 'param', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
-            [
+            'pathre' => [
                 ['order' => ['param', 'throws', 'return']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'custom', 'template', 'param', 'throws', 'return']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'return', 'custom', 'template', 'param', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
-            [
+            'tepathre' => [
                 ['order' => ['template', 'param', 'throws', 'return']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'template', 'param', 'throws', 'return', 'custom']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'return', 'param', 'template', 'custom', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @template T of Extension\Extension
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
-            [
+            'tepathre2' => [
                 ['order' => ['template', 'param', 'throws', 'return']],
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'template', 'param', 'throws', 'return', 'custom']
-                ),
-                self::glueBricks(
-                    $docBlockBricks,
-                    ['title', 'description', 'internal', 'param', 'return', 'template', 'custom', 'throws']
-                ),
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @template T of Extension\Extension
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     **/
+
+EOF,
+                <<<'EOF'
+<?php
+    /**
+     * Hello there
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @param class-string<T> $id
+     * @return bool Return false on failure
+     * @return int  Return the number of changes.
+     * @template T of Extension\Extension
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     **/
+
+EOF,
             ],
         ];
-    }
-
-    /**
-     * @param array<string, string|string[]> $bricks
-     * @param string[]                       $order
-     */
-    private static function glueBricks(array $bricks, array $order): string
-    {
-        $indent = '    ';
-        $commentIndent = $indent.' *';
-        $out = '';
-        foreach ($order as $tag) {
-            // not an annotation brick
-            if (isset($bricks[$tag])) {
-                $out .= "{$commentIndent} ".str_replace("\n", "\n{$commentIndent} ", $bricks[$tag])."\n";
-            }
-            // it's an annotation
-            elseif (isset($bricks["@{$tag}"])) {
-                $annotation = "@{$tag}";
-                $brick = (array) $bricks[$annotation];
-                foreach ($brick as $line) {
-                    $out .= "{$commentIndent} {$annotation} ".str_replace("\n", "\n{$commentIndent}  ".str_repeat(' ', \strlen($annotation)), $line)."\n";
-                }
-            }
-        }
-
-        return "<?php\n{$indent}/**\n{$out}{$commentIndent}*/\n\n";
     }
 }

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
-use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -47,7 +46,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideAllAvailableOrderStyleCases
+     * @dataProvider provideDifferentOrderCases
      */
     public function testOnlyParams(array $config): void
     {
@@ -65,7 +64,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideAllAvailableOrderStyleCases
+     * @dataProvider provideDifferentOrderCases
      */
     public function testOnlyReturns(array $config): void
     {
@@ -84,7 +83,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideAllAvailableOrderStyleCases
+     * @dataProvider provideDifferentOrderCases
      */
     public function testEmpty(array $config): void
     {
@@ -93,7 +92,7 @@ EOF;
     }
 
     /**
-     * @dataProvider provideAllAvailableOrderStyleCases
+     * @dataProvider provideDifferentOrderCases
      */
     public function testNoAnnotations(array $config): void
     {
@@ -230,9 +229,9 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function testNoChangesithLaravelStyle(): void
+    public function testNoChangesWithLaravelStyle(): void
     {
-        $this->fixer->configure(['order' => PhpdocOrderFixer::ORDER_LARAVEL]);
+        $this->fixer->configure(['order' => ['param', 'return', 'throws']]);
 
         $expected = <<<'EOF'
 <?php
@@ -253,7 +252,7 @@ EOF;
 
     public function testFixBasicCaseWithLaravelStyle(): void
     {
-        $this->fixer->configure(['order' => PhpdocOrderFixer::ORDER_LARAVEL]);
+        $this->fixer->configure(['order' => ['param', 'return', 'throws']]);
 
         $expected = <<<'EOF'
 <?php
@@ -280,7 +279,7 @@ EOF;
 
     public function testFixCompeteCaseWithLaravelStyle(): void
     {
-        $this->fixer->configure(['order' => PhpdocOrderFixer::ORDER_LARAVEL]);
+        $this->fixer->configure(['order' => ['param', 'return', 'throws']]);
 
         $expected = <<<'EOF'
 <?php
@@ -339,7 +338,7 @@ EOF;
 
     public function testExampleFromSymfonyWithLaravelStyle(): void
     {
-        $this->fixer->configure(['order' => PhpdocOrderFixer::ORDER_LARAVEL]);
+        $this->fixer->configure(['order' => ['param', 'return', 'throws']]);
 
         $input = <<<'EOF'
 <?php
@@ -360,11 +359,11 @@ EOF;
         $this->doTest($input);
     }
 
-    public function provideAllAvailableOrderStyleCases(): array
+    public function provideDifferentOrderCases(): array
     {
         return [
-            [['order' => PhpdocOrderFixer::ORDER_DEFAULT]],
-            [['order' => PhpdocOrderFixer::ORDER_DEFAULT]],
+            [['order' => ['param', 'throw', 'return']]],
+            [['order' => ['param', 'return', 'throw']]],
         ];
     }
 

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -26,6 +27,22 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  */
 final class PhpdocOrderFixerTest extends AbstractFixerTestCase
 {
+    public function testEmptyOrderConfiguration(): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessage('The option "order" value is invalid. Minimum two tags are required.');
+
+        $this->fixer->configure(['order' => []]);
+    }
+
+    public function testInvalidOrderConfiguration(): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessage('The option "order" value is invalid. Minimum two tags are required.');
+
+        $this->fixer->configure(['order' => ['param']]);
+    }
+
     public function testNoChanges(): void
     {
         $expected = <<<'EOF'

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -47,6 +47,8 @@ EOF;
 
     /**
      * @dataProvider provideDifferentOrderCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testOnlyParams(array $config): void
     {
@@ -65,6 +67,8 @@ EOF;
 
     /**
      * @dataProvider provideDifferentOrderCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testOnlyReturns(array $config): void
     {
@@ -84,6 +88,8 @@ EOF;
 
     /**
      * @dataProvider provideDifferentOrderCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testEmpty(array $config): void
     {
@@ -93,6 +99,8 @@ EOF;
 
     /**
      * @dataProvider provideDifferentOrderCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testNoAnnotations(array $config): void
     {
@@ -359,6 +367,9 @@ EOF;
         $this->doTest($input);
     }
 
+    /**
+     * @return array<string, mixed>[][]
+     */
     public function provideDifferentOrderCases(): array
     {
         return [
@@ -370,17 +381,18 @@ EOF;
     /**
      * @dataProvider provideBasicCodeWithDifferentOrdersCases
      *
-     * @param mixed $config
-     * @param mixed $expected
-     * @param mixed $input
+     * @param array<string, mixed> $config
      */
-    public function testFixBasicCaseWithDifferentOrders($config, $expected, $input): void
+    public function testFixBasicCaseWithDifferentOrders(array $config, string $expected, ?string $input): void
     {
         $this->fixer->configure($config);
 
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return array<array<null|array<string, mixed>|string>>
+     */
     public function provideBasicCodeWithDifferentOrdersCases(): array
     {
         $input = <<<'EOF'
@@ -491,6 +503,8 @@ EOF;
 
     /**
      * @dataProvider provideCompeteCasesWithCustomOrdersCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testFixCompeteCasesWithCustomOrders(array $config, string $expected, string $input): void
     {
@@ -499,6 +513,9 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return array<int, array<int, string|string[][]>>
+     */
     public function provideCompeteCasesWithCustomOrdersCases(): array
     {
         $docBlockBricks = [
@@ -589,6 +606,10 @@ EOF;
         ];
     }
 
+    /**
+     * @param array<string, string|string[]> $bricks
+     * @param string[]                       $order
+     */
     private static function glueBricks(array $bricks, array $order): string
     {
         $indent = '    ';

--- a/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocOrderFixerTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
+use PhpCsFixer\Fixer\Phpdoc\PhpdocOrderFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
  * @author Graham Campbell <hello@gjcampbell.co.uk>
+ * @author Jakub Kwaśniewski <jakub@zero-85.pl>
  *
  * @internal
  *
@@ -44,8 +46,13 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function testOnlyParams(): void
+    /**
+     * @dataProvider provideAllAvailableOrderStyleCases
+     */
+    public function testOnlyParams(array $config): void
     {
+        $this->fixer->configure($config);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -57,8 +64,13 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function testOnlyReturns(): void
+    /**
+     * @dataProvider provideAllAvailableOrderStyleCases
+     */
+    public function testOnlyReturns(array $config): void
     {
+        $this->fixer->configure($config);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -71,13 +83,22 @@ EOF;
         $this->doTest($expected);
     }
 
-    public function testEmpty(): void
+    /**
+     * @dataProvider provideAllAvailableOrderStyleCases
+     */
+    public function testEmpty(array $config): void
     {
+        $this->fixer->configure($config);
         $this->doTest('/***/');
     }
 
-    public function testNoAnnotations(): void
+    /**
+     * @dataProvider provideAllAvailableOrderStyleCases
+     */
+    public function testNoAnnotations(array $config): void
     {
+        $this->fixer->configure($config);
+
         $expected = <<<'EOF'
 <?php
     /**
@@ -207,5 +228,143 @@ EOF;
 EOF;
 
         $this->doTest($expected, $input);
+    }
+
+    public function testNoChangesithLaravelStyle(): void
+    {
+        $this->fixer->configure(['style' => PhpdocOrderFixer::ORDER_STYLE_SYMFONY]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Do some cool stuff.
+     *
+     * @param EngineInterface $templating
+     * @param string          $name
+     *
+     * @return void|bar
+     *
+     * @throws Exception
+     */
+
+EOF;
+        $this->doTest($expected);
+    }
+
+    public function testFixBasicCaseWithSymfonyStyle(): void
+    {
+        $this->fixer->configure(['style' => PhpdocOrderFixer::ORDER_STYLE_SYMFONY]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * @param string $foo
+     * @return bool
+     * @throws Exception
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * @throws Exception
+     * @return bool
+     * @param string $foo
+     */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testFixCompeteCaseWithSymfonyStyle(): void
+    {
+        $this->fixer->configure(['style' => PhpdocOrderFixer::ORDER_STYLE_SYMFONY]);
+
+        $expected = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     *
+     *
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     *
+     *
+     *
+     * @param string $foo
+     * @param bool   $bar Bar
+     * @return bool Return false on failure.
+     * @return int  Return the number of changes.
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     */
+
+EOF;
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Hello there!
+     *
+     * Long description
+     * goes here.
+     *
+     * @internal
+     *
+     * @throws Exception|RuntimeException dfsdf
+     *         jkaskdnaksdnkasndansdnansdajsdnkasd
+     *
+     * @custom Test!
+     *         asldnaksdkjasdasd
+     *
+     *
+     * @return bool Return false on failure.
+     * @return int  Return the number of changes.
+     *
+     * @param string $foo
+     * @param bool   $bar Bar
+     */
+
+EOF;
+
+        $this->doTest($expected, $input);
+    }
+
+    public function testExampleFromSymfonyWithSymfonyStyle(): void
+    {
+        $this->fixer->configure(['style' => PhpdocOrderFixer::ORDER_STYLE_SYMFONY]);
+
+        $input = <<<'EOF'
+<?php
+    /**
+     * Renders a template.
+     *
+     * @param mixed $name       A template name
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @return string The evaluated template as a string
+     *
+     * @throws \InvalidArgumentException if the template does not exist
+     * @throws \RuntimeException         if the template cannot be rendered
+     */
+
+EOF;
+
+        $this->doTest($input);
+    }
+
+    public function provideAllAvailableOrderStyleCases(): array
+    {
+        return [
+            [['style' => PhpdocOrderFixer::ORDER_STYLE_PHPCS]],
+            [['style' => PhpdocOrderFixer::ORDER_STYLE_SYMFONY]],
+        ];
     }
 }

--- a/tests/Fixtures/Integration/set/@Symfony.test-in.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-in.php
@@ -34,13 +34,12 @@ class FooBar
 
     /**
      * Foo
+     *
      * @param string $dummy Some argument description
      * @param array $options
      * @param string|null $data Foo
-     *
-     * @return string|null Transformed input
-     *
      * @throws \RuntimeException
+     * @return string|null Transformed input
      */
     private function transformText($dummy, array $options = array(),$data=null)
     {

--- a/tests/Fixtures/Integration/set/@Symfony.test-in.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-in.php
@@ -64,7 +64,7 @@ class FooBar
             return ucwords($dummy);
         }
 
-        throw new \RuntimeException(sprintf('Unrecognized dummy option "%s"', $dummy));
+        throw new \RuntimeException(sprintf('Unrecognized dummy option "%s".', $dummy));
     }
     private function reverseBoolean($value = null, $theSwitch = false)
     {

--- a/tests/Fixtures/Integration/set/@Symfony.test-out.php
+++ b/tests/Fixtures/Integration/set/@Symfony.test-out.php
@@ -64,7 +64,7 @@ class FooBar
             return ucwords($dummy);
         }
 
-        throw new \RuntimeException(sprintf('Unrecognized dummy option "%s"', $dummy));
+        throw new \RuntimeException(sprintf('Unrecognized dummy option "%s".', $dummy));
     }
 
     private function reverseBoolean($value = null, $theSwitch = false)

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -94,12 +94,9 @@ final class RuleSetTest extends TestCase
             $defaultConfig[$option->getName()] = $option->getDefault();
         }
 
-        // resolve default configuration to avoid comparing not resolved options
-        $defaultConfig = $fixer->getConfigurationDefinition()->resolve($defaultConfig);
-
         static::assertNotSame(
-            $this->sortNestedArray($defaultConfig),
-            $this->sortNestedArray($ruleConfig),
+            $this->sortNestedArray($defaultConfig, $ruleName),
+            $this->sortNestedArray($ruleConfig, $ruleName),
             sprintf('Rule "%s" (in RuleSet "%s") has default config passed.', $ruleName, $setName)
         );
     }
@@ -422,23 +419,78 @@ final class RuleSetTest extends TestCase
         new RuleSet(['@Symfony:risky' => null]);
     }
 
-    private function sortNestedArray(array $array): array
+    private function sortNestedArray(array $array, string $ruleName): array
     {
-        foreach ($array as $key => $element) {
-            if (!\is_array($element)) {
-                continue;
-            }
-            $array[$key] = $this->sortNestedArray($element);
-        }
-
-        // sort by key if associative, by values otherwise
-        if (array_keys($array) === range(0, \count($array) - 1)) {
-            sort($array);
-        } else {
-            ksort($array);
-        }
+        $this->doSort($array, $ruleName);
 
         return $array;
+    }
+
+    /**
+     * Sorts an array of fixer definition recursively.
+     *
+     * Sometimes keys are all string, sometimes they are integers - we need to account for that.
+     *
+     * @param array<int|string,mixed> $data
+     */
+    private function doSort(array &$data, string $path): void
+    {
+        static $orderMatters = [
+            'ordered_imports.imports_order',
+            'phpdoc_order.order',
+        ];
+
+        if (\in_array($path, $orderMatters, true)) { // order matters
+            return;
+        }
+
+        $keys = array_keys($data);
+
+        if ($this->allInteger($keys)) {
+            // do not sort if all values are arrays
+            if (!$this->allArray($data)) {
+                sort($data);
+            }
+        } else {
+            ksort($data);
+        }
+
+        foreach ($data as $key => $value) {
+            if (\is_array($value)) {
+                $this->doSort(
+                    $data[$key],
+                    $path.('' !== $path ? '.' : '').$key
+                );
+            }
+        }
+    }
+
+    /**
+     * @param array<int|string,mixed> $values
+     */
+    private function allInteger(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (!\is_int($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int|string,mixed> $values
+     */
+    private function allArray(array $values): bool
+    {
+        foreach ($values as $value) {
+            if (!\is_array($value)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -34,6 +34,16 @@ use PhpCsFixer\Tests\TestCase;
 final class RuleSetTest extends TestCase
 {
     /**
+     * Options for which order of array elements matters.
+     *
+     * @var string[]
+     */
+    private const ORDER_MATTERS = [
+        'ordered_imports.imports_order',
+        'phpdoc_order.order',
+    ];
+
+    /**
      * @param array|bool $ruleConfig
      *
      * @dataProvider provideAllRulesFromSetsCases
@@ -435,22 +445,15 @@ final class RuleSetTest extends TestCase
      */
     private function doSort(array &$data, string $path): void
     {
-        static $orderMatters = [
-            'ordered_imports.imports_order',
-            'phpdoc_order.order',
-        ];
-
-        if (\in_array($path, $orderMatters, true)) { // order matters
+        // if order matters do not sort!
+        if (\in_array($path, self::ORDER_MATTERS, true)) {
             return;
         }
 
         $keys = array_keys($data);
 
         if ($this->allInteger($keys)) {
-            // do not sort if all values are arrays
-            if (!$this->allArray($data)) {
-                sort($data);
-            }
+            sort($data);
         } else {
             ksort($data);
         }
@@ -472,20 +475,6 @@ final class RuleSetTest extends TestCase
     {
         foreach ($values as $value) {
             if (!\is_int($value)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param array<int|string,mixed> $values
-     */
-    private function allArray(array $values): bool
-    {
-        foreach ($values as $value) {
-            if (!\is_array($value)) {
                 return false;
             }
         }

--- a/tests/RuleSet/RuleSetTest.php
+++ b/tests/RuleSet/RuleSetTest.php
@@ -94,12 +94,12 @@ final class RuleSetTest extends TestCase
             $defaultConfig[$option->getName()] = $option->getDefault();
         }
 
-        // do not sort options for which order is important
-        $excludeFromSorting = $this->orderMattersFor($ruleName);
+        // resolve default configuration to avoid comparing not resolved options
+        $defaultConfig = $fixer->getConfigurationDefinition()->resolve($defaultConfig);
 
         static::assertNotSame(
-            $this->sortNestedArray($defaultConfig, $excludeFromSorting),
-            $this->sortNestedArray($ruleConfig, $excludeFromSorting),
+            $this->sortNestedArray($defaultConfig),
+            $this->sortNestedArray($ruleConfig),
             sprintf('Rule "%s" (in RuleSet "%s") has default config passed.', $ruleName, $setName)
         );
     }
@@ -422,31 +422,13 @@ final class RuleSetTest extends TestCase
         new RuleSet(['@Symfony:risky' => null]);
     }
 
-    /**
-     * Options for which order is important.
-     *
-     * @return string[]
-     */
-    private function orderMattersFor(string $ruleName): array
-    {
-        static $orderMattersFor = [
-            'phpdoc_order' => ['order'],
-        ];
-
-        return $orderMattersFor[$ruleName] ?? [];
-    }
-
-    /**
-     * @param string[] $excludeKeys
-     */
-    private function sortNestedArray(array $array, array $excludeKeys = []): array
+    private function sortNestedArray(array $array): array
     {
         foreach ($array as $key => $element) {
-            if (!\is_array($element) || \in_array($key, $excludeKeys, true)) {
+            if (!\is_array($element)) {
                 continue;
             }
-
-            $array[$key] = $this->sortNestedArray($element, $excludeKeys);
+            $array[$key] = $this->sortNestedArray($element);
         }
 
         // sort by key if associative, by values otherwise


### PR DESCRIPTION
Closes #1602.

Introduce configurability to PhpdocOrderFixer with option ``order`` which explicitly defines sequence of annotations.

Option ``order`` accepts array of strings.
Default value is  ``['param', 'throws', 'return']``.