### PR TITLE
feature: Add separate option for closure_fn_spacing

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -805,6 +805,10 @@ List of Available Rules
      | Spacing to use before open parenthesis for closures.
      | Allowed values: ``'none'``, ``'one'``
      | Default value: ``'one'``
+   - | ``closure_fn_spacing``
+     | Spacing to use before open parenthesis for short arrow functions.
+     | Allowed values: ``'none'``, ``'one'``
+     | Default value: ``'one'``
    - | ``trailing_comma_single_line``
      | Whether trailing commas are allowed in single line signatures.
      | Allowed types: ``bool``

--- a/doc/rules/function_notation/function_declaration.rst
+++ b/doc/rules/function_notation/function_declaration.rst
@@ -16,6 +16,15 @@ Allowed values: ``'none'``, ``'one'``
 
 Default value: ``'one'``
 
+``closure_fn_spacing``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Spacing to use before open parenthesis for short arrow functions.
+
+Allowed values: ``'none'``, ``'one'``
+
+Default value: ``'one'``
+
 ``trailing_comma_single_line``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -70,7 +79,7 @@ With configuration: ``['closure_function_spacing' => 'none']``.
 Example #3
 ~~~~~~~~~~
 
-With configuration: ``['closure_function_spacing' => 'none']``.
+With configuration: ``['closure_fn_spacing' => 'none']``.
 
 .. code-block:: diff
 

--- a/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
+++ b/src/Fixer/FunctionNotation/FunctionDeclarationFixer.php
@@ -93,7 +93,7 @@ $f = function () {};
 $f = fn () => null;
 ',
                     new VersionSpecification(70400),
-                    ['closure_function_spacing' => self::SPACING_NONE]
+                    ['closure_fn_spacing' => self::SPACING_NONE]
                 ),
             ]
         );
@@ -195,7 +195,9 @@ $f = fn () => null;
                 $tokens->clearAt($startParenthesisIndex - 1);
             }
 
-            if ($isLambda && self::SPACING_NONE === $this->configuration['closure_function_spacing']) {
+            $option = $token->isGivenKind(T_FN) ? 'closure_fn_spacing' : 'closure_function_spacing';
+
+            if ($isLambda && self::SPACING_NONE === $this->configuration[$option]) {
                 // optionally remove whitespace after T_FUNCTION of a closure
                 // eg: `function () {}` => `function() {}`
                 if ($tokens[$index + 1]->isWhitespace()) {
@@ -227,6 +229,10 @@ $f = fn () => null;
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder('closure_function_spacing', 'Spacing to use before open parenthesis for closures.'))
                 ->setDefault(self::SPACING_ONE)
+                ->setAllowedValues(self::SUPPORTED_SPACINGS)
+                ->getOption(),
+            (new FixerOptionBuilder('closure_fn_spacing', 'Spacing to use before open parenthesis for short arrow functions.'))
+                ->setDefault(self::SPACING_ONE) // @TODO change to SPACING_NONE on next major 4.0
                 ->setAllowedValues(self::SUPPORTED_SPACINGS)
                 ->getOption(),
             (new FixerOptionBuilder('trailing_comma_single_line', 'Whether trailing commas are allowed in single line signatures.'))

--- a/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
+++ b/tests/Fixer/FunctionNotation/FunctionDeclarationFixerTest.php
@@ -33,6 +33,11 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
      */
     private static $configurationClosureSpacingNone = ['closure_function_spacing' => FunctionDeclarationFixer::SPACING_NONE];
 
+    /**
+     * @var array<string,string>
+     */
+    private static $configurationArrowSpacingNone = ['closure_fn_spacing' => FunctionDeclarationFixer::SPACING_NONE];
+
     public function testInvalidConfigurationClosureFunctionSpacing(): void
     {
         $this->expectException(InvalidFixerConfigurationException::class);
@@ -41,6 +46,16 @@ final class FunctionDeclarationFixerTest extends AbstractFixerTestCase
         );
 
         $this->fixer->configure(['closure_function_spacing' => 'neither']);
+    }
+
+    public function testInvalidConfigurationClosureFnSpacing(): void
+    {
+        $this->expectException(InvalidFixerConfigurationException::class);
+        $this->expectExceptionMessageMatches(
+            '#^\[function_declaration\] Invalid configuration: The option "closure_fn_spacing" with value "neither" is invalid\. Accepted values are: "none", "one"\.$#'
+        );
+
+        $this->fixer->configure(['closure_fn_spacing' => 'neither']);
     }
 
     /**
@@ -384,32 +399,32 @@ foo#
             [
                 '<?php fn($i) => null;',
                 null,
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php fn($a) => null;',
                 '<?php fn ($a)      => null;',
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php $fn = fn() => null;',
                 '<?php $fn = fn ()=> null;',
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php $fn("");',
                 null,
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php fn&($a) => null;',
                 '<?php fn &(  $a   ) => null;',
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php fn&($a,$b) => null;',
                 '<?php fn &(  $a,$b  ) => null;',
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
             [
                 '<?php $b = static fn ($a) => $a;',
@@ -418,7 +433,7 @@ foo#
             [
                 '<?php $b = static fn($a) => $a;',
                 '<?php $b = static     fn ( $a )   => $a;',
-                self::$configurationClosureSpacingNone,
+                self::$configurationArrowSpacingNone,
             ],
         ];
     }
@@ -485,7 +500,7 @@ foo#
         yield [
             '<?php fn&($a,$b) => null;',
             '<?php fn &(  $a,$b,   ) => null;',
-            self::$configurationClosureSpacingNone,
+            self::$configurationArrowSpacingNone,
         ];
 
         yield [


### PR DESCRIPTION
Resolves #5916

Notes:
* I'm not sure if `closure_fn_spacing` is the best name for the new option. I tried to make it consistent with the existing option.
* The default is still `one` for the new option. In the next major version the default should be changed to `none` since this is how arrow functions were [intended to be written](https://www.reddit.com/r/PHP/comments/fctb18/comment/fjd9u6a/).