### PR TITLE
chore: do not mark NamespaceAnalysis as internal, because it's part of public API interface

### DIFF
--- a/src/Tokenizer/Analyzer/Analysis/NamespaceAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/NamespaceAnalysis.php
@@ -17,7 +17,7 @@ namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
 /**
  * @readonly
  *
- * @internal
+ * @TODO v4: previously was mareked as internal - yet it leaked to public interface of `DocBlock`, consider making it so again.
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise.
  */
@@ -53,6 +53,9 @@ final class NamespaceAnalysis
      */
     private int $scopeEndIndex;
 
+    /**
+     * @internal
+     */
     public function __construct(string $fullName, string $shortName, int $startIndex, int $endIndex, int $scopeStartIndex, int $scopeEndIndex)
     {
         $this->fullName = $fullName;

--- a/src/Tokenizer/Analyzer/Analysis/NamespaceUseAnalysis.php
+++ b/src/Tokenizer/Analyzer/Analysis/NamespaceUseAnalysis.php
@@ -17,7 +17,7 @@ namespace PhpCsFixer\Tokenizer\Analyzer\Analysis;
 /**
  * @readonly
  *
- * @internal
+ * @TODO v4: previously was mareked as internal - yet it leaked to public interface of `DocBlock`, consider making it so again.
  *
  * @phpstan-type _ImportType 'class'|'constant'|'function'
  *
@@ -87,6 +87,8 @@ final class NamespaceUseAnalysis
      * @param self::TYPE_*     $type
      * @param non-empty-string $fullName
      * @param non-empty-string $shortName
+     *
+     * @internal
      */
     public function __construct(
         int $type,


### PR DESCRIPTION
identified accidentally,
validated with #9196 