### PR TITLE
bug: BinaryOperatorSpacesFixer: Solve issues with scoped arrow and equal alignments

### DIFF
--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -552,6 +552,7 @@ $array = [
                 // We don't align `=` on multi-line definition of function parameters with default values
                 if ($tokens[$index]->equals('(')) {
                     $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
                     continue;
                 }
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -600,10 +600,11 @@ $array = [
     {
         // Only inject placeholders for multi-line code
         if ($tokens->isPartialCodeMultiline($from, $until)) {
-            ++$this->currentLevel;
-            $this->deepestLevel = max($this->deepestLevel, $this->currentLevel);
+            ++$this->deepestLevel;
+            $currentLevel = $this->currentLevel;
+            $this->currentLevel = $this->deepestLevel;
             $this->injectAlignmentPlaceholdersDefault($tokens, $from, $until, $tokenContent);
-            --$this->currentLevel;
+            $this->currentLevel = $currentLevel;
         }
     }
 
@@ -701,10 +702,11 @@ $array = [
     {
         // Only inject placeholders for multi-line arrays
         if ($tokens->isPartialCodeMultiline($from, $until)) {
-            ++$this->currentLevel;
-            $this->deepestLevel = max($this->deepestLevel, $this->currentLevel);
+            ++$this->deepestLevel;
+            $currentLevel = $this->currentLevel;
+            $this->currentLevel = $this->deepestLevel;
             $this->injectAlignmentPlaceholdersForArrow($tokens, $from, $until);
-            --$this->currentLevel;
+            $this->currentLevel = $currentLevel;
         }
     }
 

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -560,8 +560,7 @@ $array = [
                 continue;
             }
 
-            if ($token->isGivenKind([T_FOREACH, T_FOR, T_WHILE, T_IF, T_SWITCH, T_ELSEIF])) {
-                $index = $tokens->getNextMeaningfulToken($index);
+            if ($token->equals('(')) {
                 $until = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
                 $this->injectAlignmentPlaceholders($tokens, $index + 1, $until - 1, $tokenContent);
                 $index = $until;
@@ -589,8 +588,8 @@ $array = [
     {
         // Only inject placeholders for multi-line code
         if ($tokens->isPartialCodeMultiline($from, $until)) {
-            ++$this->deepestLevel;
             ++$this->currentLevel;
+            $this->deepestLevel = max($this->deepestLevel, $this->currentLevel);
             $this->injectAlignmentPlaceholdersDefault($tokens, $from, $until, $tokenContent);
             --$this->currentLevel;
         }
@@ -690,8 +689,8 @@ $array = [
     {
         // Only inject placeholders for multi-line arrays
         if ($tokens->isPartialCodeMultiline($from, $until)) {
-            ++$this->deepestLevel;
             ++$this->currentLevel;
+            $this->deepestLevel = max($this->deepestLevel, $this->currentLevel);
             $this->injectAlignmentPlaceholdersForArrow($tokens, $from, $until);
             --$this->currentLevel;
         }

--- a/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
+++ b/src/Fixer/Operator/BinaryOperatorSpacesFixer.php
@@ -547,9 +547,15 @@ $array = [
                 continue;
             }
 
-            if ($token->isGivenKind(T_FUNCTION)) {
-                $index = $tokens->getNextTokenOfKind($index, ['(']);
-                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+            if ($token->isGivenKind([T_FUNCTION, T_CLASS])) {
+                $openBraceIndex = $tokens->getNextTokenOfKind($index, ['{', ';']);
+                if ($tokens[$openBraceIndex]->equals(';')) {
+                    continue;
+                }
+
+                $closeBraceIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openBraceIndex);
+                $this->injectAlignmentPlaceholders($tokens, $openBraceIndex + 1, $closeBraceIndex - 1, $tokenContent);
+                $index = $closeBraceIndex;
 
                 continue;
             }

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1609,6 +1609,14 @@ $bbb = 1;
 }
 ',
             ],
+            [
+                '<?php
+$fabricator->setOverrides(
+["first" => "Bobby"], $persist = false);
+$fabricator->setOverrides(["first" => "Bobby"], $persist = false
+);
+',
+            ],
         ];
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1568,6 +1568,33 @@ $ab = [$bc];
 $abc = [$bcd];
 ',
             ],
+            [
+                '<?php
+$result = false;
+
+$callback = static function () use (&$result) {
+    $result = true;
+};
+
+$this->query = $this->db->prepare(static function ($db) {
+   $sql = "INSERT INTO {$db->protectIdentifiers($db->DBPrefix)} ("
+          . $db->protectIdentifiers("name") . ", "
+          . $db->protectIdentifiers("email") . ", "
+          . $db->protectIdentifiers("country");
+});
+
+$classSet = Closure::bind(function ($key, $value) {
+    $this->{$key} = $value;
+}, $classObj, $className);
+',
+            ],
+            [
+                '<?php
+$obj = new class() extends SomeClass {
+    public $someProperty = null;
+};
+',
+            ],
         ];
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1602,6 +1602,13 @@ $bobbyUser = $fabricator->make();
 $bobbyUser = $fabricator->make();
 ',
             ],
+            [
+                '<?php
+$a = 1; if (true) {
+$bbb = 1;
+}
+',
+            ],
         ];
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1595,6 +1595,13 @@ $obj = new class() extends SomeClass {
 };
 ',
             ],
+            [
+                '<?php
+$fabricator->setOverrides(["first" => "Bobby"], $persist = false);
+$bobbyUser = $fabricator->make();
+$bobbyUser = $fabricator->make();
+',
+            ],
         ];
     }
 

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -1617,6 +1617,15 @@ $fabricator->setOverrides(["first" => "Bobby"], $persist = false
 );
 ',
             ],
+            [
+                '<?php
+$start = (
+    $input["start"] !== "" && ($date = DateTime::parse($input["start"]))
+        ? $date->setTimezone("UTC")
+        : $date->setTimezone("Europe/London")
+);
+',
+            ],
         ];
     }
 
@@ -2249,6 +2258,22 @@ class test
         }
     }
 }
+',
+            ],
+            [
+                '<?php
+$array = [
+    "foo"     => 123,
+    "longkey" => "test",
+    "baz"     => fn () => "value",
+];
+',
+                '<?php
+$array = [
+    "foo" => 123,
+    "longkey" => "test",
+    "baz" => fn () => "value",
+];
 ',
             ],
         ];

--- a/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Fixer/Operator/BinaryOperatorSpacesFixerTest.php
@@ -2158,6 +2158,50 @@ function asd() {
 }
 ',
             ],
+            [
+                '<?php
+collect()
+    ->map(fn ($arg) => [])
+    ->keyBy(fn ($arg) => []);
+',
+            ],
+            [
+                '<?php
+if ($this->save([
+    "bar"       => "baz",
+    "barbarbar" => "baz",
+])) {
+    // Do the work
+}
+',
+                '<?php
+if ($this->save([
+    "bar" => "baz",
+    "barbarbar" => "baz",
+])) {
+    // Do the work
+}
+',
+            ],
+            [
+                '<?php
+class test
+{
+    public function __construct()
+    {
+        $result = $this->test1(fn () => $this->test2($a));
+        foreach ($result as $k => $v)
+        {
+        }
+
+        $result = $this->test1(fn () => $this->test2($a, $b));
+        foreach ($result as $k => $v)
+        {
+        }
+    }
+}
+',
+            ],
         ];
     }
 


### PR DESCRIPTION
The PR https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6384 was valid and close:
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6220
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6223
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5896

For the discussion, https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6384#discussion_r927633989
it was solved by https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/6450

I also added a fix for
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5980

cc @julienfalque 

Edit:
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6510
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6514
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5648

Edit2:
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6379
Closes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6348