### PR TITLE
feature: Support continuation indent

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -68,6 +68,7 @@ final class Cache implements CacheInterface
             'php' => $this->getSignature()->getPhpVersion(),
             'version' => $this->getSignature()->getFixerVersion(),
             'indent' => $this->getSignature()->getIndent(),
+            'continuationIndent' => $this->getSignature()->getContinuationIndent(),
             'lineEnding' => $this->getSignature()->getLineEnding(),
             'rules' => $this->getSignature()->getRules(),
             'hashes' => $this->hashes,
@@ -102,6 +103,7 @@ final class Cache implements CacheInterface
             'php',
             'version',
             'indent',
+            'continuationIndent',
             'lineEnding',
             'rules',
             'hashes',
@@ -120,6 +122,7 @@ final class Cache implements CacheInterface
             $data['php'],
             $data['version'],
             $data['indent'],
+            $data['continuationIndent'],
             $data['lineEnding'],
             $data['rules']
         );

--- a/src/Cache/Signature.php
+++ b/src/Cache/Signature.php
@@ -27,15 +27,18 @@ final class Signature implements SignatureInterface
 
     private string $indent;
 
+    private string $continuationIndent;
+
     private string $lineEnding;
 
     private array $rules;
 
-    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $lineEnding, array $rules)
+    public function __construct(string $phpVersion, string $fixerVersion, string $indent, string $continuationIndent, string $lineEnding, array $rules)
     {
         $this->phpVersion = $phpVersion;
         $this->fixerVersion = $fixerVersion;
         $this->indent = $indent;
+        $this->continuationIndent = $continuationIndent;
         $this->lineEnding = $lineEnding;
         $this->rules = self::utf8Encode($rules);
     }
@@ -55,6 +58,11 @@ final class Signature implements SignatureInterface
         return $this->indent;
     }
 
+    public function getContinuationIndent(): string
+    {
+        return $this->continuationIndent;
+    }
+
     public function getLineEnding(): string
     {
         return $this->lineEnding;
@@ -70,6 +78,7 @@ final class Signature implements SignatureInterface
         return $this->phpVersion === $signature->getPhpVersion()
             && $this->fixerVersion === $signature->getFixerVersion()
             && $this->indent === $signature->getIndent()
+            && $this->continuationIndent === $signature->getContinuationIndent()
             && $this->lineEnding === $signature->getLineEnding()
             && $this->rules === $signature->getRules();
     }

--- a/src/Cache/SignatureInterface.php
+++ b/src/Cache/SignatureInterface.php
@@ -27,6 +27,8 @@ interface SignatureInterface
 
     public function getIndent(): string;
 
+    public function getContinuationIndent(): string;
+
     public function getLineEnding(): string;
 
     public function getRules(): array;

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,8 @@ class Config implements ConfigInterface
 
     private string $indent = '    ';
 
+    private string $continuationIndent = '    ';
+
     private bool $isRiskyAllowed = false;
 
     private string $lineEnding = "\n";
@@ -111,6 +113,14 @@ class Config implements ConfigInterface
     public function getIndent(): string
     {
         return $this->indent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContinuationIndent(): string
+    {
+        return $this->continuationIndent;
     }
 
     /**
@@ -219,6 +229,16 @@ class Config implements ConfigInterface
     public function setIndent(string $indent): ConfigInterface
     {
         $this->indent = $indent;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContinuationIndent(string $indent): ConfigInterface
+    {
+        $this->continuationIndent = $indent;
 
         return $this;
     }

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -53,6 +53,8 @@ interface ConfigInterface
 
     public function getIndent(): string;
 
+    public function getContinuationIndent(): string;
+
     public function getLineEnding(): string;
 
     /**
@@ -110,6 +112,8 @@ interface ConfigInterface
     public function setHideProgress(bool $hideProgress): self;
 
     public function setIndent(string $indent): self;
+
+    public function setContinuationIndent(string $indent): self;
 
     public function setLineEnding(string $lineEnding): self;
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -225,6 +225,7 @@ final class ConfigurationResolver
                         PHP_VERSION,
                         $this->toolInfo->getVersion(),
                         $this->getConfig()->getIndent(),
+                        $this->getConfig()->getContinuationIndent(),
                         $this->getConfig()->getLineEnding(),
                         $this->getRules()
                     ),
@@ -319,7 +320,7 @@ final class ConfigurationResolver
         if (null === $this->fixers) {
             $this->fixers = $this->createFixerFactory()
                 ->useRuleSet($this->getRuleSet())
-                ->setWhitespacesConfig(new WhitespacesFixerConfig($this->config->getIndent(), $this->config->getLineEnding()))
+                ->setWhitespacesConfig(new WhitespacesFixerConfig($this->config->getIndent(), $this->config->getLineEnding(), $this->config->getContinuationIndent()))
                 ->getFixers()
             ;
 

--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -323,7 +323,7 @@ SAMPLE
             ;
         }
 
-        $indentation = $existingIndentation.$this->whitespacesConfig->getIndent();
+        $indentation = $existingIndentation.$this->whitespacesConfig->getContinuationIndent();
         $endFunctionIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $startFunctionIndex);
 
         $wasWhitespaceBeforeEndFunctionAddedAsNewToken = $tokens->ensureWhitespaceAtIndex(

--- a/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
+++ b/src/Fixer/Whitespace/MethodChainingIndentationFixer.php
@@ -99,7 +99,6 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
     private function getExpectedIndentAt(Tokens $tokens, int $index): string
     {
         $index = $tokens->getPrevMeaningfulToken($index);
-        $indent = $this->whitespacesConfig->getIndent();
 
         for ($i = $index; $i >= 0; --$i) {
             if ($tokens[$i]->equals(')')) {
@@ -112,13 +111,13 @@ final class MethodChainingIndentationFixer extends AbstractFixer implements Whit
             }
 
             if ($this->currentLineRequiresExtraIndentLevel($tokens, $i, $index)) {
-                return $currentIndent.$indent;
+                return $currentIndent.$this->whitespacesConfig->getContinuationIndent();
             }
 
             return $currentIndent;
         }
 
-        return $indent;
+        return $this->whitespacesConfig->getIndent();
     }
 
     /**

--- a/src/WhitespacesFixerConfig.php
+++ b/src/WhitespacesFixerConfig.php
@@ -21,12 +21,18 @@ final class WhitespacesFixerConfig
 {
     private string $indent;
 
+    private string $continuationIndent;
+
     private string $lineEnding;
 
-    public function __construct(string $indent = '    ', string $lineEnding = "\n")
+    public function __construct(string $indent = '    ', string $lineEnding = "\n", string $continuationIndent = '    ')
     {
         if (!\in_array($indent, ['  ', '    ', "\t"], true)) {
             throw new \InvalidArgumentException('Invalid "indent" param, expected tab or two or four spaces.');
+        }
+
+        if (!\in_array($continuationIndent, ['  ', '    ', '        ', "\t", "\t\t"], true)) {
+            throw new \InvalidArgumentException('Invalid "continuationIndent" param, expected (double) tab or two, four or eight spaces.');
         }
 
         if (!\in_array($lineEnding, ["\n", "\r\n"], true)) {
@@ -34,12 +40,18 @@ final class WhitespacesFixerConfig
         }
 
         $this->indent = $indent;
+        $this->continuationIndent = $continuationIndent;
         $this->lineEnding = $lineEnding;
     }
 
     public function getIndent(): string
     {
         return $this->indent;
+    }
+
+    public function getContinuationIndent(): string
+    {
+        return $this->continuationIndent;
     }
 
     public function getLineEnding(): string

--- a/tests/AbstractFixerTest.php
+++ b/tests/AbstractFixerTest.php
@@ -83,15 +83,17 @@ final class AbstractFixerTest extends TestCase
         $config = $fixer->getWhitespacesConfig();
 
         static::assertSame('    ', $config->getIndent());
+        static::assertSame('    ', $config->getContinuationIndent());
         static::assertSame("\n", $config->getLineEnding());
 
-        $newConfig = new WhitespacesFixerConfig("\t", "\r\n");
+        $newConfig = new WhitespacesFixerConfig("\t", "\r\n", "\t\t");
 
         $fixer->setWhitespacesConfig($newConfig);
 
         $config = $fixer->getWhitespacesConfig();
 
         static::assertSame("\t", $config->getIndent());
+        static::assertSame("\t\t", $config->getContinuationIndent());
         static::assertSame("\r\n", $config->getLineEnding());
     }
 }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -165,6 +165,7 @@ final class CacheTest extends TestCase
                 PHP_VERSION,
                 '2.0',
                 '  ',
+                '    ',
                 "\r\n",
                 [
                     'foo' => true,
@@ -175,6 +176,7 @@ final class CacheTest extends TestCase
                 PHP_VERSION,
                 $toolInfo->getVersion(),
                 $config->getIndent(),
+                $config->getContinuationIndent(),
                 $config->getLineEnding(),
                 [
                     // value encoded in ANSI, not UTF
@@ -192,6 +194,7 @@ final class CacheTest extends TestCase
         $signature->getPhpVersion()->willReturn('7.1.0');
         $signature->getFixerVersion()->willReturn('2.2.0');
         $signature->getIndent()->willReturn('    ');
+        $signature->getContinuationIndent()->willReturn('    ');
         $signature->getLineEnding()->willReturn(PHP_EOL);
         $signature->getRules()->willReturn([
             $invalidUtf8Sequence => true,

--- a/tests/Cache/FileHandlerTest.php
+++ b/tests/Cache/FileHandlerTest.php
@@ -193,6 +193,7 @@ final class FileHandlerTest extends TestCase
             PHP_VERSION,
             '2.0',
             '    ',
+            '    ',
             PHP_EOL,
             [
                 'foo',

--- a/tests/Cache/SignatureTest.php
+++ b/tests/Cache/SignatureTest.php
@@ -45,6 +45,7 @@ final class SignatureTest extends TestCase
         $php = PHP_VERSION;
         $version = '2.0';
         $indent = '    ';
+        $continuationIndent = '    ';
         $lineEnding = PHP_EOL;
         $rules = [
             'foo',
@@ -55,6 +56,7 @@ final class SignatureTest extends TestCase
             $php,
             $version,
             $indent,
+            $continuationIndent,
             $lineEnding,
             $rules
         );
@@ -62,6 +64,7 @@ final class SignatureTest extends TestCase
         static::assertSame($php, $signature->getPhpVersion());
         static::assertSame($version, $signature->getFixerVersion());
         static::assertSame($indent, $signature->getIndent());
+        static::assertSame($continuationIndent, $signature->getContinuationIndent());
         static::assertSame($lineEnding, $signature->getLineEnding());
         static::assertSame($rules, $signature->getRules());
     }
@@ -79,37 +82,43 @@ final class SignatureTest extends TestCase
         $php = PHP_VERSION;
         $version = '2.0';
         $indent = '    ';
+        $continuationIndent = '    ';
         $lineEnding = "\n";
         $rules = [
             'foo',
             'bar',
         ];
 
-        $base = new Signature($php, $version, $indent, $lineEnding, $rules);
+        $base = new Signature($php, $version, $indent, $continuationIndent, $lineEnding, $rules);
 
         yield 'php' => [
             $base,
-            new Signature('50400', $version, $indent, $lineEnding, $rules),
+            new Signature('50400', $version, $indent, $continuationIndent, $lineEnding, $rules),
         ];
 
         yield 'version' => [
             $base,
-            new Signature($php, '2.12', $indent, $lineEnding, $rules),
+            new Signature($php, '2.12', $indent, $continuationIndent, $lineEnding, $rules),
         ];
 
         yield 'indent' => [
             $base,
-            new Signature($php, $version, "\t", $lineEnding, $rules),
+            new Signature($php, $version, "\t", $continuationIndent, $lineEnding, $rules),
+        ];
+
+        yield 'continuationIndent' => [
+            $base,
+            new Signature($php, $version, $indent, "\t", $lineEnding, $rules),
         ];
 
         yield 'lineEnding' => [
             $base,
-            new Signature($php, $version, $indent, "\r\n", $rules),
+            new Signature($php, $version, $indent, $continuationIndent, "\r\n", $rules),
         ];
 
         yield 'rules' => [
             $base,
-            new Signature($php, $version, $indent, $lineEnding, ['foo']),
+            new Signature($php, $version, $indent, $continuationIndent, $lineEnding, ['foo']),
         ];
     }
 
@@ -118,6 +127,7 @@ final class SignatureTest extends TestCase
         $php = PHP_VERSION;
         $version = '2.0';
         $indent = '    ';
+        $continuationIndent = '    ';
         $lineEnding = PHP_EOL;
         $rules = [
             'foo',
@@ -128,6 +138,7 @@ final class SignatureTest extends TestCase
             $php,
             $version,
             $indent,
+            $continuationIndent,
             $lineEnding,
             $rules
         );
@@ -136,6 +147,7 @@ final class SignatureTest extends TestCase
             $php,
             $version,
             $indent,
+            $continuationIndent,
             $lineEnding,
             $rules
         );

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -215,6 +215,7 @@ final class ConfigTest extends TestCase
         static::assertSame('txt', $config->getFormat());
         static::assertFalse($config->getHideProgress());
         static::assertSame('    ', $config->getIndent());
+        static::assertSame('    ', $config->getContinuationIndent());
         static::assertSame("\n", $config->getLineEnding());
         static::assertSame('default', $config->getName());
         static::assertNull($config->getPhpExecutable());
@@ -233,6 +234,9 @@ final class ConfigTest extends TestCase
 
         $config->setIndent("\t");
         static::assertSame("\t", $config->getIndent());
+
+        $config->setContinuationIndent("\t");
+        static::assertSame("\t", $config->getContinuationIndent());
 
         $finder = new Finder();
         $config->setFinder($finder);

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -53,7 +53,8 @@ final class MethodArgumentSpaceFixerTest extends AbstractFixerTestCase
         $this->fixer->configure($configuration);
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig(
             $indent,
-            $lineEnding
+            $lineEnding,
+            $indent
         ));
 
         $this->doTest($expected, $input);
@@ -1031,6 +1032,66 @@ $fn = fn(
             [
                 'on_multiline' => 'ensure_fully_multiline',
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideContinuationIndentCases
+     */
+    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void {
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", $continuationIndent));
+        $this->doTest($expected, $input);
+    }
+
+    public function provideContinuationIndentCases(): iterable {
+        yield 'Two spaces' => [
+            '  ',
+            '<?php
+functionCall(
+  1,
+  2,
+  3,
+);',
+            '<?php
+functionCall(
+    1, 2,
+    3,
+);'
+        ];
+
+        yield 'Four spaces' => [
+            '    ',
+            '<?php
+functionCall(
+    1,
+    2,
+    3,
+);',
+            '<?php
+functionCall(
+    1, 2,
+    3,
+);'
+        ];
+
+        yield 'One tab' => [
+            "\t",
+            "<?php\nfunctionCall(\n\t1,\n\t2,\n\t3,\n);",
+            '<?php
+functionCall(
+    1, 2,
+    3,
+);'
+        ];
+
+        yield 'Two tabs' => [
+            "\t\t",
+            "<?php\nfunctionCall(\n\t\t1,\n\t\t2,\n\t\t3,\n);",
+            '<?php
+functionCall(
+    1, 2,
+    3,
+);'
         ];
     }
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1038,12 +1038,14 @@ $fn = fn(
     /**
      * @dataProvider provideContinuationIndentCases
      */
-    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void {
+    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void
+    {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", $continuationIndent));
         $this->doTest($expected, $input);
     }
 
-    public function provideContinuationIndentCases(): iterable {
+    public function provideContinuationIndentCases(): iterable
+    {
         yield 'Two spaces' => [
             '  ',
             '<?php
@@ -1056,7 +1058,7 @@ functionCall(
 functionCall(
     1, 2,
     3,
-);'
+);',
         ];
 
         yield 'Four spaces' => [
@@ -1071,7 +1073,7 @@ functionCall(
 functionCall(
     1, 2,
     3,
-);'
+);',
         ];
 
         yield 'One tab' => [
@@ -1081,7 +1083,7 @@ functionCall(
 functionCall(
     1, 2,
     3,
-);'
+);',
         ];
 
         yield 'Two tabs' => [
@@ -1091,7 +1093,7 @@ functionCall(
 functionCall(
     1, 2,
     3,
-);'
+);',
         ];
     }
 

--- a/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
@@ -297,16 +297,18 @@ $foo
 '
         );
     }
+
     /**
      * @dataProvider provideContinuationIndentCases
      */
-    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void {
-
+    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void
+    {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", $continuationIndent));
         $this->doTest($expected, $input);
     }
 
-    public function provideContinuationIndentCases(): iterable {
+    public function provideContinuationIndentCases(): iterable
+    {
         yield 'Four spaces' => [
             '    ',
             '<?php

--- a/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/MethodChainingIndentationFixerTest.php
@@ -297,4 +297,94 @@ $foo
 '
         );
     }
+    /**
+     * @dataProvider provideContinuationIndentCases
+     */
+    public function testContinuationIndent(string $continuationIndent, string $expected, string $input): void {
+
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", $continuationIndent));
+        $this->doTest($expected, $input);
+    }
+
+    public function provideContinuationIndentCases(): iterable {
+        yield 'Four spaces' => [
+            '    ',
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+        ->setPassword(\'233434\')
+        ->setEmailConfirmed(false)
+        ->setEmailConfirmationCode(\'123456\')
+        ->setHashsalt(\'1234\')
+        ->setTncAccepted(true);
+',
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+
+     ->setPassword(\'233434\')
+        ->setEmailConfirmed(false)
+->setEmailConfirmationCode(\'123456\')
+
+                ->setHashsalt(\'1234\')
+  ->setTncAccepted(true);
+',
+        ];
+
+        yield 'Two spaces' => [
+            '  ',
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+      ->setPassword(\'233434\')
+      ->setEmailConfirmed(false)
+      ->setEmailConfirmationCode(\'123456\')
+      ->setHashsalt(\'1234\')
+      ->setTncAccepted(true);
+',
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+
+     ->setPassword(\'233434\')
+        ->setEmailConfirmed(false)
+->setEmailConfirmationCode(\'123456\')
+
+                ->setHashsalt(\'1234\')
+  ->setTncAccepted(true);
+',
+        ];
+
+        yield 'Tab' => [
+            "\t",
+            "<?php\n\n    \$user->setEmail('voff.web@gmail.com')\n    \t->setPassword('233434')\n    \t->setEmailConfirmed(false)\n    \t->setEmailConfirmationCode('123456')\n    \t->setHashsalt('1234')\n    \t->setTncAccepted(true);\n",
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+
+     ->setPassword(\'233434\')
+        ->setEmailConfirmed(false)
+->setEmailConfirmationCode(\'123456\')
+
+                ->setHashsalt(\'1234\')
+  ->setTncAccepted(true);
+',
+        ];
+
+        yield 'Double tab' => [
+            "\t\t",
+            "<?php\n\n    \$user->setEmail('voff.web@gmail.com')\n    \t\t->setPassword('233434')\n    \t\t->setEmailConfirmed(false)\n    \t\t->setEmailConfirmationCode('123456')\n    \t\t->setHashsalt('1234')\n    \t\t->setTncAccepted(true);\n",
+            '<?php
+
+    $user->setEmail(\'voff.web@gmail.com\')
+
+     ->setPassword(\'233434\')
+        ->setEmailConfirmed(false)
+->setEmailConfirmationCode(\'123456\')
+
+                ->setHashsalt(\'1234\')
+  ->setTncAccepted(true);
+',
+        ];
+    }
 }

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -27,7 +27,7 @@ final class StatementIndentationFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $unused, ?string $input = NULL): void
+    public function testFix(string $expected, ?string $unused, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -35,7 +35,7 @@ final class StatementIndentationFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFixContinuationIndent(string $original, ?string $expected, ?string $input = NULL): void
+    public function testFixContinuationIndent(string $original, ?string $expected, ?string $input = null): void
     {
         $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", '        '));
         $this->doTest($expected ?? $original, $input);

--- a/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
+++ b/tests/Fixer/Whitespace/StatementIndentationFixerTest.php
@@ -27,9 +27,18 @@ final class StatementIndentationFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases
      */
-    public function testFix(string $expected, ?string $input = null): void
+    public function testFix(string $expected, ?string $unused, ?string $input = NULL): void
     {
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixContinuationIndent(string $original, ?string $expected, ?string $input = NULL): void
+    {
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig('    ', "\n", '        '));
+        $this->doTest($expected ?? $original, $input);
     }
 
     public function provideFixCases(): iterable
@@ -38,6 +47,7 @@ final class StatementIndentationFixerTest extends AbstractFixerTestCase
             '<?php
 foo();
 bar();',
+            null,
             '<?php
   foo();
        bar();',
@@ -49,6 +59,7 @@ if ($foo) {
     foo();
     bar();
 }',
+            null,
             '<?php
 if ($foo) {
   foo();
@@ -62,6 +73,7 @@ if ($foo) {
     foo();
     if ($bar) { bar(); }
 }',
+            null,
             '<?php
 if ($foo) {
  foo();
@@ -77,6 +89,7 @@ if ($foo) { foo();
     foo();
 }
 foo();',
+            null,
             '<?php
 if ($foo) { foo();
  if ($bar) { bar();
@@ -91,6 +104,7 @@ if ($foo) { foo();
 if ($foo) {
     foo(); }
 foo();',
+            null,
             '<?php
 if ($foo) {
     foo(); }
@@ -108,6 +122,7 @@ if ($foo) { if ($foo) { foo();
     baz();
 }
 baz();',
+            null,
             '<?php
 if ($foo) { if ($foo) { foo();
   if ($bar) { if ($bar) { bar(); }
@@ -127,6 +142,12 @@ function foo(
 ) {
 }',
             '<?php
+function foo(
+        $bar,
+        $baz
+) {
+}',
+            '<?php
    function foo(
      $bar,
       $baz
@@ -139,6 +160,12 @@ function foo(
 $foo = function(
     $bar,
     $baz
+) {
+};',
+            '<?php
+$foo = function(
+        $bar,
+        $baz
 ) {
 };',
             '<?php
@@ -159,6 +186,13 @@ interface Foo {
 }',
             '<?php
 interface Foo {
+    public function foo(
+            $bar,
+            $baz
+    );
+}',
+            '<?php
+interface Foo {
    public function foo(
      $bar,
       $baz
@@ -172,6 +206,14 @@ class Foo {
     public function foo(
         $bar,
         $baz
+    ) {
+    }
+}',
+            '<?php
+class Foo {
+    public function foo(
+            $bar,
+            $baz
     ) {
     }
 }',
@@ -196,6 +238,14 @@ trait Foo {
 }',
             '<?php
 trait Foo {
+    public function foo(
+            $bar,
+            $baz
+    ) {
+    }
+}',
+            '<?php
+trait Foo {
    public function foo(
      $bar,
       $baz
@@ -212,6 +262,11 @@ foo(
 );',
             '<?php
 foo(
+        $bar,
+        $baz
+);',
+            '<?php
+foo(
   $bar,
    $baz
     );',
@@ -222,6 +277,11 @@ foo(
 $foo(
     $bar,
     $baz
+);',
+            '<?php
+$foo(
+        $bar,
+        $baz
 );',
             '<?php
 $foo(
@@ -238,6 +298,7 @@ if ($foo) {
                  ->baz()
     ;
 }',
+            null,
             '<?php
   if ($foo) {
          $foo
@@ -259,6 +320,7 @@ if ($foo) {
             )
     ;
 }',
+            null,
             '<?php
   if ($foo) {
          $foo = array(
@@ -284,6 +346,7 @@ if ($foo) {
             ]
     ;
 }',
+            null,
             '<?php
   if ($foo) {
          $foo = [
@@ -304,6 +367,16 @@ if ($foo) {
              foo(
                  $bar,
                  $baz
+             )
+             )
+    ;
+}',
+            '<?php
+if ($foo) {
+    $foo = array(
+             foo(
+                     $bar,
+                     $baz
              )
              )
     ;
@@ -332,6 +405,16 @@ if ($foo) {
     ;
 }',
             '<?php
+if ($foo) {
+    $foo = [
+             foo(
+                     $bar,
+                     $baz
+             )
+             ]
+    ;
+}',
+            '<?php
   if ($foo) {
          $foo = [
                   foo(
@@ -350,6 +433,16 @@ if ($foo) {
              new Foo(
                  $bar,
                  $baz
+             )
+             )
+    ;
+}',
+            '<?php
+if ($foo) {
+    $foo = array(
+             new Foo(
+                     $bar,
+                     $baz
              )
              )
     ;
@@ -378,6 +471,16 @@ if ($foo) {
     ;
 }',
             '<?php
+if ($foo) {
+    $foo = [
+             new Foo(
+                     $bar,
+                     $baz
+             )
+             ]
+    ;
+}',
+            '<?php
   if ($foo) {
          $foo = [
                   new Foo(
@@ -395,6 +498,7 @@ class Foo implements
     Bar,
     Baz
 {}',
+            null,
             '<?php
   class Foo implements
    Bar,
@@ -408,6 +512,7 @@ interface Foo extends
     Bar,
     Baz
 {}',
+            null,
             '<?php
   interface Foo extends
    Bar,
@@ -421,6 +526,7 @@ class Foo {
     use Bar,
         Baz;
 }',
+            null,
             '<?php
   class Foo {
        use Bar,
@@ -433,6 +539,11 @@ class Foo {
 $foo
  ->bar(
      $baz
+ );',
+            '<?php
+$foo
+ ->bar(
+         $baz
  );',
             '<?php
 $foo
@@ -450,6 +561,12 @@ foo(
 );',
             '<?php
 foo(
+        1
+        ,
+        2
+);',
+            '<?php
+foo(
  1
 ,
  2
@@ -464,6 +581,7 @@ if (true) {
              && $b
     ;
 }',
+            null,
             '<?php
 if (true) {
   $foo =
@@ -479,6 +597,7 @@ if ($a
        && $b) {
     foo();
 }',
+            null,
             '<?php
 if ($a
        && $b) {
@@ -499,6 +618,7 @@ switch ($foo) {
     default:
         echo "baz";
 }',
+            null,
             '<?php
 switch ($foo) {
   case 1:
@@ -525,6 +645,24 @@ if ($foo) {
 
                  public function foo(
                      $foo
+                 ) {
+                     return $foo;
+                 }
+             }
+             )
+    ;
+}',
+            '<?php
+if ($foo) {
+    $foo = array(
+             new class (
+                     $bar,
+                     $baz
+             ) {
+                 private $foo;
+
+                 public function foo(
+                         $foo
                  ) {
                      return $foo;
                  }
@@ -572,6 +710,24 @@ if ($foo) {
     ;
 }',
             '<?php
+if ($foo) {
+    $foo = [
+             new class (
+                     $bar,
+                     $baz
+             ) {
+                 private $foo;
+
+                 public function foo(
+                         $foo
+                 ) {
+                     return $foo;
+                 }
+             }
+             ]
+    ;
+}',
+            '<?php
   if ($foo) {
          $foo = [
                   new class (
@@ -599,6 +755,11 @@ if ($foo) {
 );',
             '<?php
 (\'foo\')(
+        $bar,
+        $baz
+);',
+            '<?php
+(\'foo\')(
   $bar,
    $baz
     );',
@@ -609,6 +770,11 @@ if ($foo) {
 $foo = fn(
     $bar,
     $baz
+) => null;',
+            '<?php
+$foo = fn(
+        $bar,
+        $baz
 ) => null;',
             '<?php
    $foo = fn(
@@ -624,6 +790,12 @@ foreach ($array as [
     "bar" => $bar,
 ]) {
 }',
+            '<?php
+foreach ($array as [
+        "foo" => $foo,
+        "bar" => $bar,
+]) {
+}',
         ];
 
         yield 'switch case with control structure' => [
@@ -635,6 +807,7 @@ switch ($foo) {
         }
         return true;
 }',
+            null,
             '<?php
 switch ($foo) {
     case true:
@@ -651,6 +824,7 @@ $foo
     ->baz()
     /* ->baz() */
 ;',
+            null,
         ];
 
         yield 'if with only a comment and followed by else' => [
@@ -660,6 +834,7 @@ if (true) {
 } else {
     // bar
 }',
+            null,
         ];
 
         yield 'multiple anonymous functions as function arguments' => [
@@ -669,6 +844,7 @@ foo(function () {
 }, function () {
     baz();
 });',
+            null,
         ];
 
         yield 'multiple anonymous functions as method arguments' => [
@@ -680,6 +856,7 @@ $this
         echo $b;
     })
 ;',
+            null,
         ];
 
         yield 'semicolon on a newline inside a switch case without break statement' => [
@@ -690,6 +867,7 @@ switch (true) {
             ->baz()
         ;
 }',
+            null,
         ];
 
         yield 'alternative syntax' => [
@@ -703,6 +881,25 @@ switch (true) {
     <?php endif; ?>
 <?php endif; ?>
 ',
+            null,
+        ];
+
+        yield 'array destruct' => [
+            '<?php
+[
+    $bar,
+    $baz,
+] = $foo;',
+            '<?php
+[
+        $bar,
+        $baz,
+] = $foo;',
+            '<?php
+[
+$bar,
+$baz,
+] = $foo;',
         ];
     }
 
@@ -711,7 +908,7 @@ switch (true) {
      */
     public function testFixWithTabs(string $expected, ?string $input = null): void
     {
-        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t"));
+        $this->fixer->setWhitespacesConfig(new WhitespacesFixerConfig("\t", "\n", "\t"));
         $this->doTest($expected, $input);
     }
 

--- a/tests/Fixtures/.php-cs-fixer.custom.php
+++ b/tests/Fixtures/.php-cs-fixer.custom.php
@@ -72,6 +72,14 @@ final class CustomConfig implements ConfigInterface
     /**
      * {@inheritdoc}
      */
+    public function getContinuationIndent(): string
+    {
+      return '    ';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getLineEnding(): string
     {
         return "\n";
@@ -161,6 +169,14 @@ final class CustomConfig implements ConfigInterface
      * {@inheritdoc}
      */
     public function setIndent(string $indent): ConfigInterface
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContinuationIndent(string $indent): ConfigInterface
     {
         return $this;
     }

--- a/tests/Fixtures/Integration/set/@Symfony_whitespaces.test
+++ b/tests/Fixtures/Integration/set/@Symfony_whitespaces.test
@@ -3,4 +3,4 @@ Integration of @Symfony [whitespace version].
 --RULESET--
 {"@Symfony": true}
 --CONFIG--
-{"indent": "\t", "lineEnding": "\r\n"}
+{"indent": "\t", "lineEnding": "\r\n", "continuationIndent": "\t"}

--- a/tests/Test/AbstractIntegrationCaseFactory.php
+++ b/tests/Test/AbstractIntegrationCaseFactory.php
@@ -82,6 +82,7 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
     {
         $parsed = $this->parseJson($config, [
             'indent' => '    ',
+            'continuationIndent' => '    ',
             'lineEnding' => "\n",
         ]);
 
@@ -89,6 +90,13 @@ abstract class AbstractIntegrationCaseFactory implements IntegrationCaseFactoryI
             throw new \InvalidArgumentException(sprintf(
                 'Expected string value for "indent", got "%s".',
                 \is_object($parsed['indent']) ? \get_class($parsed['indent']) : \gettype($parsed['indent']).'#'.$parsed['indent']
+            ));
+        }
+
+        if (!\is_string($parsed['continuationIndent'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected string value for "continuationIndent", got "%s".',
+                \is_object($parsed['continuationIndent']) ? \get_class($parsed['continuationIndent']) : \gettype($parsed['continuationIndent']).'#'.$parsed['continuationIndent']
             ));
         }
 

--- a/tests/Test/AbstractIntegrationTestCase.php
+++ b/tests/Test/AbstractIntegrationTestCase.php
@@ -334,7 +334,7 @@ abstract class AbstractIntegrationTestCase extends TestCase
             ->registerBuiltInFixers()
             ->useRuleSet($case->getRuleset())
             ->setWhitespacesConfig(
-                new WhitespacesFixerConfig($config['indent'], $config['lineEnding'])
+                new WhitespacesFixerConfig($config['indent'], $config['lineEnding'], $config['continuationIndent'])
             )
             ->getFixers()
         ;

--- a/tests/WhitespacesFixerConfigTest.php
+++ b/tests/WhitespacesFixerConfigTest.php
@@ -28,28 +28,32 @@ final class WhitespacesFixerConfigTest extends TestCase
     /**
      * @dataProvider provideTestCases
      */
-    public function testCases(string $indent, string $lineEnding, ?string $exceptionRegExp = null): void
+    public function testCases(string $indent, string $continuationIndent, string $lineEnding, ?string $exceptionRegExp = null): void
     {
         if (null !== $exceptionRegExp) {
             $this->expectException(\InvalidArgumentException::class);
             $this->expectExceptionMessageMatches('%^'.preg_quote($exceptionRegExp, '%').'$%');
         }
 
-        $config = new WhitespacesFixerConfig($indent, $lineEnding);
+        $config = new WhitespacesFixerConfig($indent, $lineEnding, $continuationIndent);
 
         static::assertSame($indent, $config->getIndent());
+        static::assertSame($continuationIndent, $config->getContinuationIndent());
         static::assertSame($lineEnding, $config->getLineEnding());
     }
 
     public function provideTestCases(): array
     {
         return [
-            ['    ', "\n"],
-            ["\t", "\n"],
-            ['    ', "\r\n"],
-            ["\t", "\r\n"],
-            ['    ', 'asd', 'Invalid "lineEnding" param, expected "\n" or "\r\n".'],
-            ['std', "\n", 'Invalid "indent" param, expected tab or two or four spaces.'],
+            ['    ', '    ', "\n"],
+            ["\t", '    ', "\n"],
+            ["\t", "\t", "\n"],
+            ['    ', '    ', "\r\n"],
+            ["\t", '    ', "\r\n"],
+            ["\t", "\t", "\r\n"],
+            ['    ', '    ', 'asd', 'Invalid "lineEnding" param, expected "\n" or "\r\n".'],
+            ['std', '    ', "\n", 'Invalid "indent" param, expected tab or two or four spaces.'],
+            ['    ', 'std', "\n", 'Invalid "continuationIndent" param, expected (double) tab or two, four or eight spaces.'],
         ];
     }
 }


### PR DESCRIPTION
This in my attempt to add continuation indent as described in #6496. 

With these changes I made commit https://github.com/Drenso/symfony-oidc/commit/618d2b348ee4cb76cc80f12da96e1b2632ba84ab, which now reverts the changes related to continuation indent that were added with https://github.com/Drenso/symfony-oidc/commit/443de599380a20a122cb22e69e08a0309b06210f, resulting in a final changeset of https://github.com/Drenso/symfony-oidc/compare/master...618d2b348ee4cb76cc80f12da96e1b2632ba84ab for the upgrade from cs-fixer 3.8 to 3.9.

For another (private) repository it reverted a couple of thousand undesired continuation indent changes.