### PR TITLE
DX: add env for easier finding which fixer break a PHP syntax

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ PHP_CS_FIXER_PARALLEL= # `0` / `1`, default is `0` - run PHP CS Fixer in paralle
 ## @internal
 PHP_CS_FIXER_ENFORCE_CACHE= # `0` / `1`, default is `0` - enforce cache usage
 PHP_CS_FIXER_ALLOW_XDEBUG= # `0` / `1`, default is `0` - allow Xdebug
+PHP_CS_FIXER_DEBUG= # `0` / `1`, default is `0` - lint source code after each change

--- a/src/Runner/Runner.php
+++ b/src/Runner/Runner.php
@@ -607,9 +607,11 @@ final class Runner
                         try {
                             $this->linter->lintSource($tokens->generateCode())->check();
                         } catch (LintingException $e) {
-                            echo "\n\nFixer {$fixer->getName()} introduced linting issue:\n\n{$tokens->generateCode()}\n";
+                            $this->dispatchEvent(FileProcessed::NAME, new FileProcessed(FileProcessed::STATUS_LINT));
 
-                            exit(1);
+                            $this->errorsManager->report(new Error(Error::TYPE_LINT, $filePathname, $e, [$fixer->getName()], $this->differ->diff($old, $tokens->generateCode(), $file)));
+
+                            return null;
                         }
                     }
                 }


### PR DESCRIPTION
It happened to me many times before, most recently when debugging https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/9349. The new env variable could also be used to ask the bug reporter for more details.

For the code:
```
$ cat test.php 
<?php class Foo {
    #[Bar(static function () {})]
    public function __invoke() {}
}
```
trying to check it resulted in a regular way:
```
$ docker compose run php-8.5 php php-cs-fixer check test.php -vvv
PHP CS Fixer 3.92.6-DEV Exceptional Exception by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.5.2

Found 0 of 1 files that can be fixed in 0.002 seconds, 20.00 MB memory used

Files that were not fixed due to errors reported during fixing:
   1) /fixer/test.php

                                    
        [UnexpectedValueException]  
        Missing block "start".      
                                    

      PhpCsFixer\Tokenizer\Tokens->findOppositeBlockEdge()
        in /fixer/src/Tokenizer/Tokens.php at line 549
      PhpCsFixer\Tokenizer\Tokens->findBlockStart()
        in /fixer/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php at line 470
      PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer->findCommentBlockStart()
        in /fixer/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php at line 339
      PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer->fixSpaceAboveClassElement()
        in /fixer/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php at line 214
      PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer->applyFix()
        in /fixer/src/AbstractFixer.php at line 65
      PhpCsFixer\AbstractFixer->fix()
        in /fixer/src/Runner/Runner.php at line 600
      PhpCsFixer\Runner\Runner->fixFile()
        in /fixer/src/Runner/Runner.php at line 479
      PhpCsFixer\Runner\Runner->fixSequential()
        in /fixer/src/Runner/Runner.php at line 212
      PhpCsFixer\Runner\Runner->fix()
        in /fixer/src/Console/Command/FixCommand.php at line 424
      PhpCsFixer\Console\Command\FixCommand->execute()
        in /fixer/vendor/symfony/console/Command/Command.php at line 341
      [ ... ]
To see details of the error(s), re-run the command with `--sequential -vvv [file]`
```
wrongly gives the impression that `ClassAttributesSeparationFixer` is a problem. The fact is, the fixer already got  tokens with invalid syntax:
```
$ docker compose run -e PHP_CS_FIXER_DEBUG=1 php-8.5 php php-cs-fixer check test.php -vvv
PHP CS Fixer 3.92.6-DEV Exceptional Exception by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.5.2

Fixer ordered_class_elements introduced linting issue:

<?php final class Foo {)]
    public function __invoke() {}
    #[Bar(static function () {}
}
```