### PR TITLE
feature: ArrayPushFixer now fix short arrays

### DIFF
--- a/src/Fixer/Alias/ArrayPushFixer.php
+++ b/src/Fixer/Alias/ArrayPushFixer.php
@@ -197,10 +197,6 @@ final class ArrayPushFixer extends AbstractFixer
             return null;
         }
 
-        if (!$tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
-            $index = $tokens->getNextMeaningfulToken($index);
-        }
-
         for (; $index <= $endIndex; ++$index) {
             $blockType = Tokens::detectBlockType($tokens[$index]);
 

--- a/src/Fixer/Alias/ArrayPushFixer.php
+++ b/src/Fixer/Alias/ArrayPushFixer.php
@@ -197,7 +197,9 @@ final class ArrayPushFixer extends AbstractFixer
             return null;
         }
 
-        $index = $tokens->getNextMeaningfulToken($index);
+        $index = $tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)
+            ? $index
+            : $tokens->getNextMeaningfulToken($index);
 
         for (; $index <= $endIndex; ++$index) {
             $blockType = Tokens::detectBlockType($tokens[$index]);

--- a/src/Fixer/Alias/ArrayPushFixer.php
+++ b/src/Fixer/Alias/ArrayPushFixer.php
@@ -197,9 +197,9 @@ final class ArrayPushFixer extends AbstractFixer
             return null;
         }
 
-        $index = $tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)
-            ? $index
-            : $tokens->getNextMeaningfulToken($index);
+        if (!$tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+            $index = $tokens->getNextMeaningfulToken($index);
+        }
 
         for (; $index <= $endIndex; ++$index) {
             $blockType = Tokens::detectBlockType($tokens[$index]);

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -117,14 +117,15 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
             '<?php $a[] = array($b, $c);',
             '<?php array_push($a, array($b, $c));',
         ];
-        yield 'simple empty short array' => [
-            '<?php $a[] = [];',
-            '<?php array_push($a, []);',
-        ];
 
         yield 'simple short array' => [
             '<?php $a[] = [$b, $c];',
             '<?php array_push($a, [$b, $c]);',
+        ];
+
+        yield 'multiple empty short array' => [
+            '<?php $a[] = [[],[]];',
+            '<?php array_push($a, [[],[]]);',
         ];
 
         yield [

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -128,6 +128,11 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
             '<?php array_push($a, [[], [], $b, $c]);',
         ];
 
+        yield 'second argument wrapped in `(` `)`' => [
+            '<?php $a::$c[] = ($b);',
+            '<?php array_push($a::$c, ($b));',
+        ];
+
         yield [
             '<?php $a::$c[] = $b;',
             '<?php array_push($a::$c, $b);',

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -113,6 +113,20 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
             ',
         ];
 
+        yield 'simple traditional array' => [
+            '<?php $a[] = array($b, $c);',
+            '<?php array_push($a, array($b, $c));',
+        ];
+        yield 'simple empty short array' => [
+            '<?php $a[] = [];',
+            '<?php array_push($a, []);',
+        ];
+
+        yield 'simple short array' => [
+            '<?php $a[] = [$b, $c];',
+            '<?php array_push($a, [$b, $c]);',
+        ];
+
         yield [
             '<?php $a::$c[] = $b;',
             '<?php array_push($a::$c, $b);',
@@ -164,6 +178,10 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
 
         yield 'push multiple II' => [
             '<?php ; array_push($a6a, $b9->$a(1,2), $c);',
+        ];
+
+        yield 'push multiple short' => [
+            '<?php array_push($a6, [$b,$c], []);',
         ];
 
         yield 'returns number of elements in the array I' => [

--- a/tests/Fixer/Alias/ArrayPushFixerTest.php
+++ b/tests/Fixer/Alias/ArrayPushFixerTest.php
@@ -119,13 +119,13 @@ final class ArrayPushFixerTest extends AbstractFixerTestCase
         ];
 
         yield 'simple short array' => [
-            '<?php $a[] = [$b, $c];',
-            '<?php array_push($a, [$b, $c]);',
+            '<?php $a[] = [$b];',
+            '<?php array_push($a, [$b]);',
         ];
 
-        yield 'multiple empty short array' => [
-            '<?php $a[] = [[],[]];',
-            '<?php array_push($a, [[],[]]);',
+        yield 'multiple element short array' => [
+            '<?php $a[] = [[], [], $b, $c];',
+            '<?php array_push($a, [[], [], $b, $c]);',
         ];
 
         yield [


### PR DESCRIPTION
```php
 array_push($a, [$b, $c]);
 //result
 $a[] = [$b, $c];
```