### PR TITLE
CI: `push` event only for master branch

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,8 @@ on:
       - '*.md'
       - '**/*.md'
   push:
+    branches:
+      - master
     paths:
       - '*.md'
       - '**/*.md'

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,8 +1,10 @@
 name: Static Code Analysis
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**/*.rst'
   push:
+    branches:
+      - master
     paths:
       - '**/*.rst'
 

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -6,6 +6,8 @@ on:
       - '**.yml'
       - '**.yaml'
   push:
+    branches:
+      - master
     paths:
       - '**.yml'
       - '**.yaml'


### PR DESCRIPTION
refs #9046, there are more workflows where it makes sense to add branch filter for `push` event.
