### PR TITLE
bug: Optimize unused import in comment

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -1723,7 +1723,16 @@ List of Available Rules
 
    Unused ``use`` statements must be removed.
 
-   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Configuration options:
+
+   - | ``case_sensitive_in_comment``
+     | Whether usage detection should be case sensitive
+     | Allowed types: ``bool``
+     | Default value: ``false``
+
+   *warning risky* Risky when the case insensitive to reference of classes in comment.
+
+   Part of rule sets `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_ `@Symfony:risky <./ruleSets/SymfonyRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Import\\NoUnusedImportsFixer <./../src/Fixer/Import/NoUnusedImportsFixer.php>`_
 -  `no_useless_else <./rules/control_structure/no_useless_else.rst>`_

--- a/doc/ruleSets/PhpCsFixerRisky.rst
+++ b/doc/ruleSets/PhpCsFixerRisky.rst
@@ -22,3 +22,6 @@ Rules
 - `php_unit_test_case_static_method_calls <./../rules/php_unit/php_unit_test_case_static_method_calls.rst>`_
 - `strict_comparison <./../rules/strict/strict_comparison.rst>`_
 - `strict_param <./../rules/strict/strict_param.rst>`_
+  config:
+  ``['namespaces' => true]``
+- `no_unused_imports <./../rules/import/no_unused_imports.rst>`_

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -79,7 +79,6 @@ Rules
   ``['namespaces' => true]``
 - `no_unneeded_import_alias <./../rules/import/no_unneeded_import_alias.rst>`_
 - `no_unset_cast <./../rules/cast_notation/no_unset_cast.rst>`_
-- `no_unused_imports <./../rules/import/no_unused_imports.rst>`_
 - `no_useless_nullsafe_operator <./../rules/operator/no_useless_nullsafe_operator.rst>`_
 - `no_whitespace_before_comma_in_array <./../rules/array_notation/no_whitespace_before_comma_in_array.rst>`_
 - `normalize_index_brace <./../rules/array_notation/normalize_index_brace.rst>`_

--- a/doc/ruleSets/SymfonyRisky.rst
+++ b/doc/ruleSets/SymfonyRisky.rst
@@ -45,3 +45,6 @@ Rules
 - `string_length_to_empty <./../rules/string_notation/string_length_to_empty.rst>`_
 - `string_line_ending <./../rules/string_notation/string_line_ending.rst>`_
 - `ternary_to_elvis_operator <./../rules/operator/ternary_to_elvis_operator.rst>`_
+  config:
+  ``['namespaces' => true]``
+- `no_unused_imports <./../rules/import/no_unused_imports.rst>`_

--- a/doc/rules/import/no_unused_imports.rst
+++ b/doc/rules/import/no_unused_imports.rst
@@ -4,11 +4,25 @@ Rule ``no_unused_imports``
 
 Unused ``use`` statements must be removed.
 
+Configuration
+-------------
+
+``case_sensitive_in_comment``
+~~~~~~~~~~~~~~~
+
+Whether usage detection should be case sensitive
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 Examples
 --------
 
 Example #1
 ~~~~~~~~~~
+
+*Default* configuration.
 
 .. code-block:: diff
 
@@ -17,7 +31,26 @@ Example #1
     <?php
     use \DateTime;
    -use \Exception;
+    use \Users;
 
+    //users
+    new DateTime();
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['case_sensitive_in_comment' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    use \DateTime;
+   -use \Exception;
+   -use \Users;
+
+    //users
     new DateTime();
 
 Rule sets
@@ -26,7 +59,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``no_unused_imports`` rule.
+  Using the `@PhpCsFixerRisky <./../../ruleSets/PhpCsFixerRisky.rst>`_ rule set will enable the ``no_unused_imports`` rule.
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``no_unused_imports`` rule.
+  Using the `@SymfonyRisky <./../../ruleSets/SymfonyRisky.rst>`_ rule set will enable the ``no_unused_imports`` rule.

--- a/src/RuleSet/Sets/PhpCsFixerRiskySet.php
+++ b/src/RuleSet/Sets/PhpCsFixerRiskySet.php
@@ -46,6 +46,7 @@ final class PhpCsFixerRiskySet extends AbstractRuleSetDescription
             ],
             'no_unreachable_default_argument_value' => true,
             'no_unset_on_property' => true,
+            'no_unused_imports' => true,
             'php_unit_strict' => true,
             'php_unit_test_case_static_method_calls' => true,
             'strict_comparison' => true,

--- a/src/RuleSet/Sets/SymfonyRiskySet.php
+++ b/src/RuleSet/Sets/SymfonyRiskySet.php
@@ -53,6 +53,7 @@ final class SymfonyRiskySet extends AbstractRuleSetDescription
             'no_php4_constructor' => true,
             'no_unneeded_final_method' => true,
             'no_unreachable_default_argument_value' => false,
+            'no_unused_imports' => true,
             'no_useless_sprintf' => true,
             'non_printable_character' => true,
             'ordered_traits' => true,

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -124,7 +124,6 @@ final class SymfonySet extends AbstractRuleSetDescription
             ],
             'no_unneeded_import_alias' => true,
             'no_unset_cast' => true,
-            'no_unused_imports' => true,
             'no_useless_nullsafe_operator' => true,
             'no_whitespace_before_comma_in_array' => true,
             'normalize_index_brace' => true,

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1314,6 +1314,45 @@ use Z;
     }
 
     /**
+     * @dataProvider provideFixCaseSensitive
+     */
+    public function testFixCaseSensitive(string $expected, ?string $input = null): void
+    {
+        $this->fixer->configure(['case_sensitive_in_comment' => true]);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixCaseSensitive()
+    {
+        return ['with_matches_in_comments' => [
+            '<?php
+use Foo;
+use Bar;
+use Baz;
+
+//Foo
+#Bar
+/*Baz*/',
+        ],
+            'with_case_insensitive_matches_in_comments' => [
+                '<?php
+
+//foo
+#bar
+/*baz*/',
+                '<?php
+use Foo;
+use Bar;
+use Baz;
+
+//foo
+#bar
+/*baz*/',
+            ],
+        ];
+    }
+
+    /**
      * @requires PHP <8.0
      */
     public function testFixPrePHP80(): void


### PR DESCRIPTION
Unused import will not be deleted in the following situation.

```PHP
use App\Model\User;

...

// record user log
public function recordLog()
{
}
```
I think the regular expression should at least keep consistent case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.