### PR TITLE
chore: ignore `PKSA-5jz8-6tcw-pbk4` to unblock `composer install`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,11 @@
             "ergebnis/composer-normalize": true,
             "infection/extension-installer": false
         },
+        "audit": {
+            "ignore": {
+                "PKSA-5jz8-6tcw-pbk4": "To allow installing PHPUnit 9.6 / 10.5 / 11.5 lines (no patched versions available yet)"
+            }
+        },
         "prefer-stable": true,
         "sort-packages": true
     },


### PR DESCRIPTION
Advisory [`PKSA-5jz8-6tcw-pbk4`](https://packagist.org/security-advisories/PKSA-5jz8-6tcw-pbk4) affects PHPUnit `<=12.5.21` and `13.0.0`–`13.1.5`. The `require-dev` constraint pins the `9.6.x` / `10.5.x` / `11.5.x` lines for the multi-version test matrix, and no patched versions of those lines are published on packagist yet, so every `composer install` in CI (and locally) fails at resolution.

Adds `config.audit.ignore` entry with a description explaining the reason, as suggested by @kubawerlos in #9574.

Fixes #9574.