### PR TITLE
feature: [PHP8.2] Support for new standalone types (`null`, `true`, `false`)

### DIFF
--- a/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
+++ b/src/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixer.php
@@ -42,7 +42,12 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
      * object   PHP 7.2
      * static   PHP 8.0 (return type only)
      * mixed    PHP 8.0
-     * never    PHP 8.1
+     * false    PHP 8.0 (union return type only)
+     * null     PHP 8.0 (union return type only)
+     * never    PHP 8.1 (return type only)
+     * true     PHP 8.2 (standalone type: https://wiki.php.net/rfc/true-type)
+     * false    PHP 8.2 (standalone type: https://wiki.php.net/rfc/null-false-standalone-types)
+     * null     PHP 8.2 (standalone type: https://wiki.php.net/rfc/null-false-standalone-types)
      *
      * @var array<string, true>
      */
@@ -68,12 +73,18 @@ final class NativeFunctionTypeDeclarationCasingFixer extends AbstractFixer
         ];
 
         if (\PHP_VERSION_ID >= 80000) {
-            $this->hints = array_merge($this->hints, ['static' => true]);
-            $this->hints = array_merge($this->hints, ['mixed' => true]);
+            $this->hints['false'] = true;
+            $this->hints['mixed'] = true;
+            $this->hints['null'] = true;
+            $this->hints['static'] = true;
         }
 
         if (\PHP_VERSION_ID >= 80100) {
-            $this->hints = array_merge($this->hints, ['never' => true]);
+            $this->hints['never'] = true;
+        }
+
+        if (\PHP_VERSION_ID >= 80200) {
+            $this->hints['true'] = true;
         }
 
         $this->functionsAnalyzer = new FunctionsAnalyzer();

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -215,15 +215,26 @@ function Foo(INTEGER $a) {}
     public function provideFix82Cases(): iterable
     {
         foreach (['true', 'false', 'null'] as $type) {
-            yield sprintf('standalone type `%s`', $type) => [
+            yield sprintf('standalone type `%s` in class method', $type) => [
                 sprintf('<?php class T { public function Foo(%s $A): %1$s {return $A;}}', $type),
                 sprintf('<?php class T { public function Foo(%s $A): %1$s {return $A;}}', strtoupper($type)),
             ];
 
-            yield sprintf('standalone type `%s`, leading backslash', $type) => [
-                sprintf('<?php class T { public function Foo(\%s $A): \%1$s {return $A;}}', $type),
-                sprintf('<?php class T { public function Foo(\%s $A): \%1$s {return $A;}}', strtoupper($type)),
+            yield sprintf('standalone type `%s` in function', $type) => [
+                sprintf('<?php function Foo(%s $A): %1$s {return $A;}', $type),
+                sprintf('<?php function Foo(%s $A): %1$s {return $A;}', strtoupper($type)),
             ];
+
+            yield sprintf('standalone type `%s` in closure', $type) => [
+                sprintf('<?php array_filter([], function (%s $A): %1$s {return $A;});', $type),
+                sprintf('<?php array_filter([], function (%s $A): %1$s {return $A;});', strtoupper($type)),
+            ];
+
+            // @TODO Support for closures
+            // yield sprintf('standalone type `%s` in arrow function', $type) => [
+            //     sprintf('<?php array_filter([], fn (%s $A): %1$s => $A);', $type),
+            //     sprintf('<?php array_filter([], fn (%s $A): %1$s => $A);', strtoupper($type)),
+            // ];
         }
     }
 }

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -229,12 +229,6 @@ function Foo(INTEGER $a) {}
                 sprintf('<?php array_filter([], function (%s $A): %1$s {return $A;});', $type),
                 sprintf('<?php array_filter([], function (%s $A): %1$s {return $A;});', strtoupper($type)),
             ];
-
-            // @TODO Support for closures
-            // yield sprintf('standalone type `%s` in arrow function', $type) => [
-            //     sprintf('<?php array_filter([], fn (%s $A): %1$s => $A);', $type),
-            //     sprintf('<?php array_filter([], fn (%s $A): %1$s => $A);', strtoupper($type)),
-            // ];
         }
     }
 }

--- a/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
+++ b/tests/Fixer/Casing/NativeFunctionTypeDeclarationCasingFixerTest.php
@@ -172,6 +172,16 @@ function Foo(INTEGER $a) {}
             '<?php function foo(): int|bool {}',
             '<?php function foo(): INT|BOOL {}',
         ];
+
+        yield 'return type string|false' => [
+            '<?php function foo(): string|false {}',
+            '<?php function foo(): string|FALSE {}',
+        ];
+
+        yield 'return type string|null' => [
+            '<?php function foo(): string|null {}',
+            '<?php function foo(): string|NULL {}',
+        ];
     }
 
     /**
@@ -190,5 +200,30 @@ function Foo(INTEGER $a) {}
             '<?php class T { public function Foo(object $A): never {die;}}',
             '<?php class T { public function Foo(object $A): NEVER {die;}}',
         ];
+    }
+
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        foreach (['true', 'false', 'null'] as $type) {
+            yield sprintf('standalone type `%s`', $type) => [
+                sprintf('<?php class T { public function Foo(%s $A): %1$s {return $A;}}', $type),
+                sprintf('<?php class T { public function Foo(%s $A): %1$s {return $A;}}', strtoupper($type)),
+            ];
+
+            yield sprintf('standalone type `%s`, leading backslash', $type) => [
+                sprintf('<?php class T { public function Foo(\%s $A): \%1$s {return $A;}}', $type),
+                sprintf('<?php class T { public function Foo(\%s $A): \%1$s {return $A;}}', strtoupper($type)),
+            ];
+        }
     }
 }

--- a/tests/Fixtures/Integration/misc/PHP8_2.test
+++ b/tests/Fixtures/Integration/misc/PHP8_2.test
@@ -28,11 +28,25 @@ class FalseNull
     ) {
     }
 
+    public function falsy(): false
+    {
+        return $this->falsy;
+    }
+
+    public function nully(): null
+    {
+        return $this->nully;
+    }
+
     public function setAB(false $a, null $b): void
     {
         $this->a = $a;
         $this->b = $b;
     }
+}
+
+function falsyNull(null $n, false $f): null|false
+{
 }
 
 array_filter([], fn (null $n) => null === $n);
@@ -48,10 +62,20 @@ class TrueType
     ) {
     }
 
+    public function havingABud(): true
+    {
+        return $this->havingABud;
+    }
+
     public function setA(true $a): void
     {
         $this->a = $a;
     }
+}
+
+function truish(true $true): true
+{
+    return $true;
 }
 
 array_filter([], fn (true $n) => true === $n);
@@ -84,11 +108,25 @@ class FalseNull {
     ) {
     }
 
+    public   function   falsy()   :   FALSE
+    {
+        return $this -> falsy;
+    }
+
+    public   function   nully()   :   NULL
+    {
+        return $this -> nully;
+    }
+
     public function setAB(FALSE $a, NULL $b): void
     {
         $this->a = $a;
         $this->b = $b;
     }
+}
+
+function   falsyNull   (NULL   $n,   FALSE   $f):   NULL|FALSE
+{
 }
 
 array_filter([], fn     (NULL     $n)     =>     NULL     ===     $n);
@@ -103,10 +141,20 @@ class TrueType {
     ) {
     }
 
+    public   function   havingABud()   :   TRUE
+    {
+        return $this -> havingABud;
+    }
+
     public function setA(TRUE $a): void
     {
         $this->a = $a;
     }
+}
+
+function truish   (TRUE   $true)   :   TRUE
+{
+    return   $true;
 }
 
 array_filter([], fn     (TRUE     $n)     =>     TRUE     ===     $n);


### PR DESCRIPTION
Continuation of work from #6427, relates to #6605 (not necessarily provides full support).