### PR TITLE
DX: Ability to run `yamllint` locally

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
           - docker-service: php-8.4
           - docker-service: sphinx-lint
           - docker-service: markdown-lint
+          - docker-service: yaml-lint
 
     steps:
       - name: Checkout repository

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,9 @@
 extends: relaxed
 
+ignore: |
+  vendor/
+  dev-tools/vendor/
+
 rules:
   indentation:
     spaces: 2

--- a/compose.yaml
+++ b/compose.yaml
@@ -63,6 +63,13 @@ services:
     volumes:
       - .:/fixer
 
+  yaml-lint:
+    image: sdesbure/yamllint
+    command: yamllint .
+    working_dir: /fixer
+    volumes:
+      - .:/fixer
+
   markdown-lint:
     image: registry.gitlab.com/pipeline-components/markdownlint:latest
     command: mdl --git-recurse .


### PR DESCRIPTION
It's run in CI so it also should be possible to run it locally to reproduce the problem and to be able to fix it.

`docker compose run --rm --remove-orphans yaml-lint`