### PR TITLE
chore: add clarifying `@return` annotations to `Config`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -194,9 +194,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this->ruleCustomisationPolicy;
     }
 
-    /**
-     * @return $this
-     */
     public function registerCustomFixers(iterable $fixers): ConfigInterface
     {
         foreach ($fixers as $fixer) {
@@ -208,8 +205,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     /**
      * @param list<RuleSetDefinitionInterface> $ruleSets
-     *
-     * @return $this
      */
     public function registerCustomRuleSets(array $ruleSets): ConfigInterface
     {
@@ -222,8 +217,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     /**
      * @param non-empty-string $cacheFile
-     *
-     * @return $this
      */
     public function setCacheFile(string $cacheFile): ConfigInterface
     {
@@ -232,9 +225,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setFinder(iterable $finder): ConfigInterface
     {
         $this->finder = $finder;
@@ -242,9 +232,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setFormat(string $format): ConfigInterface
     {
         $this->format = $format;
@@ -252,9 +239,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setHideProgress(bool $hideProgress): ConfigInterface
     {
         $this->hideProgress = $hideProgress;
@@ -264,8 +248,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     /**
      * @param non-empty-string $indent
-     *
-     * @return $this
      */
     public function setIndent(string $indent): ConfigInterface
     {
@@ -276,8 +258,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
 
     /**
      * @param non-empty-string $lineEnding
-     *
-     * @return $this
      */
     public function setLineEnding(string $lineEnding): ConfigInterface
     {
@@ -286,9 +266,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setParallelConfig(ParallelConfig $config): ConfigInterface
     {
         $this->parallelConfig = $config;
@@ -296,9 +273,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setPhpExecutable(?string $phpExecutable): ConfigInterface
     {
         $this->phpExecutable = $phpExecutable;
@@ -306,9 +280,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setRiskyAllowed(bool $isRiskyAllowed): ConfigInterface
     {
         $this->isRiskyAllowed = $isRiskyAllowed;
@@ -316,9 +287,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setRules(array $rules): ConfigInterface
     {
         $this->rules = $rules;
@@ -326,9 +294,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setUsingCache(bool $usingCache): ConfigInterface
     {
         $this->usingCache = $usingCache;
@@ -336,9 +301,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface
     {
         $this->isUnsupportedPhpVersionAllowed = $isUnsupportedPhpVersionAllowed;
@@ -346,9 +308,6 @@ class Config implements ConfigInterface, ParallelAwareConfigInterface, Unsupport
         return $this;
     }
 
-    /**
-     * @return $this
-     */
     public function setRuleCustomisationPolicy(?RuleCustomisationPolicyInterface $ruleCustomisationPolicy): ConfigInterface
     {
         // explicitly prevent policy with no proper version defined

--- a/src/Config/RuleCustomisationPolicyAwareConfigInterface.php
+++ b/src/Config/RuleCustomisationPolicyAwareConfigInterface.php
@@ -30,6 +30,8 @@ interface RuleCustomisationPolicyAwareConfigInterface extends ConfigInterface
      * Registers a filter to be applied to fixers right before running them.
      *
      * @todo v4 Introduce it in main ConfigInterface
+     *
+     * @return $this
      */
     public function setRuleCustomisationPolicy(?RuleCustomisationPolicyInterface $ruleCustomisationPolicy): ConfigInterface;
 

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -108,6 +108,8 @@ interface ConfigInterface
      * Name of custom fixer should follow `VendorName/rule_name` convention.
      *
      * @param iterable<FixerInterface> $fixers
+     *
+     * @return $this
      */
     public function registerCustomFixers(iterable $fixers): self;
 
@@ -115,25 +117,39 @@ interface ConfigInterface
      * Sets the path to the cache file.
      *
      * @param non-empty-string $cacheFile
+     *
+     * @return $this
      */
     public function setCacheFile(string $cacheFile): self;
 
     /**
      * @param iterable<\SplFileInfo> $finder
+     *
+     * @return $this
      */
     public function setFinder(iterable $finder): self;
 
+    /**
+     * @return $this
+     */
     public function setFormat(string $format): self;
 
+    /**
+     * @return $this
+     */
     public function setHideProgress(bool $hideProgress): self;
 
     /**
      * @param non-empty-string $indent
+     *
+     * @return $this
      */
     public function setIndent(string $indent): self;
 
     /**
      * @param non-empty-string $lineEnding
+     *
+     * @return $this
      */
     public function setLineEnding(string $lineEnding): self;
 
@@ -143,11 +159,15 @@ interface ConfigInterface
      * @deprecated
      *
      * @TODO 4.0 remove me
+     *
+     * @return $this
      */
     public function setPhpExecutable(?string $phpExecutable): self;
 
     /**
      * Set if it is allowed to run risky fixers.
+     *
+     * @return $this
      */
     public function setRiskyAllowed(bool $isRiskyAllowed): self;
 
@@ -160,8 +180,13 @@ interface ConfigInterface
      * (turn it on and contains configuration for FixerInterface::configure method).
      *
      * @param array<string, array<string, mixed>|bool> $rules
+     *
+     * @return $this
      */
     public function setRules(array $rules): self;
 
+    /**
+     * @return $this
+     */
     public function setUsingCache(bool $usingCache): self;
 }

--- a/src/CustomRulesetsAwareConfigInterface.php
+++ b/src/CustomRulesetsAwareConfigInterface.php
@@ -31,6 +31,8 @@ interface CustomRulesetsAwareConfigInterface extends ConfigInterface
      * @param list<RuleSetDefinitionInterface> $ruleSets
      *
      * @todo v4 Introduce it in main ConfigInterface
+     *
+     * @return $this
      */
     public function registerCustomRuleSets(array $ruleSets): ConfigInterface;
 

--- a/src/ParallelAwareConfigInterface.php
+++ b/src/ParallelAwareConfigInterface.php
@@ -27,5 +27,8 @@ interface ParallelAwareConfigInterface extends ConfigInterface
 {
     public function getParallelConfig(): ParallelConfig;
 
+    /**
+     * @return $this
+     */
     public function setParallelConfig(ParallelConfig $config): ConfigInterface;
 }

--- a/src/UnsupportedPhpVersionAllowedConfigInterface.php
+++ b/src/UnsupportedPhpVersionAllowedConfigInterface.php
@@ -26,5 +26,8 @@ interface UnsupportedPhpVersionAllowedConfigInterface extends ConfigInterface
      */
     public function getUnsupportedPhpVersionAllowed(): bool;
 
+    /**
+     * @return $this
+     */
     public function setUnsupportedPhpVersionAllowed(bool $isUnsupportedPhpVersionAllowed): ConfigInterface;
 }


### PR DESCRIPTION
When you change the order of configuration method calls, you will see these errors in the IDE and PHPStan.

<img width="944" height="1013" alt="image" src="https://github.com/user-attachments/assets/63ba40d1-cec6-4d71-ab0d-3727b8286727" />

I think it would be more correct to use `@return $this`, because the methods return an instance of the `Config` class, not just the `ConfigInterface`.
