### PR TITLE
feat: do not use magic method `__sleep`

### DIFF
--- a/src/Cache/FileCacheManager.php
+++ b/src/Cache/FileCacheManager.php
@@ -77,7 +77,7 @@ final class FileCacheManager implements CacheManagerInterface
      * This class is not intended to be serialized,
      * and cannot be deserialized (see __wakeup method).
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
     }

--- a/src/Console/Output/Progress/DotsOutput.php
+++ b/src/Console/Output/Progress/DotsOutput.php
@@ -63,7 +63,7 @@ final class DotsOutput implements ProgressOutputInterface
      * This class is not intended to be serialized,
      * and cannot be deserialized (see __wakeup method).
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.self::class);
     }

--- a/src/Console/Output/Progress/PercentageBarOutput.php
+++ b/src/Console/Output/Progress/PercentageBarOutput.php
@@ -51,7 +51,7 @@ final class PercentageBarOutput implements ProgressOutputInterface
      * This class is not intended to be serialized,
      * and cannot be deserialized (see __wakeup method).
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.self::class);
     }

--- a/src/FileRemoval.php
+++ b/src/FileRemoval.php
@@ -47,7 +47,7 @@ final class FileRemoval
      * This class is not intended to be serialized,
      * and cannot be deserialized (see __wakeup method).
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.self::class);
     }

--- a/src/Linter/ProcessLinter.php
+++ b/src/Linter/ProcessLinter.php
@@ -82,7 +82,7 @@ final class ProcessLinter implements LinterInterface
      * This class is not intended to be serialized,
      * and cannot be deserialized (see __wakeup method).
      */
-    public function __sleep(): array
+    public function __serialize(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.self::class);
     }

--- a/tests/Console/Output/Progress/DotsOutputTest.php
+++ b/tests/Console/Output/Progress/DotsOutputTest.php
@@ -157,13 +157,13 @@ final class DotsOutputTest extends TestCase
         ];
     }
 
-    public function testSleep(): void
+    public function testSerialize(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot serialize '.DotsOutput::class);
 
         $processOutput = new DotsOutput(new OutputContext(new BufferedOutput(), 1, 1));
-        $processOutput->__sleep();
+        $processOutput->__serialize();
     }
 
     public function testWakeup(): void

--- a/tests/FileRemovalTest.php
+++ b/tests/FileRemovalTest.php
@@ -104,13 +104,13 @@ final class FileRemovalTest extends TestCase
         self::assertFileDoesNotExist($fs->url().'/foo.php');
     }
 
-    public function testSleep(): void
+    public function testSerialize(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot serialize PhpCsFixer\FileRemoval');
 
         $fileRemoval = new FileRemoval();
-        $fileRemoval->__sleep();
+        $fileRemoval->__serialize();
     }
 
     public function testWakeup(): void

--- a/tests/Linter/ProcessLinterTest.php
+++ b/tests/Linter/ProcessLinterTest.php
@@ -34,13 +34,13 @@ final class ProcessLinterTest extends AbstractLinterTestCase
         self::assertTrue($this->createLinter()->isAsync());
     }
 
-    public function testSleep(): void
+    public function testSerialize(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Cannot serialize PhpCsFixer\Linter');
 
         $linter = new ProcessLinter();
-        $linter->__sleep();
+        $linter->__serialize();
     }
 
     public function testWakeup(): void


### PR DESCRIPTION
As it is going to be [deprecated in PHP 8.5](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_sleep_and_wakeup_magic_methods).