### PR TITLE
chore: cleanup `BlankLineBetweenImportGroupsFixer`

### DIFF
--- a/dev-tools/phpstan/baseline/offsetAccess.notFound.php
+++ b/dev-tools/phpstan/baseline/offsetAccess.notFound.php
@@ -742,11 +742,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Fixer/Whitespace/ArrayIndentationFixer.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Offset int<0, max> might not exist on list<int>.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Offset 0 might not exist on array{0?: string}.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Fixer/Whitespace/HeredocIndentationFixer.php',

--- a/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
+++ b/src/Fixer/Whitespace/BlankLineBetweenImportGroupsFixer.php
@@ -134,6 +134,7 @@ final class BlankLineBetweenImportGroupsFixer extends AbstractFixer implements W
         $previousType = null;
 
         for ($i = $usesCount - 1; $i >= 0; --$i) {
+            \assert(isset($uses[$i]));
             $index = $uses[$i];
             $startIndex = $tokens->getNextMeaningfulToken($index + 1);
             $endIndex = $tokens->getNextTokenOfKind($startIndex, [';', [\T_CLOSE_TAG]]);
@@ -181,7 +182,7 @@ final class BlankLineBetweenImportGroupsFixer extends AbstractFixer implements W
             $content = $tokens[$index]->getContent();
 
             if (str_contains($content, "\n")) {
-                return $index;
+                break;
             }
         }
 

--- a/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
+++ b/tests/Fixer/Whitespace/BlankLineBetweenImportGroupsFixerTest.php
@@ -36,7 +36,7 @@ final class BlankLineBetweenImportGroupsFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * @return iterable<array{string, string}>
+     * @return iterable<array{string, 1?: string}>
      */
     public static function provideFixCases(): iterable
     {
@@ -531,6 +531,10 @@ namespace Foo;
 use A\B; /* foo */  /* A */ /* B */  # X
 use const C\D; // bar
 ',
+        ];
+
+        yield 'one use statement' => [
+            '<?php use A;',
         ];
     }
 


### PR DESCRIPTION
Cleanup also for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9560