### PR TITLE
feature: FinalInternalClassFixer - Support annotations

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -729,13 +729,23 @@ List of Available Rules
    Configuration options:
 
    - | ``annotation_include``
-     | Class level annotations tags that must be set in order to fix the class. (case insensitive)
+     | Class level PHPDoc annotations tags that must be set in order to fix the class. (case insensitive)
+     | warning:: This option is deprecated and will be removed on next major version. Use ``internal`` to configure PHPDoc annotations tags and attributes.
      | Allowed types: ``array``
      | Default value: ``['@internal']``
    - | ``annotation_exclude``
-     | Class level annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)
+     | Class level PHPDoc annotations tags that must be omitted to fix the class, even if all of the white list ones are used as well. (case insensitive)
+     | warning:: This option is deprecated and will be removed on next major version. Use ``exclude`` to configure PHPDoc annotations tags and attributes.
      | Allowed types: ``array``
      | Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity', '@Document', '@ODM\\Document']``
+   - | ``include``
+     | Class level PHPDoc annotations tags or attributes of which one or more must be set in order to fix the class. (case insensitive)
+     | Allowed types: ``array``
+     | Default value: ``['internal']``
+   - | ``exclude``
+     | Class level PHPDoc annotations tags or attributes which must all be omitted to fix the class. (case insensitive)
+     | Allowed types: ``array``
+     | Default value: ``['final', 'Entity', 'ORM\\Entity', 'ORM\\Mapping\\Entity', 'Mapping\\Entity', 'Document', 'ODM\\Document']``
    - | ``consider_absent_docblock_as_internal_class``
      | Should classes without any DocBlock be fixed to final?
      | Allowed types: ``bool``

--- a/doc/rules/class_notation/final_internal_class.rst
+++ b/doc/rules/class_notation/final_internal_class.rst
@@ -18,8 +18,10 @@ Configuration
 ``annotation_include``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Class level annotations tags that must be set in order to fix the class. (case
-insensitive)
+.. warning:: This option is deprecated and will be removed on next major version. Use ``internal`` to configure PHPDoc annotations tags and attributes.
+
+Class level PHPDoc annotations tags that must be set in order to fix the class.
+(case insensitive)
 
 Allowed types: ``array``
 
@@ -28,12 +30,34 @@ Default value: ``['@internal']``
 ``annotation_exclude``
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Class level annotations tags that must be omitted to fix the class, even if all
-of the white list ones are used as well. (case insensitive)
+.. warning:: This option is deprecated and will be removed on next major version. Use ``exclude`` to configure PHPDoc annotations tags and attributes.
+
+Class level PHPDoc annotations tags that must be omitted to fix the class, even
+if all of the white list ones are used as well. (case insensitive)
 
 Allowed types: ``array``
 
 Default value: ``['@final', '@Entity', '@ORM\\Entity', '@ORM\\Mapping\\Entity', '@Mapping\\Entity', '@Document', '@ODM\\Document']``
+
+``include``
+~~~~~~~~~~~
+
+Class level PHPDoc annotations tags or attributes of which one or more must be
+set in order to fix the class. (case insensitive)
+
+Allowed types: ``array``
+
+Default value: ``['internal']``
+
+``exclude``
+~~~~~~~~~~~
+
+Class level PHPDoc annotations tags or attributes which must all be omitted to
+fix the class. (case insensitive)
+
+Allowed types: ``array``
+
+Default value: ``['final', 'Entity', 'ORM\\Entity', 'ORM\\Mapping\\Entity', 'Mapping\\Entity', 'Document', 'ODM\\Document']``
 
 ``consider_absent_docblock_as_internal_class``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,7 +92,7 @@ Example #1
 Example #2
 ~~~~~~~~~~
 
-With configuration: ``['annotation_include' => ['@Custom'], 'annotation_exclude' => ['@not-fix']]``.
+With configuration: ``['include' => ['@Custom'], 'exclude' => ['@not-fix']]``.
 
 .. code-block:: diff
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,6 @@ parameters:
         -
             message: '#^.+no value type specified in iterable type.+\.$#'
             path: src/Fixer
-            count: 117
+            count: 118
     tipsOfTheDay: false
     tmpDir: dev-tools/phpstan/cache

--- a/src/Fixer/ClassNotation/FinalClassFixer.php
+++ b/src/Fixer/ClassNotation/FinalClassFixer.php
@@ -54,7 +54,7 @@ class MyApp {}
     {
         $fixer = new FinalInternalClassFixer();
         $fixer->configure([
-            'annotation_include' => [],
+            'include' => [],
             'consider_absent_docblock_as_internal_class' => true,
         ]);
 

--- a/src/Fixer/Whitespace/IndentationTypeFixer.php
+++ b/src/Fixer/Whitespace/IndentationTypeFixer.php
@@ -139,9 +139,6 @@ final class IndentationTypeFixer extends AbstractFixer implements WhitespacesAwa
         return new Token([T_WHITESPACE, $newContent]);
     }
 
-    /**
-     * @return string mixed
-     */
     private function getExpectedIndent(string $content, string $indent): string
     {
         if ("\t" === $indent) {

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -45,7 +45,7 @@ final class FinalInternalClassFixerTest extends AbstractFixerTestCase
         }
 
         return [
-            [
+            'fix multiple classes' => [
                 $expected,
                 $input,
             ],
@@ -139,6 +139,16 @@ abstract class class4 {}
                     class A {}
 ',
             ],
+            'indent before `class`' => [
+                '<?php /** @internal */
+                    final class class1
+                    {
+                    }',
+                '<?php /** @internal */
+                    class class1
+                    {
+                    }',
+            ],
         ];
     }
 
@@ -153,119 +163,135 @@ abstract class class4 {}
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithConfigCases(): array
+    public function provideFixWithConfigCases(): iterable
     {
-        return [
+        yield [
+            "<?php\n/** @CUSTOM */final class A{}",
+            "<?php\n/** @CUSTOM */class A{}",
             [
-                "<?php\n/** @CUSTOM */final class A{}",
-                "<?php\n/** @CUSTOM */class A{}",
-                [
-                    'annotation_include' => ['@Custom'],
-                ],
+                'include' => ['@Custom'],
             ],
+        ];
+
+        yield [
+            '<?php
+/**
+* @CUSTOM
+* @abc
+*/
+final class A2{}
+
+/**
+* @CUSTOM
+*/
+final class B2{}
+',
+            '<?php
+/**
+* @CUSTOM
+* @abc
+*/
+class A2{}
+
+/**
+* @CUSTOM
+*/
+class B2{}
+',
             [
-                '<?php
-/**
- * @CUSTOM
- * @abc
- */
-final class A{}
-
-/**
- * @CUSTOM
- */
-class B{}
-',
-                '<?php
-/**
- * @CUSTOM
- * @abc
- */
-class A{}
-
-/**
- * @CUSTOM
- */
-class B{}
-',
-                [
-                    'annotation_include' => ['@Custom', '@abc'],
-                ],
+                'include' => ['@Custom', '@abc'],
             ],
+        ];
+
+        yield [
+            '<?php
+/**
+* @CUSTOM
+* @internal
+*/
+final class A3{}
+
+/**
+* @CUSTOM
+* @internal
+* @other
+*/
+final class B3{}
+
+/**
+* @CUSTOM
+* @internal
+* @not-fix
+*/
+class C3{}
+',
+            '<?php
+/**
+* @CUSTOM
+* @internal
+*/
+class A3{}
+
+/**
+* @CUSTOM
+* @internal
+* @other
+*/
+class B3{}
+
+/**
+* @CUSTOM
+* @internal
+* @not-fix
+*/
+class C3{}
+',
             [
-                '<?php
-/**
- * @CUSTOM
- * @internal
- */
- final class A{}
-
-/**
- * @CUSTOM
- * @internal
- * @other
- */
- final class B{}
-
-/**
- * @CUSTOM
- * @internal
- * @not-fix
- */
- class C{}
-',
-                '<?php
-/**
- * @CUSTOM
- * @internal
- */
- class A{}
-
-/**
- * @CUSTOM
- * @internal
- * @other
- */
- class B{}
-
-/**
- * @CUSTOM
- * @internal
- * @not-fix
- */
- class C{}
-',
-                [
-                    'annotation_include' => ['@Custom', '@internal'],
-                    'annotation_exclude' => ['@not-fix'],
-                ],
+                'include' => ['@Custom', '@internal'],
+                'exclude' => ['@not-fix'],
             ],
+        ];
+
+        yield [
+            '<?php
+/**
+* @internal
+*/
+final class A4{}
+
+/**
+* @abc
+*/
+class B4{}
+',
+            '<?php
+/**
+* @internal
+*/
+class A4{}
+
+/**
+* @abc
+*/
+class B4{}
+',
             [
-                '<?php
-/**
- * @internal
- */
-final class A{}
+                'exclude' => ['abc'],
+            ],
+        ];
 
-/**
- * @abc
- */
-class B{}
-',
-                '<?php
-/**
- * @internal
- */
-class A{}
-
-/**
- * @abc
- */
-class B{}
-',
-                [
-                    'annotation_exclude' => ['abc'],
-                ],
+        yield 'no includes, no excludes, no tags in PHPDoc' => [
+            '<?php
+/** only description */
+final class Foo {}
+            ',
+            '<?php
+/** only description */
+class Foo {}
+            ',
+            [
+                'exclude' => [],
+                'include' => [],
             ],
         ];
     }
@@ -294,37 +320,179 @@ $a = new class (){};',
 /** @internal */
 $a = new class{};',
         ];
+
+        yield [
+            '<?php $object = new /**/ class(){};',
+        ];
     }
 
     public function testConfigureSameAnnotationInBothLists(): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
-        $this->expectExceptionMessageMatches(
-            sprintf('#^%s$#', preg_quote('[final_internal_class] Annotation cannot be used in both the include and exclude list, got duplicates: "internal123".', '#'))
-        );
+        $this->expectExceptionMessageMatches(sprintf('#^%s$#', preg_quote('[final_internal_class] Annotation cannot be used in both "include" and "exclude" list, got duplicates: "internal123".', '#')));
 
         $this->fixer->configure([
-            'annotation_include' => ['@internal123', 'a'],
-            'annotation_exclude' => ['@internal123', 'b'],
+            'include' => ['@internal123', 'a'],
+            'exclude' => ['@internal123', 'b'],
         ]);
     }
 
     /**
+     * @group legacy
+     */
+    public function testConfigureBothNewAndOldSet(): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessageMatches(sprintf('#^%s$#', preg_quote('[final_internal_class] Configuration cannot contain deprecated option "annotation_include" and new option "include".', '#')));
+        $this->expectDeprecation('Option "annotation_include" for rule "final_internal_class" is deprecated and will be removed in version 4.0. Use "internal" to configure PHPDoc annotations tags and attributes.');
+
+        $this->fixer->configure([
+            'annotation_include' => ['@internal', 'a'],
+            'include' => ['@internal', 'b'],
+        ]);
+    }
+
+    /**
+     * @param array<string, list<string>> $config
+     *
      * @dataProvider provideFix80Cases
      *
      * @requires PHP 8.0
      */
-    public function testFix80(string $expected, ?string $input = null): void
+    public function testFix80(string $expected, ?string $input, array $config): void
     {
+        $this->fixer->configure($config);
         $this->doTest($expected, $input);
     }
 
     public function provideFix80Cases(): iterable
     {
-        yield [
+        yield 'multiple attributes, all configured as not to fix' => [
+            '<?php
+#[X]
+#[A]
+class Foo {}',
+            null,
+            ['exclude' => ['a', 'X']],
+        ];
+
+        yield 'multiple attributes, one configured as to fix, one as not to fix' => [
+            '<?php
+#[Internal]
+#[A]
+class Foo {}',
+            null,
+            [
+                'include' => ['internal'],
+                'exclude' => ['A'],
+            ],
+        ];
+
+        yield 'multiple attributes, one configured as to fix' => [
+            '<?php
+#[Internal]
+#[A]
+final class Foo {}',
+            '<?php
+#[Internal]
+#[A]
+class Foo {}',
+            ['include' => ['internal']],
+        ];
+
+        yield 'single attribute configured as to fix' => [
+            '<?php
+#[Internal]
+final class Foo {}',
             '<?php
 #[Internal]
 class Foo {}',
+            ['include' => ['internal']],
+        ];
+
+        yield [
+            '<?php
+#[StandWithUkraine]
+class Foo {}',
+            null,
+            ['consider_absent_docblock_as_internal_class' => true],
+        ];
+
+        yield 'mixed bag of cases' => [
+            '<?php
+#[Entity(repositoryClass: PostRepository::class)]
+class User
+{}
+
+#[ORM\Entity]
+#[Index(name: "category_idx", columns: ["category"])]
+final class Article
+{}
+
+#[A]
+class ArticleB
+{}
+
+#[B]
+final class Foo {}
+
+#[C]
+class FooX {}
+
+$object1 = new #[ExampleAttribute] class(){};
+$object2 = new /* */ class(){};
+$object3 = new #[B] #[ExampleAttribute] class(){};
+
+/**
+ * @B
+ */
+final class PhpDocClass{}
+',
+            '<?php
+#[Entity(repositoryClass: PostRepository::class)]
+class User
+{}
+
+#[ORM\Entity]
+#[Index(name: "category_idx", columns: ["category"])]
+class Article
+{}
+
+#[A]
+class ArticleB
+{}
+
+#[B]
+class Foo {}
+
+#[C]
+class FooX {}
+
+$object1 = new #[ExampleAttribute] class(){};
+$object2 = new /* */ class(){};
+$object3 = new #[B] #[ExampleAttribute] class(){};
+
+/**
+ * @B
+ */
+class PhpDocClass{}
+',
+            [
+                'exclude' => ['Entity', 'A'],
+                'include' => ['orm\entity', 'B'],
+            ],
+        ];
+
+        yield 'positive on attribute, but negative on doc' => [
+            '<?php
+/** @final */
+#[A]
+class Foo {}',
+            null,
+            [
+                'exclude' => ['final'],
+                'include' => ['A'],
+            ],
         ];
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -149,8 +149,8 @@ final class UtilsTest extends TestCase
     }
 
     /**
-     * @param list<mixed> $expected
-     * @param list<mixed> $elements
+     * @param list<string> $expected
+     * @param list<string> $elements
      *
      * @dataProvider provideStableSortCases
      */


### PR DESCRIPTION
This PR brings annotation support and a number of refinements.

Replaces: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5939
Close: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5782

- `annotation_include` has been deprecated and renamed to `include`
- `annotation_exclude` has been deprecated and renamed to `exclude`

(https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5939#discussion_r702469932)

If you provide:
- default config -> runs with annotation support
- old config and new config, both not default config, throws a config-exception
- old config that is not default config -> runs without annotation support
- new config that is not default config -> runs with annotation support
- conflicting configuration (having an item in both `include` and `exclude`) still throws a config-exception

If you provide `include` than if any annotion or the PHPDoc of the class contains at least _one_ as configured, but not necessary _all_, it will be fixed.
If you provide `exclude` than if any annotion or the PHPDoc of the class contains at least _one_ as configured, but not necessary _all_, it will _not_ be fixed.
