### PR TITLE
feature: ability to ignore mixed cases in `PhpUnitMethodCasingFixer`

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -2371,6 +2371,10 @@ List of Available Rules
      | Apply camel or snake case to test methods
      | Allowed values: ``'camel_case'``, ``'snake_case'``
      | Default value: ``'camel_case'``
+   - | ``ignore_mixed_cases``
+     | Ignore mixed cases, i.e. "test_that_FooBar_does_something"
+     | Allowed values: ``false``, ``true``
+     | Default value: ``false``
 
 
    Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_

--- a/doc/rules/php_unit/php_unit_method_casing.rst
+++ b/doc/rules/php_unit/php_unit_method_casing.rst
@@ -16,6 +16,15 @@ Allowed values: ``'camel_case'``, ``'snake_case'``
 
 Default value: ``'camel_case'``
 
+``ignore_mixed_cases``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Ignore mixed cases, i.e. "test_that_FooBar_does_something"
+
+Allowed values: ``false``, ``true``
+
+Default value: ``false``
+
 Examples
 --------
 
@@ -49,6 +58,23 @@ With configuration: ``['case' => 'snake_case']``.
     {
    -    public function testMyCode() {}
    +    public function test_my_code() {}
+    }
+
+Example #3
+~~~~~~~~~~
+
+With configuration: ``['ignore_mixed_cases' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+    class MyTest extends \PhpUnit\FrameWork\TestCase
+    {
+   -    public function test_my_code() {}
+   +    public function testMyCode() {}
+        public function test_FooBar() {}
     }
 
 Rule sets

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -212,7 +212,7 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
     private function shouldIgnoreFunctionName(string $functionNamePart): bool
     {
         return $this->configuration['ignore_mixed_cases']
-            && Preg::match('/^test_*[A-Z]+/', $functionNamePart)
+            && Preg::match('/^[a-z]+_*[A-Z]+/', $functionNamePart)
             && str_contains($functionNamePart, '_');
     }
 }

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -29,6 +29,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
 use PhpCsFixer\Utils;
+use function str_contains;
 
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
@@ -69,6 +70,16 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
 }
 ',
                     ['case' => self::SNAKE_CASE]
+                ),
+                new CodeSample(
+                    '<?php
+class MyTest extends \\PhpUnit\\FrameWork\\TestCase
+{
+    public function test_my_code() {}
+    public function test_FooBar() {}
+}
+',
+                    ['ignore_mixed_cases' => true]
                 ),
             ]
         );
@@ -116,6 +127,10 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
         $parts = explode('::', $functionName);
 
         $functionNamePart = array_pop($parts);
+
+        if ($this->shouldIgnoreFunctionName($functionNamePart)) {
+            return $functionName;
+        }
 
         if (self::CAMEL_CASE === $this->configuration['case']) {
             $newFunctionNamePart = $functionNamePart;
@@ -192,5 +207,12 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
             $lines = implode('', $lines);
             $tokens[$docBlockIndex] = new Token([T_DOC_COMMENT, $lines]);
         }
+    }
+
+    private function shouldIgnoreFunctionName(string $functionNamePart): bool
+    {
+        return $this->configuration['ignore_mixed_cases']
+            && Preg::match('/^test_*[A-Z]+/', $functionNamePart)
+            && str_contains($functionNamePart, '_');
     }
 }

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -221,7 +221,7 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
     private function shouldIgnoreFunctionName(string $functionNamePart): bool
     {
         return $this->configuration['ignore_mixed_cases']
-            && Preg::match('/^[a-z]+_*[A-Z]+/', $functionNamePart)
+            && Preg::match('/[A-Z]+/', $functionNamePart)
             && str_contains($functionNamePart, '_');
     }
 }

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -81,6 +81,10 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
                 ->setAllowedValues([self::CAMEL_CASE, self::SNAKE_CASE])
                 ->setDefault(self::CAMEL_CASE)
                 ->getOption(),
+            (new FixerOptionBuilder('ignore_mixed_cases', 'Ignore mixed cases, i.e. "test_that_FooBar_does_something"'))
+                ->setAllowedValues([true, false])
+                ->setDefault(false)
+                ->getOption(),
         ]);
     }
 

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -74,19 +74,6 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
         );
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * Must run after PhpUnitTestAnnotationFixer.
-     */
-    public function getPriority(): int
-    {
-        return 0;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
     {
         return new FixerConfigurationResolver([
@@ -97,9 +84,6 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function applyPhpUnitClassFix(Tokens $tokens, int $startIndex, int $endIndex): void
     {
         for ($index = $endIndex - 1; $index > $startIndex; --$index) {
@@ -179,8 +163,8 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
         $lines = $doc->getLines();
 
         $docBlockNeedsUpdate = false;
-        for ($inc = 0; $inc < \count($lines); ++$inc) {
-            $lineContent = $lines[$inc]->getContent();
+        foreach ($lines as $inc => $incValue) {
+            $lineContent = $incValue->getContent();
             if (!str_contains($lineContent, '@depends')) {
                 continue;
             }

--- a/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
+++ b/src/Fixer/PhpUnit/PhpUnitMethodCasingFixer.php
@@ -29,7 +29,6 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\Tokenizer\TokensAnalyzer;
 use PhpCsFixer\Utils;
-use function str_contains;
 
 /**
  * @author Filippo Tessarotto <zoeslam@gmail.com>
@@ -83,6 +82,16 @@ class MyTest extends \\PhpUnit\\FrameWork\\TestCase
                 ),
             ]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run after PhpUnitTestAnnotationFixer.
+     */
+    public function getPriority(): int
+    {
+        return 0;
     }
 
     protected function createConfigurationDefinition(): FixerConfigurationResolverInterface

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -50,6 +50,16 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
+    /**
+     * @dataProvider provideIgnoreCases
+     */
+    public function testIgnoreMixedCase(string $ignoredExpected): void
+    {
+        $this->fixer->configure(['ignore_mixed_cases' => true]);
+        $this->doTest($ignoredExpected);
+    }
+
+
     public function provideFixCases(): \Generator
     {
         yield 'skip non phpunit methods' => [
@@ -168,6 +178,13 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
                     public function my_app_not_2() {}
                 }',
+        ];
+    }
+
+    public function provideIgnoreCases(): \Generator
+    {
+        yield 'default mixed case' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_MyApp() {} }',
         ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -46,31 +46,34 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($expected, $input);
     }
 
-    public function provideFixCases(): array
+    public function provideFixCases(): \Generator
     {
-        return [
-            'skip non phpunit methods' => [
-                '<?php class MyClass {
+        yield 'skip non phpunit methods' => [
+            '<?php class MyClass {
                     public function testMyApp() {}
                     public function test_my_app() {}
                 }',
-            ],
-            'skip non test methods' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+        ];
+
+        yield 'skip non test methods' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function not_a_test() {}
                     public function notATestEither() {}
                 }',
-            ],
-            'default sample' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function testMyApp() {} }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_my_app() {} }',
-            ],
-            'annotation' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function myApp() {} }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_app() {} }',
-            ],
-            '@depends annotation' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+        ];
+
+        yield 'default sample' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function testMyApp() {} }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_my_app() {} }',
+        ];
+
+        yield 'annotation' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function myApp() {} }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_app() {} }',
+        ];
+
+        yield '@depends annotation' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function testMyApp () {}
 
                     /**
@@ -78,7 +81,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function testMyAppToo() {}
                 }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function test_my_app () {}
 
                     /**
@@ -86,9 +89,10 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function test_my_app_too() {}
                 }',
-            ],
-            '@depends annotation with class name in PascalCase' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+        ];
+
+        yield '@depends annotation with class name in PascalCase' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function testMyApp () {}
 
                     /**
@@ -96,7 +100,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function testMyAppToo() {}
                 }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function test_my_app () {}
 
                     /**
@@ -104,9 +108,10 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function test_my_app_too() {}
                 }',
-            ],
-            '@depends annotation with class name in Snake_Case' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+        ];
+
+        yield '@depends annotation with class name in Snake_Case' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function testMyApp () {}
 
                     /**
@@ -114,7 +119,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function testMyAppToo() {}
                 }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     public function test_my_app () {}
 
                     /**
@@ -122,9 +127,10 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
                      */
                     public function test_my_app_too() {}
                 }',
-            ],
-            '@depends and @test annotation' => [
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+        ];
+
+        yield '@depends and @test annotation' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     /**
                      * @test
                      */
@@ -141,7 +147,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
                     public function my_app_not_2() {}
                 }',
-                '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
                     /**
                      * @test
                      */
@@ -158,7 +164,6 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
                     public function my_app_not_2() {}
                 }',
-            ],
         ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -186,5 +186,9 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         yield 'default mixed case' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_MyApp() {} }',
         ];
+
+        yield 'annotation' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_App_does_SomeClass() {} }',
+        ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -190,5 +190,25 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         yield '@test annotation ignored' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_App_does_SomeClass() {} }',
         ];
+
+
+        yield '@depends annotation ignored' => [
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function test_MyApp () {}
+
+                    /**
+                     * @depends test_MyApp
+                     */
+                    public function testMyAppToo() {}
+                }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {
+                    public function test_MyApp () {}
+
+                    /**
+                     * @depends test_MyApp
+                     */
+                    public function test_my_app_too() {}
+                }',
+        ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -201,13 +201,12 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
     public function provideIgnoreCases(): iterable
     {
         yield 'default ignored' => [
-            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_MyApp() {} }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_that_MyApp_does_something_with_Class() {} }',
         ];
 
         yield '@test annotation ignored' => [
-            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_App_does_SomeClass() {} }',
+            '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_app_does_SomeThing_special() {} }',
         ];
-
 
         yield '@depends annotation ignored' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase {

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -39,13 +39,8 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
      */
     public function testFixToSnakeCase(string $camelExpected, ?string $camelInput = null): void
     {
-        if (null === $camelInput) {
-            $expected = $camelExpected;
-            $input = $camelInput;
-        } else {
-            $expected = $camelInput;
-            $input = $camelExpected;
-        }
+        $expected = $camelInput ?: $camelExpected;
+        $input = $camelInput ? $camelExpected : $camelInput;
 
         $this->fixer->configure(['case' => PhpUnitMethodCasingFixer::SNAKE_CASE]);
         $this->doTest($expected, $input);

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -76,7 +76,6 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         $this->doTest($ignoredExpected, $input);
     }
 
-
     public function provideFixCases(): iterable
     {
         yield 'skip non phpunit methods' => [

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -32,6 +32,8 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
     public function testFixToCamelCase(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
+        $this->fixer->configure(['ignore_mixed_cases' => true]);
+        $this->doTest($expected, $input);
     }
 
     /**
@@ -43,6 +45,8 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         $input = $camelInput ? $camelExpected : $camelInput;
 
         $this->fixer->configure(['case' => PhpUnitMethodCasingFixer::SNAKE_CASE]);
+        $this->doTest($expected, $input);
+        $this->fixer->configure(['case' => PhpUnitMethodCasingFixer::SNAKE_CASE, 'ignore_mixed_cases' => true]);
         $this->doTest($expected, $input);
     }
 

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -77,7 +77,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
     }
 
 
-    public function provideFixCases(): \Generator
+    public function provideFixCases(): iterable
     {
         yield 'skip non phpunit methods' => [
             '<?php class MyClass {
@@ -198,7 +198,7 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
         ];
     }
 
-    public function provideIgnoreCases(): \Generator
+    public function provideIgnoreCases(): iterable
     {
         yield 'default ignored' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_MyApp() {} }',

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -53,10 +53,10 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
     /**
      * @dataProvider provideIgnoreCases
      */
-    public function testIgnoreMixedCase(string $ignoredExpected): void
+    public function testIgnoreMixedCase(string $ignoredExpected, ?string $input = null): void
     {
         $this->fixer->configure(['ignore_mixed_cases' => true]);
-        $this->doTest($ignoredExpected);
+        $this->doTest($ignoredExpected, $input);
     }
 
 
@@ -183,11 +183,11 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
     public function provideIgnoreCases(): \Generator
     {
-        yield 'default mixed case' => [
+        yield 'default ignored' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { public function test_MyApp() {} }',
         ];
 
-        yield 'annotation' => [
+        yield '@test annotation ignored' => [
             '<?php class MyTest extends \PhpUnit\FrameWork\TestCase { /** @test */ public function my_App_does_SomeClass() {} }',
         ];
     }

--- a/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitMethodCasingFixerTest.php
@@ -32,6 +32,13 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
     public function testFixToCamelCase(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixToCamelCaseWithIgnored(string $expected, ?string $input = null): void
+    {
         $this->fixer->configure(['ignore_mixed_cases' => true]);
         $this->doTest($expected, $input);
     }
@@ -46,6 +53,16 @@ final class PhpUnitMethodCasingFixerTest extends AbstractFixerTestCase
 
         $this->fixer->configure(['case' => PhpUnitMethodCasingFixer::SNAKE_CASE]);
         $this->doTest($expected, $input);
+    }
+
+    /**
+     * @dataProvider provideFixCases
+     */
+    public function testFixToSnakeCaseWithIgnored(string $camelExpected, ?string $camelInput = null): void
+    {
+        $expected = $camelInput ?: $camelExpected;
+        $input = $camelInput ? $camelExpected : $camelInput;
+
         $this->fixer->configure(['case' => PhpUnitMethodCasingFixer::SNAKE_CASE, 'ignore_mixed_cases' => true]);
         $this->doTest($expected, $input);
     }


### PR DESCRIPTION
## Context

Currently the PHPUnit method case fixer just allows to switch between camel and snake case test methods.

Often we are facing the case where both of them are mixed, i.e. when we want to refer to Domain class names within test method names:

```php
<?php

class MyTest extends \PhpUnit\FrameWork\TestCase {
    public function test_that_DomainObject_is_valid() {}
}
```

## Use case

We want to migrate an existing legacy code base that has a mix of different cases as described above, but currently the existing mixed cases are also transformed.

## Feature

This PR adds the possibility to ignore these mixed cases with a new configuration option `ignore_mixed_cases` that is disabled by default to not break current behavior.