### PR TITLE
test: Mark `DocumentationCommandTest::testGeneratingDocumentation()` as large test

### DIFF
--- a/tests/Console/Command/DocumentationCommandTest.php
+++ b/tests/Console/Command/DocumentationCommandTest.php
@@ -30,6 +30,11 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class DocumentationCommandTest extends TestCase
 {
+    /**
+     * @large
+     *
+     * @todo Find out the root cause of it being slower and hitting small test time limit
+     */
     public function testGeneratingDocumentation(): void
     {
         $filesystem = $this->createFilesystemDouble();


### PR DESCRIPTION
This test is failing in a lot of jobs, wasting people's time on re-running them multiple times. Let's allow this test to work longer and then maybe improve it somehow.

It takes ~5s locally for me (within PHPStorm), so maybe we just hit the point where we have too many files to process and generate docs for.