### PR TITLE
refactor: memoize fixer names

### DIFF
--- a/src/AbstractFixer.php
+++ b/src/AbstractFixer.php
@@ -41,6 +41,7 @@ abstract class AbstractFixer implements FixerInterface
         $nameParts = explode('\\', static::class);
         $name = substr(end($nameParts), 0, -\strlen('Fixer'));
         $this->name = Utils::camelCaseToUnderscore($name);
+
         if ($this instanceof ConfigurableFixerInterface) {
             try {
                 $this->configure([]);


### PR DESCRIPTION
The getName() method of fixers may be called more than once (for example, in a custom implementation of mine related to #9107).

That about caching its result?