### PR TITLE
feat: Introduce config option for standardized null in typehints

### DIFF
--- a/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
+++ b/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst
@@ -13,6 +13,16 @@ Rule is applied only in a PHP 7.1+ environment.
 Configuration
 -------------
 
+``force_nullable_for_default_null``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enforces explicit nullable type declarations for parameters with a default
+``null`` value, standardizing nullability in typehints
+
+Allowed types: ``bool``
+
+Default value: ``false``
+
 ``use_nullable_type_declaration``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -57,6 +67,34 @@ With configuration: ``['use_nullable_type_declaration' => false]``.
 Example #3
 ~~~~~~~~~~
 
+With configuration: ``['force_nullable_for_default_null' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function sample(?string $str = null)
+   +function sample(string|null $str = null)
+    {}
+
+Example #4
+~~~~~~~~~~
+
+With configuration: ``['force_nullable_for_default_null' => true]``.
+
+.. code-block:: diff
+
+   --- Original
+   +++ New
+    <?php
+   -function sample(string $str = null)
+   +function sample(string|null $str = null)
+    {}
+
+Example #5
+~~~~~~~~~~
+
 *Default* configuration.
 
 .. code-block:: diff
@@ -68,7 +106,7 @@ Example #3
    +function sample(string|int|null $str = null)
     {}
 
-Example #4
+Example #6
 ~~~~~~~~~~
 
 With configuration: ``['use_nullable_type_declaration' => false]``.
@@ -82,7 +120,7 @@ With configuration: ``['use_nullable_type_declaration' => false]``.
    +function sample(string|int $str = null)
     {}
 
-Example #5
+Example #7
 ~~~~~~~~~~
 
 *Default* configuration.
@@ -96,7 +134,7 @@ Example #5
    +function sample((\Foo&\Bar)|null $str = null)
     {}
 
-Example #6
+Example #8
 ~~~~~~~~~~
 
 With configuration: ``['use_nullable_type_declaration' => false]``.

--- a/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
+++ b/tests/Fixer/FunctionNotation/NullableTypeDeclarationForDefaultNullValueFixerTest.php
@@ -166,6 +166,24 @@ final class NullableTypeDeclarationForDefaultNullValueFixerTest extends Abstract
             '<?php function foo(? /*comment*/ string $param = null) {}',
             ['use_nullable_type_declaration' => false],
         ];
+
+        yield [
+            '<?php function foo(string|null $param = null) {}',
+            '<?php function foo(string $param = null) {}',
+            ['force_nullable_for_default_null' => true],
+        ];
+
+        yield [
+            '<?php function foo(string|int|null $param = null) {}',
+            '<?php function foo(string|int $param = null) {}',
+            ['force_nullable_for_default_null' => true],
+        ];
+
+        yield [
+            '<?php function foo(string|null $param = null) {}',
+            '<?php function foo(?string $param = null) {}',
+            ['force_nullable_for_default_null' => true],
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR introduces a new configuration option `force_nullable_for_default_null` to `nullable_type_declaration_for_default_null_value` rule, aimed at enhancing the consistency and clarity of typehints across our codebase. 

By automatically converting optional types to explicit union types with `null`, we enable a more standardized approach to handling nullable type declarations.

**Key Benefits:**
- **Consistency**: Ensures a uniform standard across the codebase for representing nullable types, making the code more predictable and easier to read.
- **Clarity**: Expanding `?Type` to `Type|null` makes the nullable aspect of the typehints explicit, improving readability, and comprehension for developers.
- **Flexibility**: With this configurable option, developers can tailor the behavior to their specific project needs, choosing between implicit optional types or explicit nullability.

**Implementation Details:**
The configuration option `force_nullable_for_default_null` can be toggled to automatically modify the typehints during the PHPCSFixer fix process. When enabled, it ensures that all parameters with a default `null` value explicitly include `null` in their type declaration, transforming `?Type` hints to `Type|null` for clearer and more explicit code.
