### PR TITLE
bug: Fix indentation after control structure in switch

### DIFF
--- a/src/Fixer/Whitespace/StatementIndentationFixer.php
+++ b/src/Fixer/Whitespace/StatementIndentationFixer.php
@@ -434,6 +434,12 @@ else {
                 continue;
             }
 
+            if ($tokens[$index]->equals('{')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+
             if ($tokens[$index]->equalsAny([[T_CASE], [T_DEFAULT]])) {
                 return $index;
             }

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -624,6 +624,25 @@ foreach ($array as [
 ]) {
 }',
         ];
+
+        yield 'switch case with control structure' => [
+            '<?php
+switch ($foo) {
+    case true:
+        if ($bar) {
+            bar();
+        }
+        return true;
+}',
+            '<?php
+switch ($foo) {
+    case true:
+    if ($bar) {
+      bar();
+    }
+return true;
+}',
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6448#issuecomment-1180222415 and somes cases from #6470.