### PR TITLE
bug: Fix BinaryOperatorSpacesFixer adding whitespace outside PHP blocks

### DIFF
--- a/src/Tokenizer/TokensAnalyzer.php
+++ b/src/Tokenizer/TokensAnalyzer.php
@@ -562,7 +562,7 @@ final class TokensAnalyzer
         $tokens = $this->tokens;
         $token = $tokens[$index];
 
-        if ($token->isGivenKind([T_ENCAPSED_AND_WHITESPACE, CT::T_TYPE_INTERSECTION])) {
+        if ($token->isGivenKind([T_INLINE_HTML, T_ENCAPSED_AND_WHITESPACE, CT::T_TYPE_INTERSECTION])) {
             return false;
         }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -708,6 +708,7 @@ $a
 $b;
 ',
             ],
+            ['<a href="test-<?=$path?>-<?=$id?>.html">Test</a>'],
         ];
     }
 

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -1579,6 +1579,10 @@ $b;',
                 [9 => false],
                 '<?php $a = "{$value}-{$theSwitch}";',
             ],
+            [
+                [3 => false],
+                '<?=$path?>-<?=$id?>',
+            ],
         ];
 
         $operators = [


### PR DESCRIPTION
Prevents `TokensAnalyzer::isBinaryOperator()` from treating `[T_INLINE_HTML, '-']` as operator. Fixes #6443.