### PR TITLE
docs: Add intersection type to types_spaces rule description

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2954,12 +2954,12 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\ArrayNotation\\TrimArraySpacesFixer <./../src/Fixer/ArrayNotation/TrimArraySpacesFixer.php>`_
 -  `types_spaces <./rules/whitespace/types_spaces.rst>`_
 
-   A single space or none should be around union type operator.
+   A single space or none should be around union type and intersection type operators.
 
    Configuration options:
 
    - | ``space``
-     | spacing to apply around union type operator.
+     | spacing to apply around union type and intersection type operators.
      | Allowed values: ``'none'``, ``'single'``
      | Default value: ``'none'``
    - | ``space_multiple_catch``

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -860,4 +860,4 @@ Whitespace
   Each statement must be indented.
 - `types_spaces <./whitespace/types_spaces.rst>`_
 
-  A single space or none should be around union type operator.
+  A single space or none should be around union type and intersection type operators.

--- a/doc/rules/whitespace/types_spaces.rst
+++ b/doc/rules/whitespace/types_spaces.rst
@@ -2,7 +2,8 @@
 Rule ``types_spaces``
 =====================
 
-A single space or none should be around union type operator.
+A single space or none should be around union type and intersection type
+operators.
 
 Configuration
 -------------
@@ -10,7 +11,7 @@ Configuration
 ``space``
 ~~~~~~~~~
 
-spacing to apply around union type operator.
+spacing to apply around union type and intersection type operators.
 
 Allowed values: ``'none'``, ``'single'``
 

--- a/src/Fixer/Whitespace/TypesSpacesFixer.php
+++ b/src/Fixer/Whitespace/TypesSpacesFixer.php
@@ -46,7 +46,7 @@ final class TypesSpacesFixer extends AbstractFixer implements ConfigurableFixerI
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'A single space or none should be around union type operator.',
+            'A single space or none should be around union type and intersection type operators.',
             [
                 new CodeSample(
                     "<?php\ntry\n{\n    new Foo();\n} catch (ErrorA | ErrorB \$e) {\necho'error';}\n"
@@ -77,7 +77,7 @@ final class TypesSpacesFixer extends AbstractFixer implements ConfigurableFixerI
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
-            (new FixerOptionBuilder('space', 'spacing to apply around union type operator.'))
+            (new FixerOptionBuilder('space', 'spacing to apply around union type and intersection type operators.'))
                 ->setAllowedValues(['none', 'single'])
                 ->setDefault('none')
                 ->getOption(),


### PR DESCRIPTION
Not sure if this is intended, but the `type_spaces` rule also affects intersection types.

Updated the documentation according to the current behavior.