### PR TITLE
chore: adjust autoloader to exclude all Internal classes in classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
             "PhpCsFixer\\": "src/"
         },
         "exclude-from-classmap": [
-            "src/Fixer/Internal/*"
+            "src/**/Internal/"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
maybe not needed at all due to current solution with gitattributes,
not sure - let's at least keep those in sync