### PR TITLE
DX: Allow development on PHP 8.5

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
           - docker-service: php-8.2
           - docker-service: php-8.3
           - docker-service: php-8.4
+          - docker-service: php-8.5
           - docker-service: sphinx-lint
           - docker-service: markdown-lint
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,6 +34,7 @@ $fileHeaderParts = [
 
 return (new Config())
     ->setParallelConfig(ParallelConfigFactory::detect()) // @TODO 4.0 no need to call this manually
+    ->setUnsupportedPhpVersionAllowed(true)
     ->setRiskyAllowed(true)
     ->registerCustomFixers([
         new ConfigurableFixerTemplateFixer(),

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN if [ ! -z "$DOCKER_GROUP_ID" ] && [ ! getent group "${DOCKER_GROUP_ID}" > /d
     fi \
     && apk add git \
     && sync \
-    && install-php-extensions pcov xdebug-${PHP_XDEBUG_VERSION} \
+    && if [ ! -z "$PHP_XDEBUG_VERSION" ] ; then install-php-extensions pcov xdebug-${PHP_XDEBUG_VERSION}; fi \
     && curl --location --output /usr/local/bin/xdebug https://github.com/julienfalque/xdebug/releases/download/v2.0.0/xdebug \
     && chmod +x /usr/local/bin/xdebug
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,6 +56,17 @@ services:
       <<: *default_environment
       XDEBUG_MODE: coverage
 
+  php-8.5:
+    <<: *php
+    build:
+      args:
+        ALPINE_VERSION: '3.22'
+        PHP_VERSION: 8.5.0beta3
+        PHP_XDEBUG_VERSION: ''
+    environment:
+      <<: *default_environment
+      XDEBUG_MODE: coverage
+
   sphinx-lint:
     build:
       target: sphinx-lint

--- a/tests/AutoReview/CiConfigurationTest.php
+++ b/tests/AutoReview/CiConfigurationTest.php
@@ -111,6 +111,11 @@ final class CiConfigurationTest extends TestCase
         $dockerMap = [];
         foreach ($yaml['services'] as $item) {
             if (isset($item['build']['args']['PHP_VERSION'], $item['build']['args']['ALPINE_VERSION'])) {
+                // PHP 8.5 at this point is only allowed for local development and is not a part of Docker releases
+                if (str_starts_with($item['build']['args']['PHP_VERSION'], '8.5')) {
+                    continue;
+                }
+
                 $dockerMap[$item['build']['args']['PHP_VERSION']] = $item['build']['args']['ALPINE_VERSION'];
             }
         }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -33,7 +33,7 @@ final class ApplicationTest extends TestCase
     {
         $regex = '/^PHP CS Fixer <info>\d+.\d+.\d+(-DEV)?<\/info> <info>.+<\/info>'
             .' by <comment>Fabien Potencier<\/comment>, <comment>Dariusz Ruminski<\/comment> and <comment>contributors<\/comment>\.'
-            ."\nPHP runtime: <info>\\d+.\\d+.\\d+(-dev)?<\\/info>$/";
+            ."\nPHP runtime: <info>\\d+.\\d+.\\d+(-dev|beta\\d+)?<\\/info>$/";
 
         self::assertMatchesRegularExpression($regex, (new Application())->getLongVersion());
     }


### PR DESCRIPTION
Provide Docker Compose setup for PHP 8.5 in order to be able to develop and run QA suite using this runtime. Genesis of this is that PHP 8.5 CI job fails all the time and we should be able to debug this (well, without XDebug it's harder, but still it's better to have basic setup).

PS. There is no XDebug release that supports PHP 8.5 yet, so I modified our `Dockerfile` to install XDebug only if `PHP_XDEBUG_VERSION` is not empty (and set it empty for PHP 8.5 build args).