### PR TITLE
fix: `AttributeBlockNoSpacesFixer` - skipping some attributes

### DIFF
--- a/src/Fixer/AttributeNotation/AttributeBlockNoSpacesFixer.php
+++ b/src/Fixer/AttributeNotation/AttributeBlockNoSpacesFixer.php
@@ -64,17 +64,18 @@ class User
         $index = 0;
 
         while (null !== $index = $tokens->getNextTokenOfKind($index, [[\T_ATTRIBUTE]])) {
+            $nextIndex = $index;
             $attributeAnalysis = AttributeAnalyzer::collectOne($tokens, $index);
 
             $endIndex = $attributeAnalysis->getEndIndex();
-            while ($index <= $endIndex) {
-                $token = $tokens[$index];
+            while ($nextIndex <= $endIndex) {
+                $token = $tokens[$nextIndex];
 
                 $toDelete = [];
 
                 if ($token->isGivenKind([\T_ATTRIBUTE])) {
-                    $nextTokenIndex = $tokens->getNextMeaningfulToken($index);
-                    for ($i = $index + 1; $i < $nextTokenIndex; ++$i) {
+                    $nextTokenIndex = $tokens->getNextMeaningfulToken($nextIndex);
+                    for ($i = $nextIndex + 1; $i < $nextTokenIndex; ++$i) {
                         if (!$tokens[$i]->isWhitespace()) {
                             $toDelete = [];
 
@@ -85,8 +86,8 @@ class User
                 }
 
                 if ($token->isGivenKind([CT::T_ATTRIBUTE_CLOSE])) {
-                    $prevTokenIndex = $tokens->getPrevMeaningfulToken($index);
-                    for ($i = $prevTokenIndex + 1; $i < $index; ++$i) {
+                    $prevTokenIndex = $tokens->getPrevMeaningfulToken($nextIndex);
+                    for ($i = $prevTokenIndex + 1; $i < $nextIndex; ++$i) {
                         if (!$tokens[$i]->isWhitespace()) {
                             $toDelete = [];
 
@@ -100,7 +101,7 @@ class User
                     $tokens->clearAt($i);
                 }
 
-                ++$index;
+                ++$nextIndex;
             }
         }
     }

--- a/tests/Fixer/AttributeNotation/AttributeBlockNoSpacesFixerTest.php
+++ b/tests/Fixer/AttributeNotation/AttributeBlockNoSpacesFixerTest.php
@@ -111,5 +111,30 @@ class User
     private string $name;
 }', null,
         ];
+
+        yield 'With multiple attributes in a row' => [
+            '<?php
+class User
+{
+    #[ApiProperty1()]
+    #[ApiProperty2()]
+    #[ApiProperty3()]
+    private string $name;
+}',
+            '<?php
+class User
+{
+    #[
+        ApiProperty1()
+    ]
+    #[
+        ApiProperty2()
+    ]
+    #[
+        ApiProperty3()
+    ]
+    private string $name;
+}',
+        ];
     }
 }


### PR DESCRIPTION
`AttributeBlockNoSpacesFixer` was introduced in https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9264.

There is an issue with it not applying to all attributes when several attributes in a row are present. I have added a test case for this and a fix similar to https://github.com/Codevate/PHP-CS-Fixer/blob/master/src/Fixer/AttributeNotation/AttributeEmptyParenthesesFixer.php#L84