### PR TITLE
feature: PHP8.2 - Transformers - Support Disjunctive Normal Form Types

### DIFF
--- a/src/Tokenizer/AbstractTypeTransformer.php
+++ b/src/Tokenizer/AbstractTypeTransformer.php
@@ -37,10 +37,12 @@ abstract class AbstractTypeTransformer extends AbstractTransformer
 
         if ($prevToken->isGivenKind([
             CT::T_TYPE_COLON, // `:` is part of a function return type `foo(): X|Y`
-            CT::T_TYPE_ALTERNATION, // `|` is part of a union (chain) `X|Y`
-            CT::T_TYPE_INTERSECTION,
+            CT::T_TYPE_ALTERNATION, // `|` is part of a union (chain) `W|X|Y`
+            CT::T_TYPE_INTERSECTION, // `&` is part of a intersection (chain) `W&X&Y`
             T_STATIC, T_VAR, T_PUBLIC, T_PROTECTED, T_PRIVATE, // `var X|Y $a;`, `private X|Y $a` or `public static X|Y $a`
             CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC, // promoted properties
+            CT::T_DNF_TYPE_PARENTHESIS_CLOSE, // `|` is part of DNF `(A&B)|X`
+            CT::T_DNF_TYPE_PARENTHESIS_OPEN, // `&` is part of DNF `(A&B)`
         ])) {
             $this->replaceToken($tokens, $index);
 

--- a/src/Tokenizer/CT.php
+++ b/src/Tokenizer/CT.php
@@ -54,6 +54,8 @@ final class CT
     public const T_NAMED_ARGUMENT_COLON = 10033;
     public const T_FIRST_CLASS_CALLABLE = 10034;
     public const T_TYPE_INTERSECTION = 10035;
+    public const T_DNF_TYPE_PARENTHESIS_OPEN = 10036;
+    public const T_DNF_TYPE_PARENTHESIS_CLOSE = 10037;
 
     private function __construct()
     {

--- a/src/Tokenizer/Token.php
+++ b/src/Tokenizer/Token.php
@@ -118,7 +118,7 @@ final class Token
 
         if (null === $objectOperators) {
             $objectOperators = [T_OBJECT_OPERATOR];
-            if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+            if (\defined('T_NULLSAFE_OBJECT_OPERATOR')) { // @TODO: drop condition when PHP 8.0+ is required
                 $objectOperators[] = T_NULLSAFE_OBJECT_OPERATOR;
             }
         }

--- a/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
+++ b/src/Tokenizer/Transformer/ArrayTypehintTransformer.php
@@ -46,9 +46,8 @@ final class ArrayTypehintTransformer extends AbstractTransformer
         }
 
         $nextIndex = $tokens->getNextMeaningfulToken($index);
-        $nextToken = $tokens[$nextIndex];
 
-        if (!$nextToken->equals('(')) {
+        if (!$tokens[$nextIndex]->equals('(')) {
             $tokens[$index] = new Token([CT::T_ARRAY_TYPEHINT, $token->getContent()]);
         }
     }

--- a/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
+++ b/src/Tokenizer/Transformer/BraceClassInstantiationTransformer.php
@@ -34,7 +34,6 @@ final class BraceClassInstantiationTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // must run after CurlyBraceTransformer and SquareBraceTransformer
         return -2;
     }
 

--- a/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeBracesTransformer.php
+++ b/src/Tokenizer/Transformer/DisjunctiveNormalFormTypeBracesTransformer.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tokenizer\Transformer;
+
+use PhpCsFixer\Tokenizer\AbstractTransformer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * @internal
+ */
+final class DisjunctiveNormalFormTypeBracesTransformer extends AbstractTransformer
+{
+    /**
+     * @var list<int>
+     */
+    private array $propertyModifierTypes = []; // @TODO: replace with `const` when PHP 8.1+ is required
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomTokens(): array
+    {
+        return [
+            CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+            CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+        ];
+    }
+
+    public function getPriority(): int
+    {
+        return -12;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredPhpVersionId(): int
+    {
+        return 80200;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(Tokens $tokens, Token $token, int $index): void
+    {
+        $this->initializeModifiersTypes();
+
+        if ($tokens[$index]->isGivenKind(CT::T_TYPE_COLON)) {
+            $this->fixBracesOfReturnTypeCandidate($tokens, $index);
+
+            return;
+        }
+
+        if ($tokens[$index]->isGivenKind($this->propertyModifierTypes)) {
+            $this->fixBracesOfPropertyCandidate($tokens, $index);
+
+            return;
+        }
+
+        if ($tokens[$index]->isGivenKind(T_FUNCTION)) {
+            $functionBraceOpenIndex = $tokens->getNextTokenOfKind($index, ['(']);
+
+            $this->fixBracesInFunctionArgumentsCandidate(
+                $tokens,
+                $tokens->getNextMeaningfulToken($functionBraceOpenIndex),
+                $this->findBraceCloseIndex($tokens, $functionBraceOpenIndex)
+            );
+
+            // implicit return
+        }
+    }
+
+    private function fixBracesOfReturnTypeCandidate(Tokens $tokens, int $index): void
+    {
+        $index = $tokens->getNextMeaningfulToken($index);
+
+        if ($this->isPossibleStartOfDnfType($tokens, $index)) {
+            $this->fixBracesOfDnfTypeCandidate($tokens, $index);
+        }
+    }
+
+    private function fixBracesOfPropertyCandidate(Tokens $tokens, int $index): void
+    {
+        if ($tokens[$index]->isGivenKind([T_STATIC])) {
+            $this->fixBracesOfStaticPropertyCandidate($tokens, $index);
+
+            return;
+        }
+
+        do {
+            $index = $tokens->getNextMeaningfulToken($index);
+        } while ($tokens[$index]->isGivenKind($this->propertyModifierTypes));
+
+        if ($this->isPossibleStartOfDnfType($tokens, $index)) {
+            $this->fixBracesOfDnfTypeCandidate($tokens, $index);
+        }
+    }
+
+    private function fixBracesOfStaticPropertyCandidate(Tokens $tokens, int $index): void
+    {
+        $nextMeaningfulIndex = $tokens->getNextMeaningfulToken($index);
+
+        if ($tokens[$nextMeaningfulIndex]->isGivenKind([T_READONLY])) {
+            $nextMeaningfulIndex = $tokens->getNextMeaningfulToken($index);
+        }
+
+        if (!$this->isPossibleStartOfDnfType($tokens, $nextMeaningfulIndex)) {
+            return;
+        }
+
+        $prev = $tokens->getPrevMeaningfulToken($index);
+
+        if (!$tokens[$prev]->equalsAny(['{', ';', [CT::T_ATTRIBUTE_CLOSE]])) { // FIXME utests
+            return;
+        }
+
+        $this->fixBracesOfDnfTypeCandidate($tokens, $nextMeaningfulIndex);
+    }
+
+    private function fixBracesInFunctionArgumentsCandidate(Tokens $tokens, int $index, int $endIndex): void
+    {
+        while (true) {
+            if ($this->isPossibleStartOfDnfType($tokens, $index)) {
+                $this->fixBracesOfDnfTypeCandidate($tokens, $index);
+            }
+
+            $index = $tokens->getNextTokenOfKind($index, [',', [T_ARRAY], [CT::T_ARRAY_SQUARE_BRACE_OPEN]]);
+
+            if (null === $index || $index >= $endIndex) {
+                break;
+            }
+
+            if ($tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+                $index = $tokens->getNextMeaningfulToken($index);
+            } elseif ($tokens[$index]->isGivenKind(T_ARRAY)) {
+                $index = $tokens->getNextMeaningfulToken($index);
+                $index = $this->findBraceCloseIndex($tokens, $index);
+                $index = $tokens->getNextMeaningfulToken($index);
+            }
+
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
+    }
+
+    private function fixBracesOfDnfTypeCandidate(Tokens $tokens, int $index): void
+    {
+        if ($tokens[$index]->equals('(')) {
+            $closeIndex = $this->findBraceCloseIndex($tokens, $index);
+            $this->replaceBraces($tokens, $index, $closeIndex);
+            $index = $tokens->getNextMeaningfulToken($closeIndex);
+        } elseif ($tokens[$index]->isGivenKind([T_NS_SEPARATOR, T_STRING])) {
+            do {
+                $index = $tokens->getNextMeaningfulToken($index);
+            } while ($tokens[$index]->isGivenKind([T_NS_SEPARATOR, T_STRING]));
+        } else {
+            return;
+        }
+
+        if ($tokens[$index]->equals('|')) {
+            $this->fixBracesOfDnfTypeCandidate($tokens, $tokens->getNextMeaningfulToken($index));
+        }
+    }
+
+    private function replaceBraces(Tokens $tokens, int $openBraceIndex, int $closeBraceIndex): void
+    {
+        $tokens[$openBraceIndex] = new Token([CT::T_DNF_TYPE_PARENTHESIS_OPEN, '(']);
+        $tokens[$closeBraceIndex] = new Token([CT::T_DNF_TYPE_PARENTHESIS_CLOSE, ')']);
+    }
+
+    private function findBraceCloseIndex(Tokens $tokens, int $openBraceIndex): int
+    {
+        $closeBraceIndex = $openBraceIndex;
+        $depth = 1;
+
+        do {
+            $closeBraceIndex = $tokens->getNextMeaningfulToken($closeBraceIndex);
+
+            if ($tokens[$closeBraceIndex]->equals(')')) {
+                --$depth;
+            } elseif ($tokens[$closeBraceIndex]->equals('(')) {
+                ++$depth;
+            }
+        } while (0 !== $depth);
+
+        return $closeBraceIndex;
+    }
+
+    private function isPossibleStartOfDnfType(Tokens $tokens, int $index): bool
+    {
+        return $tokens[$index]->equalsAny(['(', [T_NS_SEPARATOR], [T_STRING]]);
+    }
+
+    private function initializeModifiersTypes(): void
+    {
+        if (0 === \count($this->propertyModifierTypes)) {
+            $this->propertyModifierTypes = [
+                T_PRIVATE,
+                T_PROTECTED,
+                T_PUBLIC,
+                T_READONLY,
+                T_STATIC,
+                CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE,
+                CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED,
+                CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PUBLIC,
+            ];
+        }
+    }
+}

--- a/src/Tokenizer/Transformer/ImportTransformer.php
+++ b/src/Tokenizer/Transformer/ImportTransformer.php
@@ -37,7 +37,6 @@ final class ImportTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // Should run after CurlyBraceTransformer and ReturnRefTransformer
         return -1;
     }
 

--- a/src/Tokenizer/Transformer/NameQualifiedTransformer.php
+++ b/src/Tokenizer/Transformer/NameQualifiedTransformer.php
@@ -30,7 +30,7 @@ final class NameQualifiedTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        return 1; // must run before NamespaceOperatorTransformer
+        return 1;
     }
 
     /**

--- a/src/Tokenizer/Transformer/NamedArgumentTransformer.php
+++ b/src/Tokenizer/Transformer/NamedArgumentTransformer.php
@@ -31,7 +31,6 @@ final class NamedArgumentTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // needs to run after TypeColonTransformer
         return -15;
     }
 

--- a/src/Tokenizer/Transformer/NullableTypeTransformer.php
+++ b/src/Tokenizer/Transformer/NullableTypeTransformer.php
@@ -33,7 +33,6 @@ final class NullableTypeTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // needs to run after TypeColonTransformer
         return -20;
     }
 

--- a/src/Tokenizer/Transformer/SquareBraceTransformer.php
+++ b/src/Tokenizer/Transformer/SquareBraceTransformer.php
@@ -37,7 +37,6 @@ final class SquareBraceTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // must run after CurlyBraceTransformer and AttributeTransformer
         return -1;
     }
 

--- a/src/Tokenizer/Transformer/TypeAlternationTransformer.php
+++ b/src/Tokenizer/Transformer/TypeAlternationTransformer.php
@@ -34,7 +34,6 @@ final class TypeAlternationTransformer extends AbstractTypeTransformer
      */
     public function getPriority(): int
     {
-        // needs to run after ArrayTypehintTransformer, TypeColonTransformer and AttributeTransformer
         return -15;
     }
 

--- a/src/Tokenizer/Transformer/TypeColonTransformer.php
+++ b/src/Tokenizer/Transformer/TypeColonTransformer.php
@@ -33,8 +33,6 @@ final class TypeColonTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // needs to run after ReturnRefTransformer and UseTransformer
-        // and before TypeAlternationTransformer
         return -10;
     }
 
@@ -74,7 +72,7 @@ final class TypeColonTransformer extends AbstractTransformer
         $prevIndex = $tokens->getPrevMeaningfulToken($startIndex);
         $prevToken = $tokens[$prevIndex];
 
-        // if this could be a function name we need to take one more step
+        // this could be a function name, we need to take one more step
         if ($prevToken->isGivenKind(T_STRING)) {
             $prevIndex = $tokens->getPrevMeaningfulToken($prevIndex);
             $prevToken = $tokens[$prevIndex];

--- a/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
+++ b/src/Tokenizer/Transformer/TypeIntersectionTransformer.php
@@ -32,7 +32,6 @@ final class TypeIntersectionTransformer extends AbstractTypeTransformer
      */
     public function getPriority(): int
     {
-        // needs to run after ArrayTypehintTransformer, TypeColonTransformer and AttributeTransformer
         return -15;
     }
 

--- a/src/Tokenizer/Transformer/UseTransformer.php
+++ b/src/Tokenizer/Transformer/UseTransformer.php
@@ -35,7 +35,6 @@ final class UseTransformer extends AbstractTransformer
      */
     public function getPriority(): int
     {
-        // Should run after CurlyBraceTransformer and before TypeColonTransformer
         return -5;
     }
 

--- a/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
+++ b/tests/Fixer/ClassNotation/SelfStaticAccessorFixerTest.php
@@ -124,7 +124,7 @@ abstract class Sample
             ],
             [
                 '<?php
-final class Foo
+final class Foo99
 {
     public function bar()
     {
@@ -135,7 +135,7 @@ final class Foo
 }
                 ',
                 '<?php
-final class Foo
+final class Foo99
 {
     public function bar()
     {
@@ -148,7 +148,7 @@ final class Foo
             ],
             'instance of' => [
                 '<?php
-final class Foo
+final class Foo100
 {
     public function isBar($foo)
     {
@@ -157,7 +157,7 @@ final class Foo
 }
                 ',
                 '<?php
-final class Foo
+final class Foo100
 {
     public function isBar($foo)
     {
@@ -167,16 +167,16 @@ final class Foo
                 ',
             ],
             'in method as new' => [
-                '<?php final class A { public static function b() { return new self(); } }',
-                '<?php final class A { public static function b() { return new static(); } }',
+                '<?php final class A0 { public static function b() { return new self(); } }',
+                '<?php final class A0 { public static function b() { return new static(); } }',
             ],
             'in method as new with comments' => [
-                '<?php final class A { public static function b() { return new /* hmm */ self(); } }',
-                '<?php final class A { public static function b() { return new /* hmm */ static(); } }',
+                '<?php final class A1 { public static function b() { return new /* hmm */ self(); } }',
+                '<?php final class A1 { public static function b() { return new /* hmm */ static(); } }',
             ],
             'in method as new without parentheses' => [
-                '<?php final class A { public static function b() { return new self; } }',
-                '<?php final class A { public static function b() { return new static; } }',
+                '<?php final class A2 { public static function b() { return new self; } }',
+                '<?php final class A2 { public static function b() { return new static; } }',
             ],
             'simple anonymous class' => [
                 '<?php
@@ -196,7 +196,7 @@ $a = new class {
             ],
             'nested anonymous class' => [
                 '<?php
-final class Foo
+final class Foo3x
 {
     public function Foo()
     {
@@ -220,7 +220,7 @@ final class Foo
 }
 ',
                 '<?php
-final class Foo
+final class Foo3x
 {
     public function Foo()
     {
@@ -246,7 +246,7 @@ final class Foo
             ],
             'anonymous classes inside lambda' => [
                 '<?php
-final class Foo
+final class Foo4y
 {
     public function bar()
     {
@@ -292,7 +292,7 @@ final class Foo
 }
 ',
                 '<?php
-final class Foo
+final class Foo4y
 {
     public function bar()
     {
@@ -343,7 +343,7 @@ final class Foo
             ],
             'do not fix inside lambda' => [
                 '<?php
-final class Foo
+final class FooT
 {
     public function Bar()
     {

--- a/tests/Tokenizer/CTTest.php
+++ b/tests/Tokenizer/CTTest.php
@@ -68,6 +68,7 @@ final class CTTest extends TestCase
     {
         static::assertGreaterThan(10000, $value);
         static::assertFalse(\defined($name), 'The CT name must not use native T_* name.');
+        static::assertMatchesRegularExpression('#^T(_[A-Z]+)+$#', $name, sprintf('Name "%s" does not match expected format.', $name));
     }
 
     public function provideConstantsCases(): iterable

--- a/tests/Tokenizer/TokensAnalyzerTest.php
+++ b/tests/Tokenizer/TokensAnalyzerTest.php
@@ -1862,6 +1862,44 @@ $b;',
     }
 
     /**
+     * @param array<int, bool> $expected
+     *
+     * @dataProvider provideIsBinaryOperator82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testIsBinaryOperator82(array $expected, string $source): void
+    {
+        $tokensAnalyzer = new TokensAnalyzer(Tokens::fromCode($source));
+
+        foreach ($expected as $index => $isBinary) {
+            static::assertSame($isBinary, $tokensAnalyzer->isBinaryOperator($index));
+
+            if ($isBinary) {
+                static::assertFalse($tokensAnalyzer->isUnarySuccessorOperator($index));
+                static::assertFalse($tokensAnalyzer->isUnaryPredecessorOperator($index));
+            }
+        }
+    }
+
+    public function provideIsBinaryOperator82Cases(): iterable
+    {
+        yield [
+            [15 => false],
+            '<?php class Dnf { public static I|(P&S11) $f2;}',
+        ];
+
+        yield [
+            [
+                7 => false,
+                19 => false,
+                29 => false,
+            ],
+            '<?php function Foo((A&B)|I $x): (X&Z)|(p\f\G&Y\Z)|z { return foo();}',
+        ];
+    }
+
+    /**
      * @dataProvider provideArrayExceptionsCases
      */
     public function testIsNotArray(string $source, int $tokenIndex): void

--- a/tests/Tokenizer/Transformer/DisjunctiveNormalFormTypeBracesTransformerTest.php
+++ b/tests/Tokenizer/Transformer/DisjunctiveNormalFormTypeBracesTransformerTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of PHP CS Fixer.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *     Dariusz Rumiński <dariusz.ruminski@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace PhpCsFixer\Tests\Tokenizer\Transformer;
+
+use PhpCsFixer\Tests\Test\AbstractTransformerTestCase;
+use PhpCsFixer\Tokenizer\CT;
+
+/**
+ * @internal
+ *
+ * @requires PHP 8.2
+ *
+ * @covers \PhpCsFixer\Tokenizer\Transformer\DisjunctiveNormalFormTypeBracesTransformer
+ */
+final class DisjunctiveNormalFormTypeBracesTransformerTest extends AbstractTransformerTestCase
+{
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcessFunctionReturnTypeCases
+     * @dataProvider provideProcessPropertyCases
+     * @dataProvider provideProcessFunctionArgumentTypeCases
+     */
+    public function testProcess(array $expectedTokens, string $source): void
+    {
+        $this->doTest($source, $expectedTokens, [CT::T_DNF_TYPE_PARENTHESIS_OPEN, CT::T_DNF_TYPE_PARENTHESIS_CLOSE]);
+    }
+
+    public function provideProcessFunctionArgumentTypeCases(): iterable
+    {
+        yield 'lambda with lots of arguments and some others' => [
+            [
+                8 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $a
+                12 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                31 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $c
+                37 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                57 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $e
+                63 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                81 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $uu
+                85 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                140 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $f
+                144 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+$a = function(
+    (X&Y)|C $a,
+    $b = array(1,2),
+    (\X&\Y)|C $c,
+    array $d = [1,2],
+    (\X&\Y)|C $e,
+    $x, $y, $z, P|(H&J) $uu,
+) {};
+
+function foo (array $a = array(66,88, $d = [99,44],array()), $e = [99,44],(C&V)|G|array $f = array()){};
+
+return new static();
+',
+        ];
+
+        yield 'one line function signatures with comments' => [
+            [
+                6 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $x1
+                10 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                20 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $x2
+                24 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                29 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // $xxx
+                33 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php function Foo1 ((A&B)|C $x1, \C|(A&B) $x2,/**/(A&B)|I $xxx): void {}',
+        ];
+
+        yield 'multiple functions and arguments' => [
+            [
+                6 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // Foo1
+                10 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                30 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // Foo2
+                34 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                52 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // Foo3
+                56 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                74 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // Foo4
+                78 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                80 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                89 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+function Foo1 ((A&B)|C $x1): void {}
+function Foo2 (C|(A&B) $x2): void {}
+function Foo3 (C|(A&B)|D $x3): void {}
+function Foo4 ((A&B)|(\C&E\B\D) $x4): void {}
+function Foo5 ($x5): void {}
+',
+        ];
+    }
+
+    public function provideProcessFunctionReturnTypeCases(): iterable
+    {
+        yield 'multiple functions including methods' => [
+            [
+                9 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                13 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                31 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                35 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                53 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                57 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                59 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                63 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                84 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                88 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+function Foo():M|(A&B)|J {}
+$a = function(): X|(A&B) {};
+interface Bar {
+    function G():(A&C)|(A&B);
+}
+class G {
+    public function X():K|(Z&Y)|P{}
+}
+',
+        ];
+
+        yield 'multiple functions including methods 2' => [
+            [
+                7 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                11 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                27 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                31 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                51 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                55 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                76 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                80 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+function Foo():(A&B)|M {}
+$a = function(): (A&B)|N {};
+interface Bar {
+    function G():(A&C)|I;
+}
+class G {
+    public function X():(Z&Y)|P{}
+}
+',
+        ];
+    }
+
+    public function provideProcessPropertyCases(): iterable
+    {
+        yield 'DNF property, A|(C&D)' => [
+            [
+                11 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                15 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+    public A|(C&D) $a;
+}
+
+const E = 1;
+const F = 2;
+
+(E&F);
+
+',
+        ];
+
+        yield 'DNF property, (E&F)|G' => [
+            [
+                11 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                15 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+    public A|(C&D) $a;
+}',
+        ];
+
+        yield 'DNF property, two groups with string and namespace separator' => [
+            [
+                9 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                19 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                21 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                31 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+public (A\BH&Z\SAD\I)|(G\J&F\G\AK) $a;
+}
+',
+        ];
+
+        yield 'bigger set of multiple DNF properties' => [
+            [
+                11 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                15 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                22 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                26 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                35 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                39 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                41 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                45 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                47 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                51 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                58 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                62 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                73 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                77 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+    public A|(C&D) $a;
+    protected (C&D)|B $b;
+    private (C&D)|(E&F)|(G&H) $c;
+    static (C&D)|Z $d;
+    public /* */ (C&D)|X $e;
+
+    public function foo($a, $b) {
+        return
+            $z|($A&$B)|(A::z&B\A::x)
+            || A::b|($A&$B)
+        ;
+    }
+}
+',
+        ];
+
+        yield 'constructor promotion' => [
+            [
+                18 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                22 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                29 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                33 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                42 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                51 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                53 => CT::T_DNF_TYPE_PARENTHESIS_OPEN,
+                63 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+    public function __construct(
+        public Y|(A&B) $x,
+        protected (A&B)|X $u,
+        private (\A\C&B\A)|(\D\C&\E\D) $i,
+    ) {}
+}
+',
+        ];
+
+        yield 'more properties' => [
+            [
+                15 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // E&D
+                19 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                44 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // E1&D1
+                48 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                67 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // D&Y
+                71 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                79 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // F&O
+                83 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                96 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // E77&D88
+                100 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                109 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // P&S
+                113 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+                126 => CT::T_DNF_TYPE_PARENTHESIS_OPEN, // f2
+                130 => CT::T_DNF_TYPE_PARENTHESIS_CLOSE,
+            ],
+            '<?php
+class Dnf
+{
+    public A|B|C|(E&D) $a;
+    public E/**/ | X\C\B | /** */  \C|(E1&D1) $v;
+    public F | B | C | (D&Y) | E | (F&O) $a;
+    static G|B|C|(E77&D88) $XYZ;
+    static public (H&S)|B $f;
+    public static I|(P&S11) $f2;
+}
+
+static $a = 1;
+return new static();
+',
+        ];
+    }
+}

--- a/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeAlternationTransformerTest.php
@@ -344,7 +344,7 @@ function f( #[Target(\'a\')] #[Target(\'b\')] #[Target(\'c\')] #[Target(\'d\')] 
     }
 
     /**
-     * @param array<int, int|string> $expectedTokens
+     * @param array<int, int> $expectedTokens
      *
      * @dataProvider provideFix81Cases
      *
@@ -391,13 +391,13 @@ class Foo
     }
 
     /**
-     * @param array<int, int|string> $expectedTokens
+     * @param array<int, int> $expectedTokens
      *
      * @dataProvider provideProcess81Cases
      *
      * @requires PHP 8.1
      */
-    public function testProcess81(string $source, array $expectedTokens): void
+    public function testProcess81(array $expectedTokens, string $source): void
     {
         $this->doTest($source, $expectedTokens);
     }
@@ -405,10 +405,52 @@ class Foo
     public function provideProcess81Cases(): iterable
     {
         yield 'arrow function with intersection' => [
-            '<?php $a = fn(int|null $item): int&null => $item * 2;',
             [
                 8 => CT::T_TYPE_ALTERNATION,
             ],
+            '<?php $a = fn(int|null $item): int&null => $item * 2;',
+        ];
+    }
+
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcessPhp82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testProcess82(array $expectedTokens, string $source): void
+    {
+        $this->doTest($source, $expectedTokens);
+    }
+
+    public function provideProcessPhp82Cases(): iterable
+    {
+        yield 'DNF' => [
+            [
+                10 => CT::T_TYPE_ALTERNATION, // C1
+                27 => CT::T_TYPE_ALTERNATION, // C2
+                40 => CT::T_TYPE_ALTERNATION, // C3
+                46 => CT::T_TYPE_ALTERNATION, // F
+                63 => CT::T_TYPE_ALTERNATION, // C4
+                76 => CT::T_TYPE_ALTERNATION, // C5
+                93 => CT::T_TYPE_ALTERNATION, // A6
+                101 => CT::T_TYPE_ALTERNATION, // A7
+                116 => CT::T_TYPE_ALTERNATION, // A8
+                130 => CT::T_TYPE_ALTERNATION, // A9
+            ],
+            '<?php
+class Dnf
+{
+    public A|(C1&D) $a;
+    protected (C2&D)|B $b;
+    private (C3&D)|(E&F)|(G&H) $c;
+    static (C4&D)|Z $d;
+    public (C5&D)|X $e;
+
+    public function Foo((A6&B)|C $a, \D|(A7&B) $b, (A8&B)|(C&D) & $g): T|(A9&B) {}
+}
+',
         ];
     }
 }

--- a/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
+++ b/tests/Tokenizer/Transformer/TypeIntersectionTransformerTest.php
@@ -20,12 +20,13 @@ use PhpCsFixer\Tokenizer\CT;
 /**
  * @internal
  *
+ * @covers \PhpCsFixer\Tokenizer\AbstractTypeTransformer
  * @covers \PhpCsFixer\Tokenizer\Transformer\TypeIntersectionTransformer
  */
 final class TypeIntersectionTransformerTest extends AbstractTransformerTestCase
 {
     /**
-     * @param array<int, int|string> $expectedTokens
+     * @param array<int, int> $expectedTokens
      *
      * @dataProvider provideProcessCases
      *
@@ -321,6 +322,45 @@ function f( #[Target(\'a\')] #[Target(\'b\')] #[Target(\'c\')] #[Target(\'d\')] 
             [
                 45 => CT::T_TYPE_INTERSECTION,
             ],
+        ];
+    }
+
+    /**
+     * @param array<int, int> $expectedTokens
+     *
+     * @dataProvider provideProcessPhp82Cases
+     *
+     * @requires PHP 8.2
+     */
+    public function testProcessPhp82(array $expectedTokens, string $source): void
+    {
+        $this->doTest(
+            $source,
+            $expectedTokens,
+            [
+                CT::T_TYPE_INTERSECTION,
+            ]
+        );
+    }
+
+    public function provideProcessPhp82Cases(): iterable
+    {
+        yield 'DNF properties' => [
+            [
+                13 => CT::T_TYPE_INTERSECTION,
+                24 => CT::T_TYPE_INTERSECTION,
+                37 => CT::T_TYPE_INTERSECTION,
+                43 => CT::T_TYPE_INTERSECTION,
+                49 => CT::T_TYPE_INTERSECTION,
+            ],
+            '<?php
+class Dnf
+{
+    public A|(C&D) $a;
+    protected (C&D)|B $b;
+    private (C&D)|(E&F)|(G&H) $c;
+}
+',
         ];
     }
 }


### PR DESCRIPTION
This fixes the DNF types support on the tokens level. It adds new CT types for the braces and fixes the other transformers that didn't handle the new PHP8.2 syntax properly.