### PR TITLE
feature: Introduce PER set

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -88,14 +88,14 @@ List of Available Rules
 
    There MUST be one blank line after the namespace declaration.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\NamespaceNotation\\BlankLineAfterNamespaceFixer <./../src/Fixer/NamespaceNotation/BlankLineAfterNamespaceFixer.php>`_
 -  `blank_line_after_opening_tag <./rules/php_tag/blank_line_after_opening_tag.rst>`_
 
    Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\PhpTag\\BlankLineAfterOpeningTagFixer <./../src/Fixer/PhpTag/BlankLineAfterOpeningTagFixer.php>`_
 -  `blank_line_before_statement <./rules/whitespace/blank_line_before_statement.rst>`_
@@ -117,7 +117,7 @@ List of Available Rules
 
    Putting blank lines between ``use`` statement groups.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\BlankLineBetweenImportGroupsFixer <./../src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php>`_
 -  `braces <./rules/basic/braces.rst>`_
@@ -148,7 +148,7 @@ List of Available Rules
      | Default value: ``'same'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Basic\\BracesFixer <./../src/Fixer/Basic/BracesFixer.php>`_
 -  `cast_spaces <./rules/cast_notation/cast_spaces.rst>`_
@@ -209,7 +209,7 @@ List of Available Rules
      | Default value: ``true``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\ClassDefinitionFixer <./../src/Fixer/ClassNotation/ClassDefinitionFixer.php>`_
 -  `class_keyword_remove <./rules/language_construct/class_keyword_remove.rst>`_
@@ -280,7 +280,7 @@ List of Available Rules
 
    Rule is applied only in a PHP 7.1+ environment.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\CompactNullableTypehintFixer <./../src/Fixer/Whitespace/CompactNullableTypehintFixer.php>`_
 -  `concat_space <./rules/operator/concat_space.rst>`_
@@ -310,7 +310,7 @@ List of Available Rules
      | Default value: ``'lower'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Casing\\ConstantCaseFixer <./../src/Fixer/Casing/ConstantCaseFixer.php>`_
 -  `control_structure_braces <./rules/control_structure/control_structure_braces.rst>`_
@@ -400,7 +400,7 @@ List of Available Rules
      | Default value: ``'none'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\LanguageConstruct\\DeclareEqualNormalizeFixer <./../src/Fixer/LanguageConstruct/DeclareEqualNormalizeFixer.php>`_
 -  `declare_parentheses <./rules/language_construct/declare_parentheses.rst>`_
@@ -562,7 +562,7 @@ List of Available Rules
 
    The keyword ``elseif`` should be used instead of ``else if`` so that all control keywords look like single words.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\ElseifFixer <./../src/Fixer/ControlStructure/ElseifFixer.php>`_
 -  `empty_loop_body <./rules/control_structure/empty_loop_body.rst>`_
@@ -599,7 +599,7 @@ List of Available Rules
 
    PHP code MUST use only UTF-8 without BOM (remove BOM).
 
-   Part of rule sets `@PSR1 <./ruleSets/PSR1.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR1 <./ruleSets/PSR1.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Basic\\EncodingFixer <./../src/Fixer/Basic/EncodingFixer.php>`_
 -  `ereg_to_preg <./rules/alias/ereg_to_preg.rst>`_
@@ -789,7 +789,7 @@ List of Available Rules
 
    PHP code must use the long ``<?php`` tags or short-echo ``<?=`` tags and not other tag variations.
 
-   Part of rule sets `@PSR1 <./ruleSets/PSR1.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR1 <./ruleSets/PSR1.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\PhpTag\\FullOpeningTagFixer <./../src/Fixer/PhpTag/FullOpeningTagFixer.php>`_
 -  `function_declaration <./rules/function_notation/function_declaration.rst>`_
@@ -808,7 +808,7 @@ List of Available Rules
      | Default value: ``false``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\FunctionDeclarationFixer <./../src/Fixer/FunctionNotation/FunctionDeclarationFixer.php>`_
 -  `function_to_constant <./rules/language_construct/function_to_constant.rst>`_
@@ -992,7 +992,7 @@ List of Available Rules
 
    Code MUST use configured indentation type.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\IndentationTypeFixer <./../src/Fixer/Whitespace/IndentationTypeFixer.php>`_
 -  `integer_literal_case <./rules/casing/integer_literal_case.rst>`_
@@ -1029,7 +1029,7 @@ List of Available Rules
 
    All PHP files must use same line ending.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\LineEndingFixer <./../src/Fixer/Whitespace/LineEndingFixer.php>`_
 -  `list_syntax <./rules/list_notation/list_syntax.rst>`_
@@ -1061,21 +1061,21 @@ List of Available Rules
 
    Cast should be written in lower case.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\CastNotation\\LowercaseCastFixer <./../src/Fixer/CastNotation/LowercaseCastFixer.php>`_
 -  `lowercase_keywords <./rules/casing/lowercase_keywords.rst>`_
 
    PHP keywords MUST be in lower case.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Casing\\LowercaseKeywordsFixer <./../src/Fixer/Casing/LowercaseKeywordsFixer.php>`_
 -  `lowercase_static_reference <./rules/casing/lowercase_static_reference.rst>`_
 
    Class static references ``self``, ``static`` and ``parent`` MUST be in lower case.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Casing\\LowercaseStaticReferenceFixer <./../src/Fixer/Casing/LowercaseStaticReferenceFixer.php>`_
 -  `magic_constant_casing <./rules/casing/magic_constant_casing.rst>`_
@@ -1120,7 +1120,7 @@ List of Available Rules
      | Default value: ``false``
 
 
-   Part of rule sets `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\MethodArgumentSpaceFixer <./../src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php>`_
 -  `method_chaining_indentation <./rules/whitespace/method_chaining_indentation.rst>`_
@@ -1264,7 +1264,7 @@ List of Available Rules
      | Default value: ``true``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Operator\\NewWithBracesFixer <./../src/Fixer/Operator/NewWithBracesFixer.php>`_
 -  `non_printable_character <./rules/basic/non_printable_character.rst>`_
@@ -1370,7 +1370,7 @@ List of Available Rules
 
    There should be no empty lines after class opening brace.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\NoBlankLinesAfterClassOpeningFixer <./../src/Fixer/ClassNotation/NoBlankLinesAfterClassOpeningFixer.php>`_
 -  `no_blank_lines_after_phpdoc <./rules/phpdoc/no_blank_lines_after_phpdoc.rst>`_
@@ -1400,14 +1400,14 @@ List of Available Rules
      | Default value: ``'no break'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\NoBreakCommentFixer <./../src/Fixer/ControlStructure/NoBreakCommentFixer.php>`_
 -  `no_closing_tag <./rules/php_tag/no_closing_tag.rst>`_
 
    The closing ``?>`` tag MUST be omitted from files containing only PHP.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\PhpTag\\NoClosingTagFixer <./../src/Fixer/PhpTag/NoClosingTagFixer.php>`_
 -  `no_empty_comment <./rules/comment/no_empty_comment.rst>`_
@@ -1460,7 +1460,7 @@ List of Available Rules
 
    Remove leading slashes in ``use`` clauses.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Import\\NoLeadingImportSlashFixer <./../src/Fixer/Import/NoLeadingImportSlashFixer.php>`_
 -  `no_leading_namespace_whitespace <./rules/namespace_notation/no_leading_namespace_whitespace.rst>`_
@@ -1532,7 +1532,7 @@ List of Available Rules
 
    When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\NoSpacesAfterFunctionNameFixer <./../src/Fixer/FunctionNotation/NoSpacesAfterFunctionNameFixer.php>`_
 -  `no_spaces_around_offset <./rules/whitespace/no_spaces_around_offset.rst>`_
@@ -1554,14 +1554,14 @@ List of Available Rules
 
    There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\NoSpacesInsideParenthesisFixer <./../src/Fixer/Whitespace/NoSpacesInsideParenthesisFixer.php>`_
 -  `no_space_around_double_colon <./rules/operator/no_space_around_double_colon.rst>`_
 
    There must be no space around double colons (also called Scope Resolution Operator or Paamayim Nekudotayim).
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Operator\\NoSpaceAroundDoubleColonFixer <./../src/Fixer/Operator/NoSpaceAroundDoubleColonFixer.php>`_
 -  `no_superfluous_elseif <./rules/control_structure/no_superfluous_elseif.rst>`_
@@ -1619,14 +1619,14 @@ List of Available Rules
 
    Remove trailing whitespace at the end of non-blank lines.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\NoTrailingWhitespaceFixer <./../src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php>`_
 -  `no_trailing_whitespace_in_comment <./rules/comment/no_trailing_whitespace_in_comment.rst>`_
 
    There MUST be no trailing spaces inside comment or PHPDoc.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Comment\\NoTrailingWhitespaceInCommentFixer <./../src/Fixer/Comment/NoTrailingWhitespaceInCommentFixer.php>`_
 -  `no_trailing_whitespace_in_string <./rules/string_notation/no_trailing_whitespace_in_string.rst>`_
@@ -1636,7 +1636,7 @@ List of Available Rules
    *warning risky* Changing the whitespaces in strings might affect string comparisons and
    outputs.
 
-   Part of rule sets `@PSR12:risky <./ruleSets/PSR12Risky.rst>`_ `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_ `@Symfony:risky <./ruleSets/SymfonyRisky.rst>`_
+   Part of rule sets `@PER:risky <./ruleSets/PERRisky.rst>`_ `@PSR12:risky <./ruleSets/PSR12Risky.rst>`_ `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_ `@Symfony:risky <./ruleSets/SymfonyRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\StringNotation\\NoTrailingWhitespaceInStringFixer <./../src/Fixer/StringNotation/NoTrailingWhitespaceInStringFixer.php>`_
 -  `no_unneeded_control_parentheses <./rules/control_structure/no_unneeded_control_parentheses.rst>`_
@@ -1701,7 +1701,7 @@ List of Available Rules
    as some Symfony components) that rely on those (for example through
    reflection).
 
-   Part of rule sets `@PHP80Migration:risky <./ruleSets/PHP80MigrationRisky.rst>`_ `@PSR12:risky <./ruleSets/PSR12Risky.rst>`_ `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_
+   Part of rule sets `@PER:risky <./ruleSets/PERRisky.rst>`_ `@PHP80Migration:risky <./ruleSets/PHP80MigrationRisky.rst>`_ `@PSR12:risky <./ruleSets/PSR12Risky.rst>`_ `@PhpCsFixer:risky <./ruleSets/PhpCsFixerRisky.rst>`_
 
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\NoUnreachableDefaultArgumentValueFixer <./../src/Fixer/FunctionNotation/NoUnreachableDefaultArgumentValueFixer.php>`_
 -  `no_unset_cast <./rules/cast_notation/no_unset_cast.rst>`_
@@ -1780,7 +1780,7 @@ List of Available Rules
 
    Remove trailing whitespace at the end of blank lines.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\NoWhitespaceInBlankLineFixer <./../src/Fixer/Whitespace/NoWhitespaceInBlankLineFixer.php>`_
 -  `nullable_type_declaration_for_default_null_value <./rules/function_notation/nullable_type_declaration_for_default_null_value.rst>`_
@@ -1847,7 +1847,7 @@ List of Available Rules
      | Default value: ``'none'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\OrderedClassElementsFixer <./../src/Fixer/ClassNotation/OrderedClassElementsFixer.php>`_
 -  `ordered_imports <./rules/import/ordered_imports.rst>`_
@@ -1866,7 +1866,7 @@ List of Available Rules
      | Default value: ``null``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Import\\OrderedImportsFixer <./../src/Fixer/Import/OrderedImportsFixer.php>`_
 -  `ordered_interfaces <./rules/class_notation/ordered_interfaces.rst>`_
@@ -2628,7 +2628,7 @@ List of Available Rules
      | Default value: ``'none'``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\FunctionNotation\\ReturnTypeDeclarationFixer <./../src/Fixer/FunctionNotation/ReturnTypeDeclarationFixer.php>`_
 -  `self_accessor <./rules/class_notation/self_accessor.rst>`_
@@ -2667,7 +2667,7 @@ List of Available Rules
 
    Cast ``(boolean)`` and ``(integer)`` should be written as ``(bool)`` and ``(int)``, ``(double)`` and ``(real)`` as ``(float)``, ``(binary)`` as ``(string)``.
 
-   Part of rule sets `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\CastNotation\\ShortScalarCastFixer <./../src/Fixer/CastNotation/ShortScalarCastFixer.php>`_
 -  `simple_to_complex_string_variable <./rules/string_notation/simple_to_complex_string_variable.rst>`_
@@ -2694,14 +2694,14 @@ List of Available Rules
 
    A PHP file without end tag must always end with a single empty line feed.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Whitespace\\SingleBlankLineAtEofFixer <./../src/Fixer/Whitespace/SingleBlankLineAtEofFixer.php>`_
 -  `single_blank_line_before_namespace <./rules/namespace_notation/single_blank_line_before_namespace.rst>`_
 
    There should be exactly one blank line before a namespace declaration.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\NamespaceNotation\\SingleBlankLineBeforeNamespaceFixer <./../src/Fixer/NamespaceNotation/SingleBlankLineBeforeNamespaceFixer.php>`_
 -  `single_class_element_per_statement <./rules/class_notation/single_class_element_per_statement.rst>`_
@@ -2716,7 +2716,7 @@ List of Available Rules
      | Default value: ``['const', 'property']``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\SingleClassElementPerStatementFixer <./../src/Fixer/ClassNotation/SingleClassElementPerStatementFixer.php>`_
 -  `single_import_per_statement <./rules/import/single_import_per_statement.rst>`_
@@ -2731,14 +2731,14 @@ List of Available Rules
      | Default value: ``true``
 
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Import\\SingleImportPerStatementFixer <./../src/Fixer/Import/SingleImportPerStatementFixer.php>`_
 -  `single_line_after_imports <./rules/import/single_line_after_imports.rst>`_
 
    Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Import\\SingleLineAfterImportsFixer <./../src/Fixer/Import/SingleLineAfterImportsFixer.php>`_
 -  `single_line_comment_spacing <./rules/comment/single_line_comment_spacing.rst>`_
@@ -2804,7 +2804,7 @@ List of Available Rules
 
    Each trait ``use`` must be done as single statement.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\SingleTraitInsertPerStatementFixer <./../src/Fixer/ClassNotation/SingleTraitInsertPerStatementFixer.php>`_
 -  `space_after_semicolon <./rules/semicolon/space_after_semicolon.rst>`_
@@ -2894,14 +2894,14 @@ List of Available Rules
 
    A case should be followed by a colon and not a semicolon.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\SwitchCaseSemicolonToColonFixer <./../src/Fixer/ControlStructure/SwitchCaseSemicolonToColonFixer.php>`_
 -  `switch_case_space <./rules/control_structure/switch_case_space.rst>`_
 
    Removes extra spaces between colon and case value.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ControlStructure\\SwitchCaseSpaceFixer <./../src/Fixer/ControlStructure/SwitchCaseSpaceFixer.php>`_
 -  `switch_continue_to_break <./rules/control_structure/switch_continue_to_break.rst>`_
@@ -2915,7 +2915,7 @@ List of Available Rules
 
    Standardize spaces around ternary operator.
 
-   Part of rule sets `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\Operator\\TernaryOperatorSpacesFixer <./../src/Fixer/Operator/TernaryOperatorSpacesFixer.php>`_
 -  `ternary_to_elvis_operator <./rules/operator/ternary_to_elvis_operator.rst>`_
@@ -3008,7 +3008,7 @@ List of Available Rules
      | Default value: ``['property', 'method', 'const']``
 
 
-   Part of rule sets `@PHP71Migration <./ruleSets/PHP71Migration.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+   Part of rule sets `@PER <./ruleSets/PER.rst>`_ `@PHP71Migration <./ruleSets/PHP71Migration.rst>`_ `@PHP73Migration <./ruleSets/PHP73Migration.rst>`_ `@PHP74Migration <./ruleSets/PHP74Migration.rst>`_ `@PHP80Migration <./ruleSets/PHP80Migration.rst>`_ `@PHP81Migration <./ruleSets/PHP81Migration.rst>`_ `@PSR12 <./ruleSets/PSR12.rst>`_ `@PSR2 <./ruleSets/PSR2.rst>`_ `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
 
    `Source PhpCsFixer\\Fixer\\ClassNotation\\VisibilityRequiredFixer <./../src/Fixer/ClassNotation/VisibilityRequiredFixer.php>`_
 -  `void_return <./rules/function_notation/void_return.rst>`_

--- a/doc/ruleSets/PER.rst
+++ b/doc/ruleSets/PER.rst
@@ -1,0 +1,10 @@
+=================
+Rule set ``@PER``
+=================
+
+Rules that follow `PER Coding Style <https://www.php-fig.org/per/coding-style/>`_.
+
+Rules
+-----
+
+- `@PSR12 <./PSR12.rst>`_

--- a/doc/ruleSets/PERRisky.rst
+++ b/doc/ruleSets/PERRisky.rst
@@ -1,0 +1,10 @@
+=======================
+Rule set ``@PER:risky``
+=======================
+
+Rules that follow `PER Coding Style <https://www.php-fig.org/per/coding-style/>`_. This set contains rules that are risky.
+
+Rules
+-----
+
+- `@PSR12:risky <./PSR12Risky.rst>`_

--- a/doc/ruleSets/PhpCsFixer.rst
+++ b/doc/ruleSets/PhpCsFixer.rst
@@ -7,6 +7,7 @@ Rule set as used by the PHP-CS-Fixer development team, highly opinionated.
 Rules
 -----
 
+- `@PER <./PER.rst>`_
 - `@Symfony <./Symfony.rst>`_
 - `align_multiline_comment <./../rules/phpdoc/align_multiline_comment.rst>`_
 - `array_indentation <./../rules/whitespace/array_indentation.rst>`_

--- a/doc/ruleSets/PhpCsFixerRisky.rst
+++ b/doc/ruleSets/PhpCsFixerRisky.rst
@@ -7,6 +7,7 @@ Rule set as used by the PHP-CS-Fixer development team, highly opinionated. This 
 Rules
 -----
 
+- `@PER:risky <./PERRisky.rst>`_
 - `@Symfony:risky <./SymfonyRisky.rst>`_
 - `comment_to_phpdoc <./../rules/comment/comment_to_phpdoc.rst>`_
 - `final_internal_class <./../rules/class_notation/final_internal_class.rst>`_

--- a/doc/ruleSets/index.rst
+++ b/doc/ruleSets/index.rst
@@ -2,6 +2,8 @@
 List of Available Rule sets
 ===========================
 - `@DoctrineAnnotation <./DoctrineAnnotation.rst>`_
+- `@PER <./PER.rst>`_
+- `@PER:risky <./PERRisky.rst>`_
 - `@PHP54Migration <./PHP54Migration.rst>`_
 - `@PHP56Migration:risky <./PHP56MigrationRisky.rst>`_
 - `@PHP70Migration <./PHP70Migration.rst>`_

--- a/doc/rules/basic/braces.rst
+++ b/doc/rules/basic/braces.rst
@@ -179,6 +179,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``braces`` rule with the config below:
+
+  ``['allow_single_line_anonymous_class_with_empty_body' => true]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``braces`` rule with the config below:
 

--- a/doc/rules/basic/encoding.rst
+++ b/doc/rules/basic/encoding.rst
@@ -24,6 +24,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``encoding`` rule.
+
 @PSR1
   Using the `@PSR1 <./../../ruleSets/PSR1.rst>`_ rule set will enable the ``encoding`` rule.
 

--- a/doc/rules/casing/constant_case.rst
+++ b/doc/rules/casing/constant_case.rst
@@ -58,6 +58,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``constant_case`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``constant_case`` rule with the default config.
 

--- a/doc/rules/casing/lowercase_keywords.rst
+++ b/doc/rules/casing/lowercase_keywords.rst
@@ -38,6 +38,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``lowercase_keywords`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``lowercase_keywords`` rule.
 

--- a/doc/rules/casing/lowercase_static_reference.rst
+++ b/doc/rules/casing/lowercase_static_reference.rst
@@ -59,6 +59,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``lowercase_static_reference`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``lowercase_static_reference`` rule.
 

--- a/doc/rules/cast_notation/lowercase_cast.rst
+++ b/doc/rules/cast_notation/lowercase_cast.rst
@@ -80,6 +80,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``lowercase_cast`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``lowercase_cast`` rule.
 

--- a/doc/rules/cast_notation/short_scalar_cast.rst
+++ b/doc/rules/cast_notation/short_scalar_cast.rst
@@ -52,6 +52,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``short_scalar_cast`` rule.
+
 @PHP74Migration
   Using the `@PHP74Migration <./../../ruleSets/PHP74Migration.rst>`_ rule set will enable the ``short_scalar_cast`` rule.
 

--- a/doc/rules/class_notation/class_definition.rst
+++ b/doc/rules/class_notation/class_definition.rst
@@ -172,6 +172,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``class_definition`` rule with the config below:
+
+  ``['inline_constructor_arguments' => false, 'space_before_parenthesis' => true]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``class_definition`` rule with the config below:
 

--- a/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
+++ b/doc/rules/class_notation/no_blank_lines_after_class_opening.rst
@@ -28,6 +28,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_blank_lines_after_class_opening`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_blank_lines_after_class_opening`` rule.
 

--- a/doc/rules/class_notation/ordered_class_elements.rst
+++ b/doc/rules/class_notation/ordered_class_elements.rst
@@ -119,6 +119,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``ordered_class_elements`` rule with the config below:
+
+  ``['order' => ['use_trait']]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``ordered_class_elements`` rule with the config below:
 

--- a/doc/rules/class_notation/single_class_element_per_statement.rst
+++ b/doc/rules/class_notation/single_class_element_per_statement.rst
@@ -62,6 +62,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_class_element_per_statement`` rule with the config below:
+
+  ``['elements' => ['property']]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_class_element_per_statement`` rule with the config below:
 

--- a/doc/rules/class_notation/single_trait_insert_per_statement.rst
+++ b/doc/rules/class_notation/single_trait_insert_per_statement.rst
@@ -26,6 +26,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_trait_insert_per_statement`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_trait_insert_per_statement`` rule.
 

--- a/doc/rules/class_notation/visibility_required.rst
+++ b/doc/rules/class_notation/visibility_required.rst
@@ -65,6 +65,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
+
 @PHP71Migration
   Using the `@PHP71Migration <./../../ruleSets/PHP71Migration.rst>`_ rule set will enable the ``visibility_required`` rule with the default config.
 

--- a/doc/rules/comment/no_trailing_whitespace_in_comment.rst
+++ b/doc/rules/comment/no_trailing_whitespace_in_comment.rst
@@ -25,6 +25,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_trailing_whitespace_in_comment`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_trailing_whitespace_in_comment`` rule.
 

--- a/doc/rules/control_structure/elseif.rst
+++ b/doc/rules/control_structure/elseif.rst
@@ -26,6 +26,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``elseif`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``elseif`` rule.
 

--- a/doc/rules/control_structure/no_break_comment.rst
+++ b/doc/rules/control_structure/no_break_comment.rst
@@ -71,6 +71,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_break_comment`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_break_comment`` rule with the default config.
 

--- a/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
+++ b/doc/rules/control_structure/switch_case_semicolon_to_colon.rst
@@ -29,6 +29,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``switch_case_semicolon_to_colon`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``switch_case_semicolon_to_colon`` rule.
 

--- a/doc/rules/control_structure/switch_case_space.rst
+++ b/doc/rules/control_structure/switch_case_space.rst
@@ -29,6 +29,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``switch_case_space`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``switch_case_space`` rule.
 

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -85,6 +85,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``function_declaration`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``function_declaration`` rule with the default config.
 

--- a/doc/rules/function_notation/method_argument_space.rst
+++ b/doc/rules/function_notation/method_argument_space.rst
@@ -209,6 +209,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``method_argument_space`` rule with the config below:
+
+  ``['on_multiline' => 'ensure_fully_multiline']``
+
 @PHP73Migration
   Using the `@PHP73Migration <./../../ruleSets/PHP73Migration.rst>`_ rule set will enable the ``method_argument_space`` rule with the config below:
 

--- a/doc/rules/function_notation/no_spaces_after_function_name.rst
+++ b/doc/rules/function_notation/no_spaces_after_function_name.rst
@@ -30,6 +30,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_spaces_after_function_name`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_spaces_after_function_name`` rule.
 

--- a/doc/rules/function_notation/no_unreachable_default_argument_value.rst
+++ b/doc/rules/function_notation/no_unreachable_default_argument_value.rst
@@ -33,6 +33,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER:risky
+  Using the `@PER:risky <./../../ruleSets/PERRisky.rst>`_ rule set will enable the ``no_unreachable_default_argument_value`` rule.
+
 @PHP80Migration:risky
   Using the `@PHP80Migration:risky <./../../ruleSets/PHP80MigrationRisky.rst>`_ rule set will enable the ``no_unreachable_default_argument_value`` rule.
 

--- a/doc/rules/function_notation/return_type_declaration.rst
+++ b/doc/rules/function_notation/return_type_declaration.rst
@@ -68,6 +68,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``return_type_declaration`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``return_type_declaration`` rule with the default config.
 

--- a/doc/rules/import/no_leading_import_slash.rst
+++ b/doc/rules/import/no_leading_import_slash.rst
@@ -24,6 +24,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_leading_import_slash`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_leading_import_slash`` rule.
 

--- a/doc/rules/import/ordered_imports.rst
+++ b/doc/rules/import/ordered_imports.rst
@@ -137,6 +137,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``ordered_imports`` rule with the config below:
+
+  ``['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'none']``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``ordered_imports`` rule with the config below:
 

--- a/doc/rules/import/single_import_per_statement.rst
+++ b/doc/rules/import/single_import_per_statement.rst
@@ -58,6 +58,11 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_import_per_statement`` rule with the config below:
+
+  ``['group_to_single_imports' => false]``
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_import_per_statement`` rule with the config below:
 

--- a/doc/rules/import/single_line_after_imports.rst
+++ b/doc/rules/import/single_line_after_imports.rst
@@ -48,6 +48,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_line_after_imports`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_line_after_imports`` rule.
 

--- a/doc/rules/language_construct/declare_equal_normalize.rst
+++ b/doc/rules/language_construct/declare_equal_normalize.rst
@@ -51,6 +51,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``declare_equal_normalize`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``declare_equal_normalize`` rule with the default config.
 

--- a/doc/rules/namespace_notation/blank_line_after_namespace.rst
+++ b/doc/rules/namespace_notation/blank_line_after_namespace.rst
@@ -37,6 +37,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``blank_line_after_namespace`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``blank_line_after_namespace`` rule.
 

--- a/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
+++ b/doc/rules/namespace_notation/single_blank_line_before_namespace.rst
@@ -36,6 +36,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_blank_line_before_namespace`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_blank_line_before_namespace`` rule.
 

--- a/doc/rules/operator/new_with_braces.rst
+++ b/doc/rules/operator/new_with_braces.rst
@@ -77,6 +77,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``new_with_braces`` rule with the default config.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``new_with_braces`` rule with the default config.
 

--- a/doc/rules/operator/no_space_around_double_colon.rst
+++ b/doc/rules/operator/no_space_around_double_colon.rst
@@ -24,6 +24,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_space_around_double_colon`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_space_around_double_colon`` rule.
 

--- a/doc/rules/operator/ternary_operator_spaces.rst
+++ b/doc/rules/operator/ternary_operator_spaces.rst
@@ -22,6 +22,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``ternary_operator_spaces`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``ternary_operator_spaces`` rule.
 

--- a/doc/rules/php_tag/blank_line_after_opening_tag.rst
+++ b/doc/rules/php_tag/blank_line_after_opening_tag.rst
@@ -26,6 +26,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``blank_line_after_opening_tag`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``blank_line_after_opening_tag`` rule.
 

--- a/doc/rules/php_tag/full_opening_tag.rst
+++ b/doc/rules/php_tag/full_opening_tag.rst
@@ -25,6 +25,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``full_opening_tag`` rule.
+
 @PSR1
   Using the `@PSR1 <./../../ruleSets/PSR1.rst>`_ rule set will enable the ``full_opening_tag`` rule.
 

--- a/doc/rules/php_tag/no_closing_tag.rst
+++ b/doc/rules/php_tag/no_closing_tag.rst
@@ -27,6 +27,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_closing_tag`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_closing_tag`` rule.
 

--- a/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
+++ b/doc/rules/string_notation/no_trailing_whitespace_in_string.rst
@@ -33,6 +33,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER:risky
+  Using the `@PER:risky <./../../ruleSets/PERRisky.rst>`_ rule set will enable the ``no_trailing_whitespace_in_string`` rule.
+
 @PSR12:risky
   Using the `@PSR12:risky <./../../ruleSets/PSR12Risky.rst>`_ rule set will enable the ``no_trailing_whitespace_in_string`` rule.
 

--- a/doc/rules/whitespace/blank_line_between_import_groups.rst
+++ b/doc/rules/whitespace/blank_line_between_import_groups.rst
@@ -84,6 +84,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``blank_line_between_import_groups`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``blank_line_between_import_groups`` rule.
 

--- a/doc/rules/whitespace/compact_nullable_typehint.rst
+++ b/doc/rules/whitespace/compact_nullable_typehint.rst
@@ -29,6 +29,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``compact_nullable_typehint`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``compact_nullable_typehint`` rule.
 

--- a/doc/rules/whitespace/indentation_type.rst
+++ b/doc/rules/whitespace/indentation_type.rst
@@ -26,6 +26,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``indentation_type`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``indentation_type`` rule.
 

--- a/doc/rules/whitespace/line_ending.rst
+++ b/doc/rules/whitespace/line_ending.rst
@@ -28,6 +28,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``line_ending`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``line_ending`` rule.
 

--- a/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
+++ b/doc/rules/whitespace/no_spaces_inside_parenthesis.rst
@@ -40,6 +40,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_spaces_inside_parenthesis`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_spaces_inside_parenthesis`` rule.
 

--- a/doc/rules/whitespace/no_trailing_whitespace.rst
+++ b/doc/rules/whitespace/no_trailing_whitespace.rst
@@ -23,6 +23,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_trailing_whitespace`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_trailing_whitespace`` rule.
 

--- a/doc/rules/whitespace/no_whitespace_in_blank_line.rst
+++ b/doc/rules/whitespace/no_whitespace_in_blank_line.rst
@@ -24,6 +24,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``no_whitespace_in_blank_line`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``no_whitespace_in_blank_line`` rule.
 

--- a/doc/rules/whitespace/single_blank_line_at_eof.rst
+++ b/doc/rules/whitespace/single_blank_line_at_eof.rst
@@ -35,6 +35,9 @@ Rule sets
 
 The rule is part of the following rule sets:
 
+@PER
+  Using the `@PER <./../../ruleSets/PER.rst>`_ rule set will enable the ``single_blank_line_at_eof`` rule.
+
 @PSR12
   Using the `@PSR12 <./../../ruleSets/PSR12.rst>`_ rule set will enable the ``single_blank_line_at_eof`` rule.
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,6 @@ parameters:
         -
             message: '#^.+no value type specified in iterable type.+\.$#'
             path: *
-            count: 538
+            count: 499
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,6 @@ parameters:
         -
             message: '#^.+no value type specified in iterable type.+\.$#'
             path: *
-            count: 499
+            count: 482
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/src/DocBlock/TypeExpression.php
+++ b/src/DocBlock/TypeExpression.php
@@ -147,8 +147,8 @@ final class TypeExpression
     {
         if ($this->isUnionType) {
             return array_map(
-                static function (array $type) { return $type['expression']->toString(); },
-                $this->innerTypeExpressions
+                static fn (array $type) => $type['expression']->toString(),
+                $this->innerTypeExpressions,
             );
         }
 
@@ -179,8 +179,8 @@ final class TypeExpression
         if ($this->isUnionType) {
             $this->innerTypeExpressions = Utils::stableSort(
                 $this->innerTypeExpressions,
-                static function (array $type): self { return $type['expression']; },
-                $compareCallback
+                static fn (array $type): self => $type['expression'],
+                $compareCallback,
             );
 
             $this->value = implode($this->getTypesGlue(), $this->getTypes());

--- a/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
+++ b/src/Fixer/ConstantNotation/NativeConstantInvocationFixer.php
@@ -161,7 +161,10 @@ namespace {
 
         $caseInsensitiveConstantsToEscape = array_diff(
             array_unique($caseInsensitiveConstantsToEscape),
-            array_map(static function (string $function): string { return strtolower($function); }, $uniqueConfiguredExclude)
+            array_map(
+                static fn (string $function): string => strtolower($function),
+                $uniqueConfiguredExclude,
+            ),
         );
 
         // Store the cache

--- a/src/Fixer/Operator/OperatorLinebreakFixer.php
+++ b/src/Fixer/Operator/OperatorLinebreakFixer.php
@@ -313,7 +313,7 @@ function foo() {
                 [T_POW_EQUAL], [T_SL], [T_SL_EQUAL], [T_SR], [T_SR_EQUAL], [T_XOR_EQUAL],
                 [T_COALESCE], [T_SPACESHIP],
             ],
-            array_map(static function ($id): array { return [$id]; }, Token::getObjectOperatorKinds())
+            array_map(static fn (int $id): array => [$id], Token::getObjectOperatorKinds()),
         );
     }
 }

--- a/src/RuleSet/RuleSet.php
+++ b/src/RuleSet/RuleSet.php
@@ -30,6 +30,8 @@ final class RuleSet implements RuleSetInterface
      *
      * The key is name of rule, value is bool if the rule/set should be used.
      * The key must not point to any set.
+     *
+     * @var array<string, array<string, mixed>|bool>
      */
     private array $rules;
 
@@ -40,10 +42,12 @@ final class RuleSet implements RuleSetInterface
                 throw new \InvalidArgumentException('Rule/set name must not be empty.');
             }
 
+            // @phpstan-ignore-next-line
             if (\is_int($name)) {
                 throw new \InvalidArgumentException(sprintf('Missing value for "%s" rule/set.', $value));
             }
 
+            // @phpstan-ignore-next-line
             if (!\is_bool($value) && !\is_array($value)) {
                 $message = str_starts_with($name, '@') ? 'Set must be enabled (true) or disabled (false). Other values are not allowed.' : 'Rule must be enabled (true), disabled (false) or configured (non-empty, assoc array). Other values are not allowed.';
 
@@ -92,6 +96,8 @@ final class RuleSet implements RuleSetInterface
 
     /**
      * Resolve input set into group of rules.
+     *
+     * @param array<string, array<string, mixed>|bool> $rules
      */
     private function resolveSet(array $rules): void
     {
@@ -122,6 +128,8 @@ final class RuleSet implements RuleSetInterface
      *
      * If set value is false then disable all fixers in set,
      * if not then get value from set item.
+     *
+     * @return array<string, array<string, mixed>|bool>
      */
     private function resolveSubset(string $setName, bool $setValue): array
     {

--- a/src/RuleSet/RuleSetDescriptionInterface.php
+++ b/src/RuleSet/RuleSetDescriptionInterface.php
@@ -25,6 +25,8 @@ interface RuleSetDescriptionInterface
 
     /**
      * Get all rules from rules set.
+     *
+     * @return array<string, array<string, mixed>|bool>
      */
     public function getRules(): array;
 

--- a/src/RuleSet/RuleSetInterface.php
+++ b/src/RuleSet/RuleSetInterface.php
@@ -23,24 +23,27 @@ namespace PhpCsFixer\RuleSet;
  */
 interface RuleSetInterface
 {
+    /**
+     * @param array<string, array<string, mixed>|bool> $set
+     */
     public function __construct(array $set = []);
 
     /**
      * Get configuration for given rule.
      *
-     * @param string $rule name of rule
+     * @return null|array<string, mixed>
      */
     public function getRuleConfiguration(string $rule): ?array;
 
     /**
      * Get all rules from rules set.
+     *
+     * @return array<string, array<string, mixed>|bool>
      */
     public function getRules(): array;
 
     /**
      * Check given rule is in rules set.
-     *
-     * @param string $rule name of rule
      */
     public function hasRule(string $rule): bool;
 }

--- a/src/RuleSet/Sets/PERRiskySet.php
+++ b/src/RuleSet/Sets/PERRiskySet.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\RuleSet\Sets;
+
+use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
+
+/**
+ * @internal
+ *
+ * Last updated to PER Coding Style v1.0.0.
+ */
+final class PERRiskySet extends AbstractRuleSetDescription
+{
+    public function getRules(): array
+    {
+        return [
+            '@PSR12:risky' => true,
+        ];
+    }
+
+    public function getDescription(): string
+    {
+        return 'Rules that follow `PER Coding Style <https://www.php-fig.org/per/coding-style/>`_.';
+    }
+}

--- a/src/RuleSet/Sets/PERSet.php
+++ b/src/RuleSet/Sets/PERSet.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\RuleSet\Sets;
+
+use PhpCsFixer\RuleSet\AbstractRuleSetDescription;
+
+/**
+ * @internal
+ *
+ * Last updated to PER Coding Style v1.0.0.
+ */
+final class PERSet extends AbstractRuleSetDescription
+{
+    public function getRules(): array
+    {
+        return [
+            '@PSR12' => true,
+        ];
+    }
+
+    public function getDescription(): string
+    {
+        return 'Rules that follow `PER Coding Style <https://www.php-fig.org/per/coding-style/>`_.';
+    }
+}

--- a/src/RuleSet/Sets/PhpCsFixerRiskySet.php
+++ b/src/RuleSet/Sets/PhpCsFixerRiskySet.php
@@ -24,6 +24,7 @@ final class PhpCsFixerRiskySet extends AbstractRuleSetDescription
     public function getRules(): array
     {
         return [
+            '@PER:risky' => true,
             '@Symfony:risky' => true,
             'comment_to_phpdoc' => true,
             'final_internal_class' => true,

--- a/src/RuleSet/Sets/PhpCsFixerSet.php
+++ b/src/RuleSet/Sets/PhpCsFixerSet.php
@@ -24,6 +24,7 @@ final class PhpCsFixerSet extends AbstractRuleSetDescription
     public function getRules(): array
     {
         return [
+            '@PER' => true,
             '@Symfony' => true,
             'align_multiline_comment' => true,
             'array_indentation' => true,

--- a/tests/AutoReview/ProjectCodeTest.php
+++ b/tests/AutoReview/ProjectCodeTest.php
@@ -70,7 +70,7 @@ final class ProjectCodeTest extends TestCase
     {
         $unknownClasses = array_filter(
             self::$classesWithoutTests,
-            static function (string $class): bool { return !class_exists($class) && !trait_exists($class); }
+            static fn (string $class): bool => !class_exists($class) && !trait_exists($class),
         );
 
         static::assertSame([], $unknownClasses);
@@ -444,7 +444,7 @@ final class ProjectCodeTest extends TestCase
                 }
             }
 
-            $expected = array_filter($expected, static function ($item): bool { return false !== $item; });
+            $expected = array_filter($expected, static fn ($item): bool => false !== $item);
 
             if (\count($expected) < 2) {
                 $this->addToAssertionCount(1); // not enough parameters to test, all good!
@@ -664,7 +664,7 @@ final class ProjectCodeTest extends TestCase
     public function provideSrcConcreteClassCases(): array
     {
         return array_map(
-            static function (string $item): array { return [$item]; },
+            static fn (string $item): array => [$item],
             array_filter(
                 $this->getSrcClasses(),
                 static function (string $className): bool {

--- a/tests/Console/Command/HelpCommandTest.php
+++ b/tests/Console/Command/HelpCommandTest.php
@@ -77,7 +77,7 @@ final class HelpCommandTest extends TestCase
 
         yield [['A', 'B', 'x', 'z'], new FixerOption('foo', 'bar', false, null, ['string'], ['z', 'x', 'B', 'A'])];
 
-        yield [[0, 3, 9], new FixerOption('foo', 'bar', false, null, ['int'], [0, 3, 9, static function (): void {}])];
+        yield [[0, 3, 9], new FixerOption('foo', 'bar', false, null, ['int'], [0, 3, 9, static fn () => null])];
 
         yield [null, new FixerOption('foo', 'bar')];
     }

--- a/tests/Console/Report/FixReport/JsonReporterTest.php
+++ b/tests/Console/Report/FixReport/JsonReporterTest.php
@@ -168,8 +168,8 @@ JSON;
             implode(
                 "\n",
                 array_map(
-                    static function (array $item): string { return sprintf('Property `%s`: %s.', $item['property'], $item['message']); },
-                    $validator->getErrors()
+                    static fn (array $item): string => sprintf('Property `%s`: %s.', $item['property'], $item['message']),
+                    $validator->getErrors(),
                 )
             )
         );

--- a/tests/Console/Report/ListSetsReport/JsonReporterTest.php
+++ b/tests/Console/Report/ListSetsReport/JsonReporterTest.php
@@ -77,8 +77,8 @@ final class JsonReporterTest extends AbstractReporterTestCase
             implode(
                 "\n",
                 array_map(
-                    static function (array $item): string { return sprintf('Property `%s`: %s.', $item['property'], $item['message']); },
-                    $validator->getErrors()
+                    static fn (array $item): string => sprintf('Property `%s`: %s.', $item['property'], $item['message']),
+                    $validator->getErrors(),
                 )
             )
         );

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -237,8 +237,8 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
             $static ? ' static' : '',
             $method,
             implode(',', array_map(
-                static function (int $n): string { return sprintf('$x%d', $n); },
-                array_keys(array_fill(0, $arguments, true))
+                static fn (int $n): string => sprintf('$x%d', $n),
+                array_keys(array_fill(0, $arguments, true)),
             ))
         ));
 

--- a/tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionBuilderTest.php
@@ -48,7 +48,7 @@ final class AliasedFixerOptionBuilderTest extends TestCase
     public function testSetNormalizer(): void
     {
         $builder = new AliasedFixerOptionBuilder(new FixerOptionBuilder('foo', 'Bar.'), 'baz');
-        static::assertSame($builder, $builder->setNormalizer(static function (): void {}));
+        static::assertSame($builder, $builder->setNormalizer(static fn () => null));
     }
 
     public function testGetOption(): void
@@ -58,7 +58,7 @@ final class AliasedFixerOptionBuilderTest extends TestCase
             ->setDefault('baz')
             ->setAllowedTypes(['bool'])
             ->setAllowedValues([true, false])
-            ->setNormalizer(static function (): void {})
+            ->setNormalizer(static fn () => null)
             ->getOption()
         ;
 

--- a/tests/FixerConfiguration/AliasedFixerOptionTest.php
+++ b/tests/FixerConfiguration/AliasedFixerOptionTest.php
@@ -152,7 +152,7 @@ final class AliasedFixerOptionTest extends TestCase
 
     public function testGetAllowedValuesClosure(): void
     {
-        $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, [static function (): void {}]), 'baz');
+        $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, [static fn () => null]), 'baz');
         $allowedTypes = $option->getAllowedValues();
         static::assertIsArray($allowedTypes);
         static::assertCount(1, $allowedTypes);
@@ -165,7 +165,7 @@ final class AliasedFixerOptionTest extends TestCase
         $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.'), 'baz');
         static::assertNull($option->getNormalizer());
 
-        $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, null, static function (): void {}), 'baz');
+        $option = new AliasedFixerOption(new FixerOption('foo', 'Bar.', true, null, null, null, static fn () => null), 'baz');
         static::assertInstanceOf(\Closure::class, $option->getNormalizer());
     }
 

--- a/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
+++ b/tests/FixerConfiguration/DeprecatedFixerOptionTest.php
@@ -128,7 +128,7 @@ final class DeprecatedFixerOptionTest extends TestCase
 
     public function testGetNormalizer(): void
     {
-        $normalizer = static function (): void {};
+        $normalizer = static fn () => null;
 
         $decoratedOption = $this->prophesize(FixerOptionInterface::class);
         $decoratedOption->getNormalizer()->willReturn($normalizer);

--- a/tests/FixerConfiguration/FixerOptionBuilderTest.php
+++ b/tests/FixerConfiguration/FixerOptionBuilderTest.php
@@ -47,7 +47,7 @@ final class FixerOptionBuilderTest extends TestCase
     public function testSetNormalizer(): void
     {
         $builder = new FixerOptionBuilder('foo', 'Bar.');
-        static::assertSame($builder, $builder->setNormalizer(static function (): void {}));
+        static::assertSame($builder, $builder->setNormalizer(static fn () => null));
     }
 
     public function testGetOption(): void
@@ -57,7 +57,7 @@ final class FixerOptionBuilderTest extends TestCase
             ->setDefault('baz')
             ->setAllowedTypes(['bool'])
             ->setAllowedValues([true, false])
-            ->setNormalizer(static function (): void {})
+            ->setNormalizer(static fn () => null)
             ->getOption()
         ;
 
@@ -67,7 +67,7 @@ final class FixerOptionBuilderTest extends TestCase
             ->setDefault('baz')
             ->setAllowedTypes(['bool'])
             ->setAllowedValues([true, false])
-            ->setNormalizer(static function (): void {})
+            ->setNormalizer(static fn () => null)
             ->setDeprecationMessage('Deprecation message')
             ->getOption()
         ;

--- a/tests/FixerConfiguration/FixerOptionTest.php
+++ b/tests/FixerConfiguration/FixerOptionTest.php
@@ -83,7 +83,7 @@ final class FixerOptionTest extends TestCase
         $option = new FixerOption('foo', 'Bar.', true, null, null, ['baz', 'qux']);
         static::assertSame(['baz', 'qux'], $option->getAllowedValues());
 
-        $option = new FixerOption('foo', 'Bar.', true, null, null, [static function (): void {}]);
+        $option = new FixerOption('foo', 'Bar.', true, null, null, [static fn () => null]);
         $allowedTypes = $option->getAllowedValues();
         static::assertIsArray($allowedTypes);
         static::assertCount(1, $allowedTypes);
@@ -96,7 +96,7 @@ final class FixerOptionTest extends TestCase
         $option = new FixerOption('foo', 'Bar.');
         static::assertNull($option->getNormalizer());
 
-        $option = new FixerOption('foo', 'Bar.', true, null, null, null, static function (): void {});
+        $option = new FixerOption('foo', 'Bar.', true, null, null, null, static fn () => null);
         static::assertInstanceOf(\Closure::class, $option->getNormalizer());
     }
 

--- a/tests/PregTest.php
+++ b/tests/PregTest.php
@@ -201,7 +201,7 @@ final class PregTest extends TestCase
      */
     public function testReplaceCallback($pattern, $subject): void
     {
-        $callback = static function (array $x): string { return implode('-', $x); };
+        $callback = static fn (array $x): string => implode('-', $x);
 
         $expectedResult = preg_replace_callback($pattern, $callback, $subject);
         $actualResult = Preg::replaceCallback($pattern, $callback, $subject);

--- a/tests/RuleSet/RuleSetsTest.php
+++ b/tests/RuleSet/RuleSetsTest.php
@@ -65,6 +65,8 @@ final class RuleSetsTest extends TestCase
     public function testHasIntegrationTest(string $setDefinitionName): void
     {
         $setsWithoutTests = [
+            '@PER',
+            '@PER:risky',
             '@PHP56Migration',
             '@PHP56Migration:risky',
             '@PHP70Migration',

--- a/tests/RuleSet/Sets/PERRiskySetTest.php
+++ b/tests/RuleSet/Sets/PERRiskySetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\RuleSet\Sets;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\RuleSet\Sets\PERRiskySet
+ */
+final class PERRiskySetTest extends AbstractSetTest
+{
+}

--- a/tests/RuleSet/Sets/PERSetTest.php
+++ b/tests/RuleSet/Sets/PERSetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\RuleSet\Sets;
+
+/**
+ * @internal
+ *
+ * @covers \PhpCsFixer\RuleSet\Sets\PERSet
+ */
+final class PERSetTest extends AbstractSetTest
+{
+}

--- a/tests/Test/AbstractTransformerTestCase.php
+++ b/tests/Test/AbstractTransformerTestCase.php
@@ -135,7 +135,10 @@ abstract class AbstractTransformerTestCase extends TestCase
             static::assertStringStartsWith('CT::', CT::getName($customTokenOfTransformer));
         }
 
-        $customTokensOfTransformerList = implode(', ', array_map(static function (int $ct): string { return CT::getName($ct); }, $customTokensOfTransformer));
+        $customTokensOfTransformerList = implode(', ', array_map(
+            static fn (int $ct): string => CT::getName($ct),
+            $customTokensOfTransformer,
+        ));
 
         foreach ($tokens->observedModificationsPerTransformer as $appliedTransformerName => $modificationsOfTransformer) {
             foreach ($modificationsOfTransformer as $modification) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -169,25 +169,25 @@ final class UtilsTest extends TestCase
             [
                 ['a', 'b', 'c', 'd', 'e'],
                 ['b', 'd', 'e', 'a', 'c'],
-                static function ($element) { return $element; },
+                static fn ($element) => $element,
                 'strcmp',
             ],
             [
                 ['b', 'd', 'e', 'a', 'c'],
                 ['b', 'd', 'e', 'a', 'c'],
-                static function (): string { return 'foo'; },
+                static fn (): string => 'foo',
                 'strcmp',
             ],
             [
                 ['b', 'd', 'e', 'a', 'c'],
                 ['b', 'd', 'e', 'a', 'c'],
-                static function ($element) { return $element; },
-                static function (): int { return 0; },
+                static fn ($element) => $element,
+                static fn (): int => 0,
             ],
             [
                 ['bar1', 'baz1', 'foo1', 'bar2', 'baz2', 'foo2'],
                 ['foo1', 'foo2', 'bar1', 'bar2', 'baz1', 'baz2'],
-                static function ($element) { return preg_replace('/([a-z]+)(\d+)/', '$2$1', $element); },
+                static fn ($element) => preg_replace('/([a-z]+)(\d+)/', '$2$1', $element),
                 'strcmp',
             ],
         ];


### PR DESCRIPTION
PHP Evolving Recommendation (PER) is allowed to be updated and versioned, as opposed to PHP Standard Recommendation (PSR). [PER Coding Style](https://www.php-fig.org/per/coding-style/) is meant to be a successor of PSR-12, with v1.0 having the same rules.

This PR introduces a PER rule set, as https://github.com/php-fig/per-coding-style/releases/tag/1.0.0 has been tagged.