### PR TITLE
docs: document different default value for future-mode

### DIFF
--- a/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
+++ b/doc/rules/php_unit/php_unit_test_case_static_method_calls.rst
@@ -51,6 +51,8 @@ Allowed values: ``'10.0'``, ``'11.0'`` and ``'newest'``
 
 Default value: ``'10.0'``
 
+Default value (future-mode): ``'newest'``
+
 Examples
 --------
 


### PR DESCRIPTION
closes #9344
PhpUnitTestCaseStaticMethodCallsFixer has different default value depending on the mode in use