### PR TITLE
DX: remove AbstractFixerTestCase::getTestFile()

### DIFF
--- a/tests/Fixer/Basic/EncodingFixerTest.php
+++ b/tests/Fixer/Basic/EncodingFixerTest.php
@@ -47,8 +47,8 @@ final class EncodingFixerTest extends AbstractFixerTestCase
      */
     private static function prepareTestCase(string $expectedFilename, ?string $inputFilename = null): array
     {
-        $expectedFile = self::getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$expectedFilename);
-        $inputFile = null !== $inputFilename ? self::getTestFile(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$inputFilename) : null;
+        $expectedFile = new \SplFileInfo(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$expectedFilename);
+        $inputFile = null !== $inputFilename ? new \SplFileInfo(__DIR__.'/../../Fixtures/FixerTest/encoding/'.$inputFilename) : null;
 
         return [
             file_get_contents($expectedFile->getRealPath()),

--- a/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
+++ b/tests/Fixer/Basic/PsrAutoloadingFixerTest.php
@@ -34,7 +34,7 @@ final class PsrAutoloadingFixerTest extends AbstractFixerTestCase
         if (null === $filepath) {
             $filepath = __FILE__;
         }
-        $file = self::getTestFile($filepath);
+        $file = new \SplFileInfo($filepath);
 
         if (null !== $dir) {
             $this->fixer->configure(['dir' => $dir]);
@@ -166,43 +166,41 @@ final class PsrAutoloadingFixerTest extends AbstractFixerTestCase
             __DIR__,
         ];
 
-        $filepath = __DIR__.\DIRECTORY_SEPARATOR.'Psr'.\DIRECTORY_SEPARATOR.'Foo'.\DIRECTORY_SEPARATOR.'Bar.php';
-
         yield [ // namespace with wrong casing
             '<?php
-namespace Psr\Foo;
-class Bar {}
+namespace PhpCsFixer\Fixer;
+class FixerInterface {}
 ',
             '<?php
-namespace Psr\foo;
-class bar {}
+namespace PhpCsFixer\fixer;
+class FixerInterface {}
 ',
-            $filepath,
-            __DIR__,
+            __DIR__.'/../../../src/Fixer/FixerInterface.php',
+            __DIR__.'/../../../src',
         ];
 
         yield [ // class with wrong casing (2 levels namespace)
             '<?php
-class Psr_Foo_Bar {}
+class Fixer_Basic_PsrAutoloadingFixer {}
 ',
             '<?php
-class Psr_fOo_bAr {}
+class Fixer_bASIc_PsrAutoloadingFixer {}
 ',
-            $filepath,
-            __DIR__,
+            __DIR__.'/../../../src/Fixer/Basic/PsrAutoloadingFixer.php',
+            __DIR__.'/../../../src',
         ];
 
         yield [ // namespaced class with wrong casing
             '<?php
-namespace Psr\Foo;
-class Bar {}
+namespace PhpCsFixer\Fixer;
+class FixerInterface {}
 ',
             '<?php
-namespace Psr\foo;
-class bar {}
+namespace PhpCsFixer\Fixer;
+class fixerinterface {}
 ',
-            $filepath,
-            __DIR__,
+            __DIR__.'/../../../src/Fixer/FixerInterface.php',
+            __DIR__.'/../../../src',
         ];
 
         yield [ // multiple classy elements in file
@@ -451,7 +449,7 @@ class extends stdClass {};
      */
     public function testFix81(string $expected, ?string $input = null): void
     {
-        $this->doTest($expected, $input, self::getTestFile(__FILE__));
+        $this->doTest($expected, $input, new \SplFileInfo(__FILE__));
     }
 
     public static function provideFix81Cases(): iterable

--- a/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
+++ b/tests/Fixer/FunctionNotation/VoidReturnFixerTest.php
@@ -325,7 +325,7 @@ final class VoidReturnFixerTest extends AbstractFixerTestCase
             ))
         ));
 
-        $this->fixer->fix(self::getTestFile(), $tokens);
+        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
 
         self::assertNull($this->lintSource($tokens->generateCode()));
     }

--- a/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
+++ b/tests/Fixer/PhpUnit/PhpUnitNamespacedFixerTest.php
@@ -291,7 +291,7 @@ final class PhpUnitNamespacedFixerTest extends AbstractFixerTestCase
         Tokens::clearCache();
         $tokens = Tokens::fromCode(sprintf('<?php new %s();', $class));
 
-        $this->fixer->fix(self::getTestFile(), $tokens);
+        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
 
         self::assertTrue($tokens->isChanged());
         self::assertStringNotContainsString('_', $tokens->generateCode());

--- a/tests/Test/AbstractFixerTestCase.php
+++ b/tests/Test/AbstractFixerTestCase.php
@@ -378,20 +378,6 @@ abstract class AbstractFixerTestCase extends TestCase
         return new $fixerClassName();
     }
 
-    final protected static function getTestFile(string $filename = __FILE__): \SplFileInfo
-    {
-        static $files = [];
-
-        return $files[$filename] ?? $files[$filename] = new class($filename) extends \SplFileInfo {
-            public function getRealPath(): string
-            {
-                return false !== parent::getRealPath()
-                    ? parent::getRealPath()
-                    : $this->getPathname();
-            }
-        };
-    }
-
     /**
      * Tests if a fixer fixes a given string to match the expected result.
      *
@@ -412,7 +398,7 @@ abstract class AbstractFixerTestCase extends TestCase
             throw new \InvalidArgumentException('Input parameter must not be equal to expected parameter.');
         }
 
-        $file ??= self::getTestFile();
+        $file ??= new \SplFileInfo(__FILE__);
         $fileIsSupported = $this->fixer->supports($file);
 
         if (null !== $input) {


### PR DESCRIPTION
Replaces https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7494

Instead of having two `AbstractFixerTestCase::getTestFile` let's have none.