### PR TITLE
docs: Remove `$` from console command snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,20 +51,20 @@ and edit it to your needs. The relevant parameters that might require some tweak
 You can then build the images:
 
 ```console
-$ docker-compose build --parallel
+docker-compose build --parallel
 ```
 
 Now you can run commands needed to work on the project. For example, say you want to run PHPUnit tests on PHP 7.4:
 
 ```console
-$ docker-compose run php-7.4 vendor/bin/phpunit
+docker-compose run php-7.4 vendor/bin/phpunit
 ```
 
 Sometimes it can be more convenient to have a shell inside the container:
 
 ```console
-$ docker-compose run php-7.4 sh
-/app $ vendor/bin/phpunit
+docker-compose run php-7.4 sh
+/app vendor/bin/phpunit
 ```
 
 The images come with an [`xdebug` script](github.com/julienfalque/xdebug/) that allows running any PHP command with

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ in a dedicated `composer.json` file in your project, for example in the
 `tools/php-cs-fixer` directory:
 
 ```console
-$ mkdir --parents tools/php-cs-fixer
-$ composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+mkdir --parents tools/php-cs-fixer
+composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
 ```
 
 For more details and other installation methods, see
@@ -41,7 +41,7 @@ Assuming you installed PHP CS Fixer as instructed above, you can run the
 following command to fix the files PHP files in the `src` directory:
 
 ```console
-$ tools/php-cs-fixer/vendor/bin/php-cs-fixer fix src
+tools/php-cs-fixer/vendor/bin/php-cs-fixer fix src
 ```
 
 See [usage](./doc/usage.rst), list of [built-in rules](./doc/rules/index.rst), list of [rule sets](./doc/ruleSets/index.rst)


### PR DESCRIPTION
Sub pull request for #6599

`$` is not required for terminal commands because they throw errors when copy pasted.