### PR TITLE
docs: document composer script aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,12 +133,12 @@
         "phpstan": "Run PHPStan analysis",
         "phpstan:baseline": "Dump PHPStan baseline file - use only for updating, do not add new errors when possible",
         "post-autoload-dump": "Run additional tasks after installing/updating main dependencies",
-        "qa": "Run QA suite [alias for 'quality-assurance']",
+        "qa": "Alias for 'quality-assurance'",
         "quality-assurance": "Run QA suite",
-        "sa": "Run static analysis [alias for 'static-analysis']",
+        "sa": "Alias for 'static-analysis'",
         "self-check": "Run set of self-checks ensuring repository's validity",
         "static-analysis": "Run static analysis",
-        "test": "Run all tests [alias for 'test:all']",
+        "test": "Alias for 'test:all'",
         "test:all": "Run all tests",
         "test:coverage": "Run tool-related tests"
     }


### PR DESCRIPTION
I struggled to understand diff between some commands , maybe it's worth to explicitly mark aliases

before
<img width="776" alt="Screenshot 2023-08-14 at 22 22 40" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/2716794/561b0b61-0815-462d-9025-7b8be924876d">

after
<img width="776" alt="Screenshot 2023-08-14 at 22 23 00" src="https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/assets/2716794/f1cce34d-a44f-4167-ab82-f2c9cf695073">
