### PR TITLE
feat: Add fixer to convert multi-line PHPDoc comments to a single line when appropriate

### DIFF
--- a/src/Fixer/Phpdoc/PhpdocSingleLineMultilineCommentFixer.php
+++ b/src/Fixer/Phpdoc/PhpdocSingleLineMultilineCommentFixer.php
@@ -18,7 +18,6 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Preg;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
@@ -104,13 +103,13 @@ function setName($name)
         foreach ($lines as $line) {
             $trimmedLine = trim($line);
 
-            if ($trimmedLine === '/**' || $trimmedLine === '*/' || $trimmedLine === '*' || $trimmedLine === '') {
+            if ('/**' === $trimmedLine || '*/' === $trimmedLine || '*' === $trimmedLine || '' === $trimmedLine) {
                 continue;
             }
-            
+
             if (str_starts_with($trimmedLine, '*')) {
                 $lineContent = trim(substr($trimmedLine, 1));
-                if ($lineContent !== '') {
+                if ('' !== $lineContent) {
                     $meaningfulLines[] = $lineContent;
                 }
             } else {
@@ -118,8 +117,8 @@ function setName($name)
             }
         }
 
-        if (\count($meaningfulLines) === 1) {
-            return '/** ' . $meaningfulLines[0] . ' */';
+        if (1 === \count($meaningfulLines)) {
+            return '/** '.$meaningfulLines[0].' */';
         }
 
         return $content;

--- a/tests/Fixer/Phpdoc/PhpdocSingleLineMultilineCommentFixerTest.php
+++ b/tests/Fixer/Phpdoc/PhpdocSingleLineMultilineCommentFixerTest.php
@@ -34,7 +34,7 @@ final class PhpdocSingleLineMultilineCommentFixerTest extends AbstractFixerTestC
     }
 
     /**
-     * @return iterable<string, array{string, string|null}>
+     * @return iterable<string, array{string, null|string}>
      */
     public static function provideFixCases(): iterable
     {


### PR DESCRIPTION
This rule shortens verbose single-line docblocks into their compact one-line form, reducing visual noise while preserving all information.

For example, this:

```php
/**
 * @return string[]
 */
function list(): array
```

becomes this:

```php
/** @return string[] */
function list(): array
```

By collapsing trivial multi-line docblocks, we save vertical space and make code easier to scan, especially as these kinds of docblocks are commonplace in codebases trying to conform to static analysis tooling.