### PR TITLE
feature: Introduce configurability to PhpdocSeparationFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2096,10 +2096,6 @@ List of Available Rules
      | Sets of annotation types to be grouped together.
      | Allowed types: ``string[][]``
      | Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
-   - | ``additional_groups``
-     | Sets of additional annotation types to be grouped together.
-     | Allowed types: ``string[][]``
-     | Default value: ``[]``
    - | ``psr_standard_tags_only``
      | Whether to only process annotations defined by PSR-5 draft, which are: `api`, `author`, `category`, `copyright`, `deprecated`, `example`, `global`, `internal`, `license`, `link`, `method`, `package`, `param`, `property`, `property-read`, `property-write`, `return`, `see`, `since`, `subpackage`, `throws`, `todo`, `uses`, `var`, `version`.
      | Allowed types: ``bool``

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2096,10 +2096,6 @@ List of Available Rules
      | Sets of annotation types to be grouped together.
      | Allowed types: ``string[][]``
      | Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
-   - | ``psr_standard_tags_only``
-     | Whether to only process annotations defined by PSR-5 draft, which are: `api`, `author`, `category`, `copyright`, `deprecated`, `example`, `global`, `internal`, `license`, `link`, `method`, `package`, `param`, `property`, `property-read`, `property-write`, `return`, `see`, `since`, `subpackage`, `throws`, `todo`, `uses`, `var`, `version`.
-     | Allowed types: ``bool``
-     | Default value: ``true``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2098,10 +2098,10 @@ List of Available Rules
      | Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
    - | ``additional_groups``
      | Sets of additional annotation types to be grouped together.
-     | Allowed types: ``string[][]``, ``null``
-     | Default value: ``null``
+     | Allowed types: ``string[][]``
+     | Default value: ``[]``
    - | ``psr_standard_tags_only``
-     | Sets if process PSR PHPDoc standard annotation tags only, which are: `api`, `author`, `category`, `copyright`, `deprecated`, `example`, `global`, `internal`, `license`, `link`, `method`, `package`, `param`, `property`, `property-read`, `property-write`, `return`, `see`, `since`, `subpackage`, `throws`, `todo`, `uses`, `var`, `version`.
+     | Whether to only process annotations defined by PSR-5 draft, which are: `api`, `author`, `category`, `copyright`, `deprecated`, `example`, `global`, `internal`, `license`, `link`, `method`, `package`, `param`, `property`, `property-read`, `property-write`, `return`, `see`, `since`, `subpackage`, `throws`, `todo`, `uses`, `var`, `version`.
      | Allowed types: ``bool``
      | Default value: ``true``
 

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2088,7 +2088,23 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Phpdoc\\PhpdocScalarFixer <./../src/Fixer/Phpdoc/PhpdocScalarFixer.php>`_
 -  `phpdoc_separation <./rules/phpdoc/phpdoc_separation.rst>`_
 
-   Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.
+   Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in ``additional_groups`` option.
+
+   Configuration options:
+
+   - | ``groups``
+     | Sets of annotation types to be grouped together.
+     | Allowed types: ``string[][]``
+     | Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
+   - | ``additional_groups``
+     | Sets of additional annotation types to be grouped together.
+     | Allowed types: ``string[][]``, ``null``
+     | Default value: ``null``
+   - | ``psr_standard_tags_only``
+     | Sets if process PSR PHPDoc standard annotation tags only, which are: `api`, `author`, `category`, `copyright`, `deprecated`, `example`, `global`, `internal`, `license`, `link`, `method`, `package`, `param`, `property`, `property-read`, `property-write`, `return`, `see`, `since`, `subpackage`, `throws`, `todo`, `uses`, `var`, `version`.
+     | Allowed types: ``bool``
+     | Default value: ``true``
+
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 

--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2088,7 +2088,7 @@ List of Available Rules
    `Source PhpCsFixer\\Fixer\\Phpdoc\\PhpdocScalarFixer <./../src/Fixer/Phpdoc/PhpdocScalarFixer.php>`_
 -  `phpdoc_separation <./rules/phpdoc/phpdoc_separation.rst>`_
 
-   Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in ``additional_groups`` option.
+   Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.
 
    Configuration options:
 

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -699,7 +699,7 @@ PHPDoc
   Scalar types should always be written in the same form. ``int`` not ``integer``, ``bool`` not ``boolean``, ``float`` not ``real`` or ``double``.
 - `phpdoc_separation <./phpdoc/phpdoc_separation.rst>`_
 
-  Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in ``additional_groups`` option.
+  Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.
 - `phpdoc_single_line_var_spacing <./phpdoc/phpdoc_single_line_var_spacing.rst>`_
 
   Single line ``@var`` PHPDoc should have proper spacing.

--- a/doc/rules/index.rst
+++ b/doc/rules/index.rst
@@ -699,7 +699,7 @@ PHPDoc
   Scalar types should always be written in the same form. ``int`` not ``integer``, ``bool`` not ``boolean``, ``float`` not ``real`` or ``double``.
 - `phpdoc_separation <./phpdoc/phpdoc_separation.rst>`_
 
-  Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.
+  Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in ``additional_groups`` option.
 - `phpdoc_single_line_var_spacing <./phpdoc/phpdoc_single_line_var_spacing.rst>`_
 
   Single line ``@var`` PHPDoc should have proper spacing.

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -49,6 +49,7 @@ Example #1
      * Hello there!
      *
      * @author John Doe
+   + *
      * @custom Test!
      *
      * @throws Exception|RuntimeException foo
@@ -74,6 +75,7 @@ With configuration: ``['groups' => [['deprecated', 'link', 'see', 'since'], ['au
      * Hello there!
      *
      * @author John Doe
+   + *
      * @custom Test!
      *
      * @throws Exception|RuntimeException foo

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -3,8 +3,44 @@ Rule ``phpdoc_separation``
 ==========================
 
 Annotations in PHPDoc should be grouped together so that annotations of the same
-type immediately follow each other, and annotations of a different type are
-separated by a single blank line.
+type immediately follow each other. Annotations of a different type are
+separated by a single blank line, except those specified in
+``additional_groups`` option.
+
+Configuration
+-------------
+
+``groups``
+~~~~~~~~~~
+
+Sets of annotation types to be grouped together.
+
+Allowed types: ``string[][]``
+
+Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
+
+``additional_groups``
+~~~~~~~~~~~~~~~~~~~~~
+
+Sets of additional annotation types to be grouped together.
+
+Allowed types: ``string[][]``, ``null``
+
+Default value: ``null``
+
+``psr_standard_tags_only``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sets if process PSR PHPDoc standard annotation tags only, which are: ``api``,
+``author``, ``category``, ``copyright``, ``deprecated``, ``example``,
+``global``, ``internal``, ``license``, ``link``, ``method``, ``package``,
+``param``, ``property``, ``property-read``, ``property-write``, ``return``,
+``see``, ``since``, ``subpackage``, ``throws``, ``todo``, ``uses``, ``var``,
+``version``.
+
+Allowed types: ``bool``
+
+Default value: ``true``
 
 Examples
 --------
@@ -12,24 +48,100 @@ Examples
 Example #1
 ~~~~~~~~~~
 
+*Default* configuration.
+
 .. code-block:: diff
 
    --- Original
    +++ New
     <?php
     /**
-     * Description.
+     * Hello there!
+     *
+     * @author John Doe
+     * @custom Test!
+     *
+     * @throws Exception|RuntimeException foo
    + *
      * @param string $foo
    + * @param bool   $bar Bar
      *
-   + * @throws Exception|RuntimeException
-     *
    - * @param bool   $bar Bar
-   - * @throws Exception|RuntimeException
-     * @return bool
+     * @return int  Return the number of changes.
      */
-    function fnc($foo, $bar) {}
+
+Example #2
+~~~~~~~~~~
+
+With configuration: ``['additional_groups' => [['param', 'return']]]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+     * @author John Doe
+     * @custom Test!
+     *
+     * @throws Exception|RuntimeException foo
+   + *
+     * @param string $foo
+   - *
+     * @param bool   $bar Bar
+     * @return int  Return the number of changes.
+     */
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['additional_groups' => [['param', 'return']], 'psr_standard_tags_only' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+     * @author John Doe
+   + *
+     * @custom Test!
+     *
+     * @throws Exception|RuntimeException foo
+   + *
+     * @param string $foo
+   - *
+     * @param bool   $bar Bar
+     * @return int  Return the number of changes.
+     */
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['groups' => [['author', 'throws', 'custom'], ['return', 'param']], 'psr_standard_tags_only' => false]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    /**
+     * Hello there!
+     *
+     * @author John Doe
+     * @custom Test!
+   + * @throws Exception|RuntimeException foo
+     *
+   - * @throws Exception|RuntimeException foo
+     * @param string $foo
+   - *
+     * @param bool   $bar Bar
+     * @return int  Return the number of changes.
+     */
 
 Rule sets
 ---------
@@ -37,7 +149,7 @@ Rule sets
 The rule is part of the following rule sets:
 
 @PhpCsFixer
-  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_separation`` rule.
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``phpdoc_separation`` rule with the default config.
 
 @Symfony
-  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``phpdoc_separation`` rule.
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``phpdoc_separation`` rule with the default config.

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -18,20 +18,6 @@ Allowed types: ``string[][]``
 
 Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
 
-``psr_standard_tags_only``
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Whether to only process annotations defined by PSR-5 draft, which are: ``api``,
-``author``, ``category``, ``copyright``, ``deprecated``, ``example``,
-``global``, ``internal``, ``license``, ``link``, ``method``, ``package``,
-``param``, ``property``, ``property-read``, ``property-write``, ``return``,
-``see``, ``since``, ``subpackage``, ``throws``, ``todo``, ``uses``, ``var``,
-``version``.
-
-Allowed types: ``bool``
-
-Default value: ``true``
-
 Examples
 --------
 
@@ -89,32 +75,7 @@ With configuration: ``['groups' => [['deprecated', 'link', 'see', 'since'], ['au
 Example #3
 ~~~~~~~~~~
 
-With configuration: ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['param', 'return']], 'psr_standard_tags_only' => false]``.
-
-.. code-block:: diff
-
-   --- Original
-   +++ New
-    <?php
-    /**
-     * Hello there!
-     *
-     * @author John Doe
-   + *
-     * @custom Test!
-     *
-     * @throws Exception|RuntimeException foo
-   + *
-     * @param string $foo
-   - *
-     * @param bool   $bar Bar
-     * @return int  Return the number of changes.
-     */
-
-Example #4
-~~~~~~~~~~
-
-With configuration: ``['groups' => [['author', 'throws', 'custom'], ['return', 'param']], 'psr_standard_tags_only' => false]``.
+With configuration: ``['groups' => [['author', 'throws', 'custom'], ['return', 'param']]]``.
 
 .. code-block:: diff
 

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -19,15 +19,6 @@ Allowed types: ``string[][]``
 
 Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
 
-``additional_groups``
-~~~~~~~~~~~~~~~~~~~~~
-
-Sets of additional annotation types to be grouped together.
-
-Allowed types: ``string[][]``
-
-Default value: ``[]``
-
 ``psr_standard_tags_only``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -73,7 +64,7 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-With configuration: ``['additional_groups' => [['param', 'return']]]``.
+With configuration: ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['param', 'return']]]``.
 
 .. code-block:: diff
 
@@ -97,7 +88,7 @@ With configuration: ``['additional_groups' => [['param', 'return']]]``.
 Example #3
 ~~~~~~~~~~
 
-With configuration: ``['additional_groups' => [['param', 'return']], 'psr_standard_tags_only' => false]``.
+With configuration: ``['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write'], ['param', 'return']], 'psr_standard_tags_only' => false]``.
 
 .. code-block:: diff
 

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -24,14 +24,14 @@ Default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright'
 
 Sets of additional annotation types to be grouped together.
 
-Allowed types: ``string[][]``, ``null``
+Allowed types: ``string[][]``
 
-Default value: ``null``
+Default value: ``[]``
 
 ``psr_standard_tags_only``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sets if process PSR PHPDoc standard annotation tags only, which are: ``api``,
+Whether to only process annotations defined by PSR-5 draft, which are: ``api``,
 ``author``, ``category``, ``copyright``, ``deprecated``, ``example``,
 ``global``, ``internal``, ``license``, ``link``, ``method``, ``package``,
 ``param``, ``property``, ``property-read``, ``property-write``, ``return``,

--- a/doc/rules/phpdoc/phpdoc_separation.rst
+++ b/doc/rules/phpdoc/phpdoc_separation.rst
@@ -4,8 +4,7 @@ Rule ``phpdoc_separation``
 
 Annotations in PHPDoc should be grouped together so that annotations of the same
 type immediately follow each other. Annotations of a different type are
-separated by a single blank line, except those specified in
-``additional_groups`` option.
+separated by a single blank line.
 
 Configuration
 -------------

--- a/src/ConfigurationException/InvalidConfigurationException.php
+++ b/src/ConfigurationException/InvalidConfigurationException.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
  * Exceptions of this type are thrown on misconfiguration of the Fixer.
  *
  * @internal
+ *
  * @final Only internal extending this class is supported
  */
 class InvalidConfigurationException extends \InvalidArgumentException

--- a/src/ConfigurationException/InvalidFixerConfigurationException.php
+++ b/src/ConfigurationException/InvalidFixerConfigurationException.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Console\Command\FixCommandExitStatusCalculator;
  * Exception thrown by Fixers on misconfiguration.
  *
  * @internal
+ *
  * @final Only internal extending this class is supported
  */
 class InvalidFixerConfigurationException extends InvalidConfigurationException

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -20,15 +20,14 @@ use PhpCsFixer\Preg;
  * This represents a tag, as defined by the proposed PSR PHPDoc standard.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
+ * @author Jakub Kwaśniewski <jakub@zero-85.pl>
  */
 final class Tag
 {
     /**
      * All the tags defined by the proposed PSR PHPDoc standard.
-     *
-     * @var string[]
      */
-    private static array $tags = [
+    public const PSR_STANDARD_TAGS = [
         'api', 'author', 'category', 'copyright', 'deprecated', 'example',
         'global', 'internal', 'license', 'link', 'method', 'package', 'param',
         'property', 'property-read', 'property-write', 'return', 'see',
@@ -42,10 +41,8 @@ final class Tag
 
     /**
      * The cached tag name.
-     *
-     * @var null|string
      */
-    private $name;
+    private ?string $name = null;
 
     /**
      * Create a new tag instance.
@@ -100,6 +97,6 @@ final class Tag
      */
     public function valid(): bool
     {
-        return \in_array($this->getName(), self::$tags, true);
+        return \in_array($this->getName(), self::PSR_STANDARD_TAGS, true);
     }
 }

--- a/src/DocBlock/TagComparator.php
+++ b/src/DocBlock/TagComparator.php
@@ -40,10 +40,6 @@ final class TagComparator
      */
     private array $groups = [];
 
-    private function __construct()
-    {
-    }
-
     /**
      * @param null|string[][] $groups
      *
@@ -58,23 +54,30 @@ final class TagComparator
     }
 
     /**
-     * @param null|string[][] $additionalGroups
-     *
-     * @return $this
+     * Should the given tags be kept together, or kept apart?
+     * Check against configured groups.
      */
-    public function withAdditionalGroups(?array $additionalGroups): self
+    public function shouldBeGroupedTogether(Tag $first, Tag $second): bool
     {
-        if (\is_array($additionalGroups)) {
-            $this->groups = array_merge($this->groups, $additionalGroups);
-        }
-
-        return $this;
+        return self::whetherShouldBeTogether($first, $second, $this->groups);
     }
 
     /**
      * Should the given tags be kept together, or kept apart?
+     * Check against DEFAULT_GROUPS.
      */
-    public function shouldBeTogether(Tag $first, Tag $second): bool
+    public static function shouldBeTogether(Tag $first, Tag $second): bool
+    {
+        return self::whetherShouldBeTogether($first, $second, self::DEFAULT_GROUPS);
+    }
+
+    /**
+     * Should the given tags be kept together, or kept apart?
+     * It would be much prettier if all method and function names rhyme.
+     *
+     * @param string[][] $groups
+     */
+    private static function whetherShouldBeTogether(Tag $first, Tag $second, array $groups): bool
     {
         $firstName = $first->getName();
         $secondName = $second->getName();
@@ -83,7 +86,7 @@ final class TagComparator
             return true;
         }
 
-        foreach ($this->groups as $group) {
+        foreach ($groups as $group) {
             if (\in_array($firstName, $group, true) && \in_array($secondName, $group, true)) {
                 return true;
             }

--- a/src/DocBlock/TagComparator.php
+++ b/src/DocBlock/TagComparator.php
@@ -19,13 +19,16 @@ namespace PhpCsFixer\DocBlock;
  * together, or kept apart.
  *
  * @author Graham Campbell <hello@gjcampbell.co.uk>
+ * @author Jakub Kwaśniewski <jakub@zero-85.pl>
  */
 final class TagComparator
 {
     /**
      * Groups of tags that should be allowed to immediately follow each other.
+     *
+     * @internal
      */
-    private static array $groups = [
+    public const TAG_GROUPS = [
         ['deprecated', 'link', 'see', 'since'],
         ['author', 'copyright', 'license'],
         ['category', 'package', 'subpackage'],
@@ -33,9 +36,45 @@ final class TagComparator
     ];
 
     /**
+     * @var string[][]
+     */
+    private array $groups = [];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param null|string[][] $groups
+     *
+     * @return $this
+     */
+    public static function configure(?array $groups = null): self
+    {
+        $comparator = new self();
+        $comparator->groups = (null === $groups) ? self::TAG_GROUPS : $groups;
+
+        return $comparator;
+    }
+
+    /**
+     * @param null|string[][] $additionalGroups
+     *
+     * @return $this
+     */
+    public function withAdditionalGroups(?array $additionalGroups): self
+    {
+        if (\is_array($additionalGroups)) {
+            $this->groups = array_merge($this->groups, $additionalGroups);
+        }
+
+        return $this;
+    }
+
+    /**
      * Should the given tags be kept together, or kept apart?
      */
-    public static function shouldBeTogether(Tag $first, Tag $second): bool
+    public function shouldBeTogether(Tag $first, Tag $second): bool
     {
         $firstName = $first->getName();
         $secondName = $second->getName();
@@ -44,7 +83,7 @@ final class TagComparator
             return true;
         }
 
-        foreach (self::$groups as $group) {
+        foreach ($this->groups as $group) {
             if (\in_array($firstName, $group, true) && \in_array($secondName, $group, true)) {
                 return true;
             }

--- a/src/DocBlock/TagComparator.php
+++ b/src/DocBlock/TagComparator.php
@@ -28,7 +28,7 @@ final class TagComparator
      *
      * @internal
      */
-    public const TAG_GROUPS = [
+    public const DEFAULT_GROUPS = [
         ['deprecated', 'link', 'see', 'since'],
         ['author', 'copyright', 'license'],
         ['category', 'package', 'subpackage'],
@@ -52,7 +52,7 @@ final class TagComparator
     public static function configure(?array $groups = null): self
     {
         $comparator = new self();
-        $comparator->groups = (null === $groups) ? self::TAG_GROUPS : $groups;
+        $comparator->groups = $groups ?? self::DEFAULT_GROUPS;
 
         return $comparator;
     }

--- a/src/DocBlock/TagComparator.php
+++ b/src/DocBlock/TagComparator.php
@@ -36,48 +36,11 @@ final class TagComparator
     ];
 
     /**
-     * @var string[][]
-     */
-    private array $groups = [];
-
-    /**
-     * @param null|string[][] $groups
-     *
-     * @return $this
-     */
-    public static function configure(?array $groups = null): self
-    {
-        $comparator = new self();
-        $comparator->groups = $groups ?? self::DEFAULT_GROUPS;
-
-        return $comparator;
-    }
-
-    /**
      * Should the given tags be kept together, or kept apart?
-     * Check against configured groups.
-     */
-    public function shouldBeGroupedTogether(Tag $first, Tag $second): bool
-    {
-        return self::whetherShouldBeTogether($first, $second, $this->groups);
-    }
-
-    /**
-     * Should the given tags be kept together, or kept apart?
-     * Check against DEFAULT_GROUPS.
-     */
-    public static function shouldBeTogether(Tag $first, Tag $second): bool
-    {
-        return self::whetherShouldBeTogether($first, $second, self::DEFAULT_GROUPS);
-    }
-
-    /**
-     * Should the given tags be kept together, or kept apart?
-     * It would be much prettier if all method and function names rhyme.
      *
      * @param string[][] $groups
      */
-    private static function whetherShouldBeTogether(Tag $first, Tag $second, array $groups): bool
+    public static function shouldBeTogether(Tag $first, Tag $second, array $groups = self::DEFAULT_GROUPS): bool
     {
         $firstName = $first->getName();
         $secondName = $second->getName();

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -61,6 +61,7 @@ final class BinaryOperatorSpacesFixer extends AbstractFixer implements Configura
 
     /**
      * @internal
+     *
      * @const Placeholder used as anchor for right alignment.
      */
     public const ALIGN_PLACEHOLDER = "\x2 ALIGNABLE%d \x3";

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -35,7 +35,10 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
-    private TagComparator $tagComparator;
+    /**
+     * @var string[][]
+     */
+    private array $groups;
 
     private bool $standardTagsOnly = true;
 
@@ -62,7 +65,7 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
 EOF;
 
         return new FixerDefinition(
-            'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in `additional_groups` option.',
+            'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.',
             [
                 new CodeSample($code),
                 new CodeSample($code, ['groups' => array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']])]),
@@ -79,7 +82,7 @@ EOF;
     {
         parent::configure($configuration);
 
-        $this->tagComparator = TagComparator::configure($this->configuration['groups']);
+        $this->groups = $this->configuration['groups'];
 
         $this->standardTagsOnly = $this->configuration['psr_standard_tags_only'];
     }
@@ -177,7 +180,7 @@ EOF;
             }
 
             if (!$this->standardTagsOnly || $next->getTag()->valid()) {
-                if ($this->tagComparator->shouldBeGroupedTogether($annotation->getTag(), $next->getTag())) {
+                if (TagComparator::shouldBeTogether($annotation->getTag(), $next->getTag(), $this->groups)) {
                     $this->ensureAreTogether($doc, $annotation, $next);
                 } else {
                     $this->ensureAreSeparate($doc, $annotation, $next);

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -38,12 +38,7 @@ final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableF
     /**
      * @internal
      */
-    public const ADDITIONAL_GROUPS_DEFAULT = null;
-
-    /**
-     * @internal
-     */
-    public const ADDITIONAL_GROUPS_LARAVEL = [['param', 'return']];
+    private const ADDITIONAL_GROUPS_DEFAULT = null;
 
     private TagComparator $tagComparator;
 
@@ -75,8 +70,8 @@ EOF;
             'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in `additional_groups` option.',
             [
                 new CodeSample($code),
-                new CodeSample($code, ['additional_groups' => self::ADDITIONAL_GROUPS_LARAVEL]),
-                new CodeSample($code, ['additional_groups' => self::ADDITIONAL_GROUPS_LARAVEL, 'psr_standard_tags_only' => false]),
+                new CodeSample($code, ['additional_groups' => [['param', 'return']]]),
+                new CodeSample($code, ['additional_groups' => [['param', 'return']], 'psr_standard_tags_only' => false]),
                 new CodeSample($code, ['groups' => [['author', 'throws', 'custom'], ['return', 'param']], 'psr_standard_tags_only' => false]),
             ],
         );

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -65,8 +65,8 @@ EOF;
             'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, except those specified in `additional_groups` option.',
             [
                 new CodeSample($code),
-                new CodeSample($code, ['additional_groups' => [['param', 'return']]]),
-                new CodeSample($code, ['additional_groups' => [['param', 'return']], 'psr_standard_tags_only' => false]),
+                new CodeSample($code, ['groups' => array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']])]),
+                new CodeSample($code, ['groups' => array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']]), 'psr_standard_tags_only' => false]),
                 new CodeSample($code, ['groups' => [['author', 'throws', 'custom'], ['return', 'param']], 'psr_standard_tags_only' => false]),
             ],
         );
@@ -79,10 +79,7 @@ EOF;
     {
         parent::configure($configuration);
 
-        $this->tagComparator =
-            TagComparator::configure($this->configuration['groups'])
-                ->withAdditionalGroups($this->configuration['additional_groups'])
-        ;
+        $this->tagComparator = TagComparator::configure($this->configuration['groups']);
 
         $this->standardTagsOnly = $this->configuration['psr_standard_tags_only'];
     }
@@ -134,10 +131,6 @@ EOF;
                 ->setAllowedTypes(['string[][]'])
                 ->setDefault(TagComparator::DEFAULT_GROUPS)
                 ->getOption(),
-            (new FixerOptionBuilder('additional_groups', 'Sets of additional annotation types to be grouped together.'))
-                ->setAllowedTypes(['string[][]'])
-                ->setDefault([])
-                ->getOption(),
             (new FixerOptionBuilder(
                 'psr_standard_tags_only',
                 'Whether to only process annotations defined by PSR-5 draft, which are: '.
@@ -184,7 +177,7 @@ EOF;
             }
 
             if (!$this->standardTagsOnly || $next->getTag()->valid()) {
-                if ($this->tagComparator->shouldBeTogether($annotation->getTag(), $next->getTag())) {
+                if ($this->tagComparator->shouldBeGroupedTogether($annotation->getTag(), $next->getTag())) {
                     $this->ensureAreTogether($doc, $annotation, $next);
                 } else {
                     $this->ensureAreSeparate($doc, $annotation, $next);

--- a/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSeparationFixer.php
@@ -35,11 +35,6 @@ use PhpCsFixer\Tokenizer\Tokens;
  */
 final class PhpdocSeparationFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
-    /**
-     * @internal
-     */
-    private const ADDITIONAL_GROUPS_DEFAULT = null;
-
     private TagComparator $tagComparator;
 
     private bool $standardTagsOnly = true;
@@ -137,15 +132,15 @@ EOF;
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('groups', 'Sets of annotation types to be grouped together.'))
                 ->setAllowedTypes(['string[][]'])
-                ->setDefault(TagComparator::TAG_GROUPS)
+                ->setDefault(TagComparator::DEFAULT_GROUPS)
                 ->getOption(),
             (new FixerOptionBuilder('additional_groups', 'Sets of additional annotation types to be grouped together.'))
-                ->setAllowedTypes(['string[][]', 'null'])
-                ->setDefault(self::ADDITIONAL_GROUPS_DEFAULT)
+                ->setAllowedTypes(['string[][]'])
+                ->setDefault([])
                 ->getOption(),
             (new FixerOptionBuilder(
                 'psr_standard_tags_only',
-                'Sets if process PSR PHPDoc standard annotation tags only, which are: '.
+                'Whether to only process annotations defined by PSR-5 draft, which are: '.
                 '`'.implode('`, `', Tag::PSR_STANDARD_TAGS).'`.'
             ))
                 ->setAllowedTypes(['bool'])
@@ -188,7 +183,7 @@ EOF;
                 break;
             }
 
-            if ((false === $this->standardTagsOnly) || (true === $next->getTag()->valid())) {
+            if (!$this->standardTagsOnly || $next->getTag()->valid()) {
                 if ($this->tagComparator->shouldBeTogether($annotation->getTag(), $next->getTag())) {
                     $this->ensureAreTogether($doc, $annotation, $next);
                 } else {

--- a/src/Linter/LintingException.php
+++ b/src/Linter/LintingException.php
@@ -18,6 +18,7 @@ namespace PhpCsFixer\Linter;
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @final
+ *
  * @TODO 4.0 make class "final"
  */
 class LintingException extends \RuntimeException

--- a/src/Linter/UnavailableLinterException.php
+++ b/src/Linter/UnavailableLinterException.php
@@ -20,6 +20,7 @@ namespace PhpCsFixer\Linter;
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
  *
  * @final
+ *
  * @TODO 4.0 make class "final"
  */
 class UnavailableLinterException extends \RuntimeException

--- a/src/Tokenizer/Analyzer/AlternativeSyntaxAnalyzer.php
+++ b/src/Tokenizer/Analyzer/AlternativeSyntaxAnalyzer.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @internal
+ *
  * @TODO 4.0 remove this analyzer and move this logic into a transformer
  */
 final class AlternativeSyntaxAnalyzer

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Yaml\Yaml;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/CommandTest.php
+++ b/tests/AutoReview/CommandTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Command\Command;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/DescribeCommandTest.php
+++ b/tests/AutoReview/DescribeCommandTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/FixerFactoryTest.php
+++ b/tests/AutoReview/FixerFactoryTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/ProjectFixerConfigurationTest.php
+++ b/tests/AutoReview/ProjectFixerConfigurationTest.php
@@ -23,6 +23,7 @@ use PhpCsFixer\ToolInfo;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/AutoReview/TransformerTest.php
+++ b/tests/AutoReview/TransformerTest.php
@@ -24,6 +24,7 @@ use PhpCsFixer\Tokenizer\Transformers;
  * @internal
  *
  * @coversNothing
+ *
  * @group auto-review
  * @group covers-nothing
  */

--- a/tests/Console/Report/FixReport/GitlabReporterTest.php
+++ b/tests/Console/Report/FixReport/GitlabReporterTest.php
@@ -21,6 +21,7 @@ use PhpCsFixer\Console\Report\FixReport\ReporterInterface;
  * @author Hans-Christian Otto <c.otto@suora.com>
  *
  * @internal
+ *
  * @covers \PhpCsFixer\Console\Report\FixReport\GitlabReporter
  */
 final class GitlabReporterTest extends AbstractReporterTestCase

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -56,23 +56,22 @@ final class TagComparatorTest extends TestCase
     }
 
     /**
-     * @dataProvider provideComparatorWithAdditionalGroupsCases
+     * @dataProvider provideComparatorWithDefinedGroupsCases
      *
-     * @param string[][] $additionalGroups
+     * @param string[][] $groups
      */
-    public function testComparatorTogetherWithAdditionalGroups(array $additionalGroups, string $first, string $second, bool $expected): void
+    public function testComparatorTogetherWithDefinedGroups(array $groups, string $first, string $second, bool $expected): void
     {
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
         static::assertSame(
             $expected,
-            TagComparator::configure(array_merge(TagComparator::DEFAULT_GROUPS, $additionalGroups))
-                ->shouldBeGroupedTogether($tag1, $tag2)
+            TagComparator::shouldBeTogether($tag1, $tag2, $groups)
         );
     }
 
-    public function provideComparatorWithAdditionalGroupsCases(): array
+    public function provideComparatorWithDefinedGroupsCases(): array
     {
         return [
             [[['param', 'return']], 'return', 'return', true],
@@ -80,10 +79,10 @@ final class TagComparatorTest extends TestCase
             [[['param', 'return']], 'return', 'param', true],
             [[['param', 'return']], 'var', 'foo', false],
             [[['param', 'return']], 'api', 'deprecated', false],
-            [[['param', 'return']], 'author', 'copyright', true],
+            [[['param', 'return']], 'author', 'copyright', false],
             [[['param', 'return'], ['author', 'since']], 'author', 'since', true],
-            [[['param', 'return']], 'link', 'see', true],
-            [[['param', 'return']], 'category', 'package', true],
+            [array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']]), 'link', 'see', true],
+            [[['param', 'return']], 'category', 'package', false],
         ];
     }
 }

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -21,6 +21,7 @@ use PhpCsFixer\Tests\TestCase;
 
 /**
  * @author Graham Campbell <hello@gjcampbell.co.uk>
+ * @author Jakub Kwaśniewski <jakub@zero-85.pl>
  *
  * @internal
  *
@@ -36,7 +37,7 @@ final class TagComparatorTest extends TestCase
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
-        static::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
+        static::assertSame($expected, TagComparator::configure()->shouldBeTogether($tag1, $tag2));
     }
 
     public function provideComparatorCases(): array
@@ -51,6 +52,39 @@ final class TagComparatorTest extends TestCase
             ['author', 'since', false],
             ['link', 'see', true],
             ['category', 'package', true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideComparatorWithAdditionalGroupsCases
+     *
+     * @param null|string[][] $additionalGroups
+     */
+    public function testComparatorTogetherWithAdditionalGroups(?array $additionalGroups, string $first, string $second, bool $expected): void
+    {
+        $tag1 = new Tag(new Line('* @'.$first));
+        $tag2 = new Tag(new Line('* @'.$second));
+
+        static::assertSame(
+            $expected,
+            TagComparator::configure()
+                ->withAdditionalGroups($additionalGroups)
+                ->shouldBeTogether($tag1, $tag2)
+        );
+    }
+
+    public function provideComparatorWithAdditionalGroupsCases(): array
+    {
+        return [
+            [[['param', 'return']], 'return', 'return', true],
+            [null, 'param', 'return', false],
+            [[['param', 'return']], 'return', 'param', true],
+            [[['param', 'return']], 'var', 'foo', false],
+            [[['param', 'return']], 'api', 'deprecated', false],
+            [[['param', 'return']], 'author', 'copyright', true],
+            [[['param', 'return'], ['author', 'since']], 'author', 'since', true],
+            [[['param', 'return']], 'link', 'see', true],
+            [[['param', 'return']], 'category', 'package', true],
         ];
     }
 }

--- a/tests/DocBlock/TagComparatorTest.php
+++ b/tests/DocBlock/TagComparatorTest.php
@@ -37,7 +37,7 @@ final class TagComparatorTest extends TestCase
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
-        static::assertSame($expected, TagComparator::configure()->shouldBeTogether($tag1, $tag2));
+        static::assertSame($expected, TagComparator::shouldBeTogether($tag1, $tag2));
     }
 
     public function provideComparatorCases(): array
@@ -58,18 +58,17 @@ final class TagComparatorTest extends TestCase
     /**
      * @dataProvider provideComparatorWithAdditionalGroupsCases
      *
-     * @param null|string[][] $additionalGroups
+     * @param string[][] $additionalGroups
      */
-    public function testComparatorTogetherWithAdditionalGroups(?array $additionalGroups, string $first, string $second, bool $expected): void
+    public function testComparatorTogetherWithAdditionalGroups(array $additionalGroups, string $first, string $second, bool $expected): void
     {
         $tag1 = new Tag(new Line('* @'.$first));
         $tag2 = new Tag(new Line('* @'.$second));
 
         static::assertSame(
             $expected,
-            TagComparator::configure()
-                ->withAdditionalGroups($additionalGroups)
-                ->shouldBeTogether($tag1, $tag2)
+            TagComparator::configure(array_merge(TagComparator::DEFAULT_GROUPS, $additionalGroups))
+                ->shouldBeGroupedTogether($tag1, $tag2)
         );
     }
 
@@ -77,7 +76,7 @@ final class TagComparatorTest extends TestCase
     {
         return [
             [[['param', 'return']], 'return', 'return', true],
-            [null, 'param', 'return', false],
+            [[], 'param', 'return', false],
             [[['param', 'return']], 'return', 'param', true],
             [[['param', 'return']], 'var', 'foo', false],
             [[['param', 'return']], 'api', 'deprecated', false],

--- a/tests/FileRemovalTest.php
+++ b/tests/FileRemovalTest.php
@@ -48,6 +48,7 @@ final class FileRemovalTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     *
      * @doesNotPerformAssertions
      */
     public function testShutdownRemovesObservedFilesSetup(): void

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -243,6 +243,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -265,6 +266,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input = null): void
@@ -281,6 +283,7 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/Alias/EregToPregFixerTest.php
+++ b/tests/Fixer/Alias/EregToPregFixerTest.php
@@ -132,6 +132,7 @@ final class EregToPregFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
+++ b/tests/Fixer/Alias/NoAliasFunctionsFixerTest.php
@@ -238,6 +238,7 @@ abstract class A
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Alias/PowToExponentiationFixerTest.php
+++ b/tests/Fixer/Alias/PowToExponentiationFixerTest.php
@@ -239,6 +239,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -282,6 +283,7 @@ final class PowToExponentiationFixerTest extends AbstractFixerTestCase
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider provideFix80Cases
      */
     public function testFix80(string $expected, string $input): void

--- a/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
+++ b/tests/Fixer/Alias/RandomApiMigrationFixerTest.php
@@ -184,6 +184,7 @@ class srand extends SrandClass{
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
+++ b/tests/Fixer/ArrayNotation/NormalizeIndexBraceFixerTest.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer
+ *
  * @requires PHP <8.0
  */
 final class NormalizeIndexBraceFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
+++ b/tests/Fixer/Basic/CurlyBracesPositionFixerTest.php
@@ -670,6 +670,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -734,6 +735,7 @@ final class CurlyBracesPositionFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Basic/OctalNotationFixerTest.php
+++ b/tests/Fixer/Basic/OctalNotationFixerTest.php
@@ -27,6 +27,7 @@ final class OctalNotationFixerTest extends AbstractFixerTestCase
 {
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -448,6 +448,7 @@ class ClassTwo {};
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider providePhp80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -469,6 +470,7 @@ class extends stdClass {};
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider providePhp81Cases
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
+++ b/tests/Fixer/Casing/ClassReferenceNameCasingFixerTest.php
@@ -248,6 +248,7 @@ use Sonata\\Exporter\\Writer\\EXCEPTION;
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/ConstantCaseFixerTest.php
+++ b/tests/Fixer/Casing/ConstantCaseFixerTest.php
@@ -164,6 +164,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -178,6 +179,7 @@ final class ConstantCaseFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
+++ b/tests/Fixer/Casing/IntegerLiteralCaseFixerTest.php
@@ -55,6 +55,7 @@ final class IntegerLiteralCaseFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseKeywordsFixerTest.php
@@ -54,6 +54,7 @@ final class LowercaseKeywordsFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -100,6 +101,7 @@ class Point {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
+++ b/tests/Fixer/Casing/LowercaseStaticReferenceFixerTest.php
@@ -189,6 +189,7 @@ final class LowercaseStaticReferenceFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -246,6 +247,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicConstantCasingFixerTest.php
@@ -85,6 +85,7 @@ final class MagicConstantCasingFixerTest extends AbstractFixerTestCase
 
     /**
      * @requires PHP <8.0
+     *
      * @dataProvider provideFix74Cases
      */
     public function testFix74(string $expected, ?string $input = null): void

--- a/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
+++ b/tests/Fixer/Casing/MagicMethodCasingFixerTest.php
@@ -351,6 +351,7 @@ function __Tostring() {}',
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionCasingFixerTest.php
@@ -180,6 +180,7 @@ final class NativeFunctionCasingFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected): void

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -133,6 +133,7 @@ function Foo(INTEGER $a) {}
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -175,6 +176,7 @@ function Foo(INTEGER $a) {}
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
+++ b/tests/Fixer/CastNotation/LowercaseCastFixerTest.php
@@ -33,6 +33,7 @@ final class LowercaseCastFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixDeprecatedCases
+     *
      * @group legacy
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void

--- a/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
+++ b/tests/Fixer/CastNotation/ModernizeTypesCastingFixerTest.php
@@ -186,6 +186,7 @@ OVERRIDDEN;
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -231,6 +232,7 @@ intval#
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
+++ b/tests/Fixer/CastNotation/NoUnsetCastFixerTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\CastNotation\NoUnsetCastFixer
+ *
  * @requires PHP <8.0
  */
 final class NoUnsetCastFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
+++ b/tests/Fixer/CastNotation/ShortScalarCastFixerTest.php
@@ -33,6 +33,7 @@ final class ShortScalarCastFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixDeprecatedCases
+     *
      * @group legacy
      */
     public function testFix74Deprecated(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassAttributesSeparationFixerTest.php
@@ -1917,6 +1917,7 @@ abstract class Example
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input, array $config = null): void
@@ -2177,6 +2178,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input, array $config = null): void

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -696,6 +696,7 @@ $a = new class implements
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -309,6 +309,7 @@ $a = new class{};',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixerTest.php
@@ -217,6 +217,7 @@ trait Good
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoNullPropertyInitializationFixerTest.php
@@ -348,6 +348,7 @@ class Point {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoPhp4ConstructorFixerTest.php
@@ -1132,6 +1132,7 @@ EOF;
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -388,6 +388,7 @@ class Bar
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
+++ b/tests/Fixer/ClassNotation/OrderedClassElementsFixerTest.php
@@ -1342,6 +1342,7 @@ class TestClass
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -1412,6 +1413,7 @@ trait TestTrait
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null, ?array $configuration = null): void

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -135,6 +135,7 @@ final class Foo
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -160,6 +161,7 @@ final class Foo2 {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfAccessorFixerTest.php
@@ -171,6 +171,7 @@ final class SelfAccessorFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
+++ b/tests/Fixer/ClassNotation/SingleClassElementPerStatementFixerTest.php
@@ -825,6 +825,7 @@ EOT
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -853,6 +854,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
+++ b/tests/Fixer/ClassNotation/VisibilityRequiredFixerTest.php
@@ -766,6 +766,7 @@ AB# <- this is the name
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider provideFix80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -799,6 +800,7 @@ AB# <- this is the name
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
+++ b/tests/Fixer/ClassUsage/DateTimeImmutableFixerTest.php
@@ -179,6 +179,7 @@ final class DateTimeImmutableFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected): void

--- a/tests/Fixer/Comment/HeaderCommentFixerTest.php
+++ b/tests/Fixer/Comment/HeaderCommentFixerTest.php
@@ -805,6 +805,7 @@ echo 1;'
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(array $configuration, string $expected, ?string $input = null): void

--- a/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
+++ b/tests/Fixer/ConstantNotation/NativeConstantInvocationFixerTest.php
@@ -489,6 +489,7 @@ echo M_PI;
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected): void

--- a/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoBreakCommentFixerTest.php
@@ -1221,6 +1221,7 @@ switch ($foo) {
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -1285,6 +1286,7 @@ switch ($foo) {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoSuperfluousElseifFixerTest.php
@@ -264,6 +264,7 @@ if ($some) { return 1; } elseif ($a == 6){ $test = false; } //',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected): void

--- a/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededControlParenthesesFixerTest.php
@@ -1539,6 +1539,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider providePrePhp8Cases
+     *
      * @requires PHP <8.0
      */
     public function testPrePhp8(string $expected, string $input): void
@@ -1583,6 +1584,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void
@@ -1640,6 +1642,7 @@ final class NoUnneededControlParenthesesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFixPhp81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUnneededCurlyBracesFixerTest.php
@@ -129,6 +129,7 @@ final class NoUnneededCurlyBracesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
+++ b/tests/Fixer/ControlStructure/NoUselessElseFixerTest.php
@@ -609,6 +609,7 @@ else?><?php echo 5;',
 
     /**
      * @dataProvider provideNegativePhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testNegativePhp80Cases(string $expected): void
@@ -752,6 +753,7 @@ else?><?php echo 5;',
 
     /**
      * @dataProvider provideConditionsWithoutBraces80Cases
+     *
      * @requires PHP 8.0
      */
     public function testConditionsWithoutBraces80(string $expected): void

--- a/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixerTest.php
@@ -238,6 +238,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -265,6 +266,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -314,6 +316,7 @@ final class SwitchCaseSemicolonToColonFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
+++ b/tests/Fixer/ControlStructure/SwitchCaseSpaceFixerTest.php
@@ -334,6 +334,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -361,6 +362,7 @@ final class SwitchCaseSpaceFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -400,6 +402,7 @@ $a = function (): ?string {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
+++ b/tests/Fixer/ControlStructure/TrailingCommaInMultilineFixerTest.php
@@ -554,6 +554,7 @@ INPUT
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null, array $config = []): void

--- a/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
+++ b/tests/Fixer/ControlStructure/YodaStyleFixerTest.php
@@ -1000,6 +1000,7 @@ while (2 !== $b = array_pop($c));
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null, array $config = []): void
@@ -1046,6 +1047,7 @@ if ($a = $obj instanceof (foo()) === true) {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationArrayAssignmentFixerTest.php
@@ -177,6 +177,7 @@ final class DoctrineAnnotationArrayAssignmentFixerTest extends AbstractDoctrineA
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/CombineNestedDirnameFixerTest.php
@@ -106,6 +106,7 @@ final class CombineNestedDirnameFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixerTest.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
  * @internal
+ *
  * @covers \PhpCsFixer\Fixer\FunctionNotation\DateTimeCreateFromFormatCallFixer
  */
 final class DateTimeCreateFromFormatCallFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -423,6 +423,7 @@ foo#
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null, array $configuration = []): void

--- a/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionTypehintSpaceFixerTest.php
@@ -233,6 +233,7 @@ final class FunctionTypehintSpaceFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void

--- a/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
+++ b/tests/Fixer/FunctionNotation/LambdaNotUsedImportFixerTest.php
@@ -182,6 +182,7 @@ $foo();
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1036,6 +1036,7 @@ $fn = fn(
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NativeFunctionInvocationFixerTest.php
@@ -615,6 +615,7 @@ echo strlen($a);
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null, array $config = []): void

--- a/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixerTest.php
@@ -158,6 +158,7 @@ $$e(2);
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -180,6 +181,7 @@ $$e(2);
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoTrailingCommaInSinglelineFunctionCallFixerTest.php
@@ -200,6 +200,7 @@ $g["e"](1,); // foo',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input = null): void
@@ -221,6 +222,7 @@ $foo1b = function() use ($bar, ) {};
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixerTest.php
@@ -182,6 +182,7 @@ $bar) {}',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -224,6 +225,7 @@ $bar) {}',
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NoUselessSprintfFixerTest.php
@@ -108,6 +108,7 @@ final class NoUselessSprintfFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -429,6 +429,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -438,6 +439,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
 
     /**
      * @dataProvider provideInvertedFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixInverse80(string $expected, ?string $input = null): void
@@ -541,6 +543,7 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?array $config): void

--- a/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToPropertyTypeFixerTest.php
@@ -457,6 +457,7 @@ final class PhpdocToPropertyTypeFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected): void

--- a/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
+++ b/tests/Fixer/FunctionNotation/PhpdocToReturnTypeFixerTest.php
@@ -339,6 +339,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -368,6 +369,7 @@ final class PhpdocToReturnTypeFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
+++ b/tests/Fixer/FunctionNotation/RegularCallableCallFixerTest.php
@@ -243,6 +243,7 @@ class Foo {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/ReturnTypeDeclarationFixerTest.php
@@ -153,6 +153,7 @@ string {}',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -175,6 +176,7 @@ string {}',
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
+++ b/tests/Fixer/FunctionNotation/SingleLineThrowFixerTest.php
@@ -293,6 +293,7 @@ final class SingleLineThrowFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void

--- a/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
+++ b/tests/Fixer/Import/GlobalNamespaceImportFixerTest.php
@@ -1033,6 +1033,7 @@ class Bar
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Import/GroupImportFixerTest.php
+++ b/tests/Fixer/Import/GroupImportFixerTest.php
@@ -326,6 +326,7 @@ use function Foo\b;
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/Import/NoUnusedImportsFixerTest.php
+++ b/tests/Fixer/Import/NoUnusedImportsFixerTest.php
@@ -1348,6 +1348,7 @@ use /**/A\B/**/;
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider providePhp80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -1411,6 +1412,7 @@ class Foo {}
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider providePhp81Cases
      */
     public function testFix81(string $expected, ?string $input = null): void
@@ -1485,6 +1487,7 @@ const D = new Foo7(1,2);
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider provideFixPhp81Cases
      */
     public function testFixPhp81(string $expected): void

--- a/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/CombineConsecutiveUnsetsFixerTest.php
@@ -132,6 +132,7 @@ final class CombineConsecutiveUnsetsFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ErrorSuppressionFixerTest.php
@@ -122,6 +122,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -138,6 +139,7 @@ Trigger_Error/**/("This is a deprecation warning.", E_USER_DEPRECATED/***/); ?>'
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/ExplicitIndirectVariableFixerTest.php
@@ -74,6 +74,7 @@ $foo
      * @param mixed $input
      *
      * @dataProvider provideTestFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80($expected, $input): void

--- a/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/FunctionToConstantFixerTest.php
@@ -271,6 +271,7 @@ get_called_class#1
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/GetClassToClassKeywordFixerTest.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @covers \PhpCsFixer\Fixer\LanguageConstruct\GetClassToClassKeywordFixer
+ *
  * @requires PHP 8.0
  */
 final class GetClassToClassKeywordFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/NoUnsetOnPropertyFixerTest.php
@@ -213,6 +213,7 @@ final class NoUnsetOnPropertyFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
+++ b/tests/Fixer/LanguageConstruct/SingleSpaceAfterConstructFixerTest.php
@@ -3012,6 +3012,7 @@ namespace/* comment */ Foo;',
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -3085,6 +3086,7 @@ class Point {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void
@@ -3244,6 +3246,7 @@ class    Test {
 
     /**
      * @dataProvider provideEnumTypeColonCases
+     *
      * @requires PHP 8.1
      */
     public function testEnumTypeColon(string $expected, string $input): void

--- a/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
+++ b/tests/Fixer/ListNotation/ListSyntaxFixerTest.php
@@ -256,6 +256,7 @@ $a;#
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/NamespaceNotation/CleanNamespaceFixerTest.php
+++ b/tests/Fixer/NamespaceNotation/CleanNamespaceFixerTest.php
@@ -25,6 +25,7 @@ final class CleanNamespaceFixerTest extends AbstractFixerTestCase
 {
     /**
      * @requires PHP <8.0
+     *
      * @dataProvider provideFixCases
      */
     public function testFix(string $expected, string $input): void

--- a/tests/Fixer/Operator/NewWithBracesFixerTest.php
+++ b/tests/Fixer/Operator/NewWithBracesFixerTest.php
@@ -649,6 +649,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, ?string $input = null): void
@@ -676,6 +677,7 @@ final class NewWithBracesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -724,6 +726,7 @@ $a = new ($foo."ar");',
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Operator/NoUselessNullsafeOperatorFixerTest.php
+++ b/tests/Fixer/Operator/NoUselessNullsafeOperatorFixerTest.php
@@ -18,6 +18,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
  * @internal
+ *
  * @requires PHP 8.0
  *
  * @covers \PhpCsFixer\Fixer\Operator\NoUselessNullsafeOperatorFixer

--- a/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
+++ b/tests/Fixer/Operator/ObjectOperatorWithoutWhitespaceFixerTest.php
@@ -80,6 +80,7 @@ final class ObjectOperatorWithoutWhitespaceFixerTest extends AbstractFixerTestCa
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void

--- a/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
+++ b/tests/Fixer/Operator/StandardizeIncrementFixerTest.php
@@ -597,6 +597,7 @@ $i#3
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/TernaryOperatorSpacesFixerTest.php
@@ -199,6 +199,7 @@ $a = ($b
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -228,6 +229,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToElvisOperatorFixerTest.php
@@ -437,6 +437,7 @@ EOT
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void
@@ -493,6 +494,7 @@ EOT
 
     /**
      * @dataProvider provideDoNotFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function test80DoNotFix(string $input): void

--- a/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
+++ b/tests/Fixer/Operator/TernaryToNullCoalescingFixerTest.php
@@ -179,6 +179,7 @@ null
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitConstructFixerTest.php
@@ -187,6 +187,7 @@ final class PhpUnitConstructFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitDedicateAssertFixerTest.php
@@ -613,6 +613,7 @@ $a# 5
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -280,6 +280,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestCaseStaticMethodCallsFixerTest.php
@@ -539,6 +539,7 @@ class MyTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
+++ b/tests/Fixer/Phpdoc/GeneralPhpdocAnnotationRemoveFixerTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
  * @internal
  *
  * @author Gert de Pagter
+ *
  * @covers \PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer
  */
 final class GeneralPhpdocAnnotationRemoveFixerTest extends AbstractFixerTestCase

--- a/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
+++ b/tests/Fixer/Phpdoc/NoSuperfluousPhpdocTagsFixerTest.php
@@ -1859,6 +1859,7 @@ class Foo {
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null, array $config = []): void
@@ -2066,6 +2067,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null, array $config = []): void

--- a/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocLineSpanFixerTest.php
@@ -561,6 +561,7 @@ class Foo
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      *
      * @param array<string, mixed> $config
@@ -708,6 +709,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      *
      * @param array<string, mixed> $config

--- a/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocReturnSelfReferenceFixerTest.php
@@ -235,6 +235,7 @@ class F
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
+use PhpCsFixer\DocBlock\TagComparator;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -652,7 +653,7 @@ EOF;
 
     public function testLaravelGroups(): void
     {
-        $this->fixer->configure(['additional_groups' => [['param', 'return']]]);
+        $this->fixer->configure(['groups' => array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']])]);
 
         $expected = <<<'EOF'
 <?php
@@ -687,10 +688,10 @@ EOF;
     public function testVariousGroups(): void
     {
         $this->fixer->configure([
-            'additional_groups' => [
+            'groups' => array_merge(TagComparator::DEFAULT_GROUPS, [
                 ['deprecated', 'link', 'see', 'since', 'author', 'copyright', 'license'],
                 ['return', 'param'],
-            ],
+            ]),
             'psr_standard_tags_only' => false,
         ]);
 
@@ -741,10 +742,11 @@ EOF;
 
     public function testVariousAdditionalGroups(): void
     {
-        $this->fixer->configure(['additional_groups' => [
-            ['deprecated', 'link', 'see', 'since', 'author', 'copyright', 'license'],
-            ['return', 'param'],
-        ]]);
+        $this->fixer->configure([
+            'groups' => array_merge(TagComparator::DEFAULT_GROUPS, [
+                ['deprecated', 'link', 'see', 'since', 'author', 'copyright', 'license'],
+                ['return', 'param'],
+            ]), ]);
 
         $expected = <<<'EOF'
 <?php
@@ -823,7 +825,7 @@ EOF;
 
         return [
             [
-                ['additional_groups' => [['param', 'return']]],
+                ['groups' => array_merge(TagComparator::DEFAULT_GROUPS, [['param', 'return']])],
                 <<<'EOF'
 <?php
 /**

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Fixer\Phpdoc;
 
-use PhpCsFixer\Fixer\Phpdoc\PhpdocSeparationFixer;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
 
 /**
@@ -653,7 +652,7 @@ EOF;
 
     public function testLaravelGroups(): void
     {
-        $this->fixer->configure(['additional_groups' => PhpdocSeparationFixer::ADDITIONAL_GROUPS_LARAVEL]);
+        $this->fixer->configure(['additional_groups' => [['param', 'return']]]);
 
         $expected = <<<'EOF'
 <?php
@@ -819,7 +818,7 @@ EOF;
 
         return [
             [
-                ['additional_groups' => PhpdocSeparationFixer::ADDITIONAL_GROUPS_LARAVEL],
+                ['additional_groups' => [['param', 'return']]],
                 <<<'EOF'
 <?php
 /**

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -488,15 +488,15 @@ EOF;
         $this->doTest($expected, $input);
     }
 
-    public function testDoNotMoveUnknownAnnotations(): void
+    public function testMoveUnknownAnnotations(): void
     {
         $expected = <<<'EOF'
 <?php
     /**
      * @expectedException Exception
+     *
      * @expectedExceptionMessage Oh Noes!
      * Something when wrong!
-     *
      *
      * @Hello\Test\Foo(asd)
      * @Method("GET")
@@ -717,7 +717,6 @@ EOF;
                 ['property', 'property-read', 'property-write'],
                 ['return', 'param'],
             ],
-            'psr_standard_tags_only' => false,
         ]);
 
         $expected = <<<'EOF'
@@ -875,7 +874,7 @@ EOF,
             ],
 
             'all_tags' => [
-                ['groups' => [['author', 'throws', 'custom'], ['return', 'param']], 'psr_standard_tags_only' => false],
+                ['groups' => [['author', 'throws', 'custom'], ['return', 'param']]],
                 <<<'EOF'
 <?php
 /**
@@ -895,7 +894,7 @@ EOF,
             ],
 
             'default_groups_standard_tags' => [
-                ['groups' => TagComparator::DEFAULT_GROUPS, 'psr_standard_tags_only' => true],
+                ['groups' => TagComparator::DEFAULT_GROUPS],
                 <<<'EOF'
 <?php
 /**
@@ -930,7 +929,7 @@ EOF,
             ],
 
             'default_groups_all_tags' => [
-                ['groups' => TagComparator::DEFAULT_GROUPS, 'psr_standard_tags_only' => false],
+                ['groups' => TagComparator::DEFAULT_GROUPS],
                 <<<'EOF'
 <?php
 /**

--- a/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSeparationFixerTest.php
@@ -790,6 +790,8 @@ EOF;
 
     /**
      * @dataProvider provideDocCodeCases
+     *
+     * @param array<string, mixed> $config
      */
     public function testDocCode(array $config, string $expected, string $input): void
     {
@@ -798,6 +800,9 @@ EOF;
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @return array<array<null|array<string, mixed>|string>>
+     */
     public function provideDocCodeCases(): array
     {
         $input = <<<'EOF'

--- a/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocToCommentFixerTest.php
@@ -797,6 +797,7 @@ $first = true;// needed because by default first docblock is never fixed.
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -873,6 +874,7 @@ class Foo
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected): void

--- a/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocVarWithoutNameFixerTest.php
@@ -508,6 +508,7 @@ class A
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
+++ b/tests/Fixer/ReturnNotation/ReturnAssignmentFixerTest.php
@@ -1033,6 +1033,7 @@ function foo(&$c) {
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider providePhp80Cases
      */
     public function testFix80(string $expected, ?string $input = null): void

--- a/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
+++ b/tests/Fixer/Semicolon/NoEmptyStatementFixerTest.php
@@ -605,6 +605,7 @@ final class NoEmptyStatementFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
+++ b/tests/Fixer/Semicolon/SemicolonAfterInstructionFixerTest.php
@@ -84,6 +84,7 @@ A is equal to 5
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/ArrayIndentationFixerTest.php
@@ -907,6 +907,7 @@ INPUT
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void

--- a/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBeforeStatementFixerTest.php
@@ -1389,6 +1389,7 @@ do {
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null): void
@@ -1421,6 +1422,7 @@ do {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -529,6 +529,7 @@ use const C\D; // bar
 
     /**
      * @dataProvider provideFixPre80Cases
+     *
      * @requires PHP <8.0
      */
     public function testFixPre80(string $expected, string $input = null): void

--- a/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
+++ b/tests/Fixer/Whitespace/NoExtraBlankLinesFixerTest.php
@@ -664,6 +664,7 @@ $a = new Qux();',
 
     /**
      * @dataProvider provideRemoveBetweenUseTraitsCases
+     *
      * @group legacy
      */
     public function testRemoveBetweenUseTraits(string $expected, string $input): void
@@ -1097,6 +1098,7 @@ class Foo {}'
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(array $config, string $expected, string $input = null): void
@@ -1154,6 +1156,7 @@ function foo(){}
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input = null): void

--- a/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
+++ b/tests/Fixer/Whitespace/NoSpacesInsideParenthesisFixerTest.php
@@ -130,6 +130,7 @@ $a = $b->test(  // do not remove space
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input): void
@@ -147,6 +148,7 @@ $a = $b->test(  // do not remove space
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
+++ b/tests/Fixer/Whitespace/NoTrailingWhitespaceFixerTest.php
@@ -138,6 +138,7 @@ EOT;
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, string $input = null): void

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -805,6 +805,7 @@ if ($foo) {
 
     /**
      * @dataProvider provideFixPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFixPhp80(string $expected, ?string $input = null): void
@@ -871,6 +872,7 @@ class Foo {
 
     /**
      * @dataProvider provideFixPhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFixPhp81(string $expected, ?string $input = null): void

--- a/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
+++ b/tests/Fixer/Whitespace/TypesSpacesFixerTest.php
@@ -89,6 +89,7 @@ final class TypesSpacesFixerTest extends AbstractFixerTestCase
 
     /**
      * @dataProvider provideFix80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFix80(string $expected, ?string $input = null, array $configuration = []): void
@@ -267,6 +268,7 @@ TypeB $x) {}',
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(string $expected, string $input): void

--- a/tests/Fixtures/Integration/misc/phpdocs.test-out.php
+++ b/tests/Fixtures/Integration/misc/phpdocs.test-out.php
@@ -18,7 +18,6 @@ class Foo {
      *
      * @throws Exception
      *
-     *
      * @custom
      */
     public function fooBar ($fo, $bar, array $baz, $qux) {}

--- a/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
+++ b/tests/Indicator/PhpUnitTestCaseIndicatorTest.php
@@ -20,6 +20,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @internal
+ *
  * @covers \PhpCsFixer\Indicator\PhpUnitTestCaseIndicator
  */
 final class PhpUnitTestCaseIndicatorTest extends TestCase

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -25,6 +25,7 @@ use PhpCsFixer\Tests\Test\InternalIntegrationCaseFactory;
  * @internal
  *
  * @coversNothing
+ *
  * @group covers-nothing
  */
 final class IntegrationTest extends AbstractIntegrationTestCase

--- a/tests/Linter/ProcessLinterProcessBuilderTest.php
+++ b/tests/Linter/ProcessLinterProcessBuilderTest.php
@@ -29,6 +29,7 @@ final class ProcessLinterProcessBuilderTest extends TestCase
     /**
      * @testWith ["php", "foo.php", "'php' '-l' 'foo.php'"]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "'C:\\Program Files\\php\\php.exe' '-l' 'foo bar\\baz.php'"]
+     *
      * @requires OS Linux|Darwin
      */
     public function testPrepareCommandOnPhpOnLinuxOrMac(string $executable, string $file, string $expected): void
@@ -44,6 +45,7 @@ final class ProcessLinterProcessBuilderTest extends TestCase
     /**
      * @testWith ["php", "foo.php", "php -l foo.php"]
      *           ["C:\\Program Files\\php\\php.exe", "foo bar\\baz.php", "\"C:\\Program Files\\php\\php.exe\" -l \"foo bar\\baz.php\""]
+     *
      * @requires OS ^Win
      */
     public function testPrepareCommandOnPhpOnWindows(string $executable, string $file, string $expected): void

--- a/tests/Smoke/AbstractSmokeTest.php
+++ b/tests/Smoke/AbstractSmokeTest.php
@@ -22,7 +22,9 @@ use PhpCsFixer\Tests\TestCase;
  * @internal
  *
  * @requires OS Linux|Darwin
+ *
  * @coversNothing
+ *
  * @group covers-nothing
  */
 abstract class AbstractSmokeTest extends TestCase

--- a/tests/Smoke/CiIntegrationTest.php
+++ b/tests/Smoke/CiIntegrationTest.php
@@ -25,8 +25,11 @@ use PhpCsFixer\Console\Application;
  * @internal
  *
  * @requires OS Linux|Darwin
+ *
  * @coversNothing
+ *
  * @group covers-nothing
+ *
  * @large
  */
 final class CiIntegrationTest extends AbstractSmokeTest

--- a/tests/Smoke/InstallViaComposerTest.php
+++ b/tests/Smoke/InstallViaComposerTest.php
@@ -24,7 +24,9 @@ use Symfony\Component\Filesystem\Filesystem;
  * @internal
  *
  * @coversNothing
+ *
  * @group covers-nothing
+ *
  * @large
  */
 final class InstallViaComposerTest extends AbstractSmokeTest

--- a/tests/Smoke/PharTest.php
+++ b/tests/Smoke/PharTest.php
@@ -26,7 +26,9 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @internal
  *
  * @coversNothing
+ *
  * @group covers-nothing
+ *
  * @large
  */
 final class PharTest extends AbstractSmokeTest

--- a/tests/Smoke/StdinTest.php
+++ b/tests/Smoke/StdinTest.php
@@ -23,8 +23,11 @@ use PhpCsFixer\Preg;
  * @internal
  *
  * @requires OS Linux|Darwin
+ *
  * @coversNothing
+ *
  * @group covers-nothing
+ *
  * @large
  */
 final class StdinTest extends AbstractSmokeTest

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -121,6 +121,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
      * @see doTest()
      *
      * @large
+     *
      * @group legacy
      */
     public function testIntegration(IntegrationCase $case): void

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -119,6 +119,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
      * @dataProvider provideIntegrationCases
      *
      * @see doTest()
+     *
      * @large
      * @group legacy
      */

--- a/tests/TextDiffTest.php
+++ b/tests/TextDiffTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @internal
  *
  * @coversNothing
+ *
  * @group covers-nothing
  */
 final class TextDiffTest extends TestCase

--- a/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ArgumentsAnalyzerTest.php
@@ -87,6 +87,7 @@ final class ArgumentsAnalyzerTest extends TestCase
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider provideArguments80Cases
      */
     public function testArguments80(string $code, int $openIndex, int $closeIndex, array $arguments): void
@@ -113,6 +114,7 @@ final class ArgumentsAnalyzerTest extends TestCase
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider provideArguments81Cases
      */
     public function testArguments81(string $code, int $openIndex, int $closeIndex, array $arguments): void
@@ -265,6 +267,7 @@ final class ArgumentsAnalyzerTest extends TestCase
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider provideArgumentsInfo80Cases
      */
     public function testArgumentInfo80(string $code, int $openIndex, int $closeIndex, ArgumentAnalysis $expected): void
@@ -314,6 +317,7 @@ final class ArgumentsAnalyzerTest extends TestCase
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider provideArgumentsInfo81Cases
      */
     public function testArgumentInfo81(string $code, int $openIndex, int $closeIndex, ArgumentAnalysis $expected): void

--- a/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AttributeAnalyzerTest.php
@@ -38,6 +38,7 @@ final class AttributeAnalyzerTest extends TestCase
 
     /**
      * @requires     PHP 8.0
+     *
      * @dataProvider provideIsAttributeCases
      */
     public function testIsAttribute(bool $isInAttribute, string $code): void

--- a/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ClassyAnalyzerTest.php
@@ -147,6 +147,7 @@ final class ClassyAnalyzerTest extends TestCase
      * @param array<int, bool> $expected
      *
      * @dataProvider provideIsClassyInvocation80Cases
+     *
      * @requires PHP 8.0
      */
     public function testIsClassyInvocation80(string $source, array $expected): void
@@ -186,6 +187,7 @@ final class ClassyAnalyzerTest extends TestCase
      * @param array<int, bool> $expected
      *
      * @dataProvider provideIsClassyInvocation81Cases
+     *
      * @requires PHP 8.1
      */
     public function testIsClassyInvocation81(string $source, array $expected): void

--- a/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/CommentsAnalyzerTest.php
@@ -327,6 +327,7 @@ $bar;',
 
     /**
      * @dataProvider providePhpdocCandidatePhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testPhpdocCandidatePhp80(string $code): void
@@ -352,6 +353,7 @@ Class MyAnnotation3 {}'],
 
     /**
      * @dataProvider providePhpdocCandidatePhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testPhpdocCandidatePhp81(string $code): void

--- a/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/ControlCaseStructuresAnalyzerTest.php
@@ -321,6 +321,7 @@ endswitch ?>',
      * @param int[] $types
      *
      * @requires PHP 8.1
+     *
      * @dataProvider provideFindControlStructuresPhp81Cases
      */
     public function testFindControlStructuresPhp81(array $expectedAnalyses, string $source, array $types): void

--- a/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/FunctionsAnalyzerTest.php
@@ -282,6 +282,7 @@ A();
      * @param int[] $indices
      *
      * @dataProvider provideIsGlobalFunctionCallPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testIsGlobalFunctionCallPhp80(string $code, array $indices): void
@@ -327,6 +328,7 @@ class Foo {}
      * @param int[] $indices
      *
      * @dataProvider provideIsGlobalFunctionCallPhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testIsGlobalFunctionCallPhp81(array $indices, string $code): void
@@ -695,6 +697,7 @@ class(){};
 
     /**
      * @dataProvider provideFunctionsWithArgumentsPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testFunctionArgumentInfoPhp80(string $code, int $methodIndex, array $expected): void

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -482,6 +482,7 @@ PHP;
 
     /**
      * @dataProvider provideGetClassyElements81Cases
+     *
      * @requires PHP 8.1
      */
     public function testGetClassyElements81(array $expected, string $source): void
@@ -852,6 +853,7 @@ preg_replace_callback(
 
     /**
      * @dataProvider provideIsLambda80Cases
+     *
      * @requires PHP 8.0
      */
     public function testIsLambda80(array $expected, string $source): void
@@ -1122,6 +1124,7 @@ abstract class Baz
 
     /**
      * @dataProvider provideIsConstantInvocationPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testIsConstantInvocationPhp80(array $expected, string $source): void
@@ -1220,6 +1223,7 @@ abstract class Baz
 
     /**
      * @dataProvider provideIsConstantInvocationPhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testIsConstantInvocationPhp81(array $expected, string $source): void
@@ -1751,6 +1755,7 @@ $b;',
 
     /**
      * @dataProvider provideIsBinaryOperator80Cases
+     *
      * @requires PHP 8.0
      */
     public function testIsBinaryOperator80(array $expected, string $source): void
@@ -1792,6 +1797,7 @@ $b;',
 
     /**
      * @dataProvider provideIsBinaryOperator81Cases
+     *
      * @requires PHP 8.1
      */
     public function testIsBinaryOperator81(array $expected, string $source): void

--- a/tests/Tokenizer/TokensTest.php
+++ b/tests/Tokenizer/TokensTest.php
@@ -712,6 +712,7 @@ PHP;
 
     /**
      * @requires PHP 8.0
+     *
      * @dataProvider provideFindBlockEnd80Cases
      *
      * @param Tokens::BLOCK_TYPE_* $type

--- a/tests/Tokenizer/Transformer/AttributeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/AttributeTransformerTest.php
@@ -27,6 +27,7 @@ final class AttributeTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
+     *
      * @requires PHP 8.0
      */
     public function testProcess(string $source, array $expectedTokens): void

--- a/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/BraceClassInstantiationTransformerTest.php
@@ -345,6 +345,7 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
      * @param string[]           $observedKinds
      *
      * @dataProvider provideProcessPhp80Cases
+     *
      * @requires PHP 8.0
      */
     public function testProcessPhp80(array $expectedTokens, array $observedKinds, string $source): void
@@ -394,6 +395,7 @@ final class BraceClassInstantiationTransformerTest extends AbstractTransformerTe
      * @param array<int, string> $expectedTokens
      *
      * @dataProvider provideProcessPhp81Cases
+     *
      * @requires PHP 8.1
      */
     public function testProcessPhp81(array $expectedTokens, array $observedKinds, string $source): void

--- a/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/ConstructorPromotionTransformerTest.php
@@ -27,6 +27,7 @@ final class ConstructorPromotionTransformerTest extends AbstractTransformerTestC
 {
     /**
      * @dataProvider provideProcessCases
+     *
      * @requires PHP 8.0
      */
     public function testProcess(array $expectedTokens, string $source): void
@@ -125,6 +126,7 @@ class Point {
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(array $expectedTokens, string $source): void

--- a/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
+++ b/tests/Tokenizer/Transformer/CurlyBraceTransformerTest.php
@@ -205,6 +205,7 @@ final class CurlyBraceTransformerTest extends AbstractTransformerTestCase
 
     /**
      * @dataProvider provideProcess80Cases
+     *
      * @requires PHP 8.0
      */
     public function testProcess80(string $source, array $expectedTokens = []): void

--- a/tests/Tokenizer/Transformer/FirstClassCallableTransformerTest.php
+++ b/tests/Tokenizer/Transformer/FirstClassCallableTransformerTest.php
@@ -26,6 +26,7 @@ final class FirstClassCallableTransformerTest extends AbstractTransformerTestCas
 {
     /**
      * @dataProvider provideProcessCases
+     *
      * @requires PHP 8.1
      */
     public function testProcess(array $expectedTokens, string $source): void

--- a/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NameQualifiedTransformerTest.php
@@ -22,6 +22,7 @@ use PhpCsFixer\Tokenizer\Tokens;
 
 /**
  * @internal
+ *
  * @requires PHP 8.0
  *
  * @covers \PhpCsFixer\Tokenizer\Transformer\NameQualifiedTransformer

--- a/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NamedArgumentTransformerTest.php
@@ -27,6 +27,7 @@ final class NamedArgumentTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
+     *
      * @requires PHP 8.0
      */
     public function testProcess(string $source, array $expectedTokens): void

--- a/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
+++ b/tests/Tokenizer/Transformer/NullableTypeTransformerTest.php
@@ -114,6 +114,7 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
 
     /**
      * @dataProvider provideProcess80Cases
+     *
      * @requires PHP 8.0
      */
     public function testProcess80(array $expectedTokens, string $source): void
@@ -160,6 +161,7 @@ final class NullableTypeTransformerTest extends AbstractTransformerTestCase
 
     /**
      * @dataProvider provideProcess81Cases
+     *
      * @requires PHP 8.1
      */
     public function testProcess81(array $expectedTokens, string $source): void

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -91,6 +91,7 @@ final class TypeAlternationTransformerTest extends AbstractTransformerTestCase
 
     /**
      * @dataProvider provideProcess80Cases
+     *
      * @requires PHP 8.0
      */
     public function testProcess80(string $source, array $expectedTokens): void
@@ -316,6 +317,7 @@ class Number
 
     /**
      * @dataProvider provideFix81Cases
+     *
      * @requires PHP 8.1
      */
     public function testFix81(array $expectedTokens, string $source): void
@@ -360,6 +362,7 @@ class Foo
 
     /**
      * @dataProvider provideProcess81Cases
+     *
      * @requires PHP 8.1
      */
     public function testProcess81(string $source, array $expectedTokens): void

--- a/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeColonTransformerTest.php
@@ -103,6 +103,7 @@ final class TypeColonTransformerTest extends AbstractTransformerTestCase
 
     /**
      * @dataProvider provideProcess81Cases
+     *
      * @requires PHP 8.1
      */
     public function testProcess81(string $source, array $expectedTokens = []): void

--- a/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
@@ -26,6 +26,7 @@ final class TypeIntersectionTransformerTest extends AbstractTransformerTestCase
 {
     /**
      * @dataProvider provideProcessCases
+     *
      * @requires PHP 8.1
      */
     public function testProcess(string $source, array $expectedTokens = []): void

--- a/tests/Tokenizer/Transformer/UseTransformerTest.php
+++ b/tests/Tokenizer/Transformer/UseTransformerTest.php
@@ -149,6 +149,7 @@ use C\{D,E,};
      * @param array<int, int> $expectedTokens index => kind
      *
      * @requires PHP 8.1
+     *
      * @dataProvider provideProcessPhp81Cases
      */
     public function testProcessPhp81(string $source, array $expectedTokens = []): void


### PR DESCRIPTION
Closes #5026.

Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line, ~~except those specified in ``additional_groups`` option~~.

Configuration
-------------

 - ``groups`` - sets of annotation types to be grouped together. 
 default value: ``[['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'property-read', 'property-write']]``
  - ~~``additional_groups`` - sets of additional annotation types to be grouped together.~~

 - ~~``psr_standard_tags_only`` - whether process PSR PHPDoc standard annotation tags only or any annotation tags~~