### PR TITLE
feature: Add global_namespace_import to @Symfony ruleset

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -907,6 +907,8 @@ List of Available Rules
      | Default value: ``true``
 
 
+   Part of rule sets `@PhpCsFixer <./ruleSets/PhpCsFixer.rst>`_ `@Symfony <./ruleSets/Symfony.rst>`_
+
    `Source PhpCsFixer\\Fixer\\Import\\GlobalNamespaceImportFixer <./../src/Fixer/Import/GlobalNamespaceImportFixer.php>`_
 -  `group_import <./rules/import/group_import.rst>`_
 

--- a/doc/ruleSets/Symfony.rst
+++ b/doc/ruleSets/Symfony.rst
@@ -37,6 +37,9 @@ Rules
 - `general_phpdoc_tag_rename <./../rules/phpdoc/general_phpdoc_tag_rename.rst>`_
   config:
   ``['replacements' => ['inheritDocs' => 'inheritDoc']]``
+- `global_namespace_import <./../rules/import/global_namespace_import.rst>`_
+  config:
+  ``['import_classes' => false, 'import_constants' => false, 'import_functions' => false]``
 - `include <./../rules/control_structure/include.rst>`_
 - `increment_style <./../rules/operator/increment_style.rst>`_
 - `integer_literal_case <./../rules/casing/integer_literal_case.rst>`_

--- a/doc/rules/import/global_namespace_import.rst
+++ b/doc/rules/import/global_namespace_import.rst
@@ -106,3 +106,18 @@ With configuration: ``['import_classes' => false, 'import_constants' => false, '
    +    $d = new \DateTimeImmutable();
    +    $p = \M_PI;
     }
+
+Rule sets
+---------
+
+The rule is part of the following rule sets:
+
+@PhpCsFixer
+  Using the `@PhpCsFixer <./../../ruleSets/PhpCsFixer.rst>`_ rule set will enable the ``global_namespace_import`` rule with the config below:
+
+  ``['import_classes' => false, 'import_constants' => false, 'import_functions' => false]``
+
+@Symfony
+  Using the `@Symfony <./../../ruleSets/Symfony.rst>`_ rule set will enable the ``global_namespace_import`` rule with the config below:
+
+  ``['import_classes' => false, 'import_constants' => false, 'import_functions' => false]``

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace PhpCsFixer;
 
 use PhpCsFixer\Fixer\FixerInterface;
-use SplFileInfo;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -40,7 +39,7 @@ interface ConfigInterface
     /**
      * Returns files to scan.
      *
-     * @return iterable<SplFileInfo>
+     * @return iterable<\SplFileInfo>
      */
     public function getFinder(): iterable;
 
@@ -103,7 +102,7 @@ interface ConfigInterface
     public function setCacheFile(string $cacheFile): self;
 
     /**
-     * @param iterable<SplFileInfo> $finder
+     * @param iterable<\SplFileInfo> $finder
      */
     public function setFinder(iterable $finder): self;
 

--- a/src/Console/Command/ListFilesCommand.php
+++ b/src/Console/Command/ListFilesCommand.php
@@ -18,7 +18,6 @@ use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Console\ConfigurationResolver;
 use PhpCsFixer\ToolInfoInterface;
-use SplFileInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,7 +80,7 @@ final class ListFilesCommand extends Command
 
         $finder = $resolver->getFinder();
 
-        /** @var SplFileInfo $file */
+        /** @var \SplFileInfo $file */
         foreach ($finder as $file) {
             if ($file->isFile()) {
                 $relativePath = str_replace($cwd, '.', $file->getRealPath());

--- a/src/RuleSet/Sets/SymfonySet.php
+++ b/src/RuleSet/Sets/SymfonySet.php
@@ -59,6 +59,11 @@ final class SymfonySet extends AbstractRuleSetDescription
                     'inheritDocs' => 'inheritDoc',
                 ],
             ],
+            'global_namespace_import' => [
+                'import_classes' => false,
+                'import_constants' => false,
+                'import_functions' => false,
+            ],
             'include' => true,
             'increment_style' => true,
             'integer_literal_case' => true,

--- a/tests/FixerFactoryTest.php
+++ b/tests/FixerFactoryTest.php
@@ -21,7 +21,6 @@ use PhpCsFixer\FixerFactory;
 use PhpCsFixer\RuleSet\RuleSet;
 use PhpCsFixer\RuleSet\RuleSetInterface;
 use PhpCsFixer\WhitespacesFixerConfig;
-use stdClass;
 
 /**
  * @author Dariusz Rumiński <dariusz.ruminski@gmail.com>
@@ -375,7 +374,7 @@ final class FixerFactoryTest extends TestCase
     {
         return [
             ['bar'],
-            [new stdClass()],
+            [new \stdClass()],
             [5],
             [5.5],
         ];

--- a/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
+++ b/tests/Tokenizer/Analyzer/AlternativeSyntaxAnalyzerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Tests\Tokenizer\Analyzer;
 
-use InvalidArgumentException;
 use PhpCsFixer\Tests\TestCase;
 use PhpCsFixer\Tokenizer\Analyzer\AlternativeSyntaxAnalyzer;
 use PhpCsFixer\Tokenizer\Tokens;
@@ -190,7 +189,7 @@ final class AlternativeSyntaxAnalyzerTest extends TestCase
 
         $analyzer = new AlternativeSyntaxAnalyzer();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedMessage);
 
         $analyzer->findAlternativeSyntaxBlockEnd($tokens, $startIndex);


### PR DESCRIPTION
As per https://github.com/symfony/symfony/pull/48002#issuecomment-1291933825:
> This is a rule we have since years in the Symfony coding standards.

