### PR TITLE
feature: PHP8.2 - "readonly" class support

### DIFF
--- a/src/AbstractDoctrineAnnotationFixer.php
+++ b/src/AbstractDoctrineAnnotationFixer.php
@@ -207,13 +207,19 @@ abstract class AbstractDoctrineAnnotationFixer extends AbstractFixer implements 
 
     private function nextElementAcceptsDoctrineAnnotations(Tokens $tokens, int $index): bool
     {
+        $classModifiers = [T_ABSTRACT, T_FINAL];
+
+        if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.2+ is required
+            $classModifiers[] = T_READONLY;
+        }
+
         do {
             $index = $tokens->getNextMeaningfulToken($index);
 
             if (null === $index) {
                 return false;
             }
-        } while ($tokens[$index]->isGivenKind([T_ABSTRACT, T_FINAL]));
+        } while ($tokens[$index]->isGivenKind($classModifiers));
 
         if ($tokens[$index]->isGivenKind(T_CLASS)) {
             return true;

--- a/src/Fixer/AbstractPhpUnitFixer.php
+++ b/src/Fixer/AbstractPhpUnitFixer.php
@@ -44,9 +44,15 @@ abstract class AbstractPhpUnitFixer extends AbstractFixer
 
     final protected function getDocBlockIndex(Tokens $tokens, int $index): int
     {
+        $modifiers = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_COMMENT];
+
+        if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.2+ is required
+            $modifiers[] = T_READONLY;
+        }
+
         do {
             $index = $tokens->getPrevNonWhitespace($index);
-        } while ($tokens[$index]->isGivenKind([T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_COMMENT]));
+        } while ($tokens[$index]->isGivenKind($modifiers));
 
         return $index;
     }

--- a/src/Fixer/ClassNotation/ClassDefinitionFixer.php
+++ b/src/Fixer/ClassNotation/ClassDefinitionFixer.php
@@ -215,6 +215,8 @@ $foo = new class(){};
 
         // 4.1 The extends and implements keywords MUST be declared on the same line as the class name.
         $this->makeClassyDefinitionSingleLine($tokens, $classDefInfo['start'], $end);
+
+        $this->sortClassModifiers($tokens, $classDefInfo);
     }
 
     private function fixClassyDefinitionExtends(Tokens $tokens, int $classOpenIndex, array $classExtendsInfo): array
@@ -294,42 +296,56 @@ $foo = new class(){};
      *     extends: false|array{start: int, numberOfExtends: int, multiLine: bool},
      *     implements: false|array{start: int, numberOfImplements: int, multiLine: bool},
      *     anonymousClass: bool,
+     *     final: false|int,
+     *     abstract: false|int,
+     *     readonly: false|int,
      * }
      */
     private function getClassyDefinitionInfo(Tokens $tokens, int $classyIndex): array
     {
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
         $openIndex = $tokens->getNextTokenOfKind($classyIndex, ['{']);
-        $extends = false;
-        $implements = false;
-        $anonymousClass = false;
+        $def = [
+            'classy' => $classyIndex,
+            'open' => $openIndex,
+            'extends' => false,
+            'implements' => false,
+            'anonymousClass' => false,
+            'final' => false,
+            'abstract' => false,
+            'readonly' => false,
+        ];
 
         if (!$tokens[$classyIndex]->isGivenKind(T_TRAIT)) {
             $extends = $tokens->findGivenKind(T_EXTENDS, $classyIndex, $openIndex);
-            $extends = \count($extends) ? $this->getClassyInheritanceInfo($tokens, key($extends), 'numberOfExtends') : false;
+            $def['extends'] = \count($extends) ? $this->getClassyInheritanceInfo($tokens, key($extends), 'numberOfExtends') : false;
 
             if (!$tokens[$classyIndex]->isGivenKind(T_INTERFACE)) {
                 $implements = $tokens->findGivenKind(T_IMPLEMENTS, $classyIndex, $openIndex);
-                $implements = \count($implements) ? $this->getClassyInheritanceInfo($tokens, key($implements), 'numberOfImplements') : false;
-                $tokensAnalyzer = new TokensAnalyzer($tokens);
-                $anonymousClass = $tokensAnalyzer->isAnonymousClass($classyIndex);
+                $def['implements'] = \count($implements) ? $this->getClassyInheritanceInfo($tokens, key($implements), 'numberOfImplements') : false;
+                $def['anonymousClass'] = $tokensAnalyzer->isAnonymousClass($classyIndex);
             }
         }
 
-        if ($anonymousClass) {
+        if ($def['anonymousClass']) {
             $startIndex = $tokens->getPrevMeaningfulToken($classyIndex); // go to "new" for anonymous class
         } else {
-            $prev = $tokens->getPrevMeaningfulToken($classyIndex);
-            $startIndex = $tokens[$prev]->isGivenKind([T_FINAL, T_ABSTRACT]) ? $prev : $classyIndex;
+            $modifiers = $tokensAnalyzer->getClassyModifiers($classyIndex);
+            $startIndex = $classyIndex;
+
+            foreach (['final', 'abstract', 'readonly'] as $modifier) {
+                if (isset($modifiers[$modifier])) {
+                    $def[$modifier] = $modifiers[$modifier];
+                    $startIndex = min($startIndex, $modifiers[$modifier]);
+                } else {
+                    $def[$modifier] = false;
+                }
+            }
         }
 
-        return [
-            'start' => $startIndex,
-            'classy' => $classyIndex,
-            'open' => $openIndex,
-            'extends' => $extends,
-            'implements' => $implements,
-            'anonymousClass' => $anonymousClass,
-        ];
+        $def['start'] = $startIndex;
+
+        return $def;
     }
 
     private function getClassyInheritanceInfo(Tokens $tokens, int $startIndex, string $label): array
@@ -455,6 +471,41 @@ $foo = new class(){};
             }
 
             $i = $previousInterfaceImplementingIndex + 1;
+        }
+    }
+
+    /**
+     * @param array{
+     *     final: false|int,
+     *     abstract: false|int,
+     *     readonly: false|int,
+     * } $classDefInfo
+     */
+    private function sortClassModifiers(Tokens $tokens, array $classDefInfo): void
+    {
+        if (false === $classDefInfo['readonly']) {
+            return;
+        }
+
+        $readonlyIndex = $classDefInfo['readonly'];
+
+        foreach (['final', 'abstract'] as $accessModifier) {
+            if (false === $classDefInfo[$accessModifier] || $classDefInfo[$accessModifier] < $readonlyIndex) {
+                continue;
+            }
+
+            $accessModifierIndex = $classDefInfo[$accessModifier];
+
+            /** @var Token $readonlyToken */
+            $readonlyToken = clone $tokens[$readonlyIndex];
+
+            /** @var Token $accessToken */
+            $accessToken = clone $tokens[$accessModifierIndex];
+
+            $tokens[$readonlyIndex] = $accessToken;
+            $tokens[$accessModifierIndex] = $readonlyToken;
+
+            break;
         }
     }
 }

--- a/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
+++ b/src/Fixer/ClassNotation/NoUnneededFinalMethodFixer.php
@@ -181,8 +181,8 @@ class Bar
             }
 
             if (!\array_key_exists($classIndex, $classesAreFinal)) {
-                $prevToken = $tokens[$tokens->getPrevMeaningfulToken($classIndex)];
-                $classesAreFinal[$classIndex] = $prevToken->isGivenKind(T_FINAL);
+                $modifiers = $tokensAnalyzer->getClassyModifiers($classIndex);
+                $classesAreFinal[$classIndex] = isset($modifiers['final']);
             }
 
             $element['method_of_enum'] = false;

--- a/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
+++ b/src/Fixer/ClassNotation/ProtectedToPrivateFixer.php
@@ -28,6 +28,8 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
  */
 final class ProtectedToPrivateFixer extends AbstractFixer
 {
+    private TokensAnalyzer $tokensAnalyzer;
+
     /**
      * {@inheritdoc}
      */
@@ -80,7 +82,7 @@ final class Sample
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
-        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        $this->tokensAnalyzer = new TokensAnalyzer($tokens);
         $modifierKinds = [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_NS_SEPARATOR, T_STRING, CT::T_NULLABLE_TYPE, CT::T_ARRAY_TYPEHINT, T_STATIC, CT::T_TYPE_ALTERNATION, CT::T_TYPE_INTERSECTION];
 
         if (\defined('T_READONLY')) { // @TODO: drop condition when PHP 8.1+ is required
@@ -90,7 +92,7 @@ final class Sample
         $classesCandidate = [];
         $classElementTypes = ['method' => true, 'property' => true, 'const' => true];
 
-        foreach ($tokensAnalyzer->getClassyElements() as $index => $element) {
+        foreach ($this->tokensAnalyzer->getClassyElements() as $index => $element) {
             $classIndex = $element['classIndex'];
 
             if (!\array_key_exists($classIndex, $classesCandidate)) {
@@ -98,7 +100,7 @@ final class Sample
             }
 
             if (false === $classesCandidate[$classIndex]) {
-                continue; // not "final" class, "extends", is "anonymous", enum or uses trait
+                continue;
             }
 
             if (!isset($classElementTypes[$element['type']])) {
@@ -132,15 +134,28 @@ final class Sample
         }
     }
 
+    /**
+     * Consider symbol as candidate for fixing if it's:
+     *   - an Enum (PHP8.1+)
+     *   - a class, which:
+     *     - is not anonymous
+     *     - is not final
+     *     - does not use traits
+     *     - does not extend other class.
+     */
     private function isClassCandidate(Tokens $tokens, int $classIndex): bool
     {
         if (\defined('T_ENUM') && $tokens[$classIndex]->isGivenKind(T_ENUM)) { // @TODO: drop condition when PHP 8.1+ is required
             return true;
         }
 
-        $prevToken = $tokens[$tokens->getPrevMeaningfulToken($classIndex)];
+        if (!$tokens[$classIndex]->isGivenKind(T_CLASS) || $this->tokensAnalyzer->isAnonymousClass($classIndex)) {
+            return false;
+        }
 
-        if (!$prevToken->isGivenKind(T_FINAL)) {
+        $modifiers = $this->tokensAnalyzer->getClassyModifiers($classIndex);
+
+        if (!isset($modifiers['final'])) {
             return false;
         }
 

--- a/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
+++ b/src/Fixer/ClassNotation/SelfStaticAccessorFixer.php
@@ -24,10 +24,7 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
 
 final class SelfStaticAccessorFixer extends AbstractFixer
 {
-    /**
-     * @var TokensAnalyzer
-     */
-    private $tokensAnalyzer;
+    private TokensAnalyzer $tokensAnalyzer;
 
     /**
      * {@inheritdoc}
@@ -115,14 +112,12 @@ $a = new class() {
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
         $this->tokensAnalyzer = new TokensAnalyzer($tokens);
-
         $classIndex = $tokens->getNextTokenOfKind(0, [[T_CLASS]]);
 
         while (null !== $classIndex) {
-            if (
-                $this->tokensAnalyzer->isAnonymousClass($classIndex)
-                || $tokens[$tokens->getPrevMeaningfulToken($classIndex)]->isGivenKind(T_FINAL)
-            ) {
+            $modifiers = $this->tokensAnalyzer->getClassyModifiers($classIndex);
+
+            if (isset($modifiers['final']) || $this->tokensAnalyzer->isAnonymousClass($classIndex)) {
                 $classIndex = $this->fixClass($tokens, $classIndex);
             }
 

--- a/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
+++ b/tests/Fixer/ClassNotation/ClassDefinitionFixerTest.php
@@ -431,6 +431,9 @@ TestInterface3, /**/     TestInterface4   ,
 
         $result = $method->invoke($this->fixer, $tokens, $expected['classy']);
 
+        ksort($expected);
+        ksort($result);
+
         static::assertSame($expected, $result);
     }
 
@@ -446,6 +449,9 @@ TestInterface3, /**/     TestInterface4   ,
                     'extends' => false,
                     'implements' => false,
                     'anonymousClass' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'readonly' => false,
                 ],
             ],
             [
@@ -457,6 +463,9 @@ TestInterface3, /**/     TestInterface4   ,
                     'extends' => false,
                     'implements' => false,
                     'anonymousClass' => false,
+                    'final' => 1,
+                    'abstract' => false,
+                    'readonly' => false,
                 ],
             ],
             [
@@ -468,6 +477,9 @@ TestInterface3, /**/     TestInterface4   ,
                     'extends' => false,
                     'implements' => false,
                     'anonymousClass' => false,
+                    'final' => false,
+                    'abstract' => 1,
+                    'readonly' => false,
                 ],
             ],
             [
@@ -483,6 +495,9 @@ TestInterface3, /**/     TestInterface4   ,
                     ],
                     'implements' => false,
                     'anonymousClass' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'readonly' => false,
                 ],
             ],
             [
@@ -498,6 +513,9 @@ TestInterface3, /**/     TestInterface4   ,
                     ],
                     'implements' => false,
                     'anonymousClass' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'readonly' => false,
                 ],
             ],
         ];
@@ -725,6 +743,40 @@ $a = new class implements
     }
 
     /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'final readonly works' => [
+            '<?php final readonly class a
+{}',
+            '<?php final           readonly      class a
+{}',
+        ];
+
+        yield 'final - readonly modifiers get sorted' => [
+            '<?php final readonly class a
+{}',
+            '<?php readonly final class a
+{}',
+        ];
+
+        yield 'abstract - readonly modifiers get sorted' => [
+            '<?php abstract readonly class a
+{}',
+            '<?php readonly abstract class a
+{}',
+        ];
+    }
+
+    /**
      * @param array<string, mixed> $expected
      */
     private static function assertConfigurationSame(array $expected, ClassDefinitionFixer $fixer): void
@@ -865,11 +917,24 @@ extends
                 "<?php abstract class F extends B implements C\n{}",
                 '<?php abstract    class    F    extends     B    implements C {}',
             ],
-            [
+            'multiline abstract extends implements with comments' => [
                 "<?php abstract class G extends       //
 B /*  */ implements C\n{}",
                 '<?php abstract    class     G     extends       //
 B/*  */implements C{}',
+            ],
+            'final extends implement' => [
+                "<?php final class G extends       //
+B /*  */ implements C\n{}",
+                '<?php final    class     G     extends       //
+B/*  */implements C{}',
+            ],
+            'final' => [
+                '<?php final class G        //
+/*  */
+{}',
+                '<?php final    class     G        //
+/*  */{}',
             ],
             [
                 '<?php

--- a/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
+++ b/tests/Fixer/ClassNotation/FinalInternalClassFixerTest.php
@@ -267,6 +267,11 @@ class B{}
                     'annotation_exclude' => ['abc'],
                 ],
             ],
+            [
+                '<?php final class A{}',
+                '<?php class A{}',
+                ['consider_absent_docblock_as_internal_class' => true],
+            ],
         ];
     }
 
@@ -325,6 +330,28 @@ $a = new class{};',
             '<?php
 #[Internal]
 class Foo {}',
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, ?string $input, array $config): void
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield [
+            '<?php final readonly class A{}',
+            null,
+            ['consider_absent_docblock_as_internal_class' => true],
         ];
     }
 }

--- a/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
+++ b/tests/Fixer/ClassNotation/NoUnneededFinalMethodFixerTest.php
@@ -470,4 +470,47 @@ enum Foo: string
 var_dump(Foo::Spades);',
         ];
     }
+
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'final readonly class - final after visibility method' => [
+            '<?php
+final readonly class Foo {
+    public function foo() {}
+    protected function bar() {}
+    private function baz() {}
+}',
+            '<?php
+final readonly class Foo {
+    public final function foo() {}
+    protected final function bar() {}
+    private final function baz() {}
+}',
+        ];
+
+        yield 'readonly comment final class - final before visibility method' => [
+            '<?php
+readonly /* X */ final class Foo {
+    public function foo() {}
+    protected function bar() {}
+    private function baz() {}
+}',
+            '<?php
+readonly /* X */ final class Foo {
+    final public function foo() {}
+    final protected function bar() {}
+    final private function baz() {}
+}',
+        ];
+    }
 }

--- a/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
+++ b/tests/Fixer/ClassNotation/ProtectedToPrivateFixerTest.php
@@ -231,6 +231,88 @@ enum Foo: string
 Foo::Hearts->test();
             ',
         ];
+
+        yield 'enum with trait' => [
+            '<?php
+
+trait NamedDocumentStatus
+{
+    public function getStatusName(): string
+    {
+        return $this->getFoo();
+    }
+}
+
+enum DocumentStats {
+    use NamedDocumentStatus;
+
+    case DRAFT;
+
+    private function getFoo(): string {
+        return "X";
+    }
+}
+
+echo DocumentStats::DRAFT->getStatusName();
+',
+            '<?php
+
+trait NamedDocumentStatus
+{
+    public function getStatusName(): string
+    {
+        return $this->getFoo();
+    }
+}
+
+enum DocumentStats {
+    use NamedDocumentStatus;
+
+    case DRAFT;
+
+    protected function getFoo(): string {
+        return "X";
+    }
+}
+
+echo DocumentStats::DRAFT->getStatusName();
+',
+        ];
+    }
+
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'final readonly' => [
+            '<?php
+            final readonly class Foo {
+                private function noop(): void{}
+            }',
+            '<?php
+            final readonly class Foo {
+                protected function noop(): void{}
+            }',
+        ];
+
+        yield 'final readonly reversed' => [
+            '<?php
+            readonly final class Foo {
+                private function noop(): void{}
+            }',
+            '<?php
+            readonly final class Foo {
+                protected function noop(): void{}
+            }',
+        ];
     }
 
     private function getAttributesAndMethods(bool $original): string

--- a/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
@@ -359,4 +359,48 @@ $b = function() { return static::class; };
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'simple' => [
+            '<?php
+final readonly class Sample
+{
+    public function getBar()
+    {
+        return self::class.self::test();
+    }
+
+    private static function test()
+    {
+        return \'test\';
+    }
+}
+',
+            '<?php
+final readonly class Sample
+{
+    public function getBar()
+    {
+        return static::class.static::test();
+    }
+
+    private static function test()
+    {
+        return \'test\';
+    }
+}
+',
+        ];
+    }
 }

--- a/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
+++ b/tests/Fixer/DoctrineAnnotation/DoctrineAnnotationBracesFixerTest.php
@@ -33,9 +33,9 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithBracesCases(): array
+    public function provideFixWithBracesCases(): iterable
     {
-        $cases = $this->createTestCases([
+        yield from $this->createTestCases([
             ['
 /**
  * @Foo()
@@ -267,7 +267,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  */'],
         ]);
 
-        $cases[] = [
+        yield [
             '<?php
 
 /**
@@ -275,8 +275,6 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  */
 ',
         ];
-
-        return $cases;
     }
 
     /**
@@ -290,9 +288,9 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
         $this->doTest($expected, $input);
     }
 
-    public function provideFixWithoutBracesCases(): array
+    public function provideFixWithoutBracesCases(): iterable
     {
-        $cases = $this->createTestCases([
+        yield from $this->createTestCases([
             ['
 /**
  * Foo.
@@ -542,7 +540,7 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  */'],
         ]);
 
-        $cases[] = [
+        yield [
             '<?php
 
 /**
@@ -550,7 +548,37 @@ final class DoctrineAnnotationBracesFixerTest extends AbstractDoctrineAnnotation
  */
 ',
         ];
+    }
 
-        return $cases;
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield [
+            '<?php
+
+/**
+ * @author John Doe
+ *
+ * @Baz\Bar
+ */
+readonly class FooClass{}',
+            '<?php
+
+/**
+ * @author John Doe
+ *
+ * @Baz\Bar ( )
+ */
+readonly class FooClass{}',
+        ];
     }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitInternalClassFixerTest.php
@@ -373,4 +373,41 @@ class Test extends TestCase
             ],
         ];
     }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, ?string $input = null, array $config = []): void
+    {
+        $this->fixer->configure($config);
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'If final is not added as an option, final classes will not be marked internal' => [
+            '<?php
+final readonly class Test extends TestCase
+{}
+',
+            null,
+            [
+                'types' => ['normal'],
+            ],
+        ];
+
+        yield [
+            '<?php
+/**
+ * @internal
+ */
+readonly final class Test extends TestCase {}',
+            '<?php
+readonly final class Test extends TestCase {}',
+        ];
+    }
 }

--- a/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitTestClassRequiresCoversFixerTest.php
@@ -265,4 +265,38 @@ class FooTest extends \PHPUnit_Framework_TestCase {}
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideFix82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testFix82(string $expected, ?string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    public function provideFix82Cases(): iterable
+    {
+        yield 'without docblock #2 (class is final)' => [
+            '<?php
+
+                /**
+                 * @coversNothing
+                 */
+                readonly final class BarTest extends \PHPUnit_Framework_TestCase {}
+            ',
+            '<?php
+
+                readonly final class BarTest extends \PHPUnit_Framework_TestCase {}
+            ',
+        ];
+
+        yield 'without docblock #2 (class is abstract)' => [
+            '<?php
+                    abstract readonly class FooTest extends \PHPUnit_Framework_TestCase {}
+            ',
+            null,
+        ];
+    }
 }

--- a/tests/Fixtures/Integration/misc/PHP8_2.test
+++ b/tests/Fixtures/Integration/misc/PHP8_2.test
@@ -11,7 +11,7 @@ PHP 8.2 test.
 <?php
 
 // https://wiki.php.net/rfc/readonly_classes
-readonly final class Foo
+final readonly class Foo
 {
     public string $prop;
 }


### PR DESCRIPTION
This fixes the current the rules and code so these handle the new `readonly` classes as added in PHP8.2.
The `class_definition` rule will now also sort the `class` `modifiers following: https://github.com/php-fig/per-coding-style/blob/9dc210da72285afd5ab10ab0bd34659ff5b0529f/spec.md#46-modifier-keywords