### PR TITLE
fix: `MethodArgumentSpaceFixer` - avoid collapsing multi-line arguments

### DIFF
--- a/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
+++ b/src/Fixer/FunctionNotation/MethodArgumentSpaceFixer.php
@@ -528,10 +528,55 @@ final class MethodArgumentSpaceFixer extends AbstractFixer implements Configurab
     }
 
     /**
+     * Check if the argument content should not be collapsed — either spans multiple lines
+     * outside nested blocks and boundary whitespace, or contains comments or attributes.
+     */
+    private function argumentContentIsMultiline(Tokens $tokens, int $openParenthesis, int $closeParenthesis): bool
+    {
+        for ($index = $openParenthesis + 1; $index < $closeParenthesis; ++$index) {
+            if ($tokens[$index]->isComment()) {
+                return true;
+            }
+
+            if ($index === $openParenthesis + 1 || $index === $closeParenthesis - 1) {
+                continue;
+            }
+
+            if ($tokens[$index]->equals('(')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);
+
+                continue;
+            }
+
+            if ($tokens[$index]->isGivenKind(CT::T_ARRAY_SQUARE_BRACE_OPEN)) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE, $index);
+
+                continue;
+            }
+
+            if ($tokens[$index]->equals('{')) {
+                $index = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $index);
+
+                continue;
+            }
+
+            if ($this->isNewline($tokens[$index])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Collapse a multiline single-argument call/declaration to a single line.
      */
     private function ensureSingleLineForParentheses(Tokens $tokens, int $openParenthesis, int $closeParenthesis): void
     {
+        if ($this->argumentContentIsMultiline($tokens, $openParenthesis, $closeParenthesis)) {
+            return;
+        }
+
         for ($index = $closeParenthesis - 1; $index > $openParenthesis; --$index) {
             if ($tokens[$index]->equals(')')) {
                 $index = $tokens->findBlockStart(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $index);

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -304,6 +304,84 @@ function foo($foo, #[
     Foo\Buzz(a: \'astral\', b: 1234),
 ] $bar) {}',
         ];
+
+        yield 'ensure_single_line_for_single_argument: collapses when parameter has inline attribute' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(#[Attr] $x) {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                function foo(
+                    #[Attr] $x
+                ) {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation on function' => [
+            <<<'EXPECTED'
+                <?php
+                #[Attr('foo')]
+                function foo() {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                #[Attr(
+                    'foo'
+                )]
+                function foo() {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation with named argument on function' => [
+            <<<'EXPECTED'
+                <?php
+                #[Attr(value: 'foo')]
+                function foo() {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                #[Attr(
+                    value: 'foo'
+                )]
+                function foo() {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses inner multiline single-argument attribute when parameter has attribute on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(
+                    #[Attr(value: 'something')]
+                    $x
+                ) {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                function foo(
+                    #[Attr(
+                        value: 'something'
+                    )]
+                    $x
+                ) {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when parameter has attribute on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(
+                    #[Attr]
+                    $x
+                ) {}
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
     }
 
     /**
@@ -1464,84 +1542,6 @@ f(1,2,
                 foo(
                     $a # hello
                 );
-                EXPECTED,
-            null,
-            ['on_multiline' => 'ensure_single_line_for_single_argument'],
-        ];
-
-        yield 'ensure_single_line_for_single_argument: collapses when parameter has inline attribute' => [
-            <<<'EXPECTED'
-                <?php
-                function foo(#[Attr] $x) {}
-                EXPECTED,
-            <<<'INPUT'
-                <?php
-                function foo(
-                    #[Attr] $x
-                ) {}
-                INPUT,
-            ['on_multiline' => 'ensure_single_line_for_single_argument'],
-        ];
-
-        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation on function' => [
-            <<<'EXPECTED'
-                <?php
-                #[Attr('foo')]
-                function foo() {}
-                EXPECTED,
-            <<<'INPUT'
-                <?php
-                #[Attr(
-                    'foo'
-                )]
-                function foo() {}
-                INPUT,
-            ['on_multiline' => 'ensure_single_line_for_single_argument'],
-        ];
-
-        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation with named argument on function' => [
-            <<<'EXPECTED'
-                <?php
-                #[Attr(value: 'foo')]
-                function foo() {}
-                EXPECTED,
-            <<<'INPUT'
-                <?php
-                #[Attr(
-                    value: 'foo'
-                )]
-                function foo() {}
-                INPUT,
-            ['on_multiline' => 'ensure_single_line_for_single_argument'],
-        ];
-
-        yield 'ensure_single_line_for_single_argument: collapses inner multiline single-argument attribute when parameter has attribute on previous line' => [
-            <<<'EXPECTED'
-                <?php
-                function foo(
-                    #[Attr(value: 'something')]
-                    $x
-                ) {}
-                EXPECTED,
-            <<<'INPUT'
-                <?php
-                function foo(
-                    #[Attr(
-                        value: 'something'
-                    )]
-                    $x
-                ) {}
-                INPUT,
-            ['on_multiline' => 'ensure_single_line_for_single_argument'],
-        ];
-
-        yield 'ensure_single_line_for_single_argument: does not collapse when parameter has attribute on previous line' => [
-            <<<'EXPECTED'
-                <?php
-                function foo(
-                    #[Attr]
-                    $x
-                ) {}
                 EXPECTED,
             null,
             ['on_multiline' => 'ensure_single_line_for_single_argument'],

--- a/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
+++ b/tests/Fixer/FunctionNotation/MethodArgumentSpaceFixerTest.php
@@ -1331,6 +1331,240 @@ f(1,2,
             ['on_multiline' => 'ensure_single_line_for_single_argument'],
         ];
 
+        yield 'ensure_single_line_for_single_argument: collapses single-line method chain as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo(Foo::bar()->baz($quz));
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                foo(
+                    Foo::bar()->baz($quz)
+                );
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse multiline method chain as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    Foo::bar()
+                        ->baz($quz)
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse multiline method chain with nested multiline call as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    Foo::bar()
+                        ->baz($quz)
+                        ->qux(
+                            $foo,
+                            $bar
+                        )
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses single-line string concatenation as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo('hello ' . 'world');
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                foo(
+                    'hello ' . 'world'
+                );
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse multiline string concatenation as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    'hello '
+                        . 'world'
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has inline block comment before it' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    /* hello */ $a
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has inline block comment after it' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    $a /* hello */
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has block comment on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    /* hello */
+                    $a
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has docblock on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    /**
+                     * hello
+                     */
+                    $a
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has trailing double-slash comment' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    $a // hello
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when argument has trailing hash comment' => [
+            <<<'EXPECTED'
+                <?php
+                foo(
+                    $a # hello
+                );
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses when parameter has inline attribute' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(#[Attr] $x) {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                function foo(
+                    #[Attr] $x
+                ) {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation on function' => [
+            <<<'EXPECTED'
+                <?php
+                #[Attr('foo')]
+                function foo() {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                #[Attr(
+                    'foo'
+                )]
+                function foo() {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses single-argument attribute invocation with named argument on function' => [
+            <<<'EXPECTED'
+                <?php
+                #[Attr(value: 'foo')]
+                function foo() {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                #[Attr(
+                    value: 'foo'
+                )]
+                function foo() {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses inner multiline single-argument attribute when parameter has attribute on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(
+                    #[Attr(value: 'something')]
+                    $x
+                ) {}
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                function foo(
+                    #[Attr(
+                        value: 'something'
+                    )]
+                    $x
+                ) {}
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: does not collapse when parameter has attribute on previous line' => [
+            <<<'EXPECTED'
+                <?php
+                function foo(
+                    #[Attr]
+                    $x
+                ) {}
+                EXPECTED,
+            null,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
+        yield 'ensure_single_line_for_single_argument: collapses multiline closure as single argument' => [
+            <<<'EXPECTED'
+                <?php
+                foo(function () {
+                        return true;
+                    });
+                EXPECTED,
+            <<<'INPUT'
+                <?php
+                foo(
+                    function () {
+                        return true;
+                    }
+                );
+                INPUT,
+            ['on_multiline' => 'ensure_single_line_for_single_argument'],
+        ];
+
         yield 'ensure_single_line_for_single_argument: handles array as single argument' => [
             <<<'EXPECTED'
                 <?php


### PR DESCRIPTION
This pull request

- [x] adds more test cases for the `MethodArgumentSpaceFixer`
- [x] fixes failing tests

Follows https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9504.