### PR TITLE
docs: [DateTimeCreateFromFormatCallFixer] Fix typos in the code sample

### DIFF
--- a/doc/list.rst
+++ b/doc/list.rst
@@ -374,9 +374,9 @@ List of Available Rules
 
    Consider this code:
        ``DateTime::createFromFormat('Y-m-d', '2022-02-11')``.
-       What value will be returned? '2022-01-11 00:00:00.0'? No, actual return
+       What value will be returned? '2022-02-11 00:00:00.0'? No, actual return
    value has 'H:i:s' section like '2022-02-11 16:55:37.0'.
-       Change 'Y-m-d' to '!Y-m-d', return value will be '2022-01-11 00:00:00.0'.
+       Change 'Y-m-d' to '!Y-m-d', return value will be '2022-02-11 00:00:00.0'.
        So, adding ``!`` to format string will make return value more intuitive.
 
    *warning risky* Risky when depending on the actual timings being used even when not explicit

--- a/doc/rules/function_notation/date_time_create_from_format_call.rst
+++ b/doc/rules/function_notation/date_time_create_from_format_call.rst
@@ -10,9 +10,9 @@ Description
 
 Consider this code:
     ``DateTime::createFromFormat('Y-m-d', '2022-02-11')``.
-    What value will be returned? '2022-01-11 00:00:00.0'? No, actual return
+    What value will be returned? '2022-02-11 00:00:00.0'? No, actual return
 value has 'H:i:s' section like '2022-02-11 16:55:37.0'.
-    Change 'Y-m-d' to '!Y-m-d', return value will be '2022-01-11 00:00:00.0'.
+    Change 'Y-m-d' to '!Y-m-d', return value will be '2022-02-11 00:00:00.0'.
     So, adding ``!`` to format string will make return value more intuitive.
 
 Warning

--- a/src/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixer.php
+++ b/src/Fixer/FunctionNotation/DateTimeCreateFromFormatCallFixer.php
@@ -35,8 +35,8 @@ final class DateTimeCreateFromFormatCallFixer extends AbstractFixer
             ],
             "Consider this code:
     `DateTime::createFromFormat('Y-m-d', '2022-02-11')`.
-    What value will be returned? '2022-01-11 00:00:00.0'? No, actual return value has 'H:i:s' section like '2022-02-11 16:55:37.0'.
-    Change 'Y-m-d' to '!Y-m-d', return value will be '2022-01-11 00:00:00.0'.
+    What value will be returned? '2022-02-11 00:00:00.0'? No, actual return value has 'H:i:s' section like '2022-02-11 16:55:37.0'.
+    Change 'Y-m-d' to '!Y-m-d', return value will be '2022-02-11 00:00:00.0'.
     So, adding `!` to format string will make return value more intuitive.",
             'Risky when depending on the actual timings being used even when not explicit set in format.'
         );


### PR DESCRIPTION
Just a fix for typos in the code sample of DateTimeCreateFromFormatCallFixer.

