### PR TITLE
test: update PHP 8.5 compat test to cover closure in attribute and prevent conversion to empty arrow function

### DIFF
--- a/tests/Fixtures/Integration/php_compat/PHP8.5.test
+++ b/tests/Fixtures/Integration/php_compat/PHP8.5.test
@@ -47,6 +47,13 @@ switch ($a) {
         break;
 }
 
+// https://wiki.php.net/rfc/closures_in_const_expr
+class ClosuresInAttibutes
+{
+    #[Attribute123(someName: static function (): void {})]
+    public string $foo;
+}
+
 --INPUT--
 <?php
 
@@ -85,4 +92,11 @@ switch ($a) {
 
     default;
         break;
+}
+
+// https://wiki.php.net/rfc/closures_in_const_expr
+class ClosuresInAttibutes
+{
+    #[Attribute123(someName: static function (): void {})]
+    public string $foo;
 }


### PR DESCRIPTION

https://3v4l.org/O0dN8#v8.5.2


so we do not break accidentally when implementing #9372 