### PR TITLE
fix: `MethodArgumentSpaceFixer` - Do not collapse nested arguments when using `ensure_single_line_for_single_argument` option for `on_multiline`

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -533,6 +533,24 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
     private function ensureSingleLineForParentheses(Tokens $tokens, int $openParenthesis, int $closeParenthesis): void
     {
         for ($index = $closeParenthesis - 1; $index > $openParenthesis; --$index) {
+            if ($tokens[$index]->equals(')')) {
+                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
+                continue;
+            }
+
+            if ($tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_CLOSE)) {
+                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+
+                continue;
+            }
+
+            if ($tokens[$index]->equals('}')) {
+                $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+
             if ($tokens[$index]->isWhitespace()) {
                 $previousToken = $tokens[$index - 1];
 

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1289,6 +1289,48 @@ f(1,2,
             ['on_multiline' => 'ensure_single_line_for_single_argument'],
         ];
 
+        yield 'ensure_single_line_for_single_argument: does not collapse nested multiline call with multiple arguments' => [
+            <<<'EXPECTED'
+                <?php
+                foo(bar(
+                    $a,
+                    $b
+                ));
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                foo(
+                    bar(
+                        $a,
+                        $b
+                    )
+                );
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse nested multiline array as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo([
+                    'a',
+                    'b',
+                    'c',
+                ]);
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                foo(
+                    [
+                        'a',
+                        'b',
+                        'c',
+                    ]
+                );
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
         yield 'ensure_single_line_for_single_argument: handles array as single argument' => [
             <<<'EXPECTED'
                 <?php

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1313,10 +1313,10 @@ f(1,2,
             <<<'EXPECTED'
                 <?php
                 foo([
-                    'a',
-                    'b',
-                    'c',
-                ]);
+                        'a',
+                        'b',
+                        'c',
+                    ]);
                 EXPECTED,
             <<<'INPUT'
                 <?php


### PR DESCRIPTION
This pull request

- [x] adds a test for the `MethodArgumentSpaceFixer` exposing the undesired collapsing of arguments
- [x] adjusts the `MethodArgumentSpaceFixer` to stop collapsing nested arguments when using the `ensure_single_line_for_single_argument` option for `on_multiline`

Follows #9504.