### PR TITLE
chore: use accidentally missing `@auto:risky`

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -41,6 +41,7 @@ return (new Config())
     ])
     ->setRules([
         '@auto' => true,
+        '@auto:risky' => true,
         '@PhpCsFixer' => true,
         '@PhpCsFixer:risky' => true,
         'general_phpdoc_annotation_remove' => ['annotations' => ['expectedDeprecation']], // one should use PHPUnit built-in method instead


### PR DESCRIPTION
noticed with #9097
