### PR TITLE
minor: Use md5 for file hashing to reduce possible collisions

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -128,7 +128,7 @@ final class Cache implements CacheInterface
 
         $cache->hashes = array_map(function ($v): string {
             // before v3.11.1 the hashes were crc32 encoded and saved as integers
-            // TODO remove the to string cast/array_map in v4.0
+            // @TODO: remove the to string cast/array_map in v4.0
             return \is_int($v) ? (string) $v : $v;
         }, $data['hashes']);
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -24,7 +24,7 @@ final class Cache implements CacheInterface
     private SignatureInterface $signature;
 
     /**
-     * @var array<string, int>
+     * @var array<string, string>
      */
     private array $hashes = [];
 
@@ -43,7 +43,7 @@ final class Cache implements CacheInterface
         return \array_key_exists($file, $this->hashes);
     }
 
-    public function get(string $file): ?int
+    public function get(string $file): ?string
     {
         if (!$this->has($file)) {
             return null;
@@ -52,7 +52,7 @@ final class Cache implements CacheInterface
         return $this->hashes[$file];
     }
 
-    public function set(string $file, int $hash): void
+    public function set(string $file, string $hash): void
     {
         $this->hashes[$file] = $hash;
     }
@@ -126,7 +126,11 @@ final class Cache implements CacheInterface
 
         $cache = new self($signature);
 
-        $cache->hashes = $data['hashes'];
+        $cache->hashes = array_map(function ($v): string {
+            // before v3.11.1 the hashes were crc32 encoded and saved as integers
+            // TODO remove the to string cast/array_map in v4.0
+            return \is_int($v) ? (string) $v : $v;
+        }, $data['hashes']);
 
         return $cache;
     }

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -25,9 +25,9 @@ interface CacheInterface
 
     public function has(string $file): bool;
 
-    public function get(string $file): ?int;
+    public function get(string $file): ?string;
 
-    public function set(string $file, int $hash): void;
+    public function set(string $file, string $hash): void;
 
     public function clear(string $file): void;
 

--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -122,8 +122,8 @@ final class FileCacheManager implements CacheManagerInterface
         $this->handler->write($this->cache);
     }
 
-    private function calcHash(string $content): int
+    private function calcHash(string $content): string
     {
-        return crc32($content);
+        return md5($content);
     }
 }

--- a/src/Linter/CachingLinter.php
+++ b/src/Linter/CachingLinter.php
@@ -24,7 +24,7 @@ final class CachingLinter implements LinterInterface
     private LinterInterface $sublinter;
 
     /**
-     * @var array<int, LintingResultInterface>
+     * @var array<string, LintingResultInterface>
      */
     private array $cache = [];
 
@@ -46,7 +46,7 @@ final class CachingLinter implements LinterInterface
      */
     public function lintFile(string $path): LintingResultInterface
     {
-        $checksum = crc32(file_get_contents($path));
+        $checksum = md5(file_get_contents($path));
 
         if (!isset($this->cache[$checksum])) {
             $this->cache[$checksum] = $this->sublinter->lintFile($path);
@@ -60,7 +60,7 @@ final class CachingLinter implements LinterInterface
      */
     public function lintSource(string $source): LintingResultInterface
     {
-        $checksum = crc32($source);
+        $checksum = md5($source);
 
         if (!isset($this->cache[$checksum])) {
             $this->cache[$checksum] = $this->sublinter->lintSource($source);

--- a/src/Tokenizer/CodeHasher.php
+++ b/src/Tokenizer/CodeHasher.php
@@ -31,6 +31,6 @@ final class CodeHasher
      */
     public static function calculateCodeHash(string $code): string
     {
-        return (string) crc32($code);
+        return md5($code);
     }
 }

--- a/src/Tokenizer/Tokens.php
+++ b/src/Tokenizer/Tokens.php
@@ -65,7 +65,7 @@ class Tokens extends \SplFixedArray
     private array $blockEndCache = [];
 
     /**
-     * crc32 hash of code string.
+     * A MD5 hash of the code string.
      */
     private ?string $codeHash = null;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -73,7 +73,7 @@ final class CacheTest extends TestCase
         $cache = new Cache($signature);
 
         $file = 'test.php';
-        $hash = crc32('hello');
+        $hash = md5('hello');
 
         $cache->set($file, $hash);
 
@@ -88,7 +88,7 @@ final class CacheTest extends TestCase
         $cache = new Cache($signature);
 
         $file = 'test.php';
-        $hash = crc32('hello');
+        $hash = md5('hello');
 
         $cache->set($file, $hash);
         $cache->clear($file);
@@ -146,7 +146,7 @@ final class CacheTest extends TestCase
         $cache = new Cache($signature);
 
         $file = 'test.php';
-        $hash = crc32('hello');
+        $hash = md5('hello');
 
         $cache->set($file, $hash);
         $cached = Cache::fromJson($cache->toJson());

--- a/tests/Cache/FileCacheManagerTest.php
+++ b/tests/Cache/FileCacheManagerTest.php
@@ -161,7 +161,7 @@ final class FileCacheManagerTest extends TestCase
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
         $cacheProphecy->has(Argument::is($file))->willReturn(true);
-        $cacheProphecy->get(Argument::is($file))->willReturn(crc32($previousFileContent));
+        $cacheProphecy->get(Argument::is($file))->willReturn(md5($previousFileContent));
         $cache = $cacheProphecy->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
@@ -192,7 +192,7 @@ final class FileCacheManagerTest extends TestCase
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
         $cacheProphecy->has(Argument::is($file))->willReturn(true);
-        $cacheProphecy->get(Argument::is($file))->willReturn(crc32($fileContent));
+        $cacheProphecy->get(Argument::is($file))->willReturn(md5($fileContent));
         $cache = $cacheProphecy->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
@@ -261,7 +261,7 @@ final class FileCacheManagerTest extends TestCase
 
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
-        $cacheProphecy->set(Argument::is($file), Argument::is(crc32($fileContent)))->shouldBeCalled();
+        $cacheProphecy->set(Argument::is($file), Argument::is(md5($fileContent)))->shouldBeCalled();
         $cache = $cacheProphecy->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
@@ -294,7 +294,7 @@ final class FileCacheManagerTest extends TestCase
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
         $cacheProphecy->has(Argument::is($file))->willReturn(false);
-        $cacheProphecy->set(Argument::is($file), Argument::is(crc32($fileContent)))->shouldBeCalled();
+        $cacheProphecy->set(Argument::is($file), Argument::is(md5($fileContent)))->shouldBeCalled();
         $cache = $cacheProphecy->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);
@@ -329,7 +329,7 @@ final class FileCacheManagerTest extends TestCase
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
         $cacheProphecy->has(Argument::is($file))->willReturn(true);
-        $cacheProphecy->get(Argument::is($file))->willReturn(crc32($previousFileContent));
+        $cacheProphecy->get(Argument::is($file))->willReturn(md5($previousFileContent));
         $cacheProphecy->clear(Argument::is($file))->shouldBeCalled();
         $cache = $cacheProphecy->reveal();
 
@@ -366,7 +366,7 @@ final class FileCacheManagerTest extends TestCase
 
         $cacheProphecy = $this->prophesize(CacheInterface::class);
         $cacheProphecy->getSignature()->willReturn($cachedSignature);
-        $cacheProphecy->set(Argument::is($relativePathToFile), Argument::is(crc32($fileContent)))->shouldBeCalled();
+        $cacheProphecy->set(Argument::is($relativePathToFile), Argument::is(md5($fileContent)))->shouldBeCalled();
         $cache = $cacheProphecy->reveal();
 
         $handlerProphecy = $this->prophesize(FileHandlerInterface::class);

--- a/tests/Tokenizer/CodeHasherTest.php
+++ b/tests/Tokenizer/CodeHasherTest.php
@@ -26,7 +26,7 @@ final class CodeHasherTest extends TestCase
 {
     public function testCodeHasher(): void
     {
-        static::assertSame('322920910', CodeHasher::calculateCodeHash('<?php echo 1;'));
-        static::assertSame('322920910', CodeHasher::calculateCodeHash('<?php echo 1;')); // calling twice, hashes should always be the same when the input doesn't change.
+        static::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;'));
+        static::assertSame('d9de49676ba2316990a5acd04c8418e8', CodeHasher::calculateCodeHash('<?php echo 1;')); // calling twice, hashes should always be the same when the input doesn't change.
     }
 }


### PR DESCRIPTION
currently collision (with p=50%) is expected with `sqrt(2*2^32*0.5)` [1] = `65536` files only

[1] https://en.wikipedia.org/wiki/Birthday_problem#Square_approximation