### PR TITLE
CI: `push` event only for master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
In the dependabot pull requests the ci jobs are triggered twice (`pull_request` and `push` events), because they do not use a fork. So the push to a branch in main repo also triggers the ci jobs.

So I suggest to use the push trigger for `master` branch only.

<img width="696" height="318" alt="Bildschirmfoto 2025-09-12 um 15 37 55" src="https://github.com/user-attachments/assets/ad324a5e-41a0-40bb-a675-ba68ed8d86b9" />
