### PR TITLE
feat: Resolve to `json` format when `AI_AGENT` environment variable is set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
-        "ergebnis/agent-detector": "^1.1.0",
+        "ergebnis/agent-detector": "^1.1.1",
         "fidry/cpu-core-counter": "^1.3",
         "react/child-process": "^0.6.6",
         "react/event-loop": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
-        "ergebnis/agent-detector": "^1.0.1",
+        "ergebnis/agent-detector": "^1.1.0",
         "fidry/cpu-core-counter": "^1.3",
         "react/child-process": "^0.6.6",
         "react/event-loop": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "clue/ndjson-react": "^1.3",
         "composer/semver": "^3.4",
         "composer/xdebug-handler": "^3.0.5",
+        "ergebnis/agent-detector": "^1.0.1",
         "fidry/cpu-core-counter": "^1.3",
         "react/child-process": "^0.6.6",
         "react/event-loop": "^1.5",

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -63,9 +63,10 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
   * ``gitlab`` for GitLab
-  * ``json`` for AI agents (via ``AI_AGENT`` environment variable)
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
+
+When the ``AI_AGENT`` environment variable is set, the format is unconditionally resolved to ``json``.
 
 NOTE: the output for the following formats are generated in accordance with schemas
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -63,6 +63,7 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 * ``@auto`` aims to auto-select best reporter for given CI or local execution (resolution into best format is outside of BC promise and is future-ready)
 
   * ``gitlab`` for GitLab
+  * ``json`` for AI agents (via ``AI_AGENT`` environment variable)
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -66,7 +66,7 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 
-When the ``AI_AGENT`` environment variable is set, the format is unconditionally resolved to selected best fit for AI agent (currently ``json``).
+When the ``AI_AGENT`` environment variable (or another popular one) is set, the format is unconditionally resolved to the selected best fit for the AI agent (currently ``json``).
 
 NOTE: the output for the following formats are generated in accordance with schemas
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -66,7 +66,7 @@ The ``--format`` option for the output format. Supported formats are ``@auto`` (
 
 * ``@auto,{format}`` takes ``@auto`` under CI, and {format} otherwise
 
-When the ``AI_AGENT`` environment variable is set, the format is unconditionally resolved to ``json``.
+When the ``AI_AGENT`` environment variable is set, the format is unconditionally resolved to selected best fit for AI agent (currently ``json``).
 
 NOTE: the output for the following formats are generated in accordance with schemas
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -684,6 +684,10 @@ final class ConfigurationResolver
                 if (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
                     $this->format = 'gitlab';
                 }
+
+                if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
+                    $this->format = 'json';
+                }
             }
         }
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -669,6 +669,15 @@ final class ConfigurationResolver
     private function resolveFormat(): string
     {
         if (null === $this->format) {
+            /**
+             * When an AI agent is running, we ignore the format configuration entirely and use JSON format.
+             */
+            if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
+                $this->format = 'json';
+
+                return $this->format;
+            }
+
             $formatCandidate = $this->options['format'] ?? $this->getConfig()->getFormat();
             $parts = explode(',', $formatCandidate);
 
@@ -686,9 +695,6 @@ final class ConfigurationResolver
                 }
             }
 
-            if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
-                $this->format = 'json';
-            }
         }
 
         return $this->format;

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -684,10 +684,10 @@ final class ConfigurationResolver
                 if (filter_var(getenv('GITLAB_CI'), \FILTER_VALIDATE_BOOL)) {
                     $this->format = 'gitlab';
                 }
+            }
 
-                if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
-                    $this->format = 'json';
-                }
+            if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
+                $this->format = 'json';
             }
         }
 

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -669,9 +669,7 @@ final class ConfigurationResolver
     private function resolveFormat(): string
     {
         if (null === $this->format) {
-            /**
-             * When an AI agent is running, we ignore the format configuration entirely and use JSON format.
-             */
+            // When an AI agent is running, we ignore the format configuration entirely and use JSON format.
             if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
                 $this->format = 'json';
 
@@ -694,7 +692,6 @@ final class ConfigurationResolver
                     $this->format = 'gitlab';
                 }
             }
-
         }
 
         return $this->format;

--- a/src/Console/ConfigurationResolver.php
+++ b/src/Console/ConfigurationResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace PhpCsFixer\Console;
 
+use Ergebnis\AgentDetector;
 use PhpCsFixer\Cache\CacheManagerInterface;
 use PhpCsFixer\Cache\Directory;
 use PhpCsFixer\Cache\DirectoryInterface;
@@ -669,8 +670,10 @@ final class ConfigurationResolver
     private function resolveFormat(): string
     {
         if (null === $this->format) {
+            $agentDetector = new AgentDetector\Detector();
+
             // When an AI agent is running, we ignore the format configuration entirely and use JSON format.
-            if (filter_var(getenv('AI_AGENT'), \FILTER_VALIDATE_BOOL)) {
+            if ($agentDetector->isAgentPresent(getenv())) {
                 $this->format = 'json';
 
                 return $this->format;

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1501,8 +1501,20 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
 
         yield [
+            JsonReporter::class,
+            'checkstyle',
+            ['AI_AGENT' => 'true'],
+        ];
+
+        yield [
             TextReporter::class,
             'txt',
+        ];
+
+        yield [
+            JsonReporter::class,
+            'txt',
+            ['AI_AGENT' => 'true'],
         ];
 
         yield [
@@ -1512,21 +1524,18 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
         ];
 
         yield [
+            JsonReporter::class,
+            '@auto',
+            [
+                'AI_AGENT' => 'true',
+                'GITLAB_CI' => '',
+            ],
+        ];
+
+        yield [
             GitlabReporter::class,
             '@auto',
             ['GITLAB_CI' => 'true'],
-        ];
-
-        yield [
-            JsonReporter::class,
-            '@auto',
-            ['AI_AGENT' => 'true'],
-        ];
-
-        yield [
-            TextReporter::class,
-            '@auto',
-            ['AI_AGENT' => ''],
         ];
 
         yield [
@@ -1540,13 +1549,13 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         yield [
             JsonReporter::class,
-            'txt',
-            ['AI_AGENT' => 'true'],
+            '@auto,json',
         ];
 
         yield [
             JsonReporter::class,
             '@auto,json',
+            ['AI_AGENT' => 'true'],
         ];
     }
 

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1540,6 +1540,12 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         yield [
             JsonReporter::class,
+            'txt',
+            ['AI_AGENT' => 'true'],
+        ];
+
+        yield [
+            JsonReporter::class,
             '@auto,json',
         ];
     }

--- a/tests/Console/ConfigurationResolverTest.php
+++ b/tests/Console/ConfigurationResolverTest.php
@@ -1519,6 +1519,27 @@ For more info about updating see: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/b
 
         yield [
             JsonReporter::class,
+            '@auto',
+            ['AI_AGENT' => 'true'],
+        ];
+
+        yield [
+            TextReporter::class,
+            '@auto',
+            ['AI_AGENT' => ''],
+        ];
+
+        yield [
+            JsonReporter::class,
+            '@auto',
+            [
+                'AI_AGENT' => 'true',
+                'GITLAB_CI' => 'true',
+            ],
+        ];
+
+        yield [
+            JsonReporter::class,
             '@auto,json',
         ];
     }


### PR DESCRIPTION
This pull request 

- [x] resolves to `json` format when using `@auto` format and an `AI_AGENT` environment variable is set

💁‍♂️ Also see

- https://github.com/nunomaduro/pao
- https://github.com/shipfastlabs/agent-detector/blob/v1.1.2/src/AgentDetector.php#L11-L28
- https://github.com/ergebnis/agent-detector/blob/1.0.1/src/Detector.php#L31-L49