### PR TITLE
feature: separate control of braces after anonymous constructs in BracesFixer

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -146,6 +146,14 @@ List of Available Rules
      | whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions).
      | Allowed values: ``'next'``, ``'same'``
      | Default value: ``'same'``
+   - | ``position_after_anonymous_classes``
+     | whether the opening brace should be placed on "next" or "same" line after anonymous classes. If this option is not set, ``position_after_anonymous_constructs`` setting is used.
+     | Allowed values: ``'next'``, ``'same'``, ``null``
+     | Default value: ``null``
+   - | ``position_after_anonymous_functions``
+     | whether the opening brace should be placed on "next" or "same" line after anonymous lambda functions. If this option is not set, ``position_after_anonymous_constructs`` setting is used.
+     | Allowed values: ``'next'``, ``'same'``, ``null``
+     | Default value: ``null``
 
 
    Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -57,6 +57,28 @@ Allowed values: ``'next'``, ``'same'``
 
 Default value: ``'same'``
 
+``position_after_anonymous_classes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+whether the opening brace should be placed on "next" or "same" line after
+anonymous classes. If this option is not set,
+````position_after_anonymous_constructs```` setting is used.
+
+Allowed values: ``'next'``, ``'same'``, ``null``
+
+Default value: ``null``
+
+``position_after_anonymous_functions``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+whether the opening brace should be placed on "next" or "same" line after
+anonymous lambda functions. If this option is not set,
+````position_after_anonymous_constructs```` setting is used.
+
+Allowed values: ``'next'``, ``'same'``, ``null``
+
+Default value: ``null``
+
 Examples
 --------
 

--- a/src/Fixer/Basic/BracesFixer.php
+++ b/src/Fixer/Basic/BracesFixer.php
@@ -158,9 +158,9 @@ class Foo
         $this->getCurlyBracesPositionFixer()->configure([
             'control_structures_opening_brace' => $this->translatePositionOption($this->configuration['position_after_control_structures']),
             'functions_opening_brace' => $this->translatePositionOption($this->configuration['position_after_functions_and_oop_constructs']),
-            'anonymous_functions_opening_brace' => $this->translatePositionOption($this->configuration['position_after_anonymous_constructs']),
+            'anonymous_functions_opening_brace' => $this->translatePositionOption($this->configuration['position_after_anonymous_functions'] ?? $this->configuration['position_after_anonymous_constructs']),
             'classes_opening_brace' => $this->translatePositionOption($this->configuration['position_after_functions_and_oop_constructs']),
-            'anonymous_classes_opening_brace' => $this->translatePositionOption($this->configuration['position_after_anonymous_constructs']),
+            'anonymous_classes_opening_brace' => $this->translatePositionOption($this->configuration['position_after_anonymous_classes'] ?? $this->configuration['position_after_anonymous_constructs']),
             'allow_single_line_empty_anonymous_classes' => $this->configuration['allow_single_line_anonymous_class_with_empty_body'],
             'allow_single_line_anonymous_functions' => $this->configuration['allow_single_line_closure'],
         ]);
@@ -221,6 +221,14 @@ class Foo
             (new FixerOptionBuilder('position_after_anonymous_constructs', 'whether the opening brace should be placed on "next" or "same" line after anonymous constructs (anonymous classes and lambda functions).'))
                 ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME])
                 ->setDefault(self::LINE_SAME)
+                ->getOption(),
+            (new FixerOptionBuilder('position_after_anonymous_classes', 'whether the opening brace should be placed on "next" or "same" line after anonymous classes. If this option is not set, ``position_after_anonymous_constructs`` setting is used.'))
+                ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME, null])
+                ->setDefault(null)
+                ->getOption(),
+            (new FixerOptionBuilder('position_after_anonymous_functions', 'whether the opening brace should be placed on "next" or "same" line after anonymous lambda functions. If this option is not set, ``position_after_anonymous_constructs`` setting is used.'))
+                ->setAllowedValues([self::LINE_NEXT, self::LINE_SAME, null])
+                ->setDefault(null)
                 ->getOption(),
         ]);
     }
@@ -581,11 +589,12 @@ class Foo
                 || (
                     self::LINE_NEXT === $this->configuration['position_after_control_structures'] && $token->isGivenKind($controlTokens)
                     || (
-                        self::LINE_NEXT === $this->configuration['position_after_anonymous_constructs']
-                        && (
-                            $token->isGivenKind(T_FUNCTION) && $tokensAnalyzer->isLambda($index)
-                            || $token->isGivenKind(T_CLASS) && $tokensAnalyzer->isAnonymousClass($index)
-                        )
+                        self::LINE_NEXT === ($this->configuration['position_after_anonymous_classes'] ?? $this->configuration['position_after_anonymous_constructs'])
+                        && $token->isGivenKind(T_CLASS) && $tokensAnalyzer->isAnonymousClass($index)
+                    )
+                    || (
+                        self::LINE_NEXT === ($this->configuration['position_after_anonymous_functions'] ?? $this->configuration['position_after_anonymous_constructs'])
+                        && $token->isGivenKind(T_FUNCTION) && $tokensAnalyzer->isLambda($index)
                     )
                 )
             ) {

--- a/tests/Fixer/Basic/BracesFixerTest.php
+++ b/tests/Fixer/Basic/BracesFixerTest.php
@@ -5662,4 +5662,152 @@ break;
  case Bar = "bar";}',
         ];
     }
+
+    /**
+     * @dataProvider provideFixAnonymousStructuresCases
+     *
+     * @param string[] $configuration
+     */
+    public function testFixAnonymousStructures(string $expected, ?string $input = null, array $configuration = []): void
+    {
+        $this->fixer->configure($configuration);
+
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFixAnonymousStructuresCases(): iterable
+    {
+        yield 'next-same-next' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar {
+    private $x;
+};
+$bar = function($a)
+{
+    echo $a;
+};
+',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar { private $x;
+};
+$bar = function($a) { echo $a; };
+',
+            [
+                'position_after_anonymous_constructs' => 'next',
+                'position_after_anonymous_classes' => 'same',
+                'position_after_anonymous_functions' => 'next',
+            ],
+        ];
+
+        yield 'next-same-same' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar {
+    private $x;
+};
+$bar = function($a) {
+    echo $a;
+};
+',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar { private $x;
+};
+$bar = function($a) { echo $a; };
+',
+            [
+                'position_after_anonymous_constructs' => 'next',
+                'position_after_anonymous_classes' => 'same',
+                'position_after_anonymous_functions' => 'same',
+            ],
+        ];
+
+        yield 'same-next-next' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar
+{
+    private $x;
+};
+$bar = function($a)
+{
+    echo $a;
+};
+',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar { private $x;
+};
+$bar = function($a) { echo $a; };
+',
+            [
+                'position_after_anonymous_constructs' => 'same',
+                'position_after_anonymous_classes' => 'next',
+                'position_after_anonymous_functions' => 'next',
+            ],
+        ];
+
+        yield 'next-same-null' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar {
+    private $x;
+};',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar
+{
+private $x;
+};',
+            [
+                'position_after_anonymous_constructs' => 'next',
+                'position_after_anonymous_classes' => 'same',
+            ],
+        ];
+
+        yield 'same-next-null' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar
+{
+    private $x;
+    function fooBar($fo,$bar,array $baz,$qux)
+    {
+        parent::fooBar($fo,$bar,$baz,$qux);
+        $this->x = function ($foo) {
+            return $bar + $baz;
+        };
+    }
+};',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar {
+private $x;
+function fooBar($fo,$bar,array $baz,$qux){
+parent::fooBar($fo,$bar,$baz,$qux);
+$this->x = function ($foo) { return $bar + $baz;
+};}};',
+            [
+                'position_after_anonymous_constructs' => 'same',
+                'position_after_anonymous_classes' => 'next',
+            ],
+        ];
+
+        yield 'single-line-closure' => [
+            '<?php
+$foo = new class ($a) extends Foo implements Bar
+{
+    private $x;
+    function fooBar($fo,$bar,array $baz,$qux)
+    {
+        parent::fooBar($fo,$bar,$baz,$qux);
+        $this->x = function ($foo) { return $bar + $baz; };
+    }
+};',
+            '<?php
+$foo = new class ($a) extends Foo implements Bar
+{ private $x;
+function fooBar($fo,$bar,array $baz,$qux){
+parent::fooBar($fo,$bar,$baz,$qux);
+$this->x = function ($foo) { return $bar + $baz; };
+}};',
+            [
+                'allow_single_line_closure' => true,
+                'position_after_anonymous_constructs' => 'next',
+                'position_after_anonymous_functions' => 'same',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Add two "optional" options that give more control of how braces are positioned:

 - ``position_after_anonymous_classes`` - whether the opening brace should be placed on "next" or "same" line after anonymous classes. If not set, ``position_after_anonymous_constructs`` setting is used.

 - ``position_after_anonymous_functions``- whether the opening brace should be placed on "next" or "same" line after anonymous lambda functions. If not set, ``position_after_anonymous_constructs`` setting is used.

To meet **Laravel** braces code style criteria configure fixer with:
```php
[ 
'allow_single_line_anonymous_class_with_empty_body' => false,
'allow_single_line_closure' => false,
'position_after_functions_and_oop_constructs' => 'next',
'position_after_control_structures' => 'same',
'position_after_anonymous_classes' => 'next',
'position_after_anonymous_functions' => 'same',
]
```

----------------------------------
Yes, I know, BracesFixer is going to be deprecated but this PR does small changes and brings very helpful capability. At least for Laravel developers. ;-)
