### PR TITLE
chore: cleanup `NoExtraBlankLinesFixer`

### DIFF
--- a/dev-tools/phpstan/baseline/offsetAccess.notFound.php
+++ b/dev-tools/phpstan/baseline/offsetAccess.notFound.php
@@ -762,21 +762,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../../src/Fixer/Whitespace/IndentationTypeFixer.php',
 ];
 $ignoreErrors[] = [
-    'rawMessage' => 'Offset int might not exist on array<int, callable(int): void>.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Offset int<1, max> might not exist on list<string>.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Offset string might not exist on array<string, callable(int): void>.',
-    'count' => 1,
-    'path' => __DIR__ . '/../../../src/Fixer/Whitespace/NoExtraBlankLinesFixer.php',
-];
-$ignoreErrors[] = [
     'rawMessage' => 'Offset 0 might not exist on list<string>.',
     'count' => 1,
     'path' => __DIR__ . '/../../../src/Fixer/Whitespace/NoTrailingWhitespaceFixer.php',

--- a/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
+++ b/src/Fixer/Whitespace/NoExtraBlankLinesFixer.php
@@ -352,6 +352,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
                 continue;
             }
 
+            \assert(isset($this->tokenKindCallbackMap[$token->getId()]));
             \call_user_func_array($this->tokenKindCallbackMap[$token->getId()], [$index]);
 
             return;
@@ -362,6 +363,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
                 continue;
             }
 
+            \assert(isset($this->tokenEqualsMap[$token->getContent()]));
             \call_user_func_array($this->tokenEqualsMap[$token->getContent()], [$index]);
 
             return;
@@ -393,6 +395,7 @@ final class NoExtraBlankLinesFixer extends AbstractFixer implements Configurable
         $count = \count($parts);
 
         if ($count > $expected) {
+            \assert(isset($parts[$count - 1]));
             $this->tokens[$index] = new Token([\T_WHITESPACE, implode('', \array_slice($parts, 0, $expected)).rtrim($parts[$count - 1], "\r\n")]);
         }
     }


### PR DESCRIPTION
Cleanup also for https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9560