### PR TITLE
minor: GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - push
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -4,6 +4,9 @@ on:
   - pull_request
   - push
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**.y?ml'
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   validate-yaml:
     name: Validate YAML


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.